### PR TITLE
only set CURL NOBODY option (to true) when http method is HEAD.

### DIFF
--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -108,7 +108,9 @@ class Http extends AbstractTransport
             curl_setopt($conn, CURLOPT_POSTFIELDS, $content);
         }
 
-        curl_setopt($conn, CURLOPT_NOBODY, $httpMethod == 'HEAD');
+        if ('HEAD' == $httpMethod) {
+            curl_setopt($conn, CURLOPT_NOBODY, true);
+        }
 
         curl_setopt($conn, CURLOPT_CUSTOMREQUEST, $httpMethod);
 


### PR DESCRIPTION
Because on some version of curl, when setting the CURL NOBODY option even to FALSE, this remove any POSTFIELDS data from the request...

Related to #485
