### PR TITLE
Added methods to enable the _all field and set its params

### DIFF
--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -161,6 +161,28 @@ class Mapping
     }
 
     /**
+     * Sets params for the "_all" field
+     *
+     * @param array                       $params _all Params (enabled, store, term_vector, analyzer)
+     * @return \Elastica\Type\Mapping
+     */
+    public function setAllField(array $params)
+    {
+        return $this->setParam('_all', $params);
+    }
+
+    /**
+     * Enables the "_all" field
+     *
+     * @param  bool                      $enabled OPTIONAL (default = true)
+     * @return \Elastica\Type\Mapping
+     */
+    public function enableAllField($enabled = true)
+    {
+        return $this->setAllField(array('enabled' => $enabled));
+    }
+
+    /**
      * Converts the mapping to an array
      *
      * @throws \Elastica\Exception\InvalidException


### PR DESCRIPTION
I find that it is a common operation to either enable the _all field or enable it and set it's params. It might be helpful to have a couple of methods that make it a little easier to accomplish these operations.
