### PR TITLE
Elastica_Log

### DIFF
--- a/lib/Elastica/Log.php
+++ b/lib/Elastica/Log.php
@@ -33,7 +33,9 @@ class Elastica_Log
 	 * @param string|Elastica_Request $message
 	 */
 	public function log($message) {
-		if (!$this->_log) return;
+		if (!$this->_log) {
+			return;
+		}
 			
 		if ($message instanceof Elastica_Request) {
 			$message = $this->_convertRequest($message);


### PR DESCRIPTION
_convertRequest can use alot of memory on a bulk request and it occurs anyways for no real reason that I can see when _log == false.
