### PR TITLE
Added Util::convertDateTimeObject to support converting \DateTime object...

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-10-22
+- Added Util::convertDateTimeObject to Util class to easily convert \DateTime objects to required format #708
+
 2014-10-10
 - Fixed Response::isOk() to work better with bulk update api
 

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -120,6 +120,23 @@ class Util
     }
 
     /**
+     * Convert a \DateTime object to format: 1995-12-31T23:59:59Z+02:00
+     *
+     * Converts it to the lucene format, including the appropriate TimeZone
+     *
+     * @param \DateTime $dateTime
+     * @param boolean $includeTimezone
+     * @return string
+     */
+    public static function convertDateTimeObject(\DateTime $dateTime, $includeTimezone = true)
+    {
+        $formatString = 'Y-m-d\TH:i:s' . ($includeTimezone === true ? 'P' : '\Z');
+        $string = $dateTime->format($formatString);
+
+        return $string;
+    }
+
+    /**
      * Tries to guess the name of the param, based on its class
      * Example: \Elastica\Filter\HasChildFilter => has_child
      *

--- a/test/lib/Elastica/Test/UtilTest.php
+++ b/test/lib/Elastica/Test/UtilTest.php
@@ -74,4 +74,28 @@ class UtilTest extends BaseTest
         $this->assertEquals($expected, $curlCommand);
 
     }
+
+    public function testConvertDateTimeObjectWithTimezone()
+    {
+        $dateTimeObject = new \DateTime();
+        $timestamp = $dateTimeObject->getTimestamp();
+
+        $convertedString = Util::convertDateTimeObject($dateTimeObject);
+
+        $date = date('Y-m-d\TH:i:sP', $timestamp);
+
+        $this->assertEquals($convertedString, $date);
+    }
+
+    public function testConvertDateTimeObjectWithoutTimezone()
+    {
+        $dateTimeObject = new \DateTime();
+        $timestamp = $dateTimeObject->getTimestamp();
+
+        $convertedString = Util::convertDateTimeObject($dateTimeObject, false);
+
+        $date = date('Y-m-d\TH:i:s\Z', $timestamp);
+
+        $this->assertEquals($convertedString, $date);
+    }
 }


### PR DESCRIPTION
As per issue #708 , added another method into the `Util` class called `Util::convertDateTimeObject` to simplify \DateTime conversion to the required lucene format. 
