### PR TITLE
Fix Type->deleteByQuery() not working with query objects

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-03-02
+- Issue #554: Fixed Type->deleteByQuery() not working with Query objects
+
 2014-02-27
 - Update to elasticsearch 1.0.1. Update Thrift and Geocluster plugin.
 
@@ -7,7 +10,7 @@ CHANGES
 - Issue #559: add JSON_UNESCAPED_UNICODE and JSON_UNESCAPED_SLASHES options in Elastica/Transport/Http, Elastica/Bulk/Action
 
 2014-02-20
-- Issue #558: fixed unregister percolator (still used _percolator instead of .percolator). removed duplicate slash from register percolator route. 
+- Issue #558: fixed unregister percolator (still used _percolator instead of .percolator). removed duplicate slash from register percolator route.
 
 2014-02-17
 - Throw PartialShardFailureException if response has failed shards

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -452,7 +452,7 @@ class Type implements SearchableInterface
         }
         $query = Query::create($query);
 
-        return $this->request('_query', Request::DELETE, $query->getQuery());
+        return $this->request('_query', Request::DELETE, array('query' => $query->getQuery()));
     }
 
     /**

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -8,6 +8,7 @@ use Elastica\Exception\NotFoundException;
 use Elastica\Exception\ResponseException;
 use Elastica\Query;
 use Elastica\Query\MatchAll;
+use Elastica\Query\SimpleQueryString;
 use Elastica\Script;
 use Elastica\Search;
 use Elastica\Filter\Term;
@@ -339,7 +340,7 @@ class TypeTest extends BaseTest
         $type->getDocument(1);
     }
 
-    public function testDeleteByQuery()
+    public function testDeleteByQueryWithQueryString()
     {
         $index = $this->_createIndex();
         $type = new Type($index, 'test');
@@ -355,6 +356,34 @@ class TypeTest extends BaseTest
 
         // Delete first document
         $response = $type->deleteByQuery('nicolas');
+        $this->assertTrue($response->isOk());
+
+        $index->refresh();
+
+        // Makes sure, document is deleted
+        $response = $index->search('ruflin*');
+        $this->assertEquals(1, $response->count());
+
+        $response = $index->search('nicolas');
+        $this->assertEquals(0, $response->count());
+    }
+
+    public function testDeleteByQueryWithQuery()
+    {
+        $index = $this->_createIndex();
+        $type = new Type($index, 'test');
+        $type->addDocument(new Document(1, array('name' => 'ruflin nicolas')));
+        $type->addDocument(new Document(2, array('name' => 'ruflin')));
+        $index->refresh();
+
+        $response = $index->search('ruflin*');
+        $this->assertEquals(2, $response->count());
+
+        $response = $index->search('nicolas');
+        $this->assertEquals(1, $response->count());
+
+        // Delete first document
+        $response = $type->deleteByQuery(new SimpleQueryString('nicolas'));
         $this->assertTrue($response->isOk());
 
         $index->refresh();


### PR DESCRIPTION
1.0.0.RC1 requires query bodies to be wrapped in a `query` key, like a search.

http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
