### PR TITLE
Send scroll_id via HTTP body instead of as query param

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,7 @@
 CHANGES
+2013-12-12
+- Always send scroll_id via HTTP body instead of as a query param
+
 2013-12-11
 - Pass arguments to optimize as query
 - Add refreshAll on Client

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -420,10 +420,18 @@ class Search
 
         $params = $this->getOptions();
 
+        // Send scroll_id via raw HTTP body to handle cases of very large (> 4kb) ids.
+        if ('_search/scroll' == $path) {
+            $data = $params[self::OPTION_SCROLL_ID];
+            unset($params[self::OPTION_SCROLL_ID]);
+        } else {
+            $data = $query->toArray();
+        }
+
         $response = $this->getClient()->request(
             $path,
             Request::GET,
-            $query->toArray(),
+            $data,
             $params
         );
 


### PR DESCRIPTION
Elasticsearch scrolling queries can accept `scroll_id` either as a query
parameter or as the raw HTTP body. The Elastica should always pass the id
via HTTP body for safety.

The Elasticsearch `scroll_id` is a base64 encoded value that appears to be
a serialized string that contains key/value pair data for each shard in
the cluster. As the number of shards grow the size of `scroll_id`
increases proportionally. In addition by default Elasticsearch caps URLs
at 4kb as governed by the `http.max_initial_line_length` setting.

Thus as the size of a cluster grows at some point all scrolling queries
will fail if passed via the query parameter.
