### PR TITLE
Move ResultSet creation to the Client

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-10-05
+ - ResultSet creation moved to static ResultSet::create() method #690
+
 2014-10-04
 - Release v1.3.4.0
 - Update to elasticsearch 1.3.4 #691

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -16,6 +16,13 @@ use Elastica\Exception\InvalidException;
 class ResultSet implements \Iterator, \Countable, \ArrayAccess
 {
     /**
+     * Class for the static create method to use.
+     *
+     * @var string
+     */
+    protected static $_class = 'Elastica\\ResultSet';
+
+    /**
      * Results
      *
      * @var array Results
@@ -74,6 +81,31 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
         $this->rewind();
         $this->_init($response);
         $this->_query = $query;
+    }
+
+    /**
+     * Creates a new ResultSet object. Can be configured to return a different
+     * implementation of the ResultSet class.
+     *
+     * @param Response $response
+     * @param Query $query
+     * @return ResultSet
+     */
+    public static function create(Response $response, Query $query)
+    {
+        $class = static::$_class;
+
+        return new $class($response, $query);
+    }
+
+    /**
+     * Sets the class to be used for the static create method.
+     *
+     * @param string $class
+     */
+    public static function setClass($class)
+    {
+        static::$_class = $class;
     }
 
     /**

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -436,7 +436,7 @@ class Search
             $params
         );
 
-        return new ResultSet($response, $query);
+        return ResultSet::create($response, $query);
     }
 
     /**
@@ -458,7 +458,7 @@ class Search
             $query->toArray(),
             array(self::OPTION_SEARCH_TYPE => self::OPTION_SEARCH_TYPE_COUNT)
         );
-        $resultSet = new ResultSet($response, $query);
+        $resultSet = ResultSet::create($response, $query);
 
         return $fullResult ? $resultSet : $resultSet->getTotalHits();
     }

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -492,7 +492,7 @@ class Type implements SearchableInterface
 
         $response = $this->request($path, Request::GET, $query->toArray(), $params);
 
-        return new ResultSet($response, $query);
+        return ResultSet::create($response, $query);
     }
 
     /**


### PR DESCRIPTION
FOSElasticaBundle needs to override the Result object to provide additional methods. Without this change, it means we need to override many more methods in the Index and Type classes, and I'd prefer to support consumption of Elastica without making users use our Index/Type objects.

I wish to add a method, getTransformed() to the result which will lazily transform an entire ResultSet when accessed, allowing us to remain much closer to the Elastica API rather than providing our own.
