### PR TITLE
Deprecating PSR-0 in favor of PSR-4

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2014-10-31
+- Adding PSR-4 autoloading support
+
 2014-10-22
 - Added Util::convertDateTimeObject to Util class to easily convert \DateTime objects to required format #708
 

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
         "monolog/monolog": "Logging request"
     },
     "autoload": {
-        "psr-0": {
-            "Elastica": "lib/",
-            "Elastica\\Test": "test/lib/"
+        "psr-4": {
+            "Elastica\\": "lib/Elastica/",
+            "Elastica\\Test\\": "test/lib/Elastica/Test/"
         }
     },
     "extra": {


### PR DESCRIPTION
As of 2014-10-21 PSR-0 has been marked as deprecated. PSR-4 is now recommended as an alternative (http://www.php-fig.org/psr/psr-0)
