### PR TITLE
Fix PHPDoc of query param

### DIFF
--- a/lib/Elastica/Query/CustomFiltersScore.php
+++ b/lib/Elastica/Query/CustomFiltersScore.php
@@ -24,7 +24,7 @@ class CustomFiltersScore extends AbstractQuery
     const SCORE_MODE_MULTIPLY   = 'multiply';
 
     /**
-     * @param mixed $query Query object or data to build it, match_all query will be created be default
+     * @param string|\Elastica\Query|Elastica\Query\AbstractQuery $query match_all query will be created by default
      */
     public function __construct($query = null)
     {
@@ -34,7 +34,7 @@ class CustomFiltersScore extends AbstractQuery
     /**
      * Sets a query
      *
-     * @param  mixed                                  $query Query object or data to build it
+     * @param  string|\Elastica\Query|Elastica\Query\AbstractQuery $query
      * @return \Elastica\Query\CustomFiltersScore Current object
      */
     public function setQuery($query)

--- a/lib/Elastica/Query/CustomScore.php
+++ b/lib/Elastica/Query/CustomScore.php
@@ -19,7 +19,7 @@ class CustomScore extends AbstractQuery
      * Constructor
      *
      * @param string|array|\Elastica\Script        $script
-     * @param string|\Elastica\Query\AbstractQuery $query
+     * @param string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
      */
     public function __construct($script = null, $query= null)
     {

--- a/lib/Elastica/Query/HasChild.php
+++ b/lib/Elastica/Query/HasChild.php
@@ -16,7 +16,7 @@ class HasChild extends AbstractQuery
     /**
      * Construct HasChild Query
      *
-     * @param string|\Elastica\Query $query Query string or a Elastica\Query object
+     * @param string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
      * @param string                $type  Parent document type
      */
     public function __construct($query, $type = null)

--- a/lib/Elastica/Query/HasParent.php
+++ b/lib/Elastica/Query/HasParent.php
@@ -15,7 +15,7 @@ class HasParent extends AbstractQuery
     /**
      * Construct HasChild Query
      *
-     * @param string|\Elastica\Query $query Query string or a Elastica\Query object
+     * @param string|\Elastica\Query|\Elastica\Query\AbstractQuery $query 
      * @param string                $type  Parent document type
      */
     public function __construct($query, $type)

--- a/lib/Elastica/Query/TopChildren.php
+++ b/lib/Elastica/Query/TopChildren.php
@@ -16,7 +16,7 @@ class TopChildren extends AbstractQuery
     /**
      * Construct topChildren query
      *
-     * @param string|\Elastica\Query $query Query string or a Elastica\Query object
+     * @param string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
      * @param string                $type  Parent document type
      */
     public function __construct($query, $type = null)


### PR DESCRIPTION
Just a little fix to make the PHPdoc of the `query` param consistent with the `setQuery` method
