### PR TITLE
Fix FunstionScore Query random_score without seed bug

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-07-07
+ - Fix FunstionScore Query random_score without seed bug. #647
+
 2014-07-02
 - Add setPostFilter method to Elastica\Query (http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_filtering_queries_and_aggregations.html#_post_filter) #645
 

--- a/lib/Elastica/Query/FunctionScore.php
+++ b/lib/Elastica/Query/FunctionScore.php
@@ -171,9 +171,9 @@ class FunctionScore extends AbstractQuery
      */
     public function setRandomScore($seed = NULL)
     {
-        $seedParam = array();
+        $seedParam = new \stdClass();
         if (!is_null($seed)) {
-            $seedParam['seed'] = $seed;
+            $seedParam->seed = $seed;
         }
         return $this->setParam('random_score', $seedParam);
     }

--- a/test/lib/Elastica/Test/Query/FunctionScoreTest.php
+++ b/test/lib/Elastica/Test/Query/FunctionScoreTest.php
@@ -170,6 +170,16 @@ class FunctionScoreTest extends BaseTest
         $this->assertEquals("Miller's Field", $result0['name']);
     }
 
+    public function testRandomScoreWithoutSeed()
+    {
+        $query = new FunctionScore();
+        $query->setRandomScore();
+
+        $response = $this->type->search($query);
+
+        $this->assertEquals(2, $response->count());
+    }
+
     public function testScriptScore()
     {
         $scriptString = "_score * doc['price'].value";


### PR DESCRIPTION
Hi,

Quick fix for a random_score without seed. When we want to execute match all query with random sorting

``` php
$Query = new Elastica\Query();
$QueryFS  = new Elastica\Query\FunctionScore();
$QueryFS->setRandomScore();
$Query->setQuery($QueryFS);
```

``` json
{
    "query": {
        "function_score": {
            "random_score": []
        }
    }
}
```

This will fail in Elasticsearch because of "random_score": []: 

``` json
{
    "query": {
        "function_score": {
            "random_score": {}
        }
    }
}
```

Should be like this :)
Added a test with empty seed to check if it workd in ES.

Pawel
