### PR TITLE
Support array values for fields in the Query Builder

### DIFF
--- a/lib/Elastica/Query/Builder.php
+++ b/lib/Elastica/Query/Builder.php
@@ -316,12 +316,15 @@ class Elastica_Query_Builder extends Elastica_Query_Abstract
 	 */
 	public function field($name, $value)
 	{
-		if (is_bool($value))
-		{
-			$value = var_export($value, true);
+		if (is_bool($value)) {
+			$value = '"'. var_export($value, true) . '"';
+		} else if (is_array($value)) {
+			$value = '['.implode(',', $value).']';
+		} else {
+			$value = '"'.$value.'"';
 		}
 
-		$this->_string .= '"'.$name.'":"'.$value.'",';
+		$this->_string .= '"'.$name.'":'.$value.',';
 
 		return $this;
 	}


### PR DESCRIPTION
Consider the following example:

``` php
<?php
$builder = new Elastica_Query_Builder();                                                              
$builder                                                                                              
  ->query()                                                                                         
    ->term()
      ->field('category.id', array(1, 2, 3))                                                        
    ->termClose()
  ->queryClose();                                                                                   

echo json_encode($builder->toArray());
```

outputs:

```
{"query":{"term":{"category.id":"Array"}}}
```

after the fix in this PR the output is:

```
{"query":{"term":{"category.id":[1,2,3]}}}
```
