### PR TITLE
Fix call to a variable name when getting the transfer info.

### DIFF
--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -58,7 +58,7 @@ class Elastica_Response {
 	}
 
 	public function getTransferInfo() {
-		return $this->_transferInfo();
+		return $this->_transferInfo;
 	}
 
 	public function setTransferInfo(array $transferInfo) {


### PR DESCRIPTION
The transfer info function had a call to it's variable in it.
