### PR TITLE
[WIP] added an interface that entities can implement

### DIFF
--- a/lib/Elastica/DocumentObjectInterface.php
+++ b/lib/Elastica/DocumentObjectInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Elastica;
+
+/**
+ * Elastica document object interface
+ *
+ * This interface can be implemented by entities that will be persisted as an Elastica Document
+ *
+ * *WARNING* This interface is EXPERIMENTAL and will likely be changed/expanded in the future
+ *
+ * @category Xodoa
+ * @package  Elastica
+ * @author   Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+interface DocumentObjectInterface
+{
+    /**
+     * Get the elastica ID
+     *
+     * @return string The id to use when persisting this entity
+     */
+    public function getElasticaDocumentId();
+}


### PR DESCRIPTION
this is just an idea ..
the `getElasticaId` method on the interface makes it possible to skip passing in a document instance just to customize the ID. the other two are just additional ideas that i have not explored yet in detail. the theory would be having the idea to just add a bunch of objects that know themselves in which index and type they should be put.

however i wonder if it wouldnt be better to have some configuration here. ie. the ability to define a mapping of entity class names to an array defining a method to use to get the id, the index and type.
