### PR TITLE
Added Match Query

### DIFF
--- a/lib/Elastica/Query/Match.php
+++ b/lib/Elastica/Query/Match.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Match query
+ *
+ * @uses Elastica_Query_Abstract
+ * @category Xodoa
+ * @package Elastica
+ * @author F21
+ * @link http://www.elasticsearch.org/guide/reference/query-dsl/match-query.html
+ */
+class Elastica_Query_Match extends Elastica_Query_Abstract
+{
+    /**
+     * Sets a param for the message array
+     *
+     * @param  string              $field
+     * @param  mixed               $values
+     * @return Elastica_Query_Match
+     */
+    public function setField($field, $values)
+    {
+        return $this->setParam($field, $values);
+    }
+
+    /**
+     * Sets a param for the given field
+     *
+     * @param  string              $field
+     * @param  string              $key
+     * @param  string              $value
+     * @return Elastica_Query_Text
+     */
+    public function setFieldParam($field, $key, $value)
+    {
+        if (!isset($this->_params[$field])) {
+            $this->_params[$field] = array();
+        }
+
+        $this->_params[$field][$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Sets the query string
+     *
+     * @param  string              $field
+     * @param  string              $query
+     * @return Elastica_Query_Text
+     */
+    public function setFieldQuery($field, $query)
+    {
+        return $this->setFieldParam($field, 'query', $query);
+    }
+
+    /**
+     * Set field type
+     *
+     * @param  string              $field
+     * @param  string              $type  Text query type
+     * @return Elastica_Query_Text
+     */
+    public function setFieldType($field, $type)
+    {
+        return $this->setFieldParam($field, 'type', $type);
+    }
+
+    /**
+     * Set field max expansions
+     *
+     * @param  string              $field
+     * @param  int                 $maxExpansions
+     * @return Elastica_Query_Text
+     */
+    public function setFieldMaxExpansions($field, $maxExpansions)
+    {
+        return $this->setFieldParam($field, 'max_expansions', $maxExpansions);
+    }
+}

--- a/test/lib/Elastica/Query/MatchTest.php
+++ b/test/lib/Elastica/Query/MatchTest.php
@@ -1,0 +1,64 @@
+<?php
+require_once dirname(__FILE__) . '/../../../bootstrap.php';
+
+class Elastica_Query_MatchTest extends PHPUnit_Framework_TestCase
+{
+    public function testToArray()
+    {
+        $queryText = 'Nicolas Ruflin';
+        $type = 'text_phrase';
+        $analyzer = 'myanalyzer';
+        $maxExpansions = 12;
+        $field = 'test';
+
+        $query = new Elastica_Query_Text();
+        $query->setFieldQuery($field, $queryText);
+        $query->setFieldType($field, $type);
+        $query->setFieldParam($field, 'analyzer', $analyzer);
+        $query->setFieldMaxExpansions($field, $maxExpansions);
+
+        $expectedArray = array(
+            'text' => array(
+                $field => array(
+                    'query' => $queryText,
+                    'type' => $type,
+                    'analyzer' => $analyzer,
+                    'max_expansions' => $maxExpansions,
+                )
+            )
+        );
+
+        $this->assertEquals($expectedArray, $query->toArray());
+    }
+
+    public function testTextPhrase()
+    {
+        $client = new Elastica_Client();
+        $index = $client->getIndex('test');
+        $index->create(array(), true);
+        $type = $index->getType('test');
+
+        $doc = new Elastica_Document(1, array('name' => 'Basel-Stadt'));
+        $type->addDocument($doc);
+        $doc = new Elastica_Document(2, array('name' => 'New York'));
+        $type->addDocument($doc);
+        $doc = new Elastica_Document(3, array('name' => 'New Hampshire'));
+        $type->addDocument($doc);
+        $doc = new Elastica_Document(4, array('name' => 'Basel Land'));
+        $type->addDocument($doc);
+
+        $index->refresh();
+
+        $type = 'text_phrase';
+        $field = 'name';
+
+        $query = new Elastica_Query_Text();
+        $query->setFieldQuery($field, 'Basel New');
+        $query->setField('operator', 'OR');
+        $query->setFieldType($field, $type);
+
+        $resultSet = $index->search($query);
+
+        $this->assertEquals(4, $resultSet->count());
+    }
+}


### PR DESCRIPTION
The match query replaces the text query as of 0.19.9 (see documentation [here](http://www.elasticsearch.org/guide/reference/query-dsl/text-query.html)).

I have added the Match query to the library, but have left the text query alone for now (as it is still supported in elasticsearch but deprecated).

When the Text query is removed from elasticsearch, then we will remove it from Elastica.
