### PR TITLE
Allow scripts to be used in Elastica_Query_CustomFiltersScore

### DIFF
--- a/lib/Elastica/Query/CustomFiltersScore.php
+++ b/lib/Elastica/Query/CustomFiltersScore.php
@@ -38,25 +38,12 @@ class Elastica_Query_CustomFiltersScore extends Elastica_Query_Abstract
 	 * Add a filter with a script to calculate the score
 	 *
 	 * @param Elastica_Filter_Abstract $filter Filter object
-	 * @param string $script Script for calculating the score
+	 * @param Elastica_Script $script Script for calculating the score
 	 * @return Elastica_Query_CustomFiltersScore Current object
 	 */
-	public function addFilterScript(Elastica_Filter_Abstract $filter, $script) {
-		$filterParam = array('filter' => $filter->toArray(), 'script' => $script);
+	public function addFilterScript(Elastica_Filter_Abstract $filter, Elastica_Script $script) {
+		$filterParam = array('filter' => $filter->toArray(), 'script' => $script->getScript());
 		$this->addParam('filters', $filterParam);
-		return $this;
-	}
-
-	/**
-	 * Add a filter with a script to calculate the score
-	 *
-	 * @param Elastica_Filter_Abstract $filter Filter object
-	 * @param string $script Script for calculating the score
-	 * @return Elastica_Query_CustomFiltersScore Current object
-	 */
-	public function addFilterScript(Elastica_Filter_Abstract $filter, $script) {
-		$filter_param = array('filter' => $filter->toArray(), 'script' => $script);
-		$this->addParam('filters', $filter_param);
 		return $this;
 	}
 }


### PR DESCRIPTION
Using it like this for changing the score based on the age of a document.

  $boosted_query = new Elastica_Query_CustomFiltersScore();
  $boosted_query->setQuery($query);
  $boosted_query->setParam('score_mode', 'multiply');
  $boosted_query->addFilterScript(
    new Elastica_Filter_Type('foo'),
    "50_exp(1.098e-8_(doc['time_updated'].doubleValue - time()/1000))"
  );
