### PR TITLE
Bulk index type

### DIFF
--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -108,12 +108,7 @@ class Elastica_Client
 
 			// Always newline needed
 			$queryString .= json_encode($baseArray) . PHP_EOL;
-
-			$docArray = array(
-				$doc->getType() => $doc->getData()
-			);
-
-			$queryString .= json_encode($docArray) . PHP_EOL;
+			$queryString .= json_encode($doc->getData()) . PHP_EOL;
 		}
 
 		return $this->request($path, Elastica_Request::PUT, $queryString);


### PR DESCRIPTION
Shay let me know that it's not advisable (anymore) to enclose each bulk-indexed item in a type.  This makes future searches across types easier, along with some miscellaneous bookkeeping.

This might not be entirely backward-compatible with existing indexes, though. :(
