### PR TITLE
Use fully qualified class names to avoid conflicting on Query from within the Filter namespace

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2013-10-21
+- Fix \Elastica\Filter\HasParent usage of \Elastica\Query as to not collide with \Elastica\Filter\Query, bring \Elasitca\Filter\HasChild into line
+
 2013-09-20
 - Update to geocluster-facet 0.0.8
 - Add support for term suggest API

--- a/lib/Elastica/Filter/HasChild.php
+++ b/lib/Elastica/Filter/HasChild.php
@@ -2,8 +2,6 @@
 
 namespace Elastica\Filter;
 
-use Elastica\Query as ElasticaQuery;
-
 /**
  * Returns parent documents having child docs matching the query
  *
@@ -34,7 +32,7 @@ class HasChild extends AbstractFilter
      */
     public function setQuery($query)
     {
-        $query = ElasticaQuery::create($query);
+        $query = \Elastica\Query::create($query);
         $data = $query->toArray();
 
         return $this->setParam('query', $data['query']);

--- a/lib/Elastica/Filter/HasParent.php
+++ b/lib/Elastica/Filter/HasParent.php
@@ -2,8 +2,6 @@
 
 namespace Elastica\Filter;
 
-use Elastica\Query;
-
 /**
  * Returns child documents having parent docs matching the query
  *
@@ -33,7 +31,7 @@ class HasParent extends AbstractFilter
      */
     public function setQuery($query)
     {
-        $query = Query::create($query);
+        $query = \Elastica\Query::create($query);
         $data = $query->toArray();
 
         return $this->setParam('query', $data['query']);


### PR DESCRIPTION
I made the change to HasParent and then discovered that someone had already fixed this bug in the HasChild class.

Personally I think using fully qualified class names is nicer / cleaner, so did that and brought the HasChild class into line, but not really fussed either way – if you'd prefer aliasing just say.

Is there any documentation on how to run the tests locally? I've had a quick look but can't see anything, so going to let Travis run them for this change…

Thanks.
