### PR TITLE
Fix IDE doc for better auto-completion

### DIFF
--- a/lib/Elastica/Aggregation/AbstractAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractAggregation.php
@@ -58,7 +58,7 @@ abstract class AbstractAggregation extends Param
      * Add a sub-aggregation
      * @param  AbstractAggregation                  $aggregation
      * @throws \Elastica\Exception\InvalidException
-     * @return AbstractAggregation
+     * @return static
      */
     public function addAggregation(AbstractAggregation $aggregation)
     {

--- a/lib/Elastica/Aggregation/AbstractAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractAggregation.php
@@ -58,7 +58,7 @@ abstract class AbstractAggregation extends Param
      * Add a sub-aggregation
      * @param  AbstractAggregation                  $aggregation
      * @throws \Elastica\Exception\InvalidException
-     * @return static
+     * @return $this
      */
     public function addAggregation(AbstractAggregation $aggregation)
     {

--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -9,7 +9,7 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
     /**
      * Set the field for this aggregation
      * @param  string                    $field the name of the document field on which to perform this aggregation
-     * @return AbstractSimpleAggregation
+     * @return static
      */
     public function setField($field)
     {
@@ -19,7 +19,7 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
     /**
      * Set a script for this aggregation
      * @param  string|Script             $script
-     * @return AbstractSimpleAggregation
+     * @return static
      */
     public function setScript($script)
     {

--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -9,7 +9,7 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
     /**
      * Set the field for this aggregation
      * @param  string                    $field the name of the document field on which to perform this aggregation
-     * @return static
+     * @return $this
      */
     public function setField($field)
     {
@@ -19,7 +19,7 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
     /**
      * Set a script for this aggregation
      * @param  string|Script             $script
-     * @return static
+     * @return $this
      */
     public function setScript($script)
     {

--- a/lib/Elastica/Aggregation/Histogram.php
+++ b/lib/Elastica/Aggregation/Histogram.php
@@ -24,7 +24,7 @@ class Histogram extends AbstractSimpleAggregation
     /**
      * Set the interval by which documents will be bucketed
      * @param  int       $interval
-     * @return static
+     * @return $this
      */
     public function setInterval($interval)
     {
@@ -35,7 +35,7 @@ class Histogram extends AbstractSimpleAggregation
      * Set the bucket sort order
      * @param  string    $order     "_count", "_term", or the name of a sub-aggregation or sub-aggregation response field
      * @param  string    $direction "asc" or "desc"
-     * @return static
+     * @return $this
      */
     public function setOrder($order, $direction)
     {
@@ -45,7 +45,7 @@ class Histogram extends AbstractSimpleAggregation
     /**
      * Set the minimum number of documents which must fall into a bucket in order for the bucket to be returned
      * @param  int       $count set to 0 to include empty buckets
-     * @return static
+     * @return $this
      */
     public function setMinimumDocumentCount($count)
     {

--- a/lib/Elastica/Aggregation/Histogram.php
+++ b/lib/Elastica/Aggregation/Histogram.php
@@ -24,7 +24,7 @@ class Histogram extends AbstractSimpleAggregation
     /**
      * Set the interval by which documents will be bucketed
      * @param  int       $interval
-     * @return Histogram
+     * @return static
      */
     public function setInterval($interval)
     {
@@ -35,7 +35,7 @@ class Histogram extends AbstractSimpleAggregation
      * Set the bucket sort order
      * @param  string    $order     "_count", "_term", or the name of a sub-aggregation or sub-aggregation response field
      * @param  string    $direction "asc" or "desc"
-     * @return Histogram
+     * @return static
      */
     public function setOrder($order, $direction)
     {
@@ -45,7 +45,7 @@ class Histogram extends AbstractSimpleAggregation
     /**
      * Set the minimum number of documents which must fall into a bucket in order for the bucket to be returned
      * @param  int       $count set to 0 to include empty buckets
-     * @return Histogram
+     * @return static
      */
     public function setMinimumDocumentCount($count)
     {

--- a/lib/Elastica/Aggregation/Range.php
+++ b/lib/Elastica/Aggregation/Range.php
@@ -15,7 +15,7 @@ class Range extends AbstractSimpleAggregation
      * @param  int|float                            $fromValue low end of this range, exclusive (greater than)
      * @param  int|float                            $toValue   high end of this range, exclusive (less than)
      * @param  string                               $key       customized key value
-     * @return static
+     * @return $this
      * @throws \Elastica\Exception\InvalidException
      */
     public function addRange($fromValue = null, $toValue = null, $key = null)
@@ -40,7 +40,7 @@ class Range extends AbstractSimpleAggregation
     /**
      * If set to true, a unique string key will be associated with each bucket, and ranges will be returned as an associative array
      * @param  bool  $keyed
-     * @return static
+     * @return $this
      */
     public function setKeyedResponse($keyed = true)
     {

--- a/lib/Elastica/Aggregation/Range.php
+++ b/lib/Elastica/Aggregation/Range.php
@@ -15,7 +15,7 @@ class Range extends AbstractSimpleAggregation
      * @param  int|float                            $fromValue low end of this range, exclusive (greater than)
      * @param  int|float                            $toValue   high end of this range, exclusive (less than)
      * @param  string                               $key       customized key value
-     * @return Range
+     * @return static
      * @throws \Elastica\Exception\InvalidException
      */
     public function addRange($fromValue = null, $toValue = null, $key = null)
@@ -40,7 +40,7 @@ class Range extends AbstractSimpleAggregation
     /**
      * If set to true, a unique string key will be associated with each bucket, and ranges will be returned as an associative array
      * @param  bool  $keyed
-     * @return Range
+     * @return static
      */
     public function setKeyedResponse($keyed = true)
     {

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -78,7 +78,7 @@ class Param
      *
      * @param  string          $key   Key to set
      * @param  mixed           $value Key Value
-     * @return static
+     * @return $this
      */
     public function setParam($key, $value)
     {
@@ -91,7 +91,7 @@ class Param
      * Sets (overwrites) all params of this object
      *
      * @param  array           $params Parameter list
-     * @return static
+     * @return $this
      */
     public function setParams(array $params)
     {
@@ -107,7 +107,7 @@ class Param
      *
      * @param  string          $key   Param key
      * @param  mixed           $value Value to set
-     * @return static
+     * @return $this
      */
     public function addParam($key, $value)
     {

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -78,7 +78,7 @@ class Param
      *
      * @param  string          $key   Key to set
      * @param  mixed           $value Key Value
-     * @return \Elastica\Param
+     * @return static
      */
     public function setParam($key, $value)
     {
@@ -91,7 +91,7 @@ class Param
      * Sets (overwrites) all params of this object
      *
      * @param  array           $params Parameter list
-     * @return \Elastica\Param
+     * @return static
      */
     public function setParams(array $params)
     {
@@ -107,7 +107,7 @@ class Param
      *
      * @param  string          $key   Param key
      * @param  mixed           $value Value to set
-     * @return \Elastica\Param
+     * @return static
      */
     public function addParam($key, $value)
     {


### PR DESCRIPTION
On modern IDE (at least on PHPStorm), returning static allows to let the IDE resolve on real-time based on the caller type. This is necessary if we still want to have nice autocompletion with the fluent interface. I've only fixed that for param and aggregations, I'll do another PR in the future if I find other cases :)