### PR TITLE
Aggragations/Filter - fix for es1.2 when no sub aggregations

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-05-27
+- Fix Aggragations/Filter to work with es v1.2.0
+
 2014-05-25
 - Added Guzzle transport as an alternative to the default Http transport #618
 - Added Elastica\ScanAndScroll Iterator (http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html) #617

--- a/lib/Elastica/Aggregation/Filter.php
+++ b/lib/Elastica/Aggregation/Filter.php
@@ -27,9 +27,15 @@ class Filter extends AbstractAggregation
      */
     public function toArray()
     {
-        return array(
-            "filter" => $this->getParam("filter"),
-            "aggs" => $this->_aggs
+        $array = array(
+            "filter" => $this->getParam("filter")
         );
+
+        if($this->_aggs)
+        {
+            $array['aggs'] = $this->_aggs;
+        }
+
+        return $array;
     }
 }

--- a/test/lib/Elastica/Test/Aggregation/FilterTest.php
+++ b/test/lib/Elastica/Test/Aggregation/FilterTest.php
@@ -54,10 +54,25 @@ class FilterTest extends BaseAggregationTest
 
         $query = new Query();
         $query->addAggregation($agg);
+
         $results = $this->_index->search($query)->getAggregation("filter");
         $results = $results['price']['value'];
 
         $this->assertEquals((5 + 8) / 2.0, $results);
+    }
+
+    public function testFilterNoSubAggregation()
+    {
+        $agg = new Avg("price");
+        $agg->setField("price");
+
+        $query = new Query();
+        $query->addAggregation($agg);
+
+        $results = $this->_index->search($query)->getAggregation("price");
+        $results = $results['value'];
+
+        $this->assertEquals((5 + 8 + 1 + 3) / 4.0, $results);
     }
 }
  


### PR DESCRIPTION
Hi,

Small fix for Elastica/Aggregation/Filter.php. There is a bug when no subaggregation is set ... see "by_category_feature"

``` json
"aggs": {
        "global": {
            "global": {},
            "aggs": {
                "by_category_feature": {
                    "filter": {
                        "match_all": {}
                    },
                  "aggs": []
                }
            }
        }
    }
```

This will cause an error in elasticsearch because "aggs" cannot be [] ... it should be {} .. or we can just omit the aggs when there are none present.

``` json
"aggs": {
        "global": {
            "global": {},
            "aggs": {
                "by_category_feature": {
                    "filter": {
                        "match_all": {}
                    }
                }
            }
        }
    }
```

This will work fine :)
