### PR TITLE
Fixed matchDoc test in PercolatorTest failing with exception

### DIFF
--- a/test/lib/Elastica/PercolatorTest.php
+++ b/test/lib/Elastica/PercolatorTest.php
@@ -49,6 +49,7 @@ class Elastica_PercolatorTest extends Elastica_Test
         $doc2->add('name', 'nicolas');
 
         $index = new Elastica_Index($index->getClient(), '_percolator');
+        $index->optimize();
         $index->refresh();
 
         $matches1 = $percolator->matchDoc($doc1);


### PR DESCRIPTION
Elastica_Exception_Response: NoShardAvailableActionException[[_na][_na] No shard available for [org.elasticsearch.action.percolate.PercolateRequest@449cfff9]]
