### PR TITLE
I was tracking down a memory leak and found that the curl handle was the...

### DIFF
--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -49,7 +49,6 @@ class Elastica_Transport_Http extends Elastica_Transport_Abstract {
 
 		curl_setopt($conn, CURLOPT_URL, $baseUri);
 		curl_setopt($conn, CURLOPT_TIMEOUT, $request->getConfig('timeout'));
-		curl_setopt($conn, CURLOPT_RETURNTRANSFER, 1) ;
 		curl_setopt($conn, CURLOPT_CUSTOMREQUEST, $request->getMethod());
 		curl_setopt($conn, CURLOPT_FORBID_REUSE, 0);
 
@@ -82,7 +81,12 @@ class Elastica_Transport_Http extends Elastica_Transport_Abstract {
 		}
 
 		$start = microtime(true);
-		$responseString = curl_exec($conn);
+		
+		// cURL opt returntransfer leaks memory, therefore OB instead.
+		ob_start();
+		curl_exec($conn);
+		$responseString = ob_get_clean();
+		
 		$end = microtime(true);
 
 		// Checks if error exists
@@ -102,8 +106,6 @@ class Elastica_Transport_Http extends Elastica_Transport_Abstract {
 		if ($errorNumber > 0) {
 			throw new Elastica_Exception_Client($errorNumber, $request, $response);
 		}
-
-		curl_close($conn);
 		
 		return $response;
 	}
@@ -123,8 +125,9 @@ class Elastica_Transport_Http extends Elastica_Transport_Abstract {
 	 * @return resource Connection resource
 	 */
 	protected function _getConnection() {
-		self::$_connection = curl_init();
-		
+		if (!self::$_connection){
+			self::$_connection = curl_init();
+		}
 		return self::$_connection;
 	}
 }


### PR DESCRIPTION
... source.  I honestly don't know what it's persisting.  In any case, I modified it to close the handle when it's done.  I don't think it will make a difference in performance to close/re-init in this case.

I'm bulk inserting 1million+ docs, 2000 at a time, and no more memory error.
