### PR TITLE
Sends percolate request when running a bulk index.

### DIFF
--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -206,6 +206,11 @@ class Elastica_Client
 			if (!empty($parent)) {
 				$indexInfo['_parent'] = $parent;
 			}
+						
+			$percolate = $doc->getPercolate();
+			if (!empty($percolate)) {
+				$indexInfo['percolate'] = $percolate;
+			}
 
 			$params[] = array('index' => $indexInfo);
 			$params[] = $doc->getData();


### PR DESCRIPTION
Currently when performing a bulk index of documents, if those documents have percolation queries associated with them then it gets ignored.  This fixes that so that the percolation match information is returned if appropriate.
