### PR TITLE
Run elasticsearch with -server on Travis CI

### DIFF
--- a/test/bin/run_elasticsearch.sh
+++ b/test/bin/run_elasticsearch.sh
@@ -4,8 +4,7 @@ wget https://github.com/downloads/elasticsearch/elasticsearch/elasticsearch-0.18
 tar -xzf elasticsearch-0.18.4.tar.gz
 elasticsearch-0.18.4/bin/plugin install mapper-attachments
 
-JAVA_OPTS="-server"
-export JAVA_OPT
+export JAVA_OPTS="-server"
 elasticsearch-0.18.4/bin/elasticsearch &
 
 echo "Waiting until elasticsearch is ready on port 9200"


### PR DESCRIPTION
Travis CI printed a recommondation to run the JVM with the -server argument:

```
[2011-11-28 20:23:24,883][WARN ][bootstrap                ] jvm uses the client vm, make sure to run `java` with the server vm for best performance by adding `-server` to the command line
```
