### PR TITLE
Only detect real JSON parsing errors

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-04-17
+- Only trap real JSON parse errors in Response class #586
+
 2014-04-09
 - Added Cardinality aggregation #581
 

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -180,7 +180,7 @@ class Response
 
                 $tempResponse = json_decode($response, true);
                 // If error is returned, json_decode makes empty string of string
-                if (!empty($tempResponse)) {
+                if (!json_last_error()) {
                     $response = $tempResponse;
                 }
             }

--- a/test/lib/Elastica/Test/ResponseTest.php
+++ b/test/lib/Elastica/Test/ResponseTest.php
@@ -5,6 +5,7 @@ use Elastica\Document;
 use Elastica\Facet\DateHistogram;
 use Elastica\Query;
 use Elastica\Query\MatchAll;
+use Elastica\Request;
 use Elastica\Type\Mapping;
 use Elastica\Test\Base as BaseTest;
 
@@ -77,4 +78,17 @@ class ResponseTest extends BaseTest
 
         $this->assertTrue($response->isOk());
     }
+
+    public function testGetDataEmpty()
+    {
+        $index = $this->_createIndex();
+
+        $response = $index->request(
+            'non-existant-type/_mapping',
+            Request::GET
+        )->getData();
+
+        $this->assertEquals(0, count($response));
+    }
+
 }


### PR DESCRIPTION
As of 1.0 the `/index/type/_mapping` endpoint can return `{}` which is both `empty` but also valid. This change ensures that only real JSON parsing errors trigger the fallback behaviour.

Fixes #586
