### PR TITLE
Use a configuration flag to control this setting?

### DIFF
--- a/lib/Elastica/Transport/Https.php
+++ b/lib/Elastica/Transport/Https.php
@@ -20,6 +20,9 @@ class Elastica_Transport_Https extends Elastica_Transport_Http {
 	 */
 	protected function _setupCurl($connection) {
 		parent::_setupCurl($connection);
-		curl_setopt($connection, CURLOPT_SSL_VERIFYPEER, false);
+		
+		$verifyPeer = ($this->getRequest()->getConfig('verifySSL')) ? true : false;
+		
+		curl_setopt($connection, CURLOPT_SSL_VERIFYPEER, $verifyPeer);
 	}
 }


### PR DESCRIPTION
This addresses #106 - not quite sure the best way to make this configurable. It would also make more sense to have this default to "true" and only switch it off if explicitly set by the user.

Here's another (admittedly very opinionated) perspective on this issue: http://www.rubyinside.com/how-to-cure-nethttps-risky-default-https-behavior-4010.html
