### PR TITLE
added support for array in Query::setScriptFields.

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -5,7 +5,7 @@ CHANGES
 - Enforced PSR1 code style, as per https://github.com/pmjones/fig-standards/blob/psr-1-style-guide/proposed/PSR-1-basic.md
 - Added Elastica_Script::toArray
 - Added Elastica_ScriptFields
-- Elastica_Query::setScriptFields now takes Elastica_ScriptFields as argument, the old implementation was bogus.
+- Elastica_Query::setScriptFields now takes Elastica_ScriptFields or associative array as argument, the old implementation was bogus.
 
 2012-06-24
 - Simplify Elastica_Type::search and Elastica_Index::search by using Elastica_Search

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -212,11 +212,14 @@ class Elastica_Query extends Elastica_Param {
 	/**
 	 * Set script fields
 	 *
-	 * @param Elastica_ScriptFields $scriptFields Script fields
+	 * @param array|Elastica_ScriptFields $scriptFields Script fields
 	 * @return Elastica_Query Current object
 	 * @link http://www.elasticsearch.com/docs/elasticsearch/rest_api/search/script_fields/
 	 */
-	public function setScriptFields(Elastica_ScriptFields $scriptFields) {
+	public function setScriptFields($scriptFields) {
+		if (is_array($scriptFields)) {
+			$scriptFields = new Elastica_ScriptFields($scriptFields);
+		}
 		return $this->setParam('script_fields', $scriptFields->toArray());
 	}
 

--- a/test/lib/Elastica/ScriptFieldsTest.php
+++ b/test/lib/Elastica/ScriptFieldsTest.php
@@ -37,11 +37,16 @@ class Elastica_ScriptFieldsTest extends Elastica_Test {
 	public function testSetScriptFields() {
 		$query = new Elastica_Query;
 		$script = new Elastica_Script('1 + 2');
+
 		$scriptFields = new Elastica_ScriptFields(array(
 			'test' => $script
 		));
 		$query->setScriptFields($scriptFields);
+		$this->assertEquals($query->getParam('script_fields'), $scriptFields->toArray());
 
+		$query->setScriptFields(array(
+			'test' => $script
+		));
 		$this->assertEquals($query->getParam('script_fields'), $scriptFields->toArray());
 	}
 


### PR DESCRIPTION
Related: #215

If the parameter is an array, wraps in a ScriptFields.

This is because 

``` php
<?php
$query->setScriptFields(array(
  'test' => $script
));
```

is a bit simpler than

``` php
<?php
$scriptFields = new Elastica_ScriptFields(array(
  'test' => $script
));
$query->setScriptFields($scriptFields);
```
