### PR TITLE
URL-encode ids passed to Type::deleteById()

### DIFF
--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -319,6 +319,8 @@ class Type implements SearchableInterface
             throw new \InvalidArgumentException();
         }
 
+        $id = urlencode($id);
+
         $response = $this->request($id, Request::DELETE, array(), $options);
 
         $responseData = $response->getData();


### PR DESCRIPTION
Type::deleteById() builds a URL directly from the id, so an id containing a '/' will fail unless the id is URL-encoded.
