### PR TITLE
making sure id is urlencoded when using updateDocument

### DIFF
--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -148,8 +148,10 @@ class Type implements SearchableInterface
             throw new InvalidException('Document or Script id is not set');
         }
 
+        $id = urlencode($data->getId());
+
         return $this->getIndex()->getClient()->updateDocument(
-            $data->getId(),
+            $id,
             $data,
             $this->getIndex()->getName(),
             $this->getName(),

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -565,6 +565,32 @@ class TypeTest extends BaseTest
         $this->assertEquals(3, $updatedDoc['counter'], "Counter was not incremented");
     }
 
+    public function testUpdateDocumentWithIdForwardSlashes()
+    {
+        $client = $this->_getClient();
+        $index = $client->getIndex('elastica_test');
+        $type = $index->getType('update_type');
+        $id = '/id/with/forward/slashes';
+        $type->addDocument(new Document($id, array('name' => 'bruce wayne batman', 'counter' => 1)));
+        $newName = 'batman';
+
+        $document = new Document();
+        $script = new Script(
+            "ctx._source.name = name; ctx._source.counter += count",
+            array(
+                'name' => $newName,
+                'count' => 2,
+            ),
+            null,
+            $id
+        );
+        $script->setUpsert($document);
+
+        $type->updateDocument($script, array('refresh' => true));
+        $updatedDoc = $type->getDocument($id)->getData();
+        $this->assertEquals($newName, $updatedDoc['name'], "Name was not updated");
+        $this->assertEquals(3, $updatedDoc['counter'], "Counter was not incremented");
+    }
     public function testUpdateDocumentWithParameter()
     {
         $client = $this->_getClient();


### PR DESCRIPTION
Yesterday I tried to update existing elasticsearch document using Type class. Because all of my documents ids contain forward slashes elastica was throwing an exception and documents were not updated.

So when using:

(existing document)
$doc->getId() -> '/some/path'
$doc->getData() -> array(data here)

Then using
$type->updateDocument($doc);

Documents was not updated.

I have created a test and fix. Let me know if this is valid. Cheers

Mike
