### PR TITLE
Introduce ELASTICA_JSON_UNESCAPED_UNICODE ELASTICA_JSON_UNESCAPED_SLASHES

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-05-12
+- Introduce ELASTICA_JSON_UNESCAPED_UNICODE ELASTICA_JSON_UNESCAPED_SLASHES to avoid using the global defines from PHP. Follows up #559.
+
 2014-04-28
 - Typo fixes #600, #602
 - Remove unreachable return statement #598

--- a/lib/Elastica/Bulk/Action.php
+++ b/lib/Elastica/Bulk/Action.php
@@ -3,8 +3,11 @@
 namespace Elastica\Bulk;
 
 if (!defined('JSON_UNESCAPED_UNICODE')) {
-    define('JSON_UNESCAPED_SLASHES', 64);
-    define('JSON_UNESCAPED_UNICODE', 256);
+    define('ELASTICA_JSON_UNESCAPED_SLASHES', 64);
+    define('ELASTICA_JSON_UNESCAPED_UNICODE', 256);
+} else {
+    define('ELASTICA_JSON_UNESCAPED_SLASHES', JSON_UNESCAPED_SLASHES);
+    define('ELASTICA_JSON_UNESCAPED_UNICODE', JSON_UNESCAPED_UNICODE);
 }
 
 use Elastica\Bulk;
@@ -193,7 +196,7 @@ class Action
             } elseif (is_array($source) && array_key_exists('doc', $source) && is_string($source['doc'])) {
                 $string.= '{"doc": ' . $source['doc'] . '}';
             } else {
-                $string.= json_encode($source, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                $string.= json_encode($source, ELASTICA_JSON_UNESCAPED_UNICODE | ELASTICA_JSON_UNESCAPED_SLASHES);
             }
             $string.= Bulk::DELIMITER;
         }

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -3,8 +3,11 @@
 namespace Elastica\Transport;
 
 if (!defined('JSON_UNESCAPED_UNICODE')) {
-    define('JSON_UNESCAPED_SLASHES', 64);
-    define('JSON_UNESCAPED_UNICODE', 256);
+    define('ELASTICA_JSON_UNESCAPED_SLASHES', 64);
+    define('ELASTICA_JSON_UNESCAPED_UNICODE', 256);
+} else {
+    define('ELASTICA_JSON_UNESCAPED_SLASHES', JSON_UNESCAPED_SLASHES);
+    define('ELASTICA_JSON_UNESCAPED_UNICODE', JSON_UNESCAPED_UNICODE);
 }
 
 use Elastica\Exception\Connection\HttpException;
@@ -103,7 +106,7 @@ class Http extends AbstractTransport
             }
 
             if (is_array($data)) {
-                $content = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                $content = json_encode($data, ELASTICA_JSON_UNESCAPED_UNICODE | ELASTICA_JSON_UNESCAPED_SLASHES);
             } else {
                 $content = $data;
             }


### PR DESCRIPTION
Avoids using the global defines from PHP. Follows up #559.

This lead to https://bugzilla.wikimedia.org/show_bug.cgi?id=65110 being filed downstream by myself. We use the existence of JSON_UNESCAPED_\* defines to detect 5.3/5.4 behavior and handle fallbacks more gracefully. Elastica unconditionally defining these on 5.3 and below breaks our behavior detection.

Proposed PR should work on 5.3 as well as 5.4+
