### PR TITLE
Connection exceptions in Client exception

### DIFF
--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -162,8 +162,9 @@ class Client
     }
 
     /**
-     * @param string|array $key config key or path to config key
-     * @param mixed $default default value will be returned if key was not found
+     * @param string|array $keys config key or path to config key
+     * @param mixed        $default default value will be returned if key was not found
+     * @return mixed
      */
     public function getConfigValue($keys, $default = null)
     {
@@ -582,6 +583,7 @@ class Client
      * @param  string            $method Rest method to use (GET, POST, DELETE, PUT)
      * @param  array             $data   OPTIONAL Arguments as array
      * @param  array             $query  OPTIONAL Query params
+     * @throws Exception\ClientException
      * @return \Elastica\Response Response object
      */
     public function request($path, $method = Request::GET, $data = array(), array $query = array())

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -589,12 +589,12 @@ class Client
     public function request($path, $method = Request::GET, $data = array(), array $query = array())
     {
         $connectionExceptions = array();
-        $request = new Request($path, $method, $data, $query);
+
         while (true) {
             try {
                 $connection = $this->getConnection();
 
-                $request->setConnection($connection);
+                $request = new Request($path, $method, $data, $query, $connection);
 
                 $this->_log($request);
 

--- a/lib/Elastica/Exception/ClientException.php
+++ b/lib/Elastica/Exception/ClientException.php
@@ -69,7 +69,7 @@ class ClientException extends AbstractException
         if ($this->hasConnectionExceptions()) {
             $message.= "\n\nFollowing connection exceptions occurred:\n";
             foreach ($this->getConnectionExceptions() as $connectionException) {
-                $message.= $this->_getTransportDsn($connectionException);
+                $message.= $this->_getTransportUri($connectionException);
                 $message.= $connectionException->getMessage() . "\n";
             }
         }
@@ -80,19 +80,19 @@ class ClientException extends AbstractException
      * @param \Elastica\Exception\ConnectionException $connectionException
      * @return string
      */
-    protected function _getTransportDsn(ConnectionException $connectionException)
+    protected function _getTransportUri(ConnectionException $connectionException)
     {
-        $dsn = '';
+        $uri = '';
         $request = $connectionException->getRequest();
         if ($request) {
             $connection = $request->getConnection();
             if ($connection) {
                 $transport = $connection->getTransportObject();
                 if ($transport) {
-                    $dsn .= $transport->getDsn() . ': ';
+                    $uri .= $transport->getUri() . ': ';
                 }
             }
         }
-        return $dsn;
+        return $uri;
     }
 }

--- a/lib/Elastica/Exception/ClientException.php
+++ b/lib/Elastica/Exception/ClientException.php
@@ -11,4 +11,67 @@ namespace Elastica\Exception;
  */
 class ClientException extends AbstractException
 {
+    /**
+     * @var \Elastica\Exception\ConnectionException[]
+     */
+    protected $_connectionExceptions = array();
+
+    /**
+     * @param string $message
+     * @param \Elastica\Exception\ConnectionException[] $connectionExceptions
+     */
+    public function __construct($message, array $connectionExceptions = array())
+    {
+        $this->addConnectionExceptions($connectionExceptions);
+        $message.= $this->getErrorMessage();
+        parent::__construct($message);
+    }
+
+    /**
+     * @param ConnectionException $connectionException
+     */
+    public function addConnectionException(ConnectionException $connectionException)
+    {
+        $this->_connectionExceptions[] = $connectionException;
+    }
+
+    /**
+     * @param \Elastica\Exception\ConnectionException[] $connectionExceptions
+     */
+    public function addConnectionExceptions(array $connectionExceptions)
+    {
+        foreach ($connectionExceptions as $connectionException) {
+            $this->addConnectionException($connectionException);
+        }
+    }
+
+    /**
+     * @return \Elastica\Exception\ConnectionException[]
+     */
+    public function getConnectionExceptions()
+    {
+        return $this->_connectionExceptions;
+    }
+    /**
+     * @return bool
+     */
+    public function hasConnectionExceptions()
+    {
+        return !empty($this->_connectionExceptions);
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        $message = '';
+        if ($this->hasConnectionExceptions()) {
+            $message.= "\n\nFollowing connection exceptions occurred:\n";
+            foreach ($this->getConnectionExceptions() as $connectionException) {
+                $message.= $connectionException->getMessage() . "\n";
+            }
+        }
+        return $message;
+    }
 }

--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -110,5 +110,5 @@ abstract class AbstractTransport extends Param
     /**
      * @return string
      */
-    abstract public function getDsn();
+    abstract public function getUri();
 }

--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -106,4 +106,9 @@ abstract class AbstractTransport extends Param
 
         return $transport;
     }
+
+    /**
+     * @return string
+     */
+    abstract public function getDsn();
 }

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -172,7 +172,7 @@ class Http extends AbstractTransport
     /**
      * @return string
      */
-    public function getDsn()
+    public function getUri()
     {
         $connection = $this->getConnection();
         return $this->_scheme . '://' . $connection->getHost() . ':' . $connection->getPort() . '/' . $connection->getPath();

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -168,4 +168,13 @@ class Http extends AbstractTransport
 
         return self::$_curlConnection;
     }
+
+    /**
+     * @return string
+     */
+    public function getDsn()
+    {
+        $connection = $this->getConnection();
+        return $this->_scheme . '://' . $connection->getHost() . ':' . $connection->getPort() . '/' . $connection->getPath();
+    }
 }

--- a/lib/Elastica/Transport/Memcache.php
+++ b/lib/Elastica/Transport/Memcache.php
@@ -74,4 +74,14 @@ class Memcache extends AbstractTransport
 
         return $response;
     }
+
+
+    /**
+     * @return string
+     */
+    public function getDsn()
+    {
+        $connection = $this->getConnection();
+        return 'memcache://' . $connection->getHost() . ':' . $connection->getPort();
+    }
 }

--- a/lib/Elastica/Transport/Memcache.php
+++ b/lib/Elastica/Transport/Memcache.php
@@ -79,7 +79,7 @@ class Memcache extends AbstractTransport
     /**
      * @return string
      */
-    public function getDsn()
+    public function getUri()
     {
         $connection = $this->getConnection();
         return 'memcache://' . $connection->getHost() . ':' . $connection->getPort();

--- a/lib/Elastica/Transport/Null.php
+++ b/lib/Elastica/Transport/Null.php
@@ -44,7 +44,7 @@ class Null extends AbstractTransport
     /**
      * @return string
      */
-    public function getDsn()
+    public function getUri()
     {
         return 'null://';
     }

--- a/lib/Elastica/Transport/Null.php
+++ b/lib/Elastica/Transport/Null.php
@@ -40,4 +40,12 @@ class Null extends AbstractTransport
 
          return new Response(json_encode($response));
     }
+
+    /**
+     * @return string
+     */
+    public function getDsn()
+    {
+        return 'null://';
+    }
 }

--- a/lib/Elastica/Transport/Thrift.php
+++ b/lib/Elastica/Transport/Thrift.php
@@ -168,7 +168,7 @@ class Thrift extends AbstractTransport
     /**
      * @return string
      */
-    public function getDsn()
+    public function getUri()
     {
         return 'thrift://' . $this->getConnection()->getHost() . ':' . $this->getConnection()->getPort();
     }

--- a/lib/Elastica/Transport/Thrift.php
+++ b/lib/Elastica/Transport/Thrift.php
@@ -164,4 +164,12 @@ class Thrift extends AbstractTransport
 
         return $response;
     }
+
+    /**
+     * @return string
+     */
+    public function getDsn()
+    {
+        return 'thrift://' . $this->getConnection()->getHost() . ':' . $this->getConnection()->getPort();
+    }
 }

--- a/test/lib/Elastica/Test/Exception/ClientExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ClientExceptionTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Elastica\Test\Exception;
+
+use Elastica\Client;
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
+use Elastica\Request;
+use Elastica\Test\Base as BaseTest;
+
+class ClientExceptionTest extends BaseTest
+{
+    public function testConstruct()
+    {
+        $exceptions = array();
+        $exceptions[] = new ConnectionException('message1');
+        $exceptions[] = new ConnectionException('message2');
+        $exceptions[] = new ConnectionException('message3');
+
+        $clientException = new ClientException('message4', $exceptions);
+
+        $this->assertTrue($clientException->hasConnectionExceptions());
+        $this->assertEquals($exceptions, $clientException->getConnectionExceptions());
+
+        $message = $clientException->getMessage();
+        $this->assertContains('message4', $message);
+        $this->assertContains('message1', $message);
+        $this->assertContains('message2', $message);
+        $this->assertContains('message3', $message);
+
+        $connectionExceptions = $clientException->getConnectionExceptions();
+        $this->assertInternalType('array', $connectionExceptions);
+        $this->assertArrayHasKey(0, $connectionExceptions);
+        $this->assertInstanceOf('Elastica\\Exception\\ConnectionException', $connectionExceptions[0]);
+        $this->assertArrayHasKey(1, $connectionExceptions);
+        $this->assertInstanceOf('Elastica\\Exception\\ConnectionException', $connectionExceptions[1]);
+    }
+
+    public function testFailedRequest()
+    {
+        $config = array(
+            'connections' => array(
+                array(
+                    'port' => 10001
+                ),
+                array(
+                    'port' => 10002,
+                    'transport' => 'Thrift'
+                ),
+                array(
+                    'port' => 10003,
+                    'transport' => 'Https'
+                ),
+            )
+        );
+
+        $client = new Client($config);
+
+        try {
+            $client->getStatus();
+            $this->fail('Request should fail with client exception');
+        } catch (ClientException $e) {
+            $this->assertTrue($e->hasConnectionExceptions());
+            $message = $e->getMessage();
+            $this->assertContains('http://localhost:10001', $message);
+            $this->assertContains('thrift://localhost:10002', $message);
+            $this->assertContains('https://localhost:10003', $message);
+        }
+
+        try {
+            $client->getStatus();
+            $this->fail('Request should fail with client exception, because there should be no active connection');
+        } catch (ClientException $e) {
+            $this->assertFalse($e->hasConnectionExceptions());
+            $this->assertEmpty($e->getConnectionExceptions());
+        }
+    }
+}

--- a/test/lib/Elastica/Test/Transport/AbstractTransportTest.php
+++ b/test/lib/Elastica/Test/Transport/AbstractTransportTest.php
@@ -16,8 +16,6 @@ class AbstractTransportTest extends \PHPUnit_Framework_TestCase
      */
     public function getValidDefinitions()
     {
-        $connection = new Connection();
-
         return array(
             array('Http'),
             array(array('type' => 'Http')),
@@ -32,8 +30,7 @@ class AbstractTransportTest extends \PHPUnit_Framework_TestCase
     public function testCanCreateTransportInstances($transport)
     {
         $connection = new Connection();
-        $params = array();
-        $transport = AbstractTransport::create($transport, $connection, $params);
+        $transport = AbstractTransport::create($transport, $connection);
         $this->assertInstanceOf('Elastica\Transport\AbstractTransport', $transport);
         $this->assertSame($connection, $transport->getConnection());
     }
@@ -51,7 +48,7 @@ class AbstractTransportTest extends \PHPUnit_Framework_TestCase
      * @expectedException Elastica\Exception\InvalidException
      * @expectedExceptionMessage Invalid transport
      */
-    public function testThrowsExecptionOnInvalidTransportDefinition($transport)
+    public function testThrowsExceptionOnInvalidTransportDefinition($transport)
     {
         AbstractTransport::create($transport, new Connection());
     }

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -77,7 +77,7 @@ class HttpTest extends BaseTest
         $this->assertStringStartsWith('GET', $info['request_header']);
     }
 
-    public function testDsn()
+    public function testUri()
     {
         $config = array(
             'host' => 'localhost',
@@ -87,7 +87,7 @@ class HttpTest extends BaseTest
         $connection = new Connection($config);
         $transport = new Http($connection);
 
-        $dsn = $transport->getDsn();
-        $this->assertEquals('http://localhost:9300/path', $dsn);
+        $uri = $transport->getUri();
+        $this->assertEquals('http://localhost:9300/path', $uri);
     }
 }

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -3,8 +3,10 @@
 namespace Elastica\Test\Transport;
 
 use Elastica\Client;
+use Elastica\Connection;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Exception\ResponseException;
+use Elastica\Transport\Http;
 
 class HttpTest extends BaseTest
 {
@@ -73,5 +75,19 @@ class HttpTest extends BaseTest
         $status = $client->getStatus();
         $info = $status->getResponse()->getTransferInfo();
         $this->assertStringStartsWith('GET', $info['request_header']);
+    }
+
+    public function testDsn()
+    {
+        $config = array(
+            'host' => 'localhost',
+            'port' => 9300,
+            'path' => 'path'
+        );
+        $connection = new Connection($config);
+        $transport = new Http($connection);
+
+        $dsn = $transport->getDsn();
+        $this->assertEquals('http://localhost:9300/path', $dsn);
     }
 }

--- a/test/lib/Elastica/Test/Transport/NullTest.php
+++ b/test/lib/Elastica/Test/Transport/NullTest.php
@@ -57,7 +57,7 @@ class NullTest extends BaseTest
          $this->assertEquals(0, $shards["failed"]);
     }
 
-    public function testDsn()
+    public function testUri()
     {
         $config = array(
             'host' => 'null.es.host',
@@ -66,7 +66,7 @@ class NullTest extends BaseTest
         $connection = new Connection($config);
         $transport = new Null($connection);
 
-        $dsn = $transport->getDsn();
-        $this->assertEquals('null://', $dsn);
+        $uri = $transport->getUri();
+        $this->assertEquals('null://', $uri);
     }
 }

--- a/test/lib/Elastica/Test/Transport/NullTest.php
+++ b/test/lib/Elastica/Test/Transport/NullTest.php
@@ -2,10 +2,10 @@
 
 namespace Elastica\Test\Transport;
 
-use Elastica\Client;
 use Elastica\Connection;
 use Elastica\Query;
 use Elastica\Test\Base as BaseTest;
+use Elastica\Transport\Null;
 
 /**
  * Elastica Null Transport Test
@@ -55,5 +55,18 @@ class NullTest extends BaseTest
          $this->assertEquals(0, $shards["successful"]);
          $this->assertContains("failed", $shards);
          $this->assertEquals(0, $shards["failed"]);
+    }
+
+    public function testDsn()
+    {
+        $config = array(
+            'host' => 'null.es.host',
+            'port' => 9666,
+        );
+        $connection = new Connection($config);
+        $transport = new Null($connection);
+
+        $dsn = $transport->getDsn();
+        $this->assertEquals('null://', $dsn);
     }
 }

--- a/test/lib/Elastica/Test/Transport/ThriftTest.php
+++ b/test/lib/Elastica/Test/Transport/ThriftTest.php
@@ -8,6 +8,7 @@ use Elastica\Document;
 use Elastica\Index;
 use Elastica\Query;
 use Elastica\Test\Base as BaseTest;
+use Elastica\Transport\Thrift;
 
 class ThriftTest extends BaseTest
 {
@@ -89,6 +90,19 @@ class ThriftTest extends BaseTest
 
         $index = new Index($client, 'missing_index');
         $index->getStatus();
+    }
+
+    public function testDsn()
+    {
+        $config = array(
+            'host' => 'thrift.es.host',
+            'port' => 9500,
+        );
+        $connection = new Connection($config);
+        $transport = new Thrift($connection);
+
+        $dsn = $transport->getDsn();
+        $this->assertEquals('thrift://thrift.es.host:9500', $dsn);
     }
 
     public function configProvider()

--- a/test/lib/Elastica/Test/Transport/ThriftTest.php
+++ b/test/lib/Elastica/Test/Transport/ThriftTest.php
@@ -92,7 +92,7 @@ class ThriftTest extends BaseTest
         $index->getStatus();
     }
 
-    public function testDsn()
+    public function testUri()
     {
         $config = array(
             'host' => 'thrift.es.host',
@@ -101,8 +101,8 @@ class ThriftTest extends BaseTest
         $connection = new Connection($config);
         $transport = new Thrift($connection);
 
-        $dsn = $transport->getDsn();
-        $this->assertEquals('thrift://thrift.es.host:9500', $dsn);
+        $uri = $transport->getUri();
+        $this->assertEquals('thrift://thrift.es.host:9500', $uri);
     }
 
     public function configProvider()


### PR DESCRIPTION
As we discussed in #315, i've added connection exceptions to client exception so there was possibility to get more verbose information why request has failed.

Also added abstract *getDsn()* method to *AbstractTransport* and implemented it in all transports. The purpose if this method to return human readable info about transport and connection it uses like: protocol, host, port and path. For Http transport it would look like this **http://localhost:9200/path** and for Thrift protocol like this: **thrift://localhost:9500**. It is used in client connection exception message for easier understanding what connection caused error.