### PR TITLE
Remove facets param from query if is empty array

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2013-11-30
+- Remove facets param from query if is empty array
+
 2013-11-23
 - Release v0.90.7.0
 

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -324,6 +324,10 @@ class Query extends Param
             $this->setQuery(new MatchAll());
         }
 
+        if (isset($this->_params['facets']) && 0 === count($this->_params['facets'])) {
+            unset($this->_params['facets']);
+        }
+
         return $this->_params;
     }
 

--- a/test/lib/Elastica/Test/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryTest.php
@@ -8,6 +8,7 @@ use Elastica\Query\Builder;
 use Elastica\Query\Term;
 use Elastica\Query\Text;
 use Elastica\Query;
+use Elastica\Facet\Terms;
 use Elastica\Test\Base as BaseTest;
 
 class QueryTest extends BaseTest
@@ -173,5 +174,22 @@ class QueryTest extends BaseTest
         $query->setQuery($termQuery);
 
         $this->assertEquals($termQuery->toArray(), $query->getQuery());
+    }
+
+    public function testSetFacets()
+    {
+        $query = new Query();
+
+        $facet = new Terms('text');
+        $query->setFacets(array($facet));
+
+        $data = $query->toArray();
+
+        $this->assertArrayHasKey('facets', $data);
+        $this->assertEquals(array('text' => array('terms' => array())), $data['facets']);
+
+        $query->setFacets(array());
+
+        $this->assertArrayNotHasKey('facets', $query->toArray());
     }
 }


### PR DESCRIPTION
I need this if I remove all facets with `$query->setFacets(array());`
