### PR TITLE
Improve Util::getParamName()

### DIFF
--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -118,8 +118,8 @@ class Util
     }
 
     /**
-     * Tries to guess the name of the param, based on its class
-     * Exemple: \Elastica\Filter\HasChildFilter => has_child
+     * Tries to guess the name of the param, based on the Elastica class
+     * Example: \Elastica\Filter\HasChildFilter => has_child
      *
      * @param string|object Class or Class name
      * @return string parameter name
@@ -131,10 +131,18 @@ class Util
         }
 
         $parts = explode('\\', $class);
+
+        while ($parts[0] != 'Elastica') {
+            $reflectionClass = new \ReflectionClass($class);
+            $class = $reflectionClass->getParentClass()->getName();
+            $parts = explode('\\', $class);
+        }
+        
         $last  = array_pop($parts);
         $last  = preg_replace('/(Facet|Query|Filter)$/', '', $last);
         $name  = self::toSnakeCase($last);
 
         return $name;
     }
+
 }


### PR DESCRIPTION
**TL;DR: Only guess param names from classes in the Elastica namespace.**

When using a class that extends Elastica, guess the param name based on the parent Elastica class, not the child class.

e.g. Here I extend `Elastica\Query\BoolQuery`:

``` php
namespace MyNamespace\Search\Query;

use Elastica\Query;

class ProductNameQuery extends Query\BoolQuery
{
    public function __construct($productName)
    {
        $titleQuery = new Query\TextQuery();
        $titleQuery->setFieldQuery('name.normalized', $productName);
        $titleQuery->setFieldParam('name.normalized', 'analyzer', 'product_name');
        $this->addShould($titleQuery);

        $anotherTitleQuery = new Query\TextQuery();
        $anotherTitleQuery->setFieldQuery('name', $productName);
        $anotherTitleQuery->setFieldParam('name', 'analyzer', 'snowball');
        $this->addShould($anotherTitleQuery);

    }
}
```

Currently, when passing an instance of `ProductNameQuery` to `Elastica\Query` and performing the search, It will fail. This is because when serialized, the param name is guessed as `product_name` and not `bool`.

This change simply checks if the class is in the Elastica Namespace, and if not uses reflection to get to the parent class before guessing the param name.

Perhaps an unusual use-case, but helpful for me :+1: 
