### PR TITLE
Fixed request body reuse in http transport

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-03-11
+- Fixed request body reuse in http transport
+
 2014-03-08
 - Release v1.0.1.1
 - Enable goecluster-facet again as now compatible with elasticsearch 1.0 on travis

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -112,6 +112,8 @@ class Http extends AbstractTransport
             $content = str_replace('\/', '/', $content);
 
             curl_setopt($conn, CURLOPT_POSTFIELDS, $content);
+        } else {
+            curl_setopt($conn, CURLOPT_POSTFIELDS, '');
         }
 
         curl_setopt($conn, CURLOPT_NOBODY, $httpMethod == 'HEAD');


### PR DESCRIPTION
Lesson learned from elasticsearch/elasticsearch#5141: always put proxy in the middle before submitting issue.
