### PR TITLE
Removing boost argument in Elastica_Filter_Term test 

### DIFF
--- a/test/lib/Elastica/Filter/TermTest.php
+++ b/test/lib/Elastica/Filter/TermTest.php
@@ -9,8 +9,7 @@ class Elastica_Filter_TermsTest extends Elastica_Test
         $query = new Elastica_Filter_Term();
         $key = 'name';
         $value = 'ruflin';
-        $boost = 3;
-        $query->setTerm($key, $value, $boost);
+        $query->setTerm($key, $value);
 
         $data = $query->toArray();
 


### PR DESCRIPTION
There is no third argument for `Elastica_Filter_Term::setTerm()` so passing the boost to it seems redundant
