### PR TITLE
Fixes missing Elastica\Script use in Elastica\Facet\Terms::setScript()

### DIFF
--- a/lib/Elastica/Facet/Terms.php
+++ b/lib/Elastica/Facet/Terms.php
@@ -3,6 +3,7 @@
 namespace Elastica\Facet;
 
 use Elastica\Exception\InvalidException;
+use Elastica\Script;
 
 /**
  * Implements the terms facet.
@@ -38,9 +39,9 @@ class Terms extends AbstractFacet
      * Sets the script for the term.
      *
      * @param  string                   $script The script for the term.
-     * @return Elastica_Facet_Terms
+     * @return \Elastica\Facet\Terms
      */
-     public function setScript($script)
+    public function setScript($script)
     {
         $script = Script::create($script);
         foreach ($script->toArray() as $param => $value) {


### PR DESCRIPTION
After merging master got this error in test

``` sh
1) Elastica\Test\Facet\TermsTest::testFacetScript
PHPUnit_Framework_Exception: PHP Fatal error:  Class 'Elastica\Facet\Script' not found in /home/munkie/Projects/Elastica/lib/Elastica/Facet/Terms.php on line 45
```

Elastica\Facet\Terms::setScript() method was introduced in PR #324
