### PR TITLE
i think this is a bug:

### DIFF
--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -240,7 +240,7 @@ class Mapping
             throw new InvalidException('Type has to be set');
         }
 
-        return array($type->getName() => $this->_mapping);
+        return $this->_mapping;
     }
 
     /**


### PR DESCRIPTION
when i create a index and set a mapping send, it will show me the erro:
'Root type mapping not empty after parsing! Remaining fields'

$this->_index = $this->_client->getIndex('thread');
$this->_type = $this->_index->getType('data');

$this->_index->create(
					[
						"number_of_shards" => 20,
						"number_of_replicas" => 0,
						"refresh_interval" => "3s"
					]
				);

$map = new Mapping($this->_type);
				$map->setAllField(
					[
						"indexAnalyzer" => "index_ansj",
						"searchAnalyzer" => "query_ansj",
						"term_vector" => "no",
						"store" => "true"
					]
				);

$this->_type->setMapping($map);

then it will show erro