### PR TITLE
Avoid PHP notice and return empty array

### DIFF
--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -68,7 +68,7 @@ class Elastica_ResultSet implements Iterator, Countable
 	 */
 	public function getFacets() {
 		$data = $this->_response->getData();
-		return $data['facets'];
+		return isset($data['facets']) ? $data['facets'] : array();
 	}
 
 	/**


### PR DESCRIPTION
If you really want to check if there are any facets, there's still the hasFacets() method.
