### PR TITLE
feature request: filter and/or combining

### DIFF
--- a/lib/Elastica/Filter/Abstract.php
+++ b/lib/Elastica/Filter/Abstract.php
@@ -48,4 +48,46 @@ abstract class Elastica_Filter_Abstract extends Elastica_Param
     {
         return $this->setParam('_name', $name);
     }
+
+    /**
+     * Returns a filter made from this "and" argument
+     *
+     * @param  Elastica_Filter_Abstract $filter Filter to add
+     * @return Elastica_Filter_Abstract
+     */
+    public function andFilter(Elastica_Filter_Abstract $filter)
+    {
+        if ($this instanceof Elastica_Filter_MatchAll) {
+            return $filter;
+        }
+
+        if ($this instanceof Elastica_Filter_And) {
+            return $this->addFilter($filter);
+        }
+
+        $result = new Elastica_Filter_And;
+
+        return $result->addFilter($this)->addFilter($filter);
+    }
+
+    /**
+     * Returns a filter made from this "or" argument
+     *
+     * @param  Elastica_Filter_Abstract $filter Filter to add
+     * @return Elastica_Filter_Abstract
+     */
+    public function orFilter(Elastica_Filter_Abstract $filter)
+    {
+        if ($this instanceof Elastica_Filter_MatchAll) {
+            return $filter;
+        }
+
+        if ($this instanceof Elastica_Filter_Or) {
+            return $this->addFilter($filter);
+        }
+
+        $result = new Elastica_Filter_Or;
+
+        return $result->addFilter($this)->addFilter($filter);
+    }
 }

--- a/test/lib/Elastica/Filter/AbstractTest.php
+++ b/test/lib/Elastica/Filter/AbstractTest.php
@@ -64,4 +64,91 @@ class Elastica_Filter_AbstractTest extends PHPUnit_Framework_TestCase
     {
         return $this->getMockForAbstractClass('Elastica_Filter_Abstract');
     }
+
+    public function testOrFilter()
+    {
+        $filter_lhs = $this->getStub();
+        $filter_lhs->setName('lhs');
+
+        $filter_rhs = $this->getStub();
+        $filter_rhs->setName('rhs');
+
+        $orFilter = $filter_lhs->orFilter($filter_rhs);
+
+        $this->assertInstanceOf('Elastica_Filter_Or', $orFilter);
+
+        $expectedArray = array(
+            'or' => array(
+                    $filter_lhs->toArray(),
+                    $filter_rhs->toArray()
+                )
+            );
+
+        $this->assertEquals($expectedArray, $orFilter->toArray(), 'lhs.||(rhs) = lhs || rhs');
+
+        $filter_more = $this->getStub();
+        $filter_more->setName('more');
+
+        $returnValue = $orFilter->orFilter($filter_more);
+
+        $this->assertSame($orFilter, $returnValue);
+
+        $expectedArray = array(
+            'or' => array(
+                    $filter_lhs->toArray(),
+                    $filter_rhs->toArray(),
+                    $filter_more->toArray(),
+                )
+            );
+
+        $this->assertEquals($expectedArray, $returnValue->toArray(), '(lhs || rhs) || more = (lhs || rhs || more)');
+
+        $match_all = new Elastica_Filter_MatchAll;
+        $returnValue = $match_all->orFilter($filter_rhs);
+        $this->assertSame($returnValue, $filter_rhs, 'all || filter = filter');
+    }
+
+    public function testAndFilter()
+    {
+        $filter_lhs = $this->getStub();
+        $filter_lhs->setName('lhs');
+
+        $filter_rhs = $this->getStub();
+        $filter_rhs->setName('rhs');
+
+        $andFilter = $filter_lhs->andFilter($filter_rhs);
+
+        $this->assertInstanceOf('Elastica_Filter_And', $andFilter);
+
+        $expectedArray = array(
+            'and' => array(
+                    $filter_lhs->toArray(),
+                    $filter_rhs->toArray()
+                )
+            );
+
+        $this->assertEquals($expectedArray, $andFilter->toArray(), 'lhs.&&(rhs) = lhs && rhs');
+
+        $filter_more = $this->getStub();
+        $filter_more->setName('more');
+
+        $returnValue = $andFilter->andFilter($filter_more);
+
+        $this->assertSame($andFilter, $returnValue);
+
+        $expectedArray = array(
+            'and' => array(
+                    $filter_lhs->toArray(),
+                    $filter_rhs->toArray(),
+                    $filter_more->toArray(),
+                )
+            );
+
+        $this->assertEquals($expectedArray, $returnValue->toArray(), '(lhs && rhs) && more = (lhs && rhs && more)');
+
+        $match_all = new Elastica_Filter_MatchAll;
+        $returnValue = $match_all->andFilter($filter_rhs);
+
+        $this->assertSame($returnValue, $filter_rhs, 'all && filter = filter');
+    }
 }


### PR DESCRIPTION
This commit introduces orFilter()/andFilter() method to filters,
combining them in a new OR or AND filter.

``` php
$filter_blue  = new Elastica_Filter_Term(array('color' => 'blue'));
$filter_green = new Elastica_Filter_Term(array('color' => 'green'));

$filter_blue_or_green = $filter_blue->orFilter($filter_green);
```

Chaining example :

``` php
// (color = blue || color = green) && likes = cookies
$filter =  (new Elastica_Filter_Term(array('color' => 'blue')))
 ->orFilter(new Elastica_Filter_Term(array('color' => 'green')))
->andFilter(new Elastica_Filter_Term(array('likes' => 'cookies')))
;
```
