### PR TITLE
Always prepare Connection params from Client options

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2013-06-04
+- Elastica\Client::_configureParams() changed to _prepareConnectionParams(), which now takes the config array as an argument
+
 2013-05-30
 - Update Index\Status::getAliases() to use new API
 - Update Index\Status::getSettings() to use new API

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -88,28 +88,29 @@ class Client
         $connections = $this->getConfig('connections');
 
         foreach ($connections as $connection) {
-            $this->_connections[] = Connection::create($connection);
+            $this->_connections[] = Connection::create($this->_prepareConnectionParams($connection));
         }
 
         if (isset($this->_config['servers'])) {
             foreach ($this->getConfig('servers') as $server) {
-                $this->_connections[] = Connection::create($server);
+                $this->_connections[] = Connection::create($this->_prepareConnectionParams($server));
             }
         }
 
         // If no connections set, create default connection
         if (empty($this->_connections)) {
-            $this->_connections[] = Connection::create($this->_configureParams());
+            $this->_connections[] = Connection::create($this->_prepareConnectionParams($this->getConfig()));
         }
     }
 
     /**
-     * @return array $params
+     * Creates a Connection params array from a Client or server config array.
+     *
+     * @param array $config
+     * @return array
      */
-    protected function _configureParams()
+    protected function _prepareConnectionParams(array $config)
     {
-        $config = $this->getConfig();
-
         $params = array();
         $params['config'] = array();
         foreach ($config as $key => $value) {

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -86,6 +86,30 @@ class ClientTest extends BaseTest
         $resultSet = $type->search('rolf');
     }
 
+    public function testConnectionParamsArePreparedForConnectionsOption()
+    {
+        $client = new Client(array('connections' => array(array('url' => 'https://localhost:9200'))));
+        $connection = $client->getConnection();
+
+        $this->assertEquals('https://localhost:9200', $connection->getConfig('url'));
+    }
+
+    public function testConnectionParamsArePreparedForServersOption()
+    {
+        $client = new Client(array('servers' => array(array('url' => 'https://localhost:9200'))));
+        $connection = $client->getConnection();
+
+        $this->assertEquals('https://localhost:9200', $connection->getConfig('url'));
+    }
+
+    public function testConnectionParamsArePreparedForDefaultOptions()
+    {
+        $client = new Client(array('url' => 'https://localhost:9200'));
+        $connection = $client->getConnection();
+
+        $this->assertEquals('https://localhost:9200', $connection->getConfig('url'));
+    }
+
     public function testBulk()
     {
         $client = $this->_getClient();


### PR DESCRIPTION
Copying my comment from FriendsOfSymfony/FOSElasticaBundle#305, which prompted this PR:

> Looking at the constructor for [Elastica\Client](https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Client.php) and [Elastica\Connection](https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Connection.php), I think this is an issue with Elastica. This bundle always passes an array of `$servers` to the Client constructor. When that defers to the `Connection::create()` factory method (and the constructor in turn), the `curl`, `headers`, and `url` options are not given special consideration as they are in `Client::_configureParams()`. I'll open up a PR on Elastica and try to correct this, as it looks like an oversight.

I ended up renaming a protected method, which may be considered a BC break.

An alternative solution might have been to do this extraction in the Connection class, but it's likely only relevant to how Clients are constructed.
