### PR TITLE
closes ruflin/Elastica#770

### DIFF
--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -67,7 +67,7 @@ class Guzzle extends AbstractTransport
         }
 
         $req = $client->createRequest($request->getMethod(), $this->_getActionPath($request), $options);
-        $req->setHeaders($connection->hasConfig('headers') ?: array());
+        $req->setHeaders($connection->hasConfig('headers') ? $connection->getConfig('headers') : array());
 
         $data = $request->getData();
         if (!empty($data) || '0' === $data) {


### PR DESCRIPTION
The Function "setHeader" expect an array, but "hasConfig" returns a boolean value. So we must not use the ternary operator here.