### PR TITLE
Bug fix for cluster server connection setup

### DIFF
--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -84,8 +84,10 @@ class Client
             $this->_connections[] = Connection::create($connection);
         }
 
-        if (isset($_config['servers'])) {
-            $this->_connections[] = Connection::create($this->getConfig('servers'));
+        if (isset($this->_config['servers'])) {
+			foreach ($this->getConfig('servers') as $server) {
+				$this->_connections[] = Connection::create($server);
+			}
         }
 
         // If no connections set, create default connection


### PR DESCRIPTION
Hi,

I have committed a patch that fixes Elastica\Client::_initConnections();

The config call and server setup wasn't working correctly with an array server setup.
