### PR TITLE
Passing field and args through constructor in Query Range

### DIFF
--- a/lib/Elastica/Query/Range.php
+++ b/lib/Elastica/Query/Range.php
@@ -11,6 +11,19 @@
 class Elastica_Query_Range extends Elastica_Query_Abstract
 {
     /**
+     * Constructor
+     *
+     * @param string    $fieldName  Field name
+     * @param array     $args       Field arguments
+     */
+    public function __construct($fieldName = null, array $args = array())
+    {
+        if ($fieldName) {
+            $this->addField($fieldName, $args);
+        }
+    }
+
+    /**
      * Adds a range field to the query
      *
      * @param  string               $fieldName Field name
@@ -20,6 +33,5 @@ class Elastica_Query_Range extends Elastica_Query_Abstract
     public function addField($fieldName, array $args)
     {
         return $this->setParam($fieldName, $args);
-
     }
 }

--- a/test/lib/Elastica/Query/RangeTest.php
+++ b/test/lib/Elastica/Query/RangeTest.php
@@ -3,6 +3,36 @@ require_once dirname(__FILE__) . '/../../../bootstrap.php';
 
 class Elastica_Query_RangeTest extends PHPUnit_Framework_TestCase
 {
+    public function testQuery()
+    {
+        $client = new Elastica_Client();
+        $index = $client->getIndex('test');
+        $index->create(array(), true);
+        $type = $index->getType('test');
+
+        $doc = new Elastica_Document(1, array('age' => 16, 'height' => 140));
+        $type->addDocument($doc);
+        $doc = new Elastica_Document(2, array('age' => 21, 'height' => 155));
+        $type->addDocument($doc);
+        $doc = new Elastica_Document(3, array('age' => 33, 'height' => 160));
+        $type->addDocument($doc);
+        $doc = new Elastica_Document(4, array('age' => 68, 'height' => 160));
+        $type->addDocument($doc);
+
+        $index->optimize();
+        $index->refresh();
+
+        $query = new Elastica_Query_Range('age', array('from' => 10, 'to' => 20));
+        $result = $type->search($query)->count();
+        $this->assertEquals(1, $result);
+
+        $query = new Elastica_Query_Range();
+        $query->addField('height', array('gte' => 160));
+
+        $result = $type->search($query)->count();
+        $this->assertEquals(2, $result);
+    }
+
     public function testToArray()
     {
         $range = new Elastica_Query_Range();
@@ -13,6 +43,23 @@ class Elastica_Query_RangeTest extends PHPUnit_Framework_TestCase
         $expectedArray = array(
             'range' => array(
                 'age' => $field,
+            )
+        );
+
+        $this->assertEquals($expectedArray, $range->toArray());
+    }
+
+    public function testConstruct()
+    {
+        $ranges = array('from' => 20, 'to' => 40);
+        $range = new Elastica_Query_Range(
+            'age',
+            $ranges
+        );
+
+        $expectedArray = array(
+            'range' => array(
+                'age' => $ranges,
             )
         );
 


### PR DESCRIPTION
Fixes #279 
