### PR TITLE
'Fork me' ribbon on github pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-	<a href="http://github.com/ruflin/Elastica"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://a248.e.akamai.net/assets.github.com/img/30f550e0d38ceb6ef5b81500c64d970b7fb0f028/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" /></a>
+	<a href="http://github.com/ruflin/Elastica"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
 	<header>
 		<div class="container">
 			<h1>Elastica</h1>


### PR DESCRIPTION
The 'fork me' ribbon on http://ruflin.github.com/Elastica is not working. Attached commit fixes this.
