### PR TITLE
add notice descriptions for setFields  #673

### DIFF
--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -251,6 +251,8 @@ class Query extends Param
 
     /**
      * Sets the fields to be returned by the search
+     * NOTICE php will encode modified(or named keys) array into object format in json format request
+     * so the fields array must a sequence(list) type of array
      *
      * @param  array          $fields Fields to be returned
      * @return \Elastica\Query Current object


### PR DESCRIPTION
params fields must be sequence(list) array to prevent php encode array into object format in json request
