### PR TITLE
Added Null transport object to facilitate application testing.

### DIFF
--- a/lib/Elastica/Transport/Null.php
+++ b/lib/Elastica/Transport/Null.php
@@ -15,6 +15,21 @@ class Elastica_Transport_Null extends Elastica_Transport_Abstract
      */
     public function exec(array $params)
     {
-     	return new Elastica_Response(null);
+    	$response = array(
+    			"took" => 0,
+    			"timed_out" => FALSE,
+    			"_shards" => array(
+    					"total" => 0,
+    					"successful" => 0,
+    					"failed" => 0
+    					),
+    			"hits" => array(
+    					"total" => 0,
+    					"max_score" => NULL,
+    					"hits" => array()
+    					),
+    			"params" => $params
+    			);
+     	return new Elastica_Response(json_encode($response));
     }
 }

--- a/test/lib/Elastica/Transport/NullTest.php
+++ b/test/lib/Elastica/Transport/NullTest.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Elastica Null Transport Test
+ *
+ * @package Elastica
+ * @author James Boehmer <james.boehmer@jamesboehmer.com>
+ */
 require_once dirname(__FILE__) . '/../../../bootstrap.php';
 
 class Elastica_Transport_NullTest extends PHPUnit_Framework_TestCase
@@ -27,8 +33,38 @@ class Elastica_Transport_NullTest extends PHPUnit_Framework_TestCase
     	
         $index = $client->getIndex('elasticaNullTransportTest1');
 
- 		$response = $index->search("florian");
-        $this->assertNotNull($response);
+ 		$resultSet = $index->search(new Elastica_Query());
+ 		$this->assertNotNull($resultSet);
+ 		
+ 		$response = $resultSet->getResponse();
+ 		$this->assertNotNull($response);
+ 		
+ 		// Validate most of the expected fields in the response data.  Consumers of the response
+ 		// object have a reasonable expectation of finding "hits", "took", etc 
+ 		$responseData = $response->getData();
+ 		$this->assertContains("took", $responseData);
+ 		$this->assertEquals(0, $responseData["took"]);
+ 		$this->assertContains("_shards", $responseData);
+ 		$this->assertContains("hits", $responseData);
+ 		$this->assertContains("total", $responseData["hits"]);
+ 		$this->assertEquals(0, $responseData["hits"]["total"]);
+ 		$this->assertContains("params", $responseData);
+ 		
+ 		$took = $response->getEngineTime();
+ 		$this->assertEquals(0, $took);
+ 		
+ 		$errorString = $response->getError();
+ 		$this->assertEmpty($errorString);
+ 		
+ 		$shards = $response->getShardsStatistics();
+ 		$this->assertContains("total", $shards);
+ 		$this->assertEquals(0, $shards["total"]);
+ 		$this->assertContains("successful", $shards);
+ 		$this->assertEquals(0, $shards["successful"]);
+ 		$this->assertContains("failed", $shards);
+ 		$this->assertEquals(0, $shards["failed"]);
+        
+ 		
         
     }
 }


### PR DESCRIPTION
We had a need to unit test our application without actually submitting a request to Elasticsearch, so I added a simple Null transport object that does nothing but return an empty response object.
