### PR TITLE
allow to customize the key on a range aggregation

### DIFF
--- a/lib/Elastica/Aggregation/Range.php
+++ b/lib/Elastica/Aggregation/Range.php
@@ -15,10 +15,11 @@ class Range extends AbstractSimpleAggregation
      * Add a range to this aggregation
      * @param int|float $fromValue low end of this range, exclusive (greater than)
      * @param int|float $toValue high end of this range, exclusive (less than)
+     * @param string $key customized key value
      * @return Range
      * @throws \Elastica\Exception\InvalidException
      */
-    public function addRange($fromValue = null, $toValue = null)
+    public function addRange($fromValue = null, $toValue = null, $key = null)
     {
         if (is_null($fromValue) && is_null($toValue)) {
             throw new InvalidException("Either fromValue or toValue must be set. Both cannot be null.");
@@ -30,6 +31,10 @@ class Range extends AbstractSimpleAggregation
         if (!is_null($toValue)) {
             $range['to'] = $toValue;
         }
+        if (!is_null($key)) {
+            $range['key'] = $key;
+        }
+
         return $this->addParam('ranges', $range);
     }
 
@@ -42,4 +47,4 @@ class Range extends AbstractSimpleAggregation
     {
         return $this->setParam('keyed', (bool)$keyed);
     }
-} 
+}

--- a/test/lib/Elastica/Test/Aggregation/RangeTest.php
+++ b/test/lib/Elastica/Test/Aggregation/RangeTest.php
@@ -37,5 +37,38 @@ class RangeTest extends BaseAggregationTest
 
         $this->assertEquals(2, $results['buckets'][0]['doc_count']);
     }
-}
- 
+
+
+    public function testRangeAggregationWithKey()
+    {
+        $agg = new Range("range");
+        $agg->setField("price");
+        $agg->addRange(null, 50, "cheap");
+        $agg->addRange(50, 100, "average");
+        $agg->addRange(100, null, "expensive");
+
+        $expected = array (
+            'range' =>
+                array (
+                    'field' => 'price',
+                    'ranges' =>
+                        array (
+                            array (
+                                'to' => 50,
+                                'key' => 'cheap',
+                            ),
+                            array (
+                                'from' => 50,
+                                'to' => 100,
+                                'key' => 'average',
+                            ),
+                            array (
+                                'from' => 100,
+                                'key' => 'expensive',
+                            ),
+                        ),
+                ),
+        );
+
+        $this->assertEquals($expected, $agg->toArray());
+    }}


### PR DESCRIPTION
The range aggregation allow to customize the key for each range :

The documentation about this could be found here :
http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-aggregations-bucket-range-aggregation.html#_keyed_responsea

Now, the Range aggregation class has a thrird (optionnal) parameter to the `addRange` method
to passe the range customized key name.
