### PR TITLE
Index::Count always returns total documents count instead query count

### DIFF
--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -267,7 +267,7 @@ class Index implements SearchableInterface
     {
         $search = $this->createSearch($query);
 
-        return $search->count();
+        return $search->count($query);
     }
 
     /**


### PR DESCRIPTION
https://github.com/ruflin/Elastica/issues/379
