### PR TITLE
Set correct script attributes in AbstractSimpleAggregation

### DIFF
--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -25,8 +25,7 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
     public function setScript($script)
     {
         if ($script instanceof Script) {
-            $this->setParam('params', $script->getParams());
-            $script = $script->getScript();
+            return $this->setParams($script->toArray());
         }
         return $this->setParam('script', $script);
     }

--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -25,7 +25,8 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
     public function setScript($script)
     {
         if ($script instanceof Script) {
-            return $this->setParams($script->toArray());
+            $params = array_merge($this->getParams(), $script->toArray());
+            return $this->setParams($params);
         }
         return $this->setParam('script', $script);
     }

--- a/test/lib/Elastica/Test/Aggregation/ScriptTest.php
+++ b/test/lib/Elastica/Test/Aggregation/ScriptTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Elastica\Test\Aggregation;
+
+
+use Elastica\Aggregation\Sum;
+use Elastica\Document;
+use Elastica\Query;
+use Elastica\Script;
+
+class ScriptTest extends BaseAggregationTest
+{
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->_index = $this->_createIndex( 'script' );
+		$docs = array(
+			new Document('1', array('price' => 5)),
+			new Document('2', array('price' => 8)),
+			new Document('3', array('price' => 1)),
+			new Document('4', array('price' => 3)),
+		);
+		$this->_index->getType( 'test' )->addDocuments( $docs );
+		$this->_index->refresh();
+	}
+
+	public function testAggregationScript()
+	{
+		$agg = new Sum( "sum" );
+		// x = (0..1) is groovy-specific syntax, to see if lang is recognized
+		$script = new Script( "x = (0..1); return doc['price'].value", null, "groovy" );
+		$agg->setScript( $script );
+
+		$query = new Query();
+		$query->addAggregation( $agg );
+		$results = $this->_index->search( $query )->getAggregation( "sum" );
+
+		$this->assertEquals( 5 + 8 + 1 + 3, $results['value'] );
+	}
+
+	public function testSetScript() {
+		$aggregation = "sum";
+		$string = "doc['price'].value";
+		$params = array(
+			'param1' => 'one',
+			'param2' => 1,
+		);
+		$lang = "groovy";
+
+		$agg = new Sum( $aggregation );
+		$script = new Script( $string, $params, $lang );
+		$agg->setScript( $script );
+
+		$array = $agg->toArray();
+
+		$expected = array(
+			$aggregation => array(
+				'script' => $string,
+				'params' => $params,
+				'lang' => $lang,
+			)
+		);
+		$this->assertEquals($expected, $array);
+	}
+}

--- a/test/lib/Elastica/Test/Aggregation/ScriptTest.php
+++ b/test/lib/Elastica/Test/Aggregation/ScriptTest.php
@@ -13,29 +13,29 @@ class ScriptTest extends BaseAggregationTest
 	protected function setUp()
 	{
 		parent::setUp();
-		$this->_index = $this->_createIndex( 'script' );
+		$this->_index = $this->_createIndex('script');
 		$docs = array(
 			new Document('1', array('price' => 5)),
 			new Document('2', array('price' => 8)),
 			new Document('3', array('price' => 1)),
 			new Document('4', array('price' => 3)),
 		);
-		$this->_index->getType( 'test' )->addDocuments( $docs );
+		$this->_index->getType('test')->addDocuments($docs);
 		$this->_index->refresh();
 	}
 
 	public function testAggregationScript()
 	{
-		$agg = new Sum( "sum" );
+		$agg = new Sum("sum");
 		// x = (0..1) is groovy-specific syntax, to see if lang is recognized
-		$script = new Script( "x = (0..1); return doc['price'].value", null, "groovy" );
-		$agg->setScript( $script );
+		$script = new Script("x = (0..1); return doc['price'].value", null, "groovy");
+		$agg->setScript($script);
 
 		$query = new Query();
-		$query->addAggregation( $agg );
-		$results = $this->_index->search( $query )->getAggregation( "sum" );
+		$query->addAggregation($agg);
+		$results = $this->_index->search($query)->getAggregation("sum");
 
-		$this->assertEquals( 5 + 8 + 1 + 3, $results['value'] );
+		$this->assertEquals(5 + 8 + 1 + 3, $results['value']);
 	}
 
 	public function testSetScript() {
@@ -47,9 +47,9 @@ class ScriptTest extends BaseAggregationTest
 		);
 		$lang = "groovy";
 
-		$agg = new Sum( $aggregation );
-		$script = new Script( $string, $params, $lang );
-		$agg->setScript( $script );
+		$agg = new Sum($aggregation);
+		$script = new Script($string, $params, $lang);
+		$agg->setScript($script);
 
 		$array = $agg->toArray();
 

--- a/test/lib/Elastica/Test/Aggregation/ScriptTest.php
+++ b/test/lib/Elastica/Test/Aggregation/ScriptTest.php
@@ -38,6 +38,18 @@ class ScriptTest extends BaseAggregationTest
 		$this->assertEquals(5 + 8 + 1 + 3, $results['value']);
 	}
 
+	public function testAggregationScriptAsString()
+	{
+		$agg = new Sum("sum");
+		$agg->setScript("doc['price'].value");
+
+		$query = new Query();
+		$query->addAggregation( $agg );
+		$results = $this->_index->search($query)->getAggregation("sum");
+
+		$this->assertEquals(5 + 8 + 1 + 3, $results['value']);
+	}
+
 	public function testSetScript() {
 		$aggregation = "sum";
 		$string = "doc['price'].value";


### PR DESCRIPTION
Existing code would not set 'lang' (making it impossible to e.g. use groovy in those scripts)
It would also always add 'params', even if there aren't any