### PR TITLE
Fix Elastic[S]earch case and add missing "use"

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,9 @@
 CHANGES
 
+2014-04-27
+- Fix missing use in TermsStats->setOrder()
+- Replace all instances of ElasticSearch with Elasticsearch
+
 2014-04-24
 - Fixing the Bool filter with Bool filter children bug #594
 

--- a/lib/Elastica/Exception/Connection/HttpException.php
+++ b/lib/Elastica/Exception/Connection/HttpException.php
@@ -63,7 +63,7 @@ class HttpException extends ConnectionException
                 $error = "Couldn't resolve host";
                 break;
             case CURLE_COULDNT_CONNECT:
-                $error = "Couldn't connect to host, ElasticSearch down?";
+                $error = "Couldn't connect to host, Elasticsearch down?";
                 break;
             case 28:
                 $error = "Operation timed out";

--- a/lib/Elastica/Facet/AbstractFacet.php
+++ b/lib/Elastica/Facet/AbstractFacet.php
@@ -80,7 +80,7 @@ abstract class AbstractFacet extends Param
     /**
      * Sets the flag to either run the facet globally or bound to the
      * current search query. When not set, it defaults to the
-     * ElasticSearch default value.
+     * Elasticsearch default value.
      *
      * @param  bool                         $global Flag to either run the facet globally.
      * @return \Elastica\Facet\AbstractFacet

--- a/lib/Elastica/Facet/Terms.php
+++ b/lib/Elastica/Facet/Terms.php
@@ -18,7 +18,7 @@ class Terms extends AbstractFacet
 {
     /**
      * Holds the types of ordering which are allowed
-     * by ElasticSearch.
+     * by Elasticsearch.
      *
      * @var array
      */
@@ -75,7 +75,7 @@ class Terms extends AbstractFacet
     }
 
     /**
-     * Sets the ordering type for this facet. ElasticSearch
+     * Sets the ordering type for this facet. Elasticsearch
      * internal default is count.
      *
      * @param  string                              $type The order type to set use for sorting of the terms.

--- a/lib/Elastica/Facet/TermsStats.php
+++ b/lib/Elastica/Facet/TermsStats.php
@@ -2,6 +2,8 @@
 
 namespace Elastica\Facet;
 
+use Elastica\Exception\InvalidException;
+
 /**
  * Implements the statistical facet on a per term basis.
  *
@@ -15,7 +17,7 @@ class TermsStats extends AbstractFacet
 
     /**
      * Holds the types of ordering which are allowed
-     * by ElasticSearch.
+     * by Elasticsearch.
      *
      * @var array
      */
@@ -46,7 +48,7 @@ class TermsStats extends AbstractFacet
     }
 
     /**
-     * Sets the ordering type for this facet. ElasticSearch
+     * Sets the ordering type for this facet. Elasticsearch
      * internal default is count.
      *
      * @param  string                              $type The order type to set use for sorting of the terms.

--- a/lib/Elastica/Query/Builder.php
+++ b/lib/Elastica/Query/Builder.php
@@ -285,7 +285,7 @@ class Builder extends AbstractQuery
      * In the simple case, a facet can return facet counts for various facet
      * values for a specific field.
      *
-     * ElasticSearch supports more advanced facet implementations, such as
+     * Elasticsearch supports more advanced facet implementations, such as
      * statistical or date histogram facets.
      *
      * @return \Elastica\Query\Builder

--- a/test/lib/Elastica/Test/Query/MultiMatchTest.php
+++ b/test/lib/Elastica/Test/Query/MultiMatchTest.php
@@ -77,7 +77,7 @@ class MultiMatchTest extends BaseTest
 
     public function testFuzzyWithOptions1()
     {
-        // Here ElasticSearch will not accept mispells
+        // Here Elasticsearch will not accept mispells
         // on the first 6 letters.
         $this->multiMatch->setQuery('Tritsan'); // Mispell on purpose
         $this->multiMatch->setFields(array('full_name', 'name'));


### PR DESCRIPTION
See https://github.com/elasticsearch/elasticsearch/issues/4634
about the official case of Elasticsearch versus ElasticSearch.
