### PR TITLE
Use instanceof instead of is_a

### DIFF
--- a/lib/Elastica/Aggregation/AbstractAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractAggregation.php
@@ -62,7 +62,7 @@ abstract class AbstractAggregation extends Param
      */
     public function addAggregation(AbstractAggregation $aggregation)
     {
-        if(is_a($aggregation, 'Elastica\Aggregation\GlobalAggregation')) {
+        if ($aggregation instanceof GlobalAggregation) {
             throw new InvalidException('Global aggregators can only be placed as top level aggregators');
         }
 


### PR DESCRIPTION
The `is_a` method is deprecated in favour of the instanceof operator.