### PR TITLE
Adding 'from' parameter

### DIFF
--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -194,6 +194,9 @@ class Elastica_Search {
 						case 'limit' :
 							$query->setLimit($value);
 							break;
+						case 'from' :
+              $params = array('from' => $value);
+              break;
 						case 'routing' :
 							$params = array('routing' => $value);
 							break;


### PR DESCRIPTION
Now that Elastica_Index is using Elastica_Search i need the from parameter added to Elastica_Search so i can do pagination.

Originally i sent a pull request which added it to Elastica_Index (https://github.com/ruflin/Elastica/commit/17fa3a9fa883fbff5ed179ed454281e01f8e84ca)

what do you think? can we add it in here? cheers!
