### PR TITLE
Modified search method in Elastica_Index to accept and array of options

### DIFF
--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -232,22 +232,20 @@ class Elastica_Index implements Elastica_Searchable
 		} else if (is_array($options)) {
 
 			foreach ($options as $key => $value) {
-				if (empty($value) && $value !== 0){
-          			throw new Elastica_Exception_Invalid('Invalid value '.$value.' for option '.$key);
-          		}else{
-    				switch ($key) {
-    					case 'limit' :
-    					case 'size' :
-    						$query->setLimit($value);
-    						break;
-    					case 'from' :
-    						$query->setFrom($value);
-    						break;
-              			default:
-                			throw new Elastica_Exception_Invalid('Invalid option '.$key);
-              			break;
-    				}
-          		}
+
+				switch ($key) {
+					case 'limit' :
+					case 'size' :
+						$query->setLimit($value);
+						break;
+					case 'from' :
+						$query->setFrom($value);
+						break;
+          			default:
+            			throw new Elastica_Exception_Invalid('Invalid option '.$key);
+          			break;
+				}
+
 			}
 
 		}


### PR DESCRIPTION
OK i've modified the search function to now except an array of options. Much like https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Search.php

For now i've only added 'limit' and 'from' as accepted options. I wasn't sure if 'routing' and 'search_type' would be applicable to the Elastica_Index search method.

I've also altered the empty check when looping the options as the 'from' option can have a 0 and still be valid.
