### PR TITLE
Make a test in ClientTest more consistent

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-06-13
+- Stop ClientTest->testDeleteIdsIdxStringTypeString from failing 1/3 of the time #634
+
 2014-06-11
 - Allow bulk API deletes to be routed #631
 

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -271,6 +271,7 @@ class ClientTest extends BaseTest
 
         // Adds 1 document to the index
         $doc = new Document(null, $data);
+        $doc->setRouting(1);
         $result = $type->addDocument($doc);
 
         // Refresh index
@@ -291,9 +292,8 @@ class ClientTest extends BaseTest
         $this->assertEquals(true, is_string($idxString));
         $this->assertEquals(true, is_string($typeString));
 
-
-        // Try to delete doc with a routing value different from _id
-        // which should fail to delete any docs
+        // Try to delete doc with a routing value which hashes to
+        // a different shard then the id.
         $resp = $index->getClient()->deleteIds($ids, $index, $type, 2);
 
         // Refresh the index


### PR DESCRIPTION
ClientTest->testDeleteIdsIdxStringTypeString assumed that new documents
created without a specified id or routing value would route to the same
shard as "1" and a different shard from "2" when there are two shards.
This wasn't always that case because:
1.  Documents without a routing value use their ids as a route.
2.  Documents that don't specify an id get a random one.

This sets the routing for the document to "1" which, luckily, does in
fact route to a different shard then "2" when there are two shards.  And
it will stay that way forever back Elasticsearch has to maintain a consistent
routing style or it won't be safe to upgrade.

Closes #633
