### PR TITLE
translation of search options into request parameters is ignoring all but the last option

### DIFF
--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -195,10 +195,10 @@ class Elastica_Search {
 							$query->setLimit($value);
 							break;
 						case 'routing' :
-							$params = array('routing' => $value);
+							$params['routing'] = $value;
 							break;
 						case 'search_type':
-							$params = array('search_type' => $value);
+							$params['search_type'] = $value;
 							break;
 						default:
 							throw new Elastica_Exception_Invalid('Invalid option ' . $key);


### PR DESCRIPTION
The request parameter construction is ignoring the fact that you can have more than one search option translated into request parameters.
