### PR TITLE
Fix returning of suggestion results in \Elastica\ResultSet

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,8 @@
 CHANGES
+2013-12-12
+- Fix the manner in which suggestion results are returned in \Elastica\ResultSet and adjust associated tests to account for the fix.
+- Add \Elastica\Resultset::hasSuggests()
+
 2013-12-11
 - Pass arguments to optimize as query
 - Add refreshAll on Client

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -23,13 +23,6 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     protected $_results = array();
 
     /**
-    * Suggests
-    *
-    * @var array Suggests
-    */
-    protected $_suggests = array();
-
-    /**
      * Current position
      *
      * @var int Current position
@@ -101,12 +94,6 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
                 $this->_results[] = new Result($hit);
             }
         }
-
-        if(isset($result['suggest'])){
-            foreach($result['suggest'] as $key => $value){
-                $this->_suggests[$key] = $value[0];
-            }
-        }
     }
 
     /**
@@ -120,13 +107,23 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     }
 
     /**
+     * Returns true if the response contains suggestion results; false otherwise
+     * @return bool
+     */
+    public function hasSuggests(){
+        $data = $this->_response->getData();
+        return isset($data['suggest']);
+    }
+
+    /**
     * Return all suggests
     *
-    * @return Suggest[] Suggests
+    * @return array suggest results
     */
     public function getSuggests() 
     {
-        return $this->_suggests;
+        $data = $this->_response->getData();
+        return isset($data['suggest']) ? $data['suggest'] : array();
     }
 
     /**
@@ -228,7 +225,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      */
     public function countSuggests()
     {
-        return sizeof($this->_suggests);
+        return sizeof($this->getSuggests());
     }
 
     /**

--- a/test/lib/Elastica/Test/Suggest/PhraseTest.php
+++ b/test/lib/Elastica/Test/Suggest/PhraseTest.php
@@ -77,9 +77,9 @@ class PhraseTest extends BaseTest
         $suggests = $result->getSuggests();
 
         // 3 suggestions should be returned: One in which both misspellings are corrected, and two in which only one misspelling is corrected.
-        $this->assertEquals(3, sizeof($suggests['suggest1']['options']));
+        $this->assertEquals(3, sizeof($suggests['suggest1'][0]['options']));
 
-        $this->assertEquals("elasticsearch is <suggest>bonsai cool</suggest>", $suggests['suggest1']['options'][0]['highlighted']);
-        $this->assertEquals("elasticsearch is bonsai cool", $suggests['suggest1']['options'][0]['text']);
+        $this->assertEquals("elasticsearch is <suggest>bonsai cool</suggest>", $suggests['suggest1'][0]['options'][0]['highlighted']);
+        $this->assertEquals("elasticsearch is bonsai cool", $suggests['suggest1'][0]['options'][0]['text']);
     }
 }

--- a/test/lib/Elastica/Test/Suggest/TermTest.php
+++ b/test/lib/Elastica/Test/Suggest/TermTest.php
@@ -23,11 +23,12 @@ class TermTest extends BaseTest
         parent::setUp();
         $this->_index = $this->_createIndex('test_suggest');
         $docs = array();
-        $docs[] = new Document(5, array('id' => 1, 'text' => 'GitHub'));
-        $docs[] = new Document(6, array('id' => 1, 'text' => 'Elastic'));
-        $docs[] = new Document(7, array('id' => 1, 'text' => 'Search'));
-        $docs[] = new Document(3, array('id' => 1, 'text' => 'Food'));
-        $docs[] = new Document(4, array('id' => 1, 'text' => 'Folks'));
+        $docs[] = new Document(1, array('id' => 1, 'text' => 'GitHub'));
+        $docs[] = new Document(2, array('id' => 1, 'text' => 'Elastic'));
+        $docs[] = new Document(3, array('id' => 1, 'text' => 'Search'));
+        $docs[] = new Document(4, array('id' => 1, 'text' => 'Food'));
+        $docs[] = new Document(5, array('id' => 1, 'text' => 'Flood'));
+        $docs[] = new Document(6, array('id' => 1, 'text' => 'Folks'));
         $type = $this->_index->getType(self::TEST_TYPE);
         $type->addDocuments($docs);
         $this->_index->refresh();
@@ -70,7 +71,7 @@ class TermTest extends BaseTest
     {
         $suggest = new Suggest();
         $suggest1 = new Term('suggest1', '_all');
-        $suggest->addSuggestion($suggest1->setText('Foor'));
+        $suggest->addSuggestion($suggest1->setText('Foor seach'));
         $suggest2 = new Term('suggest2', '_all');
         $suggest->addSuggestion($suggest2->setText('Girhub'));
 
@@ -80,13 +81,11 @@ class TermTest extends BaseTest
 
         $suggests = $result->getSuggests();
 
-        // Ensure that one suggestion result is returned per suggestion term
-        foreach ($suggests as $sug) {
-            $this->assertEquals(1, sizeof($sug['options']));
-        }
+        // Ensure that two suggestion results are returned for suggest1
+        $this->assertEquals(2, sizeof($suggests['suggest1']));
 
-        $this->assertEquals('github', $suggests['suggest2']['options'][0]['text']);
-        $this->assertEquals('food', $suggests['suggest1']['options'][0]['text']);
+        $this->assertEquals('github', $suggests['suggest2'][0]['options'][0]['text']);
+        $this->assertEquals('food', $suggests['suggest1'][0]['options'][0]['text']);
     }
 
     public function testSuggestNoResults()
@@ -100,6 +99,6 @@ class TermTest extends BaseTest
 
         // Assert that no suggestions were returned
         $suggests = $result->getSuggests();
-        $this->assertEquals(0, sizeof($suggests['suggest1']['options']));
+        $this->assertEquals(0, sizeof($suggests['suggest1'][0]['options']));
     }
 }


### PR DESCRIPTION
Prior to this fix, only the first suggestion result per suggestion was being returned by \Elastica\ResultSet::getSuggests().
