### PR TITLE
reset php 5.3 tests on travis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,19 +1,19 @@
 <?php
 
 $finder = Symfony\CS\Finder\DefaultFinder::create()
-    ->in(['lib', 'test']);
+    ->in(array('lib', 'test'));
 
 $config = Symfony\CS\Config\Config::create()
     ->setUsingCache(true)
     ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers([
+    ->fixers(array(
         // [contrib] Multi-line whitespace before closing semicolon are prohibited.
         'multiline_spaces_before_semicolon',
         // [contrib] There should be no blank lines before a namespace declaration.
         'no_blank_lines_before_namespace',
         // [contrib] Ordering use statements.
         'ordered_use',
-    ])
+    ))
     ->finder($finder);
 
 return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 before_script:
   - mkdir -p build/logs
   - echo "extension=memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - if [ $ES_COMPOSER_NODEV == "no" ] && ! $(php -v | head -1 | grep -q 'PHP 5.3'); then composer require "guzzlehttp/guzzle" "4.2.*" --dev --no-ansi --no-progress --no-interaction; fi
 
 script:
   - phpunit -c test/phpunit-travis.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6
+
+matrix:
+    allow_failures:
+        - php: 5.3
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ install:
 before_script:
   - mkdir -p build/logs
   - echo "extension=memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - if [ $ES_COMPOSER_NODEV == "no" ] && ! $(php -v | head -1 | grep -q 'PHP 5.3'); then composer require "guzzlehttp/guzzle" "4.2.*" --dev --no-ansi --no-progress --no-interaction; fi
 
 script:
   - phpunit -c test/phpunit-travis.xml

--- a/changes.txt
+++ b/changes.txt
@@ -1,4 +1,6 @@
 CHANGES
+2015-02-04
+- Reset PHP 5.3 tests
 
 2015-01-27
 - Exception\ElasticsearchException now can be catched like all other exceptions as Exception\ExceptionInterface

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "require-dev": {
         "munkie/elasticsearch-thrift-php": "1.4.*",
         "phpunit/phpunit": "4.1.*",
-        "guzzlehttp/guzzle": "4.2.*",
         "fabpot/php-cs-fixer": "~1.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require-dev": {
         "munkie/elasticsearch-thrift-php": "1.4.*",
         "phpunit/phpunit": "4.1.*",
+        "guzzlehttp/guzzle": "4.2.*",
         "fabpot/php-cs-fixer": "~1.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.3.3",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/lib/Elastica/Index/Status.php
+++ b/lib/Elastica/Index/Status.php
@@ -93,7 +93,7 @@ class Status
             return array_keys($data['aliases']);
         }
 
-        return [];
+        return array();
     }
 
     /**

--- a/test/lib/Elastica/Test/ClusterTest.php
+++ b/test/lib/Elastica/Test/ClusterTest.php
@@ -16,7 +16,7 @@ class ClusterTest extends BaseTest
         $cluster = new Cluster($client);
 
         foreach ($cluster->getNodeNames() as $name) {
-            $this->assertContains($name, ['Silver Fox', 'Skywalker', 'Wolverine']);
+            $this->assertContains($name, array('Silver Fox', 'Skywalker', 'Wolverine'));
         }
     }
 

--- a/test/lib/Elastica/Test/NodeTest.php
+++ b/test/lib/Elastica/Test/NodeTest.php
@@ -50,7 +50,7 @@ class NodeTest extends BaseTest
         $nodes = $this->_getClient()->getCluster()->getNodes();
         $this->assertCount(3, $nodes);
         foreach ($nodes as $node) {
-            $this->assertContains($node->getName(), ['Silver Fox', 'Skywalker', 'Wolverine']);
+            $this->assertContains($node->getName(), array('Silver Fox', 'Skywalker', 'Wolverine'));
         }
     }
 }

--- a/test/lib/Elastica/Test/PercolatorTest.php
+++ b/test/lib/Elastica/Test/PercolatorTest.php
@@ -163,7 +163,7 @@ class PercolatorTest extends BaseTest
         $percolator = new Percolator($index);
 
         $query = new Term(array('name' => 'foobar'));
-        $percolator->registerQuery($percolatorName, $query, array('field1' => ['tag1', 'tag2']));
+        $percolator->registerQuery($percolatorName, $query, array('field1' => array('tag1', 'tag2')));
 
         return $percolator;
     }
@@ -231,13 +231,13 @@ class PercolatorTest extends BaseTest
         $percolator = new Percolator($index);
 
         $query = new Term(array('name' => 'foo'));
-        $response = $percolator->registerQuery('percotest', $query, array( 'field1' => ['tag1', 'tag2']));
+        $response = $percolator->registerQuery('percotest', $query, array( 'field1' => array('tag1', 'tag2')));
 
         $this->assertTrue($response->isOk());
         $this->assertFalse($response->hasError());
 
         $query = new Term(array('name' => 'foo'));
-        $response = $percolator->registerQuery('percotest1', $query, array( 'field1' => ['tag2']));
+        $response = $percolator->registerQuery('percotest1', $query, array( 'field1' => array('tag2')));
 
         $this->assertTrue($response->isOk());
         $this->assertFalse($response->hasError());
@@ -266,7 +266,7 @@ class PercolatorTest extends BaseTest
         $percolator = $this->_getDefaultPercolator($percolatorName);
 
         $query = new Term(array('name' => 'foobar'));
-        $percolator->registerQuery($percolatorName.'1', $query, array('field1' => ['tag2']));
+        $percolator->registerQuery($percolatorName.'1', $query, array('field1' => array('tag2')));
 
         $index      = $percolator->getIndex();
         $type       = $this->_addDefaultDocuments($index);

--- a/test/lib/Elastica/Test/SearchTest.php
+++ b/test/lib/Elastica/Test/SearchTest.php
@@ -357,7 +357,7 @@ class SearchTest extends BaseTest
         $this->assertTrue(($resultSet->count() === 0) && $resultSet->getTotalHits() === 11);
 
         //Timeout - this one is a bit more tricky to test
-        $mockResponse = new \Elastica\Response(json_encode(['timed_out' => true]));
+        $mockResponse = new \Elastica\Response(json_encode(array('timed_out' => true)));
         $client = $this->getMockBuilder('Elastica\\Client')
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
This PR is due to the discussion about PHP 5.3 [here](https://github.com/ruflin/Elastica/pull/764#issuecomment-72378573).

The short array syntax has been remove [in this PR](https://github.com/ruflin/Elastica/pull/737/files) by the way so it seems as simple as that. :)