### PR TITLE
Correct phpdoc for ResultSet::getResults

### DIFF
--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -98,7 +98,7 @@ class ResultSet implements \Iterator, \Countable
     /**
      * Returns all results
      *
-     * @return array Results
+     * @return Result[] Results
      */
     public function getResults()
     {


### PR DESCRIPTION
Maybe there are other places that have the same issue, but I found only this while I was working with Elastica. PhpStorm will correctly infer type in `foreach ($ResultSet->getResults as $Result)` with this patch.
