### PR TITLE
Added @throws IndexAlreadyExistsException at create()

### DIFF
--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -140,6 +140,7 @@ class Elastica_Index implements Elastica_Searchable
 	 * @param bool|array $options OPTIONAL 
 	 * 			bool=> Deletes index first if already exists (default = false). 
 	 * 			array => Associative array of options (option=>value)  
+	 * @throws IndexAlreadyExistsException Thrown when the index already exists and the 'recreate' option isnt explicitly set to true. So either create() or create(array(), false) will throw when the index already exists.
 	 * @return array Server response
 	 * @link http://www.elasticsearch.com/docs/elasticsearch/rest_api/admin/indices/create_index/
 	 */


### PR DESCRIPTION
To prevent erroneous thinking that the actual creation will just be ignored if the index already exists if you'd use create(array(), false). One should used index->exists() before calling create().
