### PR TITLE
fix the wrong name for 'fields', fix getData when result has 'fields' and no '_source'

### DIFF
--- a/lib/Elastica/Result.php
+++ b/lib/Elastica/Result.php
@@ -63,7 +63,7 @@ class Elastica_Result
 	 * @return array Fields list
 	 */
 	public function getFields() {
-		return $this->getParam('_fields');
+		return $this->getParam('fields');
 	}
 
 	/**
@@ -105,12 +105,16 @@ class Elastica_Result
 	/**
 	 * Returns result data
 	 *
-	 * Alias for getSource
+	 * Checks for partial result data with getFields, falls back to getSource
 	 *
 	 * @return array Result data array
 	 */
 	public function getData() {
-		return $this->getSource();
+		if (isset($this->_hit['fields']) && !isset($this->_hit['_source'])) {
+			return $this->getFields();
+		} else {
+			return $this->getSource();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fix the wrong name for 'fields' instead of '_fields', allows __get when there's 'fields' but no '_source' in the result.
Previously, when one used Elastica_Query::setFields, the result object could not access data that was returned in a 'fields' key instead of '_source', so access to result's data failed.
