### PR TITLE
getConnection optimization; implementation of simple connection shuffle

### DIFF
--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -410,10 +410,6 @@ class Client
     {
         $enabledConnection = null;
         
-        if (($this->_config['roundRobin'] === true) && (count($this->_connections) > 1)) {
-            shuffle($this->_connections);
-        }
-        
         foreach ($this->_connections as $connection) {
             if ($connection->isEnabled()) {
                 $enabledConnection = $connection;


### PR DESCRIPTION
The getConnection looped through all connection and then would return the last one. Changed that so the first available is immediately returned.

The roundRobin config is now used to do a random shuffle if needed.
