### PR TITLE
Adding magic __call()

### DIFF
--- a/lib/Elastica/Result.php
+++ b/lib/Elastica/Result.php
@@ -213,4 +213,20 @@ class Result
 
         return array_key_exists($key, $source) && $source[$key] !== null;
     }
+    
+    /**
+     * Magic function is triggered when invoking inaccessible methods in an object context.
+     *
+     * Returns null if key does not exist
+     *
+     * @param string $key Key name
+     * @param array $arguments enumerated array containing the parameters passed to the $key method
+     * @return mixed  Key value
+     */
+    public function __call($key, $arguments)
+    {
+        $source = $this->getData();
+
+        return array_key_exists($key, $source) ? $source[$key] : null;
+    }
 }


### PR DESCRIPTION
I'm using Elastica with Symfony and when I try to call for a key that has `null` as value inside Twig the Symfony throws:

```
Method "keyName" for object "Elastica\Result" does not exist in MyBundle:FolderName:myTemplate.html.twig at line X
```

Inside twig template I call like this:

``` twig
{{ elasticaResultVariable.keyName }}
```

Adding this magic `__call` it works.

Maybe there is something better to do, so you can cancel this PR.
