### PR TITLE
enhance percolation of existing documents

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-03-15
+- percolate existing documents and add percolate options (#570)
+
 2014-03-11
 - Fixed request body reuse in http transport #567
 

--- a/lib/Elastica/Percolator.php
+++ b/lib/Elastica/Percolator.php
@@ -75,7 +75,7 @@ class Percolator
         $path = $this->_index->getName() . '/' . $type . '/_percolate';
         $data = array('doc' => $doc->getData());
 
-        return $this->percolate($path, $query, $data, $params);
+        return $this->_percolate($path, $query, $data, $params);
     }
 
     /**
@@ -93,7 +93,7 @@ class Percolator
         $id = urlencode($id);
         $path = $this->_index->getName() . '/' . $type . '/'. $id . '/_percolate';
 
-        return $this->percolate($path, $query, array(), $params);
+        return $this->_percolate($path, $query, array(), $params);
     }
 
     /**
@@ -103,7 +103,7 @@ class Percolator
      * @param  array  $params
      * @return array
      */
-    protected function percolate($path, $query, $data = array(), $params = array())
+    protected function _percolate($path, $query, $data = array(), $params = array())
     {
         // Add query to filter the percolator queries which are executed.
         if ($query) {


### PR DESCRIPTION
- percolate without "doc" context but with a document id.
- add options which are [supported](https://github.com/elasticsearch/elasticsearch/blob/master/rest-api-spec/api/percolate.json) by the percolate api.

The options are also documented [here](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-percolate.html#_percolating_an_existing_document).
