### PR TITLE
Create .gitattributes with basic export-ignores

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/test export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+.coveralls.yml export-ignore


### PR DESCRIPTION
Files and directories with the attribute export-ignore won’t be added to archive files. This will prevent composer from downloading unnecessary files (i.e: tests) when --prefer-dist is set.