### PR TITLE
Remove unsupported use of minimum number should match for Boolean Filter...

### DIFF
--- a/lib/Elastica/Filter/Bool.php
+++ b/lib/Elastica/Filter/Bool.php
@@ -103,7 +103,6 @@ class Elastica_Filter_Bool extends Elastica_Filter_Abstract {
 
 		if (!empty($this->_should)) {
 			$args['should'] = $this->_should;
-			$args['minimum_number_should_match'] = $this->_minimumNumberShouldMatch;
 		}
 
 		if (!empty($this->_mustNot)) {


### PR DESCRIPTION
... see http://elasticsearch-users.115913.n3.nabble.com/Bool-filter-does-not-support-quot-minimum-number-should-match-quot-td4018943.html for more information.
