### PR TITLE
fixes count when using filter queries

### DIFF
--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -220,9 +220,9 @@ class Elastica_Index implements Elastica_Searchable
 	 */
 	public function count($query = '') {
 		$query = Elastica_Query::create($query);
-		$path = '_search?search_type=count';
+		$path = '_search';
 
-		$response = $this->request($path, Elastica_Request::GET, $query->toArray());
+		$response = $this->request($path, Elastica_Request::GET, $query->toArray(), array('search_type' => 'count'));
 		$resultSet = new Elastica_ResultSet($response);
 
 		return $resultSet->getTotalHits();

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -178,9 +178,9 @@ class Elastica_Type implements Elastica_Searchable {
 	 */
 	public function count($query = '') {
 		$query = Elastica_Query::create($query);
-		$path = '_search?search_type=count';
+		$path = '_search';
 
-		$response = $this->request($path, Elastica_Request::GET, $query->toArray());
+		$response = $this->request($path, Elastica_Request::GET, $query->toArray(), array('search_type' => 'count'));
 		$resultSet = new Elastica_ResultSet($response);
 
 		return $resultSet->getTotalHits();


### PR DESCRIPTION
When using filter queries the code was ignoring it by using just getQuery. Using search_type=count avoids that problem.
