### PR TITLE
Add setQuery() method to Elastica\Query\ConstantScore

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-07-14
+ - Add setQuery() method to Elastica\Query\ConstantScore #653
+
 2014-07-12
  - Be able to configure ES host/port via ENV var in test env #652
 

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -41,6 +41,21 @@ class ConstantScore extends AbstractQuery
     }
 
     /**
+     * Set query
+     *
+     * @param array|\Elastica\Query\AbstractQuery $query
+     * @return \Elastica\Query\ConstantScore         Query object
+     */
+    public function setQuery($query)
+    {
+        if ($query instanceof AbstractQuery) {
+            $query = $query->toArray();
+        }
+
+        return $this->setParam('query', $query);
+    }
+
+    /**
      * Set boost
      *
      * @param  float                        $boost


### PR DESCRIPTION
Added the ability to set query parameter for constant score query

@see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-constant-score-query.html
