### PR TITLE
Add support for fields parameter in get operation

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2013-08-17
+- Add support for fields parameter in Elastica_Type::getDocument()
+
 2013-08-13
 - Add a getQuery method on the FilteredQuery object
 

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -220,7 +220,7 @@ class Type implements SearchableInterface
 
         if (isset($result['fields'])) {
             $data = $result['fields'];
-        } elseif ($result['_source']) {
+        } elseif (isset($result['_source'])) {
             $data = $result['_source'];
         } else {
             $data = array();

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -368,6 +368,25 @@ class TypeTest extends BaseTest
     }
 
     /**
+     * Test to see if Elastica_Type::getDocument() is properly using
+     * the fields array when available instead of _source
+     */
+    public function testGetDocumentWithFieldsSelection()
+    {
+        $index = $this->_createIndex();
+        $type = new Type($index, 'test');
+        $type->addDocument(new Document(1, array('name' => 'loris', 'country' => 'FR', 'email' => 'test@test.com')));
+        $index->refresh();
+
+        $document = $type->getDocument(1, array('fields' => 'name,email'));
+        $data = $document->getData();
+
+        $this->assertArrayHasKey('name', $data);
+        $this->assertArrayHasKey('email', $data);
+        $this->assertArrayNotHasKey('country', $data);
+    }
+
+    /**
      * Test to see if search Default Limit works
      */
     public function testLimitDefaultType()


### PR DESCRIPTION
Update the getDocument method to return the `fields` field instead of `_source` if available.
Allows to get a document from ES and specify the fields you want (See fields section at http://www.elasticsearch.org/guide/reference/api/get/)
