### PR TITLE
Added setParent method to Mapping

### DIFF
--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -161,6 +161,17 @@ class Mapping
     }
 
     /**
+     * Set parent type
+     *
+     * @param string                     $type Parent type
+     * @return \Elastica\Type\Mapping
+     */
+    public function setParent($type)
+    {
+        return $this->setParam('_parent', array('type' => $type));
+    }
+
+    /**
      * Converts the mapping to an array
      *
      * @throws \Elastica\Exception\InvalidException

--- a/test/lib/Elastica/Test/Type/MappingTest.php
+++ b/test/lib/Elastica/Test/Type/MappingTest.php
@@ -138,9 +138,12 @@ class MappingTest extends BaseTest
                 'name' => array('type' => 'string', 'store' => 'yes'),
             )
         );
-        $childmapping->setParam('_parent', array('type' => 'parenttype'));
+        $childmapping->setParent('parenttype');
 
         $childtype->setMapping($childmapping);
+
+        $data = $childmapping->toArray();
+        $this->assertEquals('parenttype', $data[$childtype->getName()]['_parent']['type']);
     }
 
     public function testMappingExample()


### PR DESCRIPTION
Using Elastica for a small school project again… ;-)

This PR allows you to write 

```
$mapping = new \Elastica\Type\Mapping();
$mapping->setParent('blog');
```

instead of

```
$mapping = new \Elastica\Type\Mapping();
$mapping->setParam('_parent', array('type' => 'blog'));
```

ElasticSearch documentation: http://www.elasticsearch.org/guide/reference/mapping/parent-field/
