### PR TITLE
Fix travis build

### DIFF
--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: import elasticsearch gpg key
   apt_key: >
     id=D88E42B4
-    keyserver=pgp.mit.edu
+    url=https://packages.elasticsearch.org/GPG-KEY-elasticsearch
     state=present
 
 - name: add elasticsearch repository


### PR DESCRIPTION

Right now some builds ([1](https://travis-ci.org/ruflin/Elastica/jobs/46968655), [2](https://travis-ci.org/ruflin/Elastica/jobs/46968653), [3](https://travis-ci.org/ruflin/Elastica/jobs/46819813), [4](https://travis-ci.org/ruflin/Elastica/jobs/46968652), [5](https://travis-ci.org/ruflin/Elastica/jobs/46968648), etc) failed on step when ansible trying to import ES repository gpg key.
I'm don't sure what exactly going wrong (from virtualbox import works fine, so maybe network settings or something travis-specific), but possible solution is to retrieve key by url instead of keyserver.