### PR TITLE
Highlights

### DIFF
--- a/lib/Elastica/Result.php
+++ b/lib/Elastica/Result.php
@@ -50,6 +50,19 @@ class Elastica_Result
 		}
 	}
 	
+	/**
+	 * Returns result data
+	 * 
+	 * @return array Result data array
+	 */
+	public function getHighlights() {
+		if (isset($this->_hit['highlight'])) {
+			return $this->_hit['highlight'];
+		} else {
+			return array();
+		}
+	}
+	
 	public function __get($key) {
 		$source = $this->getData();
 		return array_key_exists($key, $source) ? $source[$key] : null; 


### PR DESCRIPTION
First of all, thanks for your work on Elastica, works great for me.

I can tell Elastica to return highlights:

```
$Query->setHighlight(array(
    'pre_tags' => array('<em class="highlight">'),
    'post_tags' => array('</em>'),
    'fields' => array(
        'TicketResponse/0/content' => array(
            'fragment_size' => 200,
            'number_of_fragments' => 1,
        ),
    ),
));
```

But wasn't able to retrieve them yet through the Result object.
With this tiny patch I can.

Cheers!
