### PR TITLE
Timeout considered in milliseconds

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,5 @@
 CHANGES
+
 2014-11-13
 - New timeInMillis config parameter in Elastica\Client, default false. Timeout could be considered as millisecods from now on.
 - New method getTimeInMillis to Elastica\Connection, determining whether the timeout should be considered as millisecods.

--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,8 @@
 CHANGES
+2014-11-13
+- New timeInMillis config parameter in Elastica\Client, default false. Timeout could be considered as millisecods from now on.
+- New method getTimeInMillis to Elastica\Connection, determining whether the timeout should be considered as millisecods.
+- Elastica\Transport\Http selects CURLOPT_TIMEOUT_MS depending on that config parameter
 
 2014-10-31
 - Adding PSR-4 autoloading support

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -27,19 +27,19 @@ class Client
      * @var array
      */
     protected $_config = array(
-        'host'            => null,
-        'port'            => null,
-        'path'            => null,
-        'url'             => null,
-        'proxy'           => null,
-        'transport'       => null,
-        'persistent'      => true,
-        'timeout'         => null,
-        'timeInMillis'    => false,
-        'connections'     => array(), // host, port, path, timeout, transport, persistent, timeout, timeInMillis, config -> (curl, headers, url)
-        'roundRobin'      => false,
-        'log'             => false,
-        'retryOnConflict' => 0,
+        'host'               => null,
+        'port'               => null,
+        'path'               => null,
+        'url'                => null,
+        'proxy'              => null,
+        'transport'          => null,
+        'persistent'         => true,
+        'timeout'            => null,
+        'millisecondTimeout' => false,
+        'connections'        => array(), // host, port, path, timeout, transport, persistent, timeout, millisecondTimeout, config -> (curl, headers, url)
+        'roundRobin'         => false,
+        'log'                => false,
+        'retryOnConflict'    => 0,
     );
 
     /**

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -35,7 +35,8 @@ class Client
         'transport'       => null,
         'persistent'      => true,
         'timeout'         => null,
-        'connections'     => array(), // host, port, path, timeout, transport, persistent, timeout, config -> (curl, headers, url)
+        'timeInMillis'    => false,
+        'connections'     => array(), // host, port, path, timeout, transport, persistent, timeout, timeInMillis, config -> (curl, headers, url)
         'roundRobin'      => false,
         'log'             => false,
         'retryOnConflict' => 0,
@@ -85,7 +86,7 @@ class Client
     protected function _initConnections()
     {
         $connections = array();
-        
+
         foreach ($this->getConfig('connections') as $connection) {
             $connections[] = Connection::create($this->_prepareConnectionParams($connection));
         }
@@ -100,7 +101,7 @@ class Client
         if (empty($connections)) {
             $connections[] = Connection::create($this->_prepareConnectionParams($this->getConfig()));
         }
-        
+
         if (!isset($this->_config['connectionStrategy'])) {
             if ($this->getConfig('roundRobin') === true) {
                 $this->setConfigValue('connectionStrategy', 'RoundRobin');
@@ -108,9 +109,9 @@ class Client
                 $this->setConfigValue('connectionStrategy', 'Simple');
             }
         }
-        
+
         $strategy = Connection\Strategy\StrategyFactory::create($this->getConfig('connectionStrategy'));
-        
+
         $this->_connectionPool = new Connection\ConnectionPool($connections, $strategy, $this->_callback);
     }
 
@@ -456,7 +457,7 @@ class Client
 
     /**
      * Determines whether a valid connection is available for use.
-     * 
+     *
      * @return bool
      */
     public function hasConnection()
@@ -480,9 +481,9 @@ class Client
     {
         return $this->_connectionPool->getConnections();
     }
-    
+
     /**
-     * 
+     *
      * @return \Connection\Strategy\StrategyInterface
      */
     public function getConnectionStrategy()

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -162,17 +162,17 @@ class Connection extends Param
      * @param bool                 $timeInMillis Whether timeout should be considered as millisecods.
      * @return \Elastica\Connection
      */
-    public function setTimeInMillis($timeInMillis)
+    public function setMillisecondTimeout($millisecondTimeout)
     {
-        return $this->setParam('timeInMillis', ($timeInMillis === true)?:false);
+        return $this->setParam('millisecondTimeout', ($millisecondTimeout === true)?:false);
     }
 
     /**
      * @return bool Whether timeout should be taken as milliseconds
      */
-    public function getTimeInMillis()
+    public function getMillisecondTimeout()
     {
-        return (bool) $this->hasParam('timeInMillis')?($this->getParam('timeInMillis') === true):false;
+        return (bool) $this->hasParam('millisecondTimeout')?($this->getParam('millisecondTimeout') === true):false;
     }
 
     /**

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -39,7 +39,7 @@ class Connection extends Param
     /**
      * Creates a new connection object. A connection is enabled by default
      *
-     * @param array $params OPTIONAL Connection params: host, port, transport, timeout. All are optional
+     * @param array $params OPTIONAL Connection params: host, port, transport, timeout, timeInMillis. All are optional
      */
     public function __construct(array $params = array())
     {
@@ -156,6 +156,23 @@ class Connection extends Param
     public function getTimeout()
     {
         return (int) $this->hasParam('timeout')?$this->getParam('timeout'):self::TIMEOUT;
+    }
+
+    /**
+     * @param bool                 $timeInMillis Whether timeout should be considered as millisecods.
+     * @return \Elastica\Connection
+     */
+    public function setTimeInMillis($timeInMillis)
+    {
+        return $this->setParam('timeInMillis', ($timeInMillis === true)?:false);
+    }
+
+    /**
+     * @return bool Whether timeout should be taken as milliseconds
+     */
+    public function getTimeInMillis()
+    {
+        return (bool) $this->hasParam('timeInMillis')?($this->getParam('timeInMillis') === true):false;
     }
 
     /**

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -68,7 +68,11 @@ class Http extends AbstractTransport
         }
 
         curl_setopt($conn, CURLOPT_URL, $baseUri);
-        curl_setopt($conn, CURLOPT_TIMEOUT, $connection->getTimeout());
+        if ($connection->getTimeInMillis()) {
+            curl_setopt($conn, CURLOPT_TIMEOUT_MS, $connection->getTimeout());
+        } else {
+            curl_setopt($conn, CURLOPT_TIMEOUT, $connection->getTimeout());
+        }
         curl_setopt($conn, CURLOPT_FORBID_REUSE, 0);
 
         $proxy = $connection->getProxy();

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -68,7 +68,7 @@ class Http extends AbstractTransport
         }
 
         curl_setopt($conn, CURLOPT_URL, $baseUri);
-        if ($connection->getTimeInMillis()) {
+        if ($connection->getMillisecondTimeout()) {
             curl_setopt($conn, CURLOPT_TIMEOUT_MS, $connection->getTimeout());
         } else {
             curl_setopt($conn, CURLOPT_TIMEOUT, $connection->getTimeout());

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -70,6 +70,7 @@ class Http extends AbstractTransport
         curl_setopt($conn, CURLOPT_URL, $baseUri);
         if ($connection->getMillisecondTimeout()) {
             curl_setopt($conn, CURLOPT_TIMEOUT_MS, $connection->getTimeout());
+            curl_setopt($conn, CURLOPT_NOSIGNAL,   1);
         } else {
             curl_setopt($conn, CURLOPT_TIMEOUT, $connection->getTimeout());
         }

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -1007,15 +1007,15 @@ class ClientTest extends BaseTest
     }
 
     /**
-     * Tries to determine whether the value for timeInMillis is propagated
+     * Tries to determine whether the value for millisecondTimeout is propagated
      * to the connection, in absence of either connections or server config
      * parameters in constructor config array
      */
-    public function testTimeInMillisFromDefaultConfig() {
+    public function testMillisecondTimeoutFromDefaultConfig() {
         $client = new Client();
-        $this->assertFalse($client->getConnection()->getTimeInMillis());
+        $this->assertFalse($client->getConnection()->getMillisecondTimeout());
 
-        $client = new Client(array("timeInMillis" => true));
-        $this->assertTrue($client->getConnection()->getTimeInMillis());
+        $client = new Client(array("millisecondTimeout" => true));
+        $this->assertTrue($client->getConnection()->getMillisecondTimeout());
     }
 }

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -958,18 +958,18 @@ class ClientTest extends BaseTest
         $this->assertEquals('value3', $client->getConfigValue(array('level1', 'level2', 'level3')));
         $this->assertInternalType('array', $client->getConfigValue(array('level1', 'level2')));
     }
-    
-    
+
+
     public function testArrayQuery()
     {
         $client = new Client();
-        
+
         $index = $client->getIndex('test');
         $index->create(array(), true);
         $type = $index->getType('test');
         $type->addDocument(new Document(1, array('username' => 'ruflin')));
         $index->refresh();
-        
+
         $query = array(
             'query' => array(
                 'query_string' => array(
@@ -977,32 +977,45 @@ class ClientTest extends BaseTest
                 )
             )
         );
-        
+
         $path = $index->getName() . '/' . $type->getName() . '/_search';
-        
+
         $response = $client->request($path, Request::GET, $query);
         $responseArray = $response->getData();
-        
+
         $this->assertEquals(1, $responseArray['hits']['total']);
     }
-    
+
     public function testJSONQuery()
     {
         $client = new Client();
-        
+
         $index = $client->getIndex('test');
         $index->create(array(), true);
         $type = $index->getType('test');
         $type->addDocument(new Document(1, array('username' => 'ruflin')));
         $index->refresh();
-        
+
         $query = '{"query":{"query_string":{"query":"ruflin"}}}';
 
         $path = $index->getName() . '/' . $type->getName() . '/_search';
-        
+
         $response = $client->request($path, Request::GET, $query);
         $responseArray = $response->getData();
-        
+
         $this->assertEquals(1, $responseArray['hits']['total']);
+    }
+
+    /**
+     * Tries to determine whether the value for timeInMillis is propagated
+     * to the connection, in absence of either connections or server config
+     * parameters in constructor config array
+     */
+    public function testTimeInMillisFromDefaultConfig() {
+        $client = new Client();
+        $this->assertFalse($client->getConnection()->getTimeInMillis());
+
+        $client = new Client(["timeInMillis" => true]);
+        $this->assertTrue($client->getConnection()->getTimeInMillis());
     }
 }

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -1015,7 +1015,7 @@ class ClientTest extends BaseTest
         $client = new Client();
         $this->assertFalse($client->getConnection()->getTimeInMillis());
 
-        $client = new Client(["timeInMillis" => true]);
+        $client = new Client(array("timeInMillis" => true));
         $this->assertTrue($client->getConnection()->getTimeInMillis());
     }
 }

--- a/test/lib/Elastica/Test/ConnectionTest.php
+++ b/test/lib/Elastica/Test/ConnectionTest.php
@@ -19,7 +19,7 @@ class ConnectionTest extends BaseTest
         $this->assertEquals(Connection::TIMEOUT, $connection->getTimeout());
         $this->assertEquals(array(), $connection->getConfig());
         $this->assertTrue($connection->isEnabled());
-        $this->assertFalse($connection->getTimeInMillis());
+        $this->assertFalse($connection->getMillisecondTimeout());
     }
 
     public function testEnabledDisable()
@@ -104,22 +104,22 @@ class ConnectionTest extends BaseTest
 
     public function testTimestampMilliseconds()
     {
-        $connection = new Connection(array('timeInMillis' => false));
-        $this->assertFalse($connection->getTimeInMillis());
+        $connection = new Connection(array('millisecondTimeout' => false));
+        $this->assertFalse($connection->getMillisecondTimeout());
 
-        $connection = new Connection(array('timeInMillis' => true));
-        $this->assertTrue($connection->getTimeInMillis());
+        $connection = new Connection(array('millisecondTimeout' => true));
+        $this->assertTrue($connection->getMillisecondTimeout());
 
-        $connection = new Connection(array('timeInMillis' => 'foo'));
-        $this->assertFalse($connection->getTimeInMillis());
+        $connection = new Connection(array('millisecondTimeout' => 'foo'));
+        $this->assertFalse($connection->getMillisecondTimeout());
 
         $connection = new Connection();
-        $this->assertFalse($connection->getTimeInMillis());
-        $connection->setTimeInMillis(true);
-        $this->assertTrue($connection->getTimeInMillis());
-        $connection->setTimeInMillis(false);
-        $this->assertFalse($connection->getTimeInMillis());
-        $connection->setTimeInMillis("foo");
-        $this->assertFalse($connection->getTimeInMillis());
+        $this->assertFalse($connection->getMillisecondTimeout());
+        $connection->setMillisecondTimeout(true);
+        $this->assertTrue($connection->getMillisecondTimeout());
+        $connection->setMillisecondTimeout(false);
+        $this->assertFalse($connection->getMillisecondTimeout());
+        $connection->setMillisecondTimeout("foo");
+        $this->assertFalse($connection->getMillisecondTimeout());
     }
 }

--- a/test/lib/Elastica/Test/ConnectionTest.php
+++ b/test/lib/Elastica/Test/ConnectionTest.php
@@ -19,6 +19,7 @@ class ConnectionTest extends BaseTest
         $this->assertEquals(Connection::TIMEOUT, $connection->getTimeout());
         $this->assertEquals(array(), $connection->getConfig());
         $this->assertTrue($connection->isEnabled());
+        $this->assertFalse($connection->getTimeInMillis());
     }
 
     public function testEnabledDisable()
@@ -99,5 +100,26 @@ class ConnectionTest extends BaseTest
     {
         $connection = new Connection();
         $connection->getConfig('url');
+    }
+
+    public function testTimestampMilliseconds()
+    {
+        $connection = new Connection(array('timeInMillis' => false));
+        $this->assertFalse($connection->getTimeInMillis());
+
+        $connection = new Connection(array('timeInMillis' => true));
+        $this->assertTrue($connection->getTimeInMillis());
+
+        $connection = new Connection(array('timeInMillis' => 'foo'));
+        $this->assertFalse($connection->getTimeInMillis());
+
+        $connection = new Connection();
+        $this->assertFalse($connection->getTimeInMillis());
+        $connection->setTimeInMillis(true);
+        $this->assertTrue($connection->getTimeInMillis());
+        $connection->setTimeInMillis(false);
+        $this->assertFalse($connection->getTimeInMillis());
+        $connection->setTimeInMillis("foo");
+        $this->assertFalse($connection->getTimeInMillis());
     }
 }


### PR DESCRIPTION
## Goal
Allowing timeouts in milliseconds

## Need
For a high performance system, I needed a connection to elasticsearch, that couldn't last more that 250ms. If that case occurs, there's a fallback in memory. 

## Problem
There's no option for curlopt_timeout_ms developed.

## Solution
A new parameter on the connection that determines whether the timeout given should be considered as milliseconds or not.

## Tests
I run the tests and everything worked fine. 

## Feedback
Please, contact me in case of any doubt.
