### PR TITLE
Added a getFilters to the Abstract Multi filter

### DIFF
--- a/lib/Elastica/Filter/Abstract/Multi.php
+++ b/lib/Elastica/Filter/Abstract/Multi.php
@@ -64,4 +64,11 @@ abstract class Elastica_Filter_Abstract_Multi extends Elastica_Filter_Abstract
 
         return $data;
     }
+
+    /**
+     * @return array An array of already set filters.
+     */
+    public function getFilters() {
+        return $this->_filters;
+    }
 }


### PR DESCRIPTION
Any reason why I shouldn't be able to get a list of the filters already setup in an Abstract Multi Filter?
