### PR TITLE
[RFR] Escape slash in Util::escapeTerm (fixes #440)

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,6 @@
 CHANGES
+2013-12-07
+- Escape slash in Util::escapeTerm, as it is used for regexp from Elastic 0.90
 
 2013-12-04
 - Remove boost from FunctionScore::addFunction because this is not supported by elasticsearch

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -44,7 +44,7 @@ class Util
     {
         $result = $term;
         // \ escaping has to be first, otherwise escaped later once again
-        $chars = array('\\', '+', '-', '&&', '||', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':');
+        $chars = array('\\', '+', '-', '&&', '||', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '/');
 
         foreach ($chars as $char) {
             $result = str_replace($char, '\\' . $char, $result);

--- a/test/lib/Elastica/Test/UtilTest.php
+++ b/test/lib/Elastica/Test/UtilTest.php
@@ -31,8 +31,8 @@ class UtilTest extends BaseTest
 
     public function testEscapeTermSpecialCharacters()
     {
-        $before = '\\+-&&||!(){}[]^"~*?:';
-        $after = '\\\\\\+\\-\\&&\\||\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:';
+        $before = '\\+-&&||!(){}[]^"~*?:/';
+        $after = '\\\\\\+\\-\\&&\\||\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\/';
 
         $this->assertEquals(Util::escapeTerm($before), $after);
     }


### PR DESCRIPTION
This PR add slash escape in `Elastica\Util::escapeTerm` method. Indeed, since [Elastic 0.90](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters), slashes are a reserved character used for regexp.

Still _Work in Progress_ as I did not succeed in launching automated tests yet.
