### PR TITLE
Add missing interface to ElasticsearchException

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2015-01-27
+- Exception\ElasticsearchException now can be catched like all other exceptions as Exception\ExceptionInterface
+
 2015-01-25
 - Release v1.4.2.0
 

--- a/lib/Elastica/Exception/ElasticsearchException.php
+++ b/lib/Elastica/Exception/ElasticsearchException.php
@@ -9,7 +9,7 @@ namespace Elastica\Exception;
  * @package Elastica
  * @author Ian Babrou <ibobrik@gmail.com>
  */
-class ElasticsearchException extends \Exception
+class ElasticsearchException extends \Exception implements ExceptionInterface
 {
     const REMOTE_TRANSPORT_EXCEPTION = 'RemoteTransportException';
 

--- a/test/lib/Elastica/Test/Exception/Bulk/Response/ActionExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Bulk/Response/ActionExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Elastica\Test\Exception\Bulk\Response;
+
+use Elastica\Test\Base as BaseTest;
+
+class ActionExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = $this->getMockBuilder('Elastica\Exception\Bulk\Response\ActionException')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/Bulk/ResponseExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Bulk/ResponseExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Elastica\Test\Exception\Bulk;
+
+use Elastica\Test\Base as BaseTest;
+
+class ResponseExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = $this->getMockBuilder('Elastica\Exception\Bulk\ResponseException')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/Bulk/UdpExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Bulk/UdpExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Elastica\Test\Exception\Bulk;
+
+use Elastica\Exception\Bulk\UdpException;
+use Elastica\Test\Base as BaseTest;
+
+class UdpExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = new UdpException();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/BulkExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/BulkExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Elastica\Test\Exception;
+
+use Elastica\Exception\BulkException;
+use Elastica\Test\Base as BaseTest;
+
+class BulkExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = new BulkException();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/ClientExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ClientExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Elastica\Test\Exception;
+
+use Elastica\Exception\ClientException;
+use Elastica\Test\Base as BaseTest;
+
+class ClientExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = new ClientException();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/Connection/GuzzleExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/GuzzleExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Elastica\Test\Exception\Connection;
+
+use Elastica\Test\Base as BaseTest;
+
+class GuzzleExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = $this->getMockBuilder('Elastica\Exception\Connection\GuzzleException')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/Connection/GuzzleExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/GuzzleExceptionTest.php
@@ -5,6 +5,13 @@ use Elastica\Test\Base as BaseTest;
 
 class GuzzleExceptionTest extends BaseTest
 {
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists('GuzzleHttp\\Client')) {
+            self::markTestSkipped('guzzlehttp/guzzle package should be installed to run guzzle transport tests');
+        }
+    }
+
     public function testInheritance()
     {
         $exception = $this->getMockBuilder('Elastica\Exception\Connection\GuzzleException')

--- a/test/lib/Elastica/Test/Exception/Connection/HttpExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/HttpExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Elastica\Test\Exception\Connection;
+
+use Elastica\Test\Base as BaseTest;
+
+class HttpExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = $this->getMockBuilder('Elastica\Exception\Connection\HttpException')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/Connection/ThriftExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/ThriftExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Elastica\Test\Exception\Connection;
+
+use Elastica\Test\Base as BaseTest;
+
+class ThriftExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = $this->getMockBuilder('Elastica\Exception\Connection\ThriftException')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/Connection/ThriftExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/ThriftExceptionTest.php
@@ -5,6 +5,13 @@ use Elastica\Test\Base as BaseTest;
 
 class ThriftExceptionTest extends BaseTest
 {
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists('Elasticsearch\\RestClient')) {
+            self::markTestSkipped('munkie/elasticsearch-thrift-php package should be installed to run thrift exception tests');
+        }
+    }
+
     public function testInheritance()
     {
         $exception = $this->getMockBuilder('Elastica\Exception\Connection\ThriftException')

--- a/test/lib/Elastica/Test/Exception/ConnectionExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ConnectionExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Elastica\Test\Exception;
+
+use Elastica\Test\Base as BaseTest;
+
+class ConnectionExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = $this->getMockBuilder('Elastica\Exception\ConnectionException')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/ElasticsearchExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ElasticsearchExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Elastica\Test\Exception;
+
+use Elastica\Test\Base as BaseTest;
+
+class ElasticsearchExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = $this->getMockBuilder('Elastica\Exception\ElasticsearchException')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/InvalidExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/InvalidExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Elastica\Test\Exception;
+
+use Elastica\Exception\InvalidException;
+use Elastica\Test\Base as BaseTest;
+
+class InvalidExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = new InvalidException();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/JSONParseExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/JSONParseExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Elastica\Test\Exception;
+
+use Elastica\Exception\JSONParseException;
+use Elastica\Test\Base as BaseTest;
+
+class JSONParseExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = new JSONParseException();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/NotFoundExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/NotFoundExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Elastica\Test\Exception;
+
+use Elastica\Exception\NotFoundException;
+use Elastica\Test\Base as BaseTest;
+
+class NotFoundExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = new NotFoundException();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/NotImplementedExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/NotImplementedExceptionTest.php
@@ -1,22 +1,23 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 use Elastica\Exception\NotImplementedException;
 use Elastica\Test\Base as BaseTest;
 
-class NotImplementedTest extends BaseTest
+class NotImplementedExceptionTest extends BaseTest
 {
+    public function testInheritance()
+    {
+        $exception = new NotImplementedException();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+
     public function testInstance()
     {
         $code = 4;
         $message = 'Hello world';
         $exception = new NotImplementedException($message, $code);
-
-        $this->assertInstanceOf('Elastica\Exception\NotImplementedException', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-        $this->assertInstanceOf('Exception', $exception);
-
         $this->assertEquals($message, $exception->getMessage());
         $this->assertEquals($code, $exception->getCode());
     }

--- a/test/lib/Elastica/Test/Exception/PartialShardFailureExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/PartialShardFailureExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 use Elastica\Document;
@@ -10,6 +9,14 @@ use Elastica\Test\Base as BaseTest;
 
 class PartialShardFailureExceptionTest extends BaseTest
 {
+    public function testInheritance()
+    {
+        $exception = $this->getMockBuilder('Elastica\Exception\PartialShardFailureException')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
 
     public function testPartialFailure()
     {

--- a/test/lib/Elastica/Test/Exception/QueryBuilderExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/QueryBuilderExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Elastica\Test\Exception;
+
+use Elastica\Exception\QueryBuilderException;
+use Elastica\Test\Base as BaseTest;
+
+class QueryBuilderExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = new QueryBuilderException();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/test/lib/Elastica/Test/Exception/ResponseExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ResponseExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 use Elastica\Document;
@@ -8,6 +7,14 @@ use Elastica\Test\Base as BaseTest;
 
 class ResponseExceptionTest extends BaseTest
 {
+    public function testInheritance()
+    {
+        $exception = $this->getMockBuilder('Elastica\Exception\ResponseException')
+                          ->disableOriginalConstructor()
+                          ->getMock();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
 
     public function testCreateExistingIndex()
     {

--- a/test/lib/Elastica/Test/Exception/RuntimeExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/RuntimeExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace Elastica\Test\Exception;
+
+use Elastica\Exception\RuntimeException;
+use Elastica\Test\Base as BaseTest;
+
+class RuntimeExceptionTest extends BaseTest
+{
+    public function testInheritance()
+    {
+        $exception = new RuntimeException();
+        $this->assertInstanceOf('Exception', $exception);
+        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
+    }
+}


### PR DESCRIPTION
This addition provides 100% assurance in behavior of code below (for example, used in [Monolog](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/ElasticSearchHandler.php#L122)):
```php
try {
    // do something
} catch (Elastica\Exception\ExceptionInterface $ex) {
    // ignore all possible exceptions from elastica,
    // but let all other exceptions be thrown
}
```
