### PR TITLE
Elastica_Type::deleteById

### DIFF
--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -168,6 +168,9 @@ class Elastica_Type
 	 * @param int|string $id 
 	 */
 	public function deleteById($id) {
+		if (empty($id) || !trim($id)) {
+			throw new InvalidArgumentException();
+		}
 		$response = $this->request($id, Elastica_Request::DELETE);
 	}
 

--- a/test/lib/Elastica/TypeTest.php
+++ b/test/lib/Elastica/TypeTest.php
@@ -123,5 +123,18 @@ class Elastica_TypeTest extends PHPUnit_Framework_TestCase
 		// rolf should no longer be there
 		$resultSet = $type->search('rolf');
 		$this->assertEquals(0, $resultSet->count());
+		
+		// it should not be possible to delete the entire type with this method
+		try { $type->deleteById(' '); } catch (Exception $e) { /* ignore */ }
+		try { $type->deleteById(null); } catch (Exception $e) { /* ignore */ }
+		try { $type->deleteById(array()); } catch (Exception $e) { /* ignore */ }
+		try { $type->deleteById('*'); } catch (Exception $e) { /* ignore */ }
+		try { $type->deleteById('*:*'); } catch (Exception $e) { /* ignore */ }
+		try { $type->deleteById('!'); } catch (Exception $e) { /* ignore */ }
+		$index->refresh();
+		
+		// rolf should no longer be there
+		$resultSet = $type->search('john');
+		$this->assertEquals(1, $resultSet->count());
 	}
 }


### PR DESCRIPTION
I added this method to delete documents based on their unique identifiers. The test for this is in TypeTest. If it doesn't correspond to your naming convention, that can easily be changed.
