### PR TITLE
Some errors from statical analysis of the code base.

### DIFF
--- a/lib/Elastica/Transport/Memcache.php
+++ b/lib/Elastica/Transport/Memcache.php
@@ -59,11 +59,6 @@ class Elastica_Transport_Memcache extends Elastica_Transport_Abstract
 
         $response = new Elastica_Response($responseString);
 
-        if (defined('DEBUG') && DEBUG) {
-            $response->setQueryTime($end - $start);
-            $response->setTransferInfo(curl_getinfo($conn));
-        }
-
         if ($response->hasError()) {
             throw new Elastica_Exception_Response($response);
         }

--- a/test/lib/Elastica/IndexTest.php
+++ b/test/lib/Elastica/IndexTest.php
@@ -18,7 +18,7 @@ class Elastica_IndexTest extends Elastica_Test
         $type->addDocument($doc);
         $index->optimize();
 
-        $storedMapping = $type->getMapping('test');
+        $storedMapping = $type->getMapping();
 
         $this->assertEquals($storedMapping['test']['properties']['id']['type'], 'integer');
         $this->assertEquals($storedMapping['test']['properties']['id']['store'], 'yes');


### PR DESCRIPTION
Summary:
Our code analysis did a lint of Elastica when upgrading, it came up with these two.

Unused variables and a method being called with too many parameters.
