### PR TITLE
Header support

### DIFF
--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -38,6 +38,11 @@ class Elastica_Client
 	 */
 	protected $_port = self::DEFAULT_PORT;
 
+    /**
+     * HTTP Headers
+     */
+    protected $_headers = array();
+
 	/**
 	 * Creates a new Elastica client
 	 *
@@ -77,6 +82,37 @@ class Elastica_Client
 		return intval($this->_port);
 	}
 
+    /**
+     * Adds a HTTP Header
+     *
+     * @param string $header The HTTP Header
+     * @param string $headerValue The HTTP Header Value
+     * @throws Elastica_Exception_Invalid If $header or $headerValue is not a string
+     */
+    public function addHeader($header, $headerValue) {
+        if (is_string($header) && is_string($headerValue)) {
+            $this->_headers[$header] = $headerValue;
+        } else {
+            throw new Elastica_Exception_Invalid('Header must be a string');
+        }
+    }
+
+    /**
+     * Remove a HTTP Header
+     *
+     * @param string $header The HTTP Header to remove
+     * @throws Elastica_Exception_Invalid IF $header is not a string
+     */
+    public function removeHeader($header) {
+        if (is_string($header)) {
+            if (array_key_exists($header, $this->_headers)) {
+                unset($this->_headers[$header]);
+            }
+        } else {
+            throw new Elastica_Exception_Invalid('Header must be a string');
+        }
+    }
+                
 	/**
 	 * Uses _bulk to send documents to the server
 	 *
@@ -232,6 +268,15 @@ class Elastica_Client
 		curl_setopt($conn, CURLOPT_PORT, $this->getPort());
 		curl_setopt($conn, CURLOPT_RETURNTRANSFER, 1) ;
 		curl_setopt($conn, CURLOPT_CUSTOMREQUEST, $request->getMethod());
+
+        if (!empty($this->_headers)) {
+            $headers = array();
+            while(list($header, $headerValue) = each($this->_headers)) {
+                array_push($headers, $header . ': ' . $headerValue);
+            }
+
+            curl_setopt($conn, CURLOPT_HTTPHEADER, $headers);
+        }
 
 		// TODO: REFACTOR
 		$data = $request->getData();


### PR DESCRIPTION
This allows you to add and remove http headers that will be sent to Elastic Search.  Useful if you are running Elastic Search behind a proxy and requires authentication, api key's, etc.
