### PR TITLE
Make Elastica_Query extend Elastica_Query_Abstract

### DIFF
--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -9,7 +9,7 @@
  * @author Nicolas Ruflin <spam@ruflin.com>
  * @link http://www.elasticsearch.com/docs/elasticsearch/rest_api/search/
  */
-class Elastica_Query
+class Elastica_Query extends Elastica_Query_Abstract
 {
 	protected $_query = array();
 


### PR DESCRIPTION
It seems that Elastica_Query should extend Elastica_Query_Abstract. Is there any reason it doesn't currently?
