### PR TITLE
Util::to(Camel|Snake)Case()

### DIFF
--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -74,7 +74,7 @@ class Elastica_Util
 	 * @return string CamelCase string
 	 */
 	public static function toCamelCase($string) {
-		return preg_replace('/_([a-z])/e', 'strtoupper("$1")', ucfirst($string));
+		return str_replace(" ", "", ucwords(str_replace("_", " ", $string)));
 	}
 
 	/**
@@ -86,8 +86,8 @@ class Elastica_Util
 	 * @return string SnakeCase string
 	 */
 	public static function toSnakeCase($string) {
-		$string = preg_replace('/([A-Z])/e', 'strtolower("_$1")', $string);
-		return substr($string, 1);
+		$string = preg_replace('/([A-Z])/', '_$1', $string);
+        	return strtolower(substr($string,1));
 	}
 
 	/**


### PR DESCRIPTION
I replaced the to(Camel|Snake)Case functions because it was using the e modifier with preg. I disallow it on my web applications with Suhosin (because it's essentially like eval() which I also disable), so it was raising alerts and ending execution. The changes give the same results and and are much faster.

Benchmark 10k iterations

toCamel:
old: 0.12451505661
new: 0.0247340202332

toSnake
old: 0.219540834427
new: 0.0532169342041
