### PR TITLE
Fix server cluster configuration

### DIFF
--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -79,13 +79,12 @@ class Client
     protected function _initConnections()
     {
         $connections = $this->getConfig('connections');
+        if (isset($this->_config['servers'])) {
+            $connections = array_merge($connections, $this->_config['servers']);
+        }
 
         foreach ($connections as $connection) {
             $this->_connections[] = Connection::create($connection);
-        }
-
-        if (isset($_config['servers'])) {
-            $this->_connections[] = Connection::create($this->getConfig('servers'));
         }
 
         // If no connections set, create default connection

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -86,6 +86,20 @@ class ClientTest extends BaseTest
         $resultSet = $type->search('rolf');
     }
 
+    public function testMergeServersAndConnectionsArray()
+    {
+        $client = new Client(array(
+            'servers' => array(
+                array('host' => 'localhost', 'port' => 9200),
+                array('host' => 'localhost', 'port' => 9201),
+            ),
+            'connections' => array(
+                array('host' => 'localhost', 'port' => 9202),
+            )
+        ));
+        $this->assertCount(3, $client->getConnections());
+    }
+
     public function testBulk()
     {
         $client = $this->_getClient();


### PR DESCRIPTION
This fixes the `Elastica\Client::_initConnections` method so that the following code in the documentation works:

```php
$elasticaClient = new \Elastica\Client(array(
    'servers' => array(
        array('host' => 'localhost', 'port' => 9200)
        array('host' => 'localhost', 'port' => 9201)
    )
));
```

Before, the code was referencing an uninitialized variable (`$_config`), and it only assumed a single connection.