### PR TITLE
Stop ScanAndScrollTest from failing spuriously

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -2,6 +2,7 @@ CHANGES
 
 2014-06-13
 - Stop ClientTest->testDeleteIdsIdxStringTypeString from failing 1/3 of the time #634
+- Stop ScanAndScrollTest->testQuerySizeOverride from failing frequently for no reason #635
 
 2014-06-11
 - Allow bulk API deletes to be routed #631

--- a/test/lib/Elastica/Test/ScanAndScrollTest.php
+++ b/test/lib/Elastica/Test/ScanAndScrollTest.php
@@ -29,6 +29,7 @@ class ScanAndScrollTest extends BaseTest {
         $query->setSize(100);
 
         $index = $this->_createIndex('test_1');
+        $index->refresh();  // Waits for the index to be fully created.
         $type = $index->getType('scanAndScrollTest');
 
         $search = new Search($this->_getClient());


### PR DESCRIPTION
ScanAndScrollTest->testQuerySizeOverride used the rewind method on
ScanAndScroll which executes a scroll query on Elasticsearch without making
sure that the index is fully allocated.  Apparently, this can cause
Elasticsearch to throw back an error.  We work around this by adding a
refresh before the rewind.
