### PR TITLE
post_filter and filter are now the same

### DIFF
--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -72,7 +72,7 @@ class Query extends Param
                 return new self($query);
             case $query instanceof AbstractFilter:
                 $newQuery = new self();
-                $newQuery->setFilter($query);
+                $newQuery->setPostFilter($query);
 
                 return $newQuery;
             case empty($query):
@@ -132,10 +132,12 @@ class Query extends Param
      *
      * @param  \Elastica\Filter\AbstractFilter $filter Filter object
      * @return \Elastica\Query                 Current object
+     * @link    https://github.com/elasticsearch/elasticsearch/issues/7422
+     * @deprecated
      */
     public function setFilter(AbstractFilter $filter)
     {
-        return $this->setParam('filter', $filter->toArray());
+        return $this->setPostFilter($filter);
     }
 
     /**
@@ -406,13 +408,19 @@ class Query extends Param
 
     /**
      * Sets post_filter argument for the query. The filter is applied after the query has executed
-     * @param   array $post
-     * @return  \Elastica\Query Current object
-     * @link    http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_filtering_queries_and_aggregations.html#_post_filter
+     *
+     * @param   array|\Elastica\Filter\AbstractFilter $filter
+     * @return  \Elastica\Param
+     * @link    http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-post-filter.html
      */
-    public function setPostFilter(array $post)
+    public function setPostFilter($filter)
     {
-        return $this->setParam("post_filter", $post);
+        if($filter instanceof AbstractFilter)
+        {
+            $filter = $filter->toArray();
+        }
+
+        return $this->setParam("post_filter", $filter);
     }
 }
 

--- a/test/benchmark/TransportTest.php
+++ b/test/benchmark/TransportTest.php
@@ -79,7 +79,7 @@ class TransportTest extends \PHPUnit_Framework_TestCase
             $test = rand(1, $this->_max);
             $query = new Query();
             $query->setQuery(new MatchAllQuery());
-            $query->setFilter(new TermFilter(array('test' => $test)));
+            $query->setPostFilter(new TermFilter(array('test' => $test)));
             $result = $type->search($query);
             $times[] = $result->getResponse()->getQueryTime();
         }

--- a/test/lib/Elastica/Test/Filter/BoolTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolTest.php
@@ -87,7 +87,7 @@ class BoolTest extends BaseTest
         $mustNotFilter->addMustNot($publisherFilter);
 
         $mainBoolFilter->addMust(array($shouldFilter, $mustNotFilter));
-        $query->setFilter($mainBoolFilter);
+        $query->setPostFilter($mainBoolFilter);
         //execute the query
         $results = $index->search($query);
 

--- a/test/lib/Elastica/Test/Filter/GeoDistanceRangeTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoDistanceRangeTest.php
@@ -53,7 +53,7 @@ class GeoDistanceRangeTest extends BaseTest
         );
 
         $query = new Query(new MatchAll());
-        $query->setFilter($geoFilter);
+        $query->setPostFilter($geoFilter);
         $this->assertEquals(1, $type->search($query)->count());
 
         // Both points should be inside
@@ -64,7 +64,7 @@ class GeoDistanceRangeTest extends BaseTest
             array('gte' => '0km', 'lte' => '40000km')
         );
         $query = new Query(new MatchAll());
-        $query->setFilter($geoFilter);
+        $query->setPostFilter($geoFilter);
         $index->refresh();
 
         $this->assertEquals(2, $type->search($query)->count());

--- a/test/lib/Elastica/Test/Filter/GeoDistanceTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoDistanceTest.php
@@ -49,14 +49,14 @@ class GeoDistanceTest extends BaseTest
         $geoFilter = new GeoDistance('point', array('lat' => 30, 'lon' => 40), '1km');
 
         $query = new Query(new MatchAll());
-        $query->setFilter($geoFilter);
+        $query->setPostFilter($geoFilter);
         $this->assertEquals(1, $type->search($query)->count());
 
         // Both points should be inside
         $query = new Query();
         $geoFilter = new GeoDistance('point', array('lat' => 30, 'lon' => 40), '40000km');
         $query = new Query(new MatchAll());
-        $query->setFilter($geoFilter);
+        $query->setPostFilter($geoFilter);
         $index->refresh();
 
         $this->assertEquals(2, $type->search($query)->count());

--- a/test/lib/Elastica/Test/Filter/GeoPolygonTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoPolygonTest.php
@@ -49,7 +49,7 @@ class GeoPolygonTest extends BaseTest
         $geoFilter = new GeoPolygon('location', $points);
 
         $query = new Query(new MatchAll());
-        $query->setFilter($geoFilter);
+        $query->setPostFilter($geoFilter);
         $this->assertEquals(1, $type->search($query)->count());
 
         // Both points should be inside
@@ -58,7 +58,7 @@ class GeoPolygonTest extends BaseTest
         $geoFilter = new GeoPolygon('location', $points);
 
         $query = new Query(new MatchAll());
-        $query->setFilter($geoFilter);
+        $query->setPostFilter($geoFilter);
 
         $this->assertEquals(2, $type->search($query)->count());
     }

--- a/test/lib/Elastica/Test/Filter/GeohashCellTest.php
+++ b/test/lib/Elastica/Test/Filter/GeohashCellTest.php
@@ -42,7 +42,7 @@ class GeohashCellTest extends BaseTest
 
         $filter = new GeohashCell('pin', array('lat' => 32.828326, 'lon' => -117.255854));
         $query = new \Elastica\Query();
-        $query->setFilter($filter);
+        $query->setPostFilter($filter);
         $results = $type->search($query);
 
         $this->assertEquals(1, $results->count());
@@ -50,7 +50,7 @@ class GeohashCellTest extends BaseTest
         //test precision parameter
         $filter = new GeohashCell('pin', '9', 1);
         $query = new \Elastica\Query();
-        $query->setFilter($filter);
+        $query->setPostFilter($filter);
         $results = $type->search($query);
 
         $this->assertEquals(2, $results->count());

--- a/test/lib/Elastica/Test/Filter/HasChildTest.php
+++ b/test/lib/Elastica/Test/Filter/HasChildTest.php
@@ -77,7 +77,7 @@ class HasChildTest extends BaseTest
         $filter = new HasChild($f, 'child');
 
         $searchQuery = new \Elastica\Query();
-        $searchQuery->setFilter($filter);
+        $searchQuery->setPostFilter($filter);
         $searchResults = $index->search($searchQuery);
 
         $this->assertEquals(1, $searchResults->count());
@@ -97,7 +97,7 @@ class HasChildTest extends BaseTest
         $filter = new HasChild($f, 'child');
 
         $searchQuery = new \Elastica\Query();
-        $searchQuery->setFilter($filter);
+        $searchQuery->setPostFilter($filter);
         $searchResults = $index->search($searchQuery);
 
         $this->assertEquals(1, $searchResults->count());
@@ -117,7 +117,7 @@ class HasChildTest extends BaseTest
         $filter = new HasChild($f, 'child');
         
         $searchQuery = new \Elastica\Query();
-        $searchQuery->setFilter($filter);
+        $searchQuery->setPostFilter($filter);
         $searchResults = $index->search($searchQuery);
         
         $this->assertEquals(1, $searchResults->count());

--- a/test/lib/Elastica/Test/Filter/HasParentTest.php
+++ b/test/lib/Elastica/Test/Filter/HasParentTest.php
@@ -77,7 +77,7 @@ class HasParentTest extends BaseTest
         $filter = new HasParent($f, 'parent');
 
         $searchQuery = new \Elastica\Query();
-        $searchQuery->setFilter($filter);
+        $searchQuery->setPostFilter($filter);
         $searchResults = $index->search($searchQuery);
 
         $this->assertEquals(1, $searchResults->count());
@@ -97,7 +97,7 @@ class HasParentTest extends BaseTest
         $filter = new HasParent($f, 'parent');
 
         $searchQuery = new \Elastica\Query();
-        $searchQuery->setFilter($filter);
+        $searchQuery->setPostFilter($filter);
         $searchResults = $index->search($searchQuery);
 
         $this->assertEquals(1, $searchResults->count());

--- a/test/lib/Elastica/Test/Filter/IndicesTest.php
+++ b/test/lib/Elastica/Test/Filter/IndicesTest.php
@@ -71,7 +71,7 @@ class IndicesTest extends BaseTest
         $filter = new Indices(new BoolNot(new Term(array("color" => "blue"))), array($this->_index1->getName()));
         $filter->setNoMatchFilter(new BoolNot(new Term(array("color" => "yellow"))));
         $query = new Query();
-        $query->setFilter($filter);
+        $query->setPostFilter($filter);
 
         // search over the alias
         $index = $this->_getClient()->getIndex("indices_filter");

--- a/test/lib/Elastica/Test/Filter/TermsTest.php
+++ b/test/lib/Elastica/Test/Filter/TermsTest.php
@@ -28,24 +28,24 @@ class TermsTest extends BaseTest
         $termsFilter = new Terms();
         $termsFilter->setLookup('lastName', $type2, 'led zeppelin', 'members', NULL);
         $query = new \Elastica\Query();
-        $query->setFilter($termsFilter);
+        $query->setPostFilter($termsFilter);
         $results = $index->search($query);
         $this->assertEquals($results->count(), 4, 'Terms lookup with null index');
         
         $termsFilter->setLookup('lastName', $type2, 'led zeppelin', 'members', $index);
-        $query->setFilter($termsFilter);
+        $query->setPostFilter($termsFilter);
         $results = $index->search($query);
         $this->assertEquals($results->count(), 4, 'Terms lookup with index as object');
         
         //Query with index given as string
         $termsFilter->setLookup('lastName', $type2, 'led zeppelin', 'members', $index->getName());
-        $query->setFilter($termsFilter);
+        $query->setPostFilter($termsFilter);
         $results = $index->search($query);
         $this->assertEquals($results->count(), 4, 'Terms lookup with index as string');
         
         //Query with array of options
         $termsFilter->setLookup('lastName', $type2, 'led zeppelin', 'members', array('index' => $index, 'cache' => false));
-        $query->setFilter($termsFilter);
+        $query->setPostFilter($termsFilter);
         $results = $index->search($query);
         $this->assertEquals($results->count(), 4, 'Terms lookup with options array');
         

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -532,7 +532,7 @@ class TypeTest extends BaseTest
         $query              = new Query();
         $filterTerm         = new Term();
         $filterTerm->setTerm('visible', true);
-        $query->setFilter($filterTerm);
+        $query->setPostFilter($filterTerm);
 
         $resultSet = $type->moreLikeThis($document, array('min_term_freq' => '1', 'min_doc_freq' => '1'), $query);
         $this->assertEquals(2, $resultSet->count());


### PR DESCRIPTION
resolves #669 

This should work fine. 

Some of the tests should probably be rewritten to use FIlteredQuery instead of Query->setPostFilter(). The results are fine ... but You should use setPostFilter only to filter results after facets/aggregations have been calculated.
