### PR TITLE
Fix fluent interface inconsistency

### DIFF
--- a/lib/Elastica/AbstractUpdateAction.php
+++ b/lib/Elastica/AbstractUpdateAction.php
@@ -20,7 +20,7 @@ class AbstractUpdateAction extends Param
     /**
      * Sets the id of the document.
      *
-     * @param  string             $id
+     * @param  string $id
      * @return $this
      */
     public function setId($id)
@@ -49,7 +49,7 @@ class AbstractUpdateAction extends Param
     /**
      * Sets lifetime of document
      *
-     * @param  string             $ttl
+     * @param  string $ttl
      * @return $this
      */
     public function setTtl($ttl)
@@ -76,7 +76,7 @@ class AbstractUpdateAction extends Param
     /**
      * Sets the document type name
      *
-     * @param  string             $type Type name
+     * @param  string $type Type name
      * @return $this
      */
     public function setType($type)
@@ -92,8 +92,9 @@ class AbstractUpdateAction extends Param
     /**
      * Return document type name
      *
-     * @return string                               Document type name
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @return string Document type name
      */
     public function getType()
     {
@@ -103,7 +104,7 @@ class AbstractUpdateAction extends Param
     /**
      * Sets the document index name
      *
-     * @param  string             $index Index name
+     * @param  string $index Index name
      * @return $this
      */
     public function setIndex($index)
@@ -118,8 +119,9 @@ class AbstractUpdateAction extends Param
     /**
      * Get the document index name
      *
-     * @return string                               Index name
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @return string Index name
      */
     public function getIndex()
     {
@@ -129,7 +131,7 @@ class AbstractUpdateAction extends Param
     /**
      * Sets the version of a document for use with optimistic concurrency control
      *
-     * @param  int                $version Document version
+     * @param  int   $version Document version
      * @return $this
      * @link http://www.elasticsearch.org/blog/2011/02/08/versioning.html
      */
@@ -160,7 +162,7 @@ class AbstractUpdateAction extends Param
      * Sets the version_type of a document
      * Default in ES is internal, but you can set to external to use custom versioning
      *
-     * @param  int                $versionType Document version type
+     * @param  int   $versionType Document version type
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/index_.html
      */
@@ -190,7 +192,7 @@ class AbstractUpdateAction extends Param
     /**
      * Sets parent document id
      *
-     * @param  string|int         $parent Parent document id
+     * @param  string|int $parent Parent document id
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/mapping/parent-field.html
      */
@@ -220,7 +222,7 @@ class AbstractUpdateAction extends Param
     /**
      * Set operation type
      *
-     * @param  string             $opType Only accept create
+     * @param  string $opType Only accept create
      * @return $this
      */
     public function setOpType($opType)
@@ -248,7 +250,7 @@ class AbstractUpdateAction extends Param
     /**
      * Set percolate query param
      *
-     * @param  string             $value percolator filter
+     * @param  string $value percolator filter
      * @return $this
      */
     public function setPercolate($value = '*')
@@ -277,7 +279,7 @@ class AbstractUpdateAction extends Param
     /**
      * Set routing query param
      *
-     * @param  string             $value routing
+     * @param  string $value routing
      * @return $this
      */
     public function setRouting($value)
@@ -304,7 +306,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
-     * @param  array|string       $fields
+     * @param  array|string $fields
      * @return $this
      */
     public function setFields($fields)
@@ -341,7 +343,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
-     * @param  int                $num
+     * @param  int   $num
      * @return $this
      */
     public function setRetryOnConflict($num)
@@ -366,7 +368,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
-     * @param  string             $timestamp
+     * @param  string $timestamp
      * @return $this
      */
     public function setTimestamp($timestamp)
@@ -391,7 +393,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
-     * @param  bool               $refresh
+     * @param  bool  $refresh
      * @return $this
      */
     public function setRefresh($refresh = true)
@@ -416,7 +418,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
-     * @param  string             $timeout
+     * @param  string $timeout
      * @return $this
      */
     public function setTimeout($timeout)
@@ -441,7 +443,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
-     * @param  string             $timeout
+     * @param  string $timeout
      * @return $this
      */
     public function setConsistency($timeout)
@@ -466,7 +468,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
-     * @param  string             $timeout
+     * @param  string $timeout
      * @return $this
      */
     public function setReplication($timeout)

--- a/lib/Elastica/AbstractUpdateAction.php
+++ b/lib/Elastica/AbstractUpdateAction.php
@@ -21,7 +21,7 @@ class AbstractUpdateAction extends Param
      * Sets the id of the document.
      *
      * @param  string             $id
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setId($id)
     {
@@ -50,7 +50,7 @@ class AbstractUpdateAction extends Param
      * Sets lifetime of document
      *
      * @param  string             $ttl
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setTtl($ttl)
     {
@@ -77,7 +77,7 @@ class AbstractUpdateAction extends Param
      * Sets the document type name
      *
      * @param  string             $type Type name
-     * @return \Elastica\Document Current object
+     * @return $this
      */
     public function setType($type)
     {
@@ -104,7 +104,7 @@ class AbstractUpdateAction extends Param
      * Sets the document index name
      *
      * @param  string             $index Index name
-     * @return \Elastica\Document Current object
+     * @return $this
      */
     public function setIndex($index)
     {
@@ -130,7 +130,7 @@ class AbstractUpdateAction extends Param
      * Sets the version of a document for use with optimistic concurrency control
      *
      * @param  int                $version Document version
-     * @return \Elastica\Document Current object
+     * @return $this
      * @link http://www.elasticsearch.org/blog/2011/02/08/versioning.html
      */
     public function setVersion($version)
@@ -161,7 +161,7 @@ class AbstractUpdateAction extends Param
      * Default in ES is internal, but you can set to external to use custom versioning
      *
      * @param  int                $versionType Document version type
-     * @return \Elastica\Document Current object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/index_.html
      */
     public function setVersionType($versionType)
@@ -191,7 +191,7 @@ class AbstractUpdateAction extends Param
      * Sets parent document id
      *
      * @param  string|int         $parent Parent document id
-     * @return \Elastica\Document Current object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/mapping/parent-field.html
      */
     public function setParent($parent)
@@ -221,7 +221,7 @@ class AbstractUpdateAction extends Param
      * Set operation type
      *
      * @param  string             $opType Only accept create
-     * @return \Elastica\Document Current object
+     * @return $this
      */
     public function setOpType($opType)
     {
@@ -249,7 +249,7 @@ class AbstractUpdateAction extends Param
      * Set percolate query param
      *
      * @param  string             $value percolator filter
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setPercolate($value = '*')
     {
@@ -278,7 +278,7 @@ class AbstractUpdateAction extends Param
      * Set routing query param
      *
      * @param  string             $value routing
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setRouting($value)
     {
@@ -305,7 +305,7 @@ class AbstractUpdateAction extends Param
 
     /**
      * @param  array|string       $fields
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setFields($fields)
     {
@@ -317,7 +317,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setFieldsSource()
     {
@@ -342,7 +342,7 @@ class AbstractUpdateAction extends Param
 
     /**
      * @param  int                $num
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setRetryOnConflict($num)
     {
@@ -367,7 +367,7 @@ class AbstractUpdateAction extends Param
 
     /**
      * @param  string             $timestamp
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setTimestamp($timestamp)
     {
@@ -392,7 +392,7 @@ class AbstractUpdateAction extends Param
 
     /**
      * @param  bool               $refresh
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setRefresh($refresh = true)
     {
@@ -417,7 +417,7 @@ class AbstractUpdateAction extends Param
 
     /**
      * @param  string             $timeout
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setTimeout($timeout)
     {
@@ -442,7 +442,7 @@ class AbstractUpdateAction extends Param
 
     /**
      * @param  string             $timeout
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setConsistency($timeout)
     {
@@ -467,7 +467,7 @@ class AbstractUpdateAction extends Param
 
     /**
      * @param  string             $timeout
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setReplication($timeout)
     {
@@ -492,7 +492,7 @@ class AbstractUpdateAction extends Param
 
     /**
      * @param  \Elastica\Document|array $data
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setUpsert($data)
     {

--- a/lib/Elastica/Aggregation/AbstractAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractAggregation.php
@@ -8,14 +8,12 @@ use Elastica\Param;
 abstract class AbstractAggregation extends Param
 {
     /**
-     * The name of this aggregation
-     * @var string
+     * @var string The name of this aggregation
      */
     protected $_name;
 
     /**
-     * Subaggregations belonging to this aggregation
-     * @var array
+     * @var array Subaggregations belonging to this aggregation
      */
     protected $_aggs = array();
 
@@ -58,8 +56,9 @@ abstract class AbstractAggregation extends Param
 
     /**
      * Add a sub-aggregation
-     * @param  AbstractAggregation                  $aggregation
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  AbstractAggregation $aggregation
      * @return $this
      */
     public function addAggregation(AbstractAggregation $aggregation)

--- a/lib/Elastica/Aggregation/AbstractAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractAggregation.php
@@ -34,6 +34,8 @@ abstract class AbstractAggregation extends Param
     public function setName($name)
     {
         $this->_name = $name;
+
+        return $this;
     }
 
     /**

--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -8,7 +8,7 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
 {
     /**
      * Set the field for this aggregation
-     * @param  string                    $field the name of the document field on which to perform this aggregation
+     * @param  string $field the name of the document field on which to perform this aggregation
      * @return $this
      */
     public function setField($field)
@@ -18,7 +18,7 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
 
     /**
      * Set a script for this aggregation
-     * @param  string|Script             $script
+     * @param  string|Script $script
      * @return $this
      */
     public function setScript($script)

--- a/lib/Elastica/Aggregation/DateHistogram.php
+++ b/lib/Elastica/Aggregation/DateHistogram.php
@@ -12,7 +12,7 @@ class DateHistogram extends Histogram
     /**
      * Set pre-rounding based on interval
      * @param  string        $preZone
-     * @return DateHistogram
+     * @return $this
      */
     public function setPreZone($preZone)
     {
@@ -22,7 +22,7 @@ class DateHistogram extends Histogram
     /**
      * Set post-rounding based on interval
      * @param  string        $postZone
-     * @return DateHistogram
+     * @return $this
      */
     public function setPostZone($postZone)
     {
@@ -32,7 +32,7 @@ class DateHistogram extends Histogram
     /**
      * Set pre-zone adjustment for larger time intervals (day and above)
      * @param  string        $adjust
-     * @return DateHistogram
+     * @return $this
      */
     public function setPreZoneAdjustLargeInterval($adjust)
     {
@@ -42,7 +42,7 @@ class DateHistogram extends Histogram
     /**
      * Adjust for granularity of date data
      * @param  int           $factor set to 1000 if date is stored in seconds rather than milliseconds
-     * @return DateHistogram
+     * @return $this
      */
     public function setFactor($factor)
     {
@@ -52,7 +52,7 @@ class DateHistogram extends Histogram
     /**
      * Set the offset for pre-rounding
      * @param  string        $offset "1d", for example
-     * @return DateHistogram
+     * @return $this
      */
     public function setPreOffset($offset)
     {
@@ -62,7 +62,7 @@ class DateHistogram extends Histogram
     /**
      * Set the offset for post-rounding
      * @param  string        $offset "1d", for example
-     * @return DateHistogram
+     * @return $this
      */
     public function setPostOffset($offset)
     {
@@ -73,7 +73,7 @@ class DateHistogram extends Histogram
      * Set the format for returned bucket key_as_string values
      * @link http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-aggregations-bucket-daterange-aggregation.html#date-format-pattern
      * @param  string        $format see link for formatting options
-     * @return DateHistogram
+     * @return $this
      */
     public function setFormat($format)
     {

--- a/lib/Elastica/Aggregation/DateHistogram.php
+++ b/lib/Elastica/Aggregation/DateHistogram.php
@@ -11,7 +11,7 @@ class DateHistogram extends Histogram
 {
     /**
      * Set pre-rounding based on interval
-     * @param  string        $preZone
+     * @param  string $preZone
      * @return $this
      */
     public function setPreZone($preZone)
@@ -21,7 +21,7 @@ class DateHistogram extends Histogram
 
     /**
      * Set post-rounding based on interval
-     * @param  string        $postZone
+     * @param  string $postZone
      * @return $this
      */
     public function setPostZone($postZone)
@@ -31,7 +31,7 @@ class DateHistogram extends Histogram
 
     /**
      * Set pre-zone adjustment for larger time intervals (day and above)
-     * @param  string        $adjust
+     * @param  string $adjust
      * @return $this
      */
     public function setPreZoneAdjustLargeInterval($adjust)
@@ -41,7 +41,7 @@ class DateHistogram extends Histogram
 
     /**
      * Adjust for granularity of date data
-     * @param  int           $factor set to 1000 if date is stored in seconds rather than milliseconds
+     * @param  int   $factor set to 1000 if date is stored in seconds rather than milliseconds
      * @return $this
      */
     public function setFactor($factor)
@@ -51,7 +51,7 @@ class DateHistogram extends Histogram
 
     /**
      * Set the offset for pre-rounding
-     * @param  string        $offset "1d", for example
+     * @param  string $offset "1d", for example
      * @return $this
      */
     public function setPreOffset($offset)
@@ -61,7 +61,7 @@ class DateHistogram extends Histogram
 
     /**
      * Set the offset for post-rounding
-     * @param  string        $offset "1d", for example
+     * @param  string $offset "1d", for example
      * @return $this
      */
     public function setPostOffset($offset)
@@ -72,7 +72,7 @@ class DateHistogram extends Histogram
     /**
      * Set the format for returned bucket key_as_string values
      * @link http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/search-aggregations-bucket-daterange-aggregation.html#date-format-pattern
-     * @param  string        $format see link for formatting options
+     * @param  string $format see link for formatting options
      * @return $this
      */
     public function setFormat($format)

--- a/lib/Elastica/Aggregation/DateRange.php
+++ b/lib/Elastica/Aggregation/DateRange.php
@@ -12,7 +12,7 @@ class DateRange extends Range
     /**
      * Set the formatting for the returned date values
      * @param  string $format see documentation for formatting options
-     * @return Range
+     * @return $this
      */
     public function setFormat($format)
     {

--- a/lib/Elastica/Aggregation/Filter.php
+++ b/lib/Elastica/Aggregation/Filter.php
@@ -14,7 +14,7 @@ class Filter extends AbstractAggregation
     /**
      * Set the filter for this aggregation
      * @param  AbstractFilter $filter
-     * @return Filter
+     * @return $this
      */
     public function setFilter(AbstractFilter $filter)
     {

--- a/lib/Elastica/Aggregation/Filters.php
+++ b/lib/Elastica/Aggregation/Filters.php
@@ -18,7 +18,7 @@ class Filters extends AbstractAggregation
      *
      * @param  AbstractFilter $filter
      * @param  string         $name
-     * @return Filters
+     * @return $this
      */
     public function addFilter(AbstractFilter $filter, $name = '')
     {

--- a/lib/Elastica/Aggregation/GeoDistance.php
+++ b/lib/Elastica/Aggregation/GeoDistance.php
@@ -28,7 +28,7 @@ class GeoDistance extends AbstractAggregation
 
     /**
      * Set the field for this aggregation
-     * @param  string      $field the name of the document field on which to perform this aggregation
+     * @param  string $field the name of the document field on which to perform this aggregation
      * @return $this
      */
     public function setField($field)
@@ -48,20 +48,24 @@ class GeoDistance extends AbstractAggregation
 
     /**
      * Add a distance range to this aggregation
-     * @param  int                                  $fromValue a distance
-     * @param  int                                  $toValue   a distance
-     * @return $this
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  int   $fromValue a distance
+     * @param  int   $toValue   a distance
+     * @return $this
      */
     public function addRange($fromValue = null, $toValue = null)
     {
         if (is_null($fromValue) && is_null($toValue)) {
             throw new InvalidException("Either fromValue or toValue must be set. Both cannot be null.");
         }
+
         $range = array();
+
         if (!is_null($fromValue)) {
             $range['from'] = $fromValue;
         }
+
         if (!is_null($toValue)) {
             $range['to'] = $toValue;
         }
@@ -71,7 +75,7 @@ class GeoDistance extends AbstractAggregation
 
     /**
      * Set the unit of distance measure for  this aggregation
-     * @param  string      $unit defaults to km
+     * @param  string $unit defaults to km
      * @return $this
      */
     public function setUnit($unit)
@@ -81,7 +85,7 @@ class GeoDistance extends AbstractAggregation
 
     /**
      * Set the method by which distances will be calculated
-     * @param  string      $distanceType see DISTANCE_TYPE_* constants for options. Defaults to sloppy_arc.
+     * @param  string $distanceType see DISTANCE_TYPE_* constants for options. Defaults to sloppy_arc.
      * @return $this
      */
     public function setDistanceType($distanceType)

--- a/lib/Elastica/Aggregation/GeoDistance.php
+++ b/lib/Elastica/Aggregation/GeoDistance.php
@@ -29,7 +29,7 @@ class GeoDistance extends AbstractAggregation
     /**
      * Set the field for this aggregation
      * @param  string      $field the name of the document field on which to perform this aggregation
-     * @return GeoDistance
+     * @return $this
      */
     public function setField($field)
     {
@@ -39,7 +39,7 @@ class GeoDistance extends AbstractAggregation
     /**
      * Set the origin point from which distances will be calculated
      * @param  string|array $origin valid formats are array("lat" => 52.3760, "lon" => 4.894), "52.3760, 4.894", and array(4.894, 52.3760)
-     * @return GeoDistance
+     * @return $this
      */
     public function setOrigin($origin)
     {
@@ -50,7 +50,7 @@ class GeoDistance extends AbstractAggregation
      * Add a distance range to this aggregation
      * @param  int                                  $fromValue a distance
      * @param  int                                  $toValue   a distance
-     * @return GeoDistance
+     * @return $this
      * @throws \Elastica\Exception\InvalidException
      */
     public function addRange($fromValue = null, $toValue = null)
@@ -72,7 +72,7 @@ class GeoDistance extends AbstractAggregation
     /**
      * Set the unit of distance measure for  this aggregation
      * @param  string      $unit defaults to km
-     * @return GeoDistance
+     * @return $this
      */
     public function setUnit($unit)
     {
@@ -82,7 +82,7 @@ class GeoDistance extends AbstractAggregation
     /**
      * Set the method by which distances will be calculated
      * @param  string      $distanceType see DISTANCE_TYPE_* constants for options. Defaults to sloppy_arc.
-     * @return GeoDistance
+     * @return $this
      */
     public function setDistanceType($distanceType)
     {

--- a/lib/Elastica/Aggregation/GeohashGrid.php
+++ b/lib/Elastica/Aggregation/GeohashGrid.php
@@ -21,7 +21,7 @@ class GeohashGrid extends AbstractAggregation
 
     /**
      * Set the field for this aggregation
-     * @param  string      $field the name of the document field on which to perform this aggregation
+     * @param  string $field the name of the document field on which to perform this aggregation
      * @return $this
      */
     public function setField($field)
@@ -31,7 +31,7 @@ class GeohashGrid extends AbstractAggregation
 
     /**
      * Set the precision for this aggregation
-     * @param  int         $precision an integer between 1 and 12, inclusive. Defaults to 5.
+     * @param  int   $precision an integer between 1 and 12, inclusive. Defaults to 5.
      * @return $this
      */
     public function setPrecision($precision)
@@ -41,7 +41,7 @@ class GeohashGrid extends AbstractAggregation
 
     /**
      * Set the maximum number of buckets to return
-     * @param  int         $size defaults to 10,000
+     * @param  int   $size defaults to 10,000
      * @return $this
      */
     public function setSize($size)
@@ -51,7 +51,7 @@ class GeohashGrid extends AbstractAggregation
 
     /**
      * Set the number of results returned from each shard
-     * @param  int         $shardSize
+     * @param  int   $shardSize
      * @return $this
      */
     public function setShardSize($shardSize)

--- a/lib/Elastica/Aggregation/GeohashGrid.php
+++ b/lib/Elastica/Aggregation/GeohashGrid.php
@@ -22,7 +22,7 @@ class GeohashGrid extends AbstractAggregation
     /**
      * Set the field for this aggregation
      * @param  string      $field the name of the document field on which to perform this aggregation
-     * @return GeohashGrid
+     * @return $this
      */
     public function setField($field)
     {
@@ -32,7 +32,7 @@ class GeohashGrid extends AbstractAggregation
     /**
      * Set the precision for this aggregation
      * @param  int         $precision an integer between 1 and 12, inclusive. Defaults to 5.
-     * @return GeohashGrid
+     * @return $this
      */
     public function setPrecision($precision)
     {
@@ -42,7 +42,7 @@ class GeohashGrid extends AbstractAggregation
     /**
      * Set the maximum number of buckets to return
      * @param  int         $size defaults to 10,000
-     * @return GeohashGrid
+     * @return $this
      */
     public function setSize($size)
     {
@@ -52,7 +52,7 @@ class GeohashGrid extends AbstractAggregation
     /**
      * Set the number of results returned from each shard
      * @param  int         $shardSize
-     * @return GeohashGrid
+     * @return $this
      */
     public function setShardSize($shardSize)
     {

--- a/lib/Elastica/Aggregation/Histogram.php
+++ b/lib/Elastica/Aggregation/Histogram.php
@@ -23,7 +23,7 @@ class Histogram extends AbstractSimpleAggregation
 
     /**
      * Set the interval by which documents will be bucketed
-     * @param  int       $interval
+     * @param  int   $interval
      * @return $this
      */
     public function setInterval($interval)
@@ -33,8 +33,8 @@ class Histogram extends AbstractSimpleAggregation
 
     /**
      * Set the bucket sort order
-     * @param  string    $order     "_count", "_term", or the name of a sub-aggregation or sub-aggregation response field
-     * @param  string    $direction "asc" or "desc"
+     * @param  string $order     "_count", "_term", or the name of a sub-aggregation or sub-aggregation response field
+     * @param  string $direction "asc" or "desc"
      * @return $this
      */
     public function setOrder($order, $direction)
@@ -44,7 +44,7 @@ class Histogram extends AbstractSimpleAggregation
 
     /**
      * Set the minimum number of documents which must fall into a bucket in order for the bucket to be returned
-     * @param  int       $count set to 0 to include empty buckets
+     * @param  int   $count set to 0 to include empty buckets
      * @return $this
      */
     public function setMinimumDocumentCount($count)

--- a/lib/Elastica/Aggregation/IpRange.php
+++ b/lib/Elastica/Aggregation/IpRange.php
@@ -23,7 +23,7 @@ class IpRange extends AbstractAggregation
 
     /**
      * Set the field for this aggregation
-     * @param  string  $field the name of the document field on which to perform this aggregation
+     * @param  string $field the name of the document field on which to perform this aggregation
      * @return $this
      */
     public function setField($field)
@@ -56,7 +56,7 @@ class IpRange extends AbstractAggregation
 
     /**
      * Add an ip range in the form of a CIDR mask
-     * @param  string  $mask a valid CIDR mask
+     * @param  string $mask a valid CIDR mask
      * @return $this
      */
     public function addMaskRange($mask)

--- a/lib/Elastica/Aggregation/IpRange.php
+++ b/lib/Elastica/Aggregation/IpRange.php
@@ -24,7 +24,7 @@ class IpRange extends AbstractAggregation
     /**
      * Set the field for this aggregation
      * @param  string  $field the name of the document field on which to perform this aggregation
-     * @return IpRange
+     * @return $this
      */
     public function setField($field)
     {
@@ -35,7 +35,7 @@ class IpRange extends AbstractAggregation
      * Add an ip range to this aggregation
      * @param  string                               $fromValue a valid ipv4 address. Low end of this range, exclusive (greater than)
      * @param  string                               $toValue   a valid ipv4 address. High end of this range, exclusive (less than)
-     * @return IpRange
+     * @return $this
      * @throws \Elastica\Exception\InvalidException
      */
     public function addRange($fromValue = null, $toValue = null)
@@ -57,7 +57,7 @@ class IpRange extends AbstractAggregation
     /**
      * Add an ip range in the form of a CIDR mask
      * @param  string  $mask a valid CIDR mask
-     * @return IpRange
+     * @return $this
      */
     public function addMaskRange($mask)
     {

--- a/lib/Elastica/Aggregation/Missing.php
+++ b/lib/Elastica/Aggregation/Missing.php
@@ -22,7 +22,7 @@ class Missing extends AbstractAggregation
     /**
      * Set the field for this aggregation
      * @param  string  $field the name of the document field on which to perform this aggregation
-     * @return Missing
+     * @return $this
      */
     public function setField($field)
     {

--- a/lib/Elastica/Aggregation/Missing.php
+++ b/lib/Elastica/Aggregation/Missing.php
@@ -21,7 +21,7 @@ class Missing extends AbstractAggregation
 
     /**
      * Set the field for this aggregation
-     * @param  string  $field the name of the document field on which to perform this aggregation
+     * @param  string $field the name of the document field on which to perform this aggregation
      * @return $this
      */
     public function setField($field)

--- a/lib/Elastica/Aggregation/Nested.php
+++ b/lib/Elastica/Aggregation/Nested.php
@@ -22,7 +22,7 @@ class Nested extends AbstractAggregation
     /**
      * Set the nested path for this aggregation
      * @param  string $path
-     * @return Nested
+     * @return $this
      */
     public function setPath($path)
     {

--- a/lib/Elastica/Aggregation/Range.php
+++ b/lib/Elastica/Aggregation/Range.php
@@ -23,13 +23,17 @@ class Range extends AbstractSimpleAggregation
         if (is_null($fromValue) && is_null($toValue)) {
             throw new InvalidException("Either fromValue or toValue must be set. Both cannot be null.");
         }
+
         $range = array();
+
         if (!is_null($fromValue)) {
             $range['from'] = $fromValue;
         }
+
         if (!is_null($toValue)) {
             $range['to'] = $toValue;
         }
+
         if (!is_null($key)) {
             $range['key'] = $key;
         }

--- a/lib/Elastica/Aggregation/ReverseNested.php
+++ b/lib/Elastica/Aggregation/ReverseNested.php
@@ -27,7 +27,7 @@ class ReverseNested extends AbstractAggregation
      * Set the nested path for this aggregation
      *
      * @param  string        $path
-     * @return ReverseNested
+     * @return $this
      */
     public function setPath($path)
     {

--- a/lib/Elastica/Aggregation/ReverseNested.php
+++ b/lib/Elastica/Aggregation/ReverseNested.php
@@ -26,7 +26,7 @@ class ReverseNested extends AbstractAggregation
     /**
      * Set the nested path for this aggregation
      *
-     * @param  string        $path
+     * @param  string $path
      * @return $this
      */
     public function setPath($path)

--- a/lib/Elastica/Aggregation/ScriptedMetric.php
+++ b/lib/Elastica/Aggregation/ScriptedMetric.php
@@ -38,8 +38,7 @@ class ScriptedMetric extends AbstractAggregation
      * Set the field for this aggregation
      *
      * @param  string $script the name of the document field on which to perform this aggregation
-     *
-     * @return static
+     * @return $this
      */
     public function setCombineScript($script)
     {
@@ -50,8 +49,7 @@ class ScriptedMetric extends AbstractAggregation
      * Set the field for this aggregation
      *
      * @param  string $script the name of the document field on which to perform this aggregation
-     *
-     * @return static
+     * @return $this
      */
     public function setInitScript($script)
     {
@@ -62,8 +60,7 @@ class ScriptedMetric extends AbstractAggregation
      * Set the field for this aggregation
      *
      * @param  string $script the name of the document field on which to perform this aggregation
-     *
-     * @return static
+     * @return $this
      */
     public function setMapScript($script)
     {
@@ -74,8 +71,7 @@ class ScriptedMetric extends AbstractAggregation
      * Set the field for this aggregation
      *
      * @param  string $script the name of the document field on which to perform this aggregation
-     *
-     * @return static
+     * @return $this
      */
     public function setReduceScript($script)
     {

--- a/lib/Elastica/Aggregation/ScriptedMetric.php
+++ b/lib/Elastica/Aggregation/ScriptedMetric.php
@@ -77,5 +77,4 @@ class ScriptedMetric extends AbstractAggregation
     {
         return $this->setParam('reduce_script', $script);
     }
-
 }

--- a/lib/Elastica/Aggregation/Terms.php
+++ b/lib/Elastica/Aggregation/Terms.php
@@ -68,7 +68,7 @@ class Terms extends AbstractSimpleAggregation
 
     /**
      * Sets the amount of terms to be returned.
-     * @param  int                         $size The amount of terms to be returned.
+     * @param  int   $size The amount of terms to be returned.
      * @return $this
      */
     public function setSize($size)
@@ -78,7 +78,7 @@ class Terms extends AbstractSimpleAggregation
 
     /**
      * Sets how many terms the coordinating node will request from each shard.
-     * @param  int                         $shard_size The amount of terms to be returned.
+     * @param  int   $shard_size The amount of terms to be returned.
      * @return $this
      */
     public function setShardSize($shard_size)

--- a/lib/Elastica/Aggregation/Terms.php
+++ b/lib/Elastica/Aggregation/Terms.php
@@ -13,7 +13,7 @@ class Terms extends AbstractSimpleAggregation
      * Set the bucket sort order
      * @param  string $order     "_count", "_term", or the name of a sub-aggregation or sub-aggregation response field
      * @param  string $direction "asc" or "desc"
-     * @return Terms
+     * @return $this
      */
     public function setOrder($order, $direction)
     {
@@ -23,7 +23,7 @@ class Terms extends AbstractSimpleAggregation
     /**
      * Set the minimum number of documents in which a term must appear in order to be returned in a bucket
      * @param  int   $count
-     * @return Terms
+     * @return $this
      */
     public function setMinimumDocumentCount($count)
     {
@@ -34,7 +34,7 @@ class Terms extends AbstractSimpleAggregation
      * Filter documents to include based on a regular expression
      * @param  string $pattern a regular expression
      * @param  string $flags   Java Pattern flags
-     * @return Terms
+     * @return $this
      */
     public function setInclude($pattern, $flags = null)
     {
@@ -52,7 +52,7 @@ class Terms extends AbstractSimpleAggregation
      * Filter documents to exclude based on a regular expression
      * @param  string $pattern a regular expression
      * @param  string $flags   Java Pattern flags
-     * @return Terms
+     * @return $this
      */
     public function setExclude($pattern, $flags = null)
     {
@@ -69,7 +69,7 @@ class Terms extends AbstractSimpleAggregation
     /**
      * Sets the amount of terms to be returned.
      * @param  int                         $size The amount of terms to be returned.
-     * @return \Elastica\Aggregation\Terms
+     * @return $this
      */
     public function setSize($size)
     {
@@ -79,7 +79,7 @@ class Terms extends AbstractSimpleAggregation
     /**
      * Sets how many terms the coordinating node will request from each shard.
      * @param  int                         $shard_size The amount of terms to be returned.
-     * @return \Elastica\Aggregation\Terms
+     * @return $this
      */
     public function setShardSize($shard_size)
     {
@@ -90,7 +90,7 @@ class Terms extends AbstractSimpleAggregation
      * Instruct Elasticsearch to use direct field data or ordinals of the field values to execute this aggregation.
      * The execution hint will be ignored if it is not applicable.
      * @param  string $hint map or ordinals
-     * @return Terms
+     * @return $this
      */
     public function setExecutionHint($hint)
     {

--- a/lib/Elastica/Aggregation/TopHits.php
+++ b/lib/Elastica/Aggregation/TopHits.php
@@ -30,7 +30,7 @@ class TopHits extends AbstractAggregation
     /**
      * The maximum number of top matching hits to return per bucket. By default the top three matching hits are returned.
      *
-     * @param  int  $size
+     * @param  int   $size
      * @return $this
      */
     public function setSize($size)
@@ -41,7 +41,7 @@ class TopHits extends AbstractAggregation
     /**
      * The offset from the first result you want to fetch.
      *
-     * @param  int  $from
+     * @param  int   $from
      * @return $this
      */
     public function setFrom($from)
@@ -74,7 +74,7 @@ class TopHits extends AbstractAggregation
     /**
      * Returns a version for each search hit.
      *
-     * @param  bool $version
+     * @param  bool  $version
      * @return $this
      */
     public function setVersion($version)
@@ -85,7 +85,7 @@ class TopHits extends AbstractAggregation
     /**
      * Enables explanation for each hit on how its score was computed.
      *
-     * @param  bool $explain
+     * @param  bool  $explain
      * @return $this
      */
     public function setExplain($explain)

--- a/lib/Elastica/Aggregation/TopHits.php
+++ b/lib/Elastica/Aggregation/TopHits.php
@@ -31,7 +31,7 @@ class TopHits extends AbstractAggregation
      * The maximum number of top matching hits to return per bucket. By default the top three matching hits are returned.
      *
      * @param  int  $size
-     * @return self
+     * @return $this
      */
     public function setSize($size)
     {
@@ -42,7 +42,7 @@ class TopHits extends AbstractAggregation
      * The offset from the first result you want to fetch.
      *
      * @param  int  $from
-     * @return self
+     * @return $this
      */
     public function setFrom($from)
     {
@@ -53,7 +53,7 @@ class TopHits extends AbstractAggregation
      * How the top matching hits should be sorted. By default the hits are sorted by the score of the main query.
      *
      * @param  array $sortArgs
-     * @return self
+     * @return $this
      */
     public function setSort(array $sortArgs)
     {
@@ -64,7 +64,7 @@ class TopHits extends AbstractAggregation
      * Allows to control how the _source field is returned with every hit.
      *
      * @param  array $fields
-     * @return self
+     * @return $this
      */
     public function setSource(array $fields)
     {
@@ -75,7 +75,7 @@ class TopHits extends AbstractAggregation
      * Returns a version for each search hit.
      *
      * @param  bool $version
-     * @return self
+     * @return $this
      */
     public function setVersion($version)
     {
@@ -86,7 +86,7 @@ class TopHits extends AbstractAggregation
      * Enables explanation for each hit on how its score was computed.
      *
      * @param  bool $explain
-     * @return self
+     * @return $this
      */
     public function setExplain($explain)
     {
@@ -97,7 +97,7 @@ class TopHits extends AbstractAggregation
      * Set script fields
      *
      * @param  array|\Elastica\ScriptFields $scriptFields
-     * @return self
+     * @return $this
      */
     public function setScriptFields($scriptFields)
     {
@@ -113,7 +113,7 @@ class TopHits extends AbstractAggregation
      *
      * @param  string           $name
      * @param  \Elastica\Script $script
-     * @return self
+     * @return $this
      */
     public function addScriptField($name, Script $script)
     {
@@ -126,7 +126,7 @@ class TopHits extends AbstractAggregation
      * Sets highlight arguments for the results
      *
      * @param  array $highlightArgs
-     * @return self
+     * @return $this
      */
     public function setHighlight(array $highlightArgs)
     {
@@ -137,7 +137,7 @@ class TopHits extends AbstractAggregation
      * Allows to return the field data representation of a field for each hit
      *
      * @param  array $fields
-     * @return self
+     * @return $this
      */
     public function setFieldDataFields(array $fields)
     {

--- a/lib/Elastica/Aggregation/ValueCount.php
+++ b/lib/Elastica/Aggregation/ValueCount.php
@@ -22,7 +22,7 @@ class ValueCount extends AbstractAggregation
     /**
      * Set the field for this aggregation
      * @param  string     $field the name of the document field on which to perform this aggregation
-     * @return ValueCount
+     * @return $this
      */
     public function setField($field)
     {

--- a/lib/Elastica/Aggregation/ValueCount.php
+++ b/lib/Elastica/Aggregation/ValueCount.php
@@ -21,7 +21,7 @@ class ValueCount extends AbstractAggregation
 
     /**
      * Set the field for this aggregation
-     * @param  string     $field the name of the document field on which to perform this aggregation
+     * @param  string $field the name of the document field on which to perform this aggregation
      * @return $this
      */
     public function setField($field)

--- a/lib/Elastica/Bulk.php
+++ b/lib/Elastica/Bulk.php
@@ -239,9 +239,10 @@ class Bulk
     }
 
     /**
-     * @param  array                                $data
-     * @return $this
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  array $data
+     * @return $this
      */
     public function addRawData(array $data)
     {
@@ -349,9 +350,10 @@ class Bulk
     }
 
     /**
-     * @param  \Elastica\Response               $response
-     * @throws Exception\Bulk\ResponseException
-     * @throws Exception\InvalidException
+     * @throws \Elastica\Exception\Bulk\ResponseException
+     * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  \Elastica\Response         $response
      * @return \Elastica\Bulk\ResponseSet
      */
     protected function _processResponse(Response $response)
@@ -401,9 +403,10 @@ class Bulk
     }
 
     /**
-     * @param  string                                $host
-     * @param  int                                   $port
      * @throws \Elastica\Exception\Bulk\UdpException
+     *
+     * @param string $host
+     * @param int    $port
      */
     public function sendUdp($host = null, $port = null)
     {

--- a/lib/Elastica/Bulk.php
+++ b/lib/Elastica/Bulk.php
@@ -277,22 +277,26 @@ class Bulk
 
     /**
      * Set a url parameter on the request bulk request.
-     * @var string $name name of the parameter
-     * @var string $value value of the parameter
+     * @param  string $name  name of the parameter
+     * @param  string $value value of the parameter
+     * @return $this
      */
     public function setRequestParam($name, $value)
     {
-        $this->_requestParams[ $name ] = $value;
+        $this->_requestParams[$name] = $value;
+
+        return $this;
     }
 
     /**
      * Set the amount of time that the request will wait the shards to come on line.
      * Requires Elasticsearch version >= 0.90.8.
-     * @var string $time timeout in Elasticsearch time format
+     * @param  string $time timeout in Elasticsearch time format
+     * @return $this
      */
     public function setShardTimeout($time)
     {
-        $this->setRequestParam('timeout', $time);
+        return $this->setRequestParam('timeout', $time);
     }
 
     /**

--- a/lib/Elastica/Bulk.php
+++ b/lib/Elastica/Bulk.php
@@ -52,7 +52,7 @@ class Bulk
 
     /**
      * @param  string|\Elastica\Index $index
-     * @return \Elastica\Bulk
+     * @return $this
      */
     public function setIndex($index)
     {
@@ -83,7 +83,7 @@ class Bulk
 
     /**
      * @param  string|\Elastica\Type $type
-     * @return \Elastica\Bulk
+     * @return $this
      */
     public function setType($type)
     {
@@ -132,7 +132,7 @@ class Bulk
 
     /**
      * @param  \Elastica\Bulk\Action $action
-     * @return \Elastica\Bulk
+     * @return $this
      */
     public function addAction(Action $action)
     {
@@ -143,7 +143,7 @@ class Bulk
 
     /**
      * @param  \Elastica\Bulk\Action[] $actions
-     * @return \Elastica\Bulk
+     * @return $this
      */
     public function addActions(array $actions)
     {
@@ -165,7 +165,7 @@ class Bulk
     /**
      * @param  \Elastica\Document $document
      * @param  string             $opType
-     * @return \Elastica\Bulk
+     * @return $this
      */
     public function addDocument(Document $document, $opType = null)
     {
@@ -177,7 +177,7 @@ class Bulk
     /**
      * @param  \Elastica\Document[] $documents
      * @param  string               $opType
-     * @return \Elastica\Bulk
+     * @return $this
      */
     public function addDocuments(array $documents, $opType = null)
     {
@@ -191,7 +191,7 @@ class Bulk
     /**
      * @param  \Elastica\Script $data
      * @param  string           $opType
-     * @return \Elastica\Bulk
+     * @return $this
      */
     public function addScript(Script $script, $opType = null)
     {
@@ -203,7 +203,7 @@ class Bulk
     /**
      * @param  \Elastica\Document[] $scripts
      * @param  string               $opType
-     * @return \Elastica\Bulk
+     * @return $this
      */
     public function addScripts(array $scripts, $opType = null)
     {
@@ -217,7 +217,7 @@ class Bulk
     /**
      * @param  \Elastica\Script|\Elastica\Document\array $data
      * @param  string                                    $opType
-     * @return \Elastica\Bulk
+     * @return $this
      */
     public function addData($data, $opType = null)
     {
@@ -240,7 +240,7 @@ class Bulk
 
     /**
      * @param  array                                $data
-     * @return \Elastica\Bulk
+     * @return $this
      * @throws \Elastica\Exception\InvalidException
      */
     public function addRawData(array $data)

--- a/lib/Elastica/Bulk/Action.php
+++ b/lib/Elastica/Bulk/Action.php
@@ -53,7 +53,7 @@ class Action
 
     /**
      * @param  string                $type
-     * @return \Elastica\Bulk\Action
+     * @return $this
      */
     public function setOpType($type)
     {
@@ -72,7 +72,7 @@ class Action
 
     /**
      * @param  array                 $metadata
-     * @return \Elastica\Bulk\Action
+     * @return $this
      */
     public function setMetadata(array $metadata)
     {
@@ -99,7 +99,7 @@ class Action
 
     /**
      * @param  array                 $source
-     * @return \Elastica\Bulk\Action
+     * @return $this
      */
     public function setSource($source)
     {
@@ -126,7 +126,7 @@ class Action
 
     /**
      * @param  string|\Elastica\Index $index
-     * @return \Elastica\Bulk\Action
+     * @return $this
      */
     public function setIndex($index)
     {
@@ -140,7 +140,7 @@ class Action
 
     /**
      * @param  string|\Elastica\Type $type
-     * @return \Elastica\Bulk\Action
+     * @return $this
      */
     public function setType($type)
     {
@@ -155,7 +155,7 @@ class Action
 
     /**
      * @param  string                $id
-     * @return \Elastica\Bulk\Action
+     * @return $this
      */
     public function setId($id)
     {
@@ -166,7 +166,7 @@ class Action
 
     /**
      * @param  string                $routing
-     * @return \Elastica\Bulk\Action
+     * @return $this
      */
     public function setRouting($routing)
     {

--- a/lib/Elastica/Bulk/Action.php
+++ b/lib/Elastica/Bulk/Action.php
@@ -52,7 +52,7 @@ class Action
     }
 
     /**
-     * @param  string                $type
+     * @param  string $type
      * @return $this
      */
     public function setOpType($type)
@@ -71,7 +71,7 @@ class Action
     }
 
     /**
-     * @param  array                 $metadata
+     * @param  array $metadata
      * @return $this
      */
     public function setMetadata(array $metadata)
@@ -98,7 +98,7 @@ class Action
     }
 
     /**
-     * @param  array                 $source
+     * @param  array $source
      * @return $this
      */
     public function setSource($source)
@@ -154,7 +154,7 @@ class Action
     }
 
     /**
-     * @param  string                $id
+     * @param  string $id
      * @return $this
      */
     public function setId($id)
@@ -165,7 +165,7 @@ class Action
     }
 
     /**
-     * @param  string                $routing
+     * @param  string $routing
      * @return $this
      */
     public function setRouting($routing)

--- a/lib/Elastica/Bulk/Action/AbstractDocument.php
+++ b/lib/Elastica/Bulk/Action/AbstractDocument.php
@@ -23,7 +23,7 @@ abstract class AbstractDocument extends Action
     }
 
     /**
-     * @param  \Elastica\Document                     $document
+     * @param  \Elastica\Document $document
      * @return $this
      */
     public function setDocument(Document $document)
@@ -38,7 +38,7 @@ abstract class AbstractDocument extends Action
     }
 
     /**
-     * @param  \Elastica\Script                       $script
+     * @param  \Elastica\Script $script
      * @return $this
      */
     public function setScript(Script $script)
@@ -56,8 +56,9 @@ abstract class AbstractDocument extends Action
     }
 
     /**
-     * @param  \Elastica\Script|\Elastica\Document    $data
      * @throws \InvalidArgumentException
+     *
+     * @param  \Elastica\Script|\Elastica\Document $data
      * @return $this
      */
     public function setData($data)
@@ -114,8 +115,8 @@ abstract class AbstractDocument extends Action
     abstract protected function _getMetadata(AbstractUpdateAction $source);
 
     /**
-     * @param  \Elastica\Document|\Elastica\Script    $data
-     * @param  string                                 $opType
+     * @param  \Elastica\Document|\Elastica\Script $data
+     * @param  string                              $opType
      * @return static
      */
     public static function create($data, $opType = null)

--- a/lib/Elastica/Bulk/Action/AbstractDocument.php
+++ b/lib/Elastica/Bulk/Action/AbstractDocument.php
@@ -24,7 +24,7 @@ abstract class AbstractDocument extends Action
 
     /**
      * @param  \Elastica\Document                     $document
-     * @return \Elastica\Bulk\Action\AbstractDocument
+     * @return $this
      */
     public function setDocument(Document $document)
     {
@@ -39,7 +39,7 @@ abstract class AbstractDocument extends Action
 
     /**
      * @param  \Elastica\Script                       $script
-     * @return \Elastica\Bulk\Action\AbstractDocument
+     * @return $this
      */
     public function setScript(Script $script)
     {
@@ -58,7 +58,7 @@ abstract class AbstractDocument extends Action
     /**
      * @param  \Elastica\Script|\Elastica\Document    $data
      * @throws \InvalidArgumentException
-     * @return \Elastica\Bulk\Action\AbstractDocument
+     * @return $this
      */
     public function setData($data)
     {
@@ -75,7 +75,7 @@ abstract class AbstractDocument extends Action
 
     /**
      * Note: This is for backwards compatibility.
-     * @return \Elastica\Document
+     * @return \Elastica\Document|null
      */
     public function getDocument()
     {
@@ -88,7 +88,7 @@ abstract class AbstractDocument extends Action
 
     /**
      * Note: This is for backwards compatibility.
-     * @return \Elastica\Script
+     * @return \Elastica\Script|null
      */
     public function getScript()
     {
@@ -116,7 +116,7 @@ abstract class AbstractDocument extends Action
     /**
      * @param  \Elastica\Document|\Elastica\Script    $data
      * @param  string                                 $opType
-     * @return \Elastica\Bulk\Action\AbstractDocument
+     * @return static
      */
     public static function create($data, $opType = null)
     {

--- a/lib/Elastica/Bulk/Action/IndexDocument.php
+++ b/lib/Elastica/Bulk/Action/IndexDocument.php
@@ -14,7 +14,7 @@ class IndexDocument extends AbstractDocument
     protected $_opType = self::OP_TYPE_INDEX;
 
     /**
-     * @param  \Elastica\Document                  $document
+     * @param  \Elastica\Document $document
      * @return $this
      */
     public function setDocument(Document $document)
@@ -45,6 +45,7 @@ class IndexDocument extends AbstractDocument
             'timestamp',
             'retry_on_conflict',
         );
+
         $metadata = $action->getOptions($params, true);
 
         return $metadata;

--- a/lib/Elastica/Bulk/Action/IndexDocument.php
+++ b/lib/Elastica/Bulk/Action/IndexDocument.php
@@ -15,7 +15,7 @@ class IndexDocument extends AbstractDocument
 
     /**
      * @param  \Elastica\Document                  $document
-     * @return \Elastica\Bulk\Action\IndexDocument
+     * @return $this
      */
     public function setDocument(Document $document)
     {

--- a/lib/Elastica/Bulk/Action/UpdateDocument.php
+++ b/lib/Elastica/Bulk/Action/UpdateDocument.php
@@ -19,7 +19,7 @@ class UpdateDocument extends IndexDocument
     /**
      * Set the document for this bulk update action.
      * @param  \Elastica\Document                   $document
-     * @return \Elastica\Bulk\Action\UpdateDocument
+     * @return $this
      */
     public function setDocument(Document $document)
     {
@@ -44,7 +44,7 @@ class UpdateDocument extends IndexDocument
 
     /**
      * @param  \Elastica\Script                       $script
-     * @return \Elastica\Bulk\Action\AbstractDocument
+     * @return $this
      */
     public function setScript(Script $script)
     {

--- a/lib/Elastica/Bulk/Action/UpdateDocument.php
+++ b/lib/Elastica/Bulk/Action/UpdateDocument.php
@@ -18,7 +18,7 @@ class UpdateDocument extends IndexDocument
 
     /**
      * Set the document for this bulk update action.
-     * @param  \Elastica\Document                   $document
+     * @param  \Elastica\Document $document
      * @return $this
      */
     public function setDocument(Document $document)
@@ -43,7 +43,7 @@ class UpdateDocument extends IndexDocument
     }
 
     /**
-     * @param  \Elastica\Script                       $script
+     * @param  \Elastica\Script $script
      * @return $this
      */
     public function setScript(Script $script)

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -137,7 +137,7 @@ class Client
     /**
      * Sets specific config values (updates and keeps default values)
      *
-     * @param  array            $config Params
+     * @param  array $config Params
      * @return $this
      */
     public function setConfig(array $config)
@@ -153,9 +153,10 @@ class Client
      * Returns a specific config key or the whole
      * config array if not set
      *
-     * @param  string                               $key Config key
      * @throws \Elastica\Exception\InvalidException
-     * @return array|string                         Config value
+     *
+     * @param  string       $key Config key
+     * @return array|string Config value
      */
     public function getConfig($key = '')
     {
@@ -173,8 +174,8 @@ class Client
     /**
      * Sets / overwrites a specific config value
      *
-     * @param  string           $key   Key to set
-     * @param  mixed            $value Value
+     * @param  string $key   Key to set
+     * @param  mixed  $value Value
      * @return $this
      */
     public function setConfigValue($key, $value)
@@ -215,10 +216,11 @@ class Client
     /**
      * Adds a HTTP Header
      *
-     * @param  string                               $header      The HTTP Header
-     * @param  string                               $headerValue The HTTP Header Value
-     * @return $this
      * @throws \Elastica\Exception\InvalidException If $header or $headerValue is not a string
+     *
+     * @param  string $header      The HTTP Header
+     * @param  string $headerValue The HTTP Header Value
+     * @return $this
      */
     public function addHeader($header, $headerValue)
     {
@@ -234,9 +236,10 @@ class Client
     /**
      * Remove a HTTP Header
      *
-     * @param  string                               $header The HTTP Header to remove
+     * @throws \Elastica\Exception\InvalidException If $header is not a string
+     *
+     * @param  string $header The HTTP Header to remove
      * @return $this
-     * @throws \Elastica\Exception\InvalidException IF $header is not a string
      */
     public function removeHeader($header)
     {
@@ -258,10 +261,11 @@ class Client
      * set inside the document, because for bulk settings documents,
      * documents can belong to any type and index
      *
-     * @param  array|\Elastica\Document[]           $docs Array of Elastica\Document
-     * @return \Elastica\Bulk\ResponseSet           Response object
      * @throws \Elastica\Exception\InvalidException If docs is empty
      * @link http://www.elasticsearch.org/guide/reference/api/bulk.html
+     *
+     * @param  array|\Elastica\Document[] $docs Array of Elastica\Document
+     * @return \Elastica\Bulk\ResponseSet Response object
      */
     public function updateDocuments(array $docs)
     {
@@ -283,10 +287,11 @@ class Client
      * set inside the document, because for bulk settings documents,
      * documents can belong to any type and index
      *
-     * @param  array|\Elastica\Document[]           $docs Array of Elastica\Document
-     * @return \Elastica\Bulk\ResponseSet           Response object
      * @throws \Elastica\Exception\InvalidException If docs is empty
      * @link http://www.elasticsearch.org/guide/reference/api/bulk.html
+     *
+     * @param  array|\Elastica\Document[] $docs Array of Elastica\Document
+     * @return \Elastica\Bulk\ResponseSet Response object
      */
     public function addDocuments(array $docs)
     {
@@ -411,9 +416,10 @@ class Client
     /**
      * Bulk deletes documents
      *
-     * @param  array|\Elastica\Document[]           $docs
-     * @return \Elastica\Bulk\ResponseSet
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  array|\Elastica\Document[] $docs
+     * @return \Elastica\Bulk\ResponseSet
      */
     public function deleteDocuments(array $docs)
     {
@@ -470,6 +476,7 @@ class Client
 
     /**
      * @throws \Elastica\Exception\ClientException
+     *
      * @return \Elastica\Connection
      */
     public function getConnection()
@@ -507,13 +514,14 @@ class Client
     /**
      * Deletes documents with the given ids, index, type from the index
      *
-     * @param  array                                $ids     Document ids
-     * @param  string|\Elastica\Index               $index   Index name
-     * @param  string|\Elastica\Type                $type    Type of documents
-     * @param  string|false                         $routing Optional routing key for all ids
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Bulk\ResponseSet           Response  object
      * @link http://www.elasticsearch.org/guide/reference/api/bulk.html
+     *
+     * @param  array                      $ids     Document ids
+     * @param  string|\Elastica\Index     $index   Index name
+     * @param  string|\Elastica\Type      $type    Type of documents
+     * @param  string|false               $routing Optional routing key for all ids
+     * @return \Elastica\Bulk\ResponseSet Response  object
      */
     public function deleteIds(array $ids, $index, $type, $routing = false)
     {
@@ -551,11 +559,12 @@ class Client
      *         array('delete' => array('_index' => 'test', '_type' => 'user', '_id' => '2'))
      * );
      *
-     * @param  array                                 $params Parameter array
      * @throws \Elastica\Exception\ResponseException
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Bulk\ResponseSet            Response object
      * @link http://www.elasticsearch.org/guide/reference/api/bulk.html
+     *
+     * @param  array                      $params Parameter array
+     * @return \Elastica\Bulk\ResponseSet Response object
      */
     public function bulk(array $params)
     {
@@ -575,12 +584,13 @@ class Client
      *
      * It's possible to make any REST query directly over this method
      *
-     * @param  string                                   $path   Path to call
-     * @param  string                                   $method Rest method to use (GET, POST, DELETE, PUT)
-     * @param  array                                    $data   OPTIONAL Arguments as array
-     * @param  array                                    $query  OPTIONAL Query params
      * @throws Exception\ConnectionException|\Exception
-     * @return \Elastica\Response                       Response object
+     *
+     * @param  string             $path   Path to call
+     * @param  string             $method Rest method to use (GET, POST, DELETE, PUT)
+     * @param  array              $data   OPTIONAL Arguments as array
+     * @param  array              $query  OPTIONAL Query params
+     * @return \Elastica\Response Response object
      */
     public function request($path, $method = Request::GET, $data = array(), array $query = array())
     {
@@ -634,8 +644,9 @@ class Client
     /**
      * logging
      *
-     * @param  string|\Elastica\Request   $context
      * @throws Exception\RuntimeException
+     *
+     * @param string|\Elastica\Request $context
      */
     protected function _log($context)
     {

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -217,6 +217,7 @@ class Client
      *
      * @param  string                               $header      The HTTP Header
      * @param  string                               $headerValue The HTTP Header Value
+     * @return $this
      * @throws \Elastica\Exception\InvalidException If $header or $headerValue is not a string
      */
     public function addHeader($header, $headerValue)
@@ -226,12 +227,15 @@ class Client
         } else {
             throw new InvalidException('Header must be a string');
         }
+
+        return $this;
     }
 
     /**
      * Remove a HTTP Header
      *
      * @param  string                               $header The HTTP Header to remove
+     * @return $this
      * @throws \Elastica\Exception\InvalidException IF $header is not a string
      */
     public function removeHeader($header)
@@ -243,6 +247,8 @@ class Client
         } else {
             throw new InvalidException('Header must be a string');
         }
+
+        return $this;
     }
 
     /**

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -138,7 +138,7 @@ class Client
      * Sets specific config values (updates and keeps default values)
      *
      * @param  array            $config Params
-     * @return \Elastica\Client
+     * @return $this
      */
     public function setConfig(array $config)
     {
@@ -175,7 +175,7 @@ class Client
      *
      * @param  string           $key   Key to set
      * @param  mixed            $value Value
-     * @return \Elastica\Client Client object
+     * @return $this
      */
     public function setConfigValue($key, $value)
     {
@@ -449,7 +449,7 @@ class Client
 
     /**
      * @param  \Elastica\Connection $connection
-     * @return \Elastica\Client
+     * @return $this
      */
     public function addConnection(Connection $connection)
     {
@@ -495,7 +495,7 @@ class Client
 
     /**
      * @param  array|\Elastica\Connection[] $connections
-     * @return \Elastica\Client
+     * @return $this
      */
     public function setConnections(array $connections)
     {

--- a/lib/Elastica/Cluster.php
+++ b/lib/Elastica/Cluster.php
@@ -140,9 +140,10 @@ class Cluster
     /**
      * Returns the cluster information (not implemented yet)
      *
-     * @param  array                                       $args Additional arguments
      * @throws \Elastica\Exception\NotImplementedException
      * @link http://www.elasticsearch.org/guide/reference/api/admin-cluster-nodes-info.html
+     *
+     * @param array $args Additional arguments
      */
     public function getInfo(array $args)
     {
@@ -152,8 +153,9 @@ class Cluster
     /**
      * Return Cluster health
      *
-     * @return \Elastica\Cluster\Health
      * @link http://www.elasticsearch.org/guide/reference/api/admin-cluster-health.html
+     *
+     * @return \Elastica\Cluster\Health
      */
     public function getHealth()
     {
@@ -173,9 +175,10 @@ class Cluster
     /**
      * Shuts down the complete cluster
      *
+     * @link http://www.elasticsearch.org/guide/reference/api/admin-cluster-nodes-shutdown.html
+     *
      * @param  string             $delay OPTIONAL Seconds to shutdown cluster after (default = 1s)
      * @return \Elastica\Response
-     * @link http://www.elasticsearch.org/guide/reference/api/admin-cluster-nodes-shutdown.html
      */
     public function shutdown($delay = '1s')
     {

--- a/lib/Elastica/Cluster/Health.php
+++ b/lib/Elastica/Cluster/Health.php
@@ -64,7 +64,7 @@ class Health
     /**
      * Refreshes the health data for the cluster.
      *
-     * @return \Elastica\Cluster\Health
+     * @return $this
      */
     public function refresh()
     {

--- a/lib/Elastica/Cluster/Health.php
+++ b/lib/Elastica/Cluster/Health.php
@@ -16,16 +16,12 @@ use Elastica\Request;
 class Health
 {
     /**
-     * Elastica client.
-     *
-     * @var \Elastica\Client Client object
+     * @var \Elastica\Client Client object.
      */
     protected $_client = null;
 
     /**
-     * The cluster health data.
-     *
-     * @var array
+     * @var array The cluster health data.
      */
     protected $_data = null;
 

--- a/lib/Elastica/Cluster/Health/Index.php
+++ b/lib/Elastica/Cluster/Health/Index.php
@@ -12,16 +12,12 @@ namespace Elastica\Cluster\Health;
 class Index
 {
     /**
-     * The name of the index.
-     *
-     * @var string
+     * @var string The name of the index.
      */
     protected $_name;
 
     /**
-     * The index health data.
-     *
-     * @var array
+     * @var array The index health data.
      */
     protected $_data;
 

--- a/lib/Elastica/Cluster/Health/Shard.php
+++ b/lib/Elastica/Cluster/Health/Shard.php
@@ -12,16 +12,12 @@ namespace Elastica\Cluster\Health;
 class Shard
 {
     /**
-     * The shard index/number.
-     *
-     * @var int
+     * @var int The shard index/number.
      */
     protected $_shardNumber;
 
     /**
-     * The shard health data.
-     *
-     * @var array
+     * @var array The shard health data.
      */
     protected $_data;
 

--- a/lib/Elastica/Cluster/Settings.php
+++ b/lib/Elastica/Cluster/Settings.php
@@ -16,8 +16,6 @@ use Elastica\Request;
 class Settings
 {
     /**
-     * Client
-     *
      * @var \Elastica\Client Client object
      */
     protected $_client = null;

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -63,7 +63,7 @@ class Connection extends Param
 
     /**
      * @param  int                  $port
-     * @return \Elastica\Connection
+     * @return $this
      */
     public function setPort($port)
     {
@@ -80,7 +80,7 @@ class Connection extends Param
 
     /**
      * @param  string               $host
-     * @return \Elastica\Connection
+     * @return $this
      */
     public function setHost($host)
     {
@@ -101,7 +101,7 @@ class Connection extends Param
      *
      * @see http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY
      * @param  string|null          $proxy
-     * @return \Elastica\Connection
+     * @return $this
      */
     public function setProxy($proxy)
     {
@@ -118,7 +118,7 @@ class Connection extends Param
 
     /**
      * @param  string|array         $transport
-     * @return \Elastica\Connection
+     * @return $this
      */
     public function setTransport($transport)
     {
@@ -135,7 +135,7 @@ class Connection extends Param
 
     /**
      * @param  string               $path
-     * @return \Elastica\Connection
+     * @return $this
      */
     public function setPath($path)
     {
@@ -144,7 +144,7 @@ class Connection extends Param
 
     /**
      * @param  int                  $timeout Timeout in seconds
-     * @return \Elastica\Connection
+     * @return $this
      */
     public function setTimeout($timeout)
     {
@@ -163,7 +163,7 @@ class Connection extends Param
      * Enables a connection
      *
      * @param  bool                 $enabled OPTIONAL (default = true)
-     * @return \Elastica\Connection
+     * @return $this
      */
     public function setEnabled($enabled = true)
     {
@@ -201,7 +201,7 @@ class Connection extends Param
 
     /**
      * @param  array                $config
-     * @return \Elastica\Connection
+     * @return $this
      */
     public function setConfig(array $config)
     {
@@ -211,7 +211,7 @@ class Connection extends Param
     /**
      * @param  string               $key
      * @param  mixed                $value
-     * @return \Elastica\Connection
+     * @return $this
      */
     public function addConfig($key, $value)
     {
@@ -256,7 +256,7 @@ class Connection extends Param
     /**
      * @param  \Elastica\Connection|array $params Params to create a connection
      * @throws Exception\InvalidException
-     * @return \Elastica\Connection
+     * @return self
      */
     public static function create($params = array())
     {

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -62,7 +62,7 @@ class Connection extends Param
     }
 
     /**
-     * @param  int                  $port
+     * @param  int   $port
      * @return $this
      */
     public function setPort($port)
@@ -79,7 +79,7 @@ class Connection extends Param
     }
 
     /**
-     * @param  string               $host
+     * @param  string $host
      * @return $this
      */
     public function setHost($host)
@@ -100,7 +100,7 @@ class Connection extends Param
      * empty string to disable proxy and proxy string to set actual http proxy.
      *
      * @see http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXY
-     * @param  string|null          $proxy
+     * @param  string|null $proxy
      * @return $this
      */
     public function setProxy($proxy)
@@ -117,7 +117,7 @@ class Connection extends Param
     }
 
     /**
-     * @param  string|array         $transport
+     * @param  string|array $transport
      * @return $this
      */
     public function setTransport($transport)
@@ -134,7 +134,7 @@ class Connection extends Param
     }
 
     /**
-     * @param  string               $path
+     * @param  string $path
      * @return $this
      */
     public function setPath($path)
@@ -143,7 +143,7 @@ class Connection extends Param
     }
 
     /**
-     * @param  int                  $timeout Timeout in seconds
+     * @param  int   $timeout Timeout in seconds
      * @return $this
      */
     public function setTimeout($timeout)
@@ -162,7 +162,7 @@ class Connection extends Param
     /**
      * Enables a connection
      *
-     * @param  bool                 $enabled OPTIONAL (default = true)
+     * @param  bool  $enabled OPTIONAL (default = true)
      * @return $this
      */
     public function setEnabled($enabled = true)
@@ -181,8 +181,9 @@ class Connection extends Param
     /**
      * Returns an instance of the transport type
      *
+     * @throws \Elastica\Exception\InvalidException If invalid transport type
+     *
      * @return \Elastica\Transport\AbstractTransport Transport object
-     * @throws \Elastica\Exception\InvalidException  If invalid transport type
      */
     public function getTransportObject()
     {
@@ -200,7 +201,7 @@ class Connection extends Param
     }
 
     /**
-     * @param  array                $config
+     * @param  array $config
      * @return $this
      */
     public function setConfig(array $config)
@@ -209,8 +210,8 @@ class Connection extends Param
     }
 
     /**
-     * @param  string               $key
-     * @param  mixed                $value
+     * @param  string $key
+     * @param  mixed  $value
      * @return $this
      */
     public function addConfig($key, $value)
@@ -235,9 +236,10 @@ class Connection extends Param
      * Returns a specific config key or the whole
      * config array if not set
      *
-     * @param  string                               $key Config key
      * @throws \Elastica\Exception\InvalidException
-     * @return array|string                         Config value
+     *
+     * @param  string       $key Config key
+     * @return array|string Config value
      */
     public function getConfig($key = '')
     {
@@ -254,8 +256,9 @@ class Connection extends Param
     }
 
     /**
-     * @param  \Elastica\Connection|array $params Params to create a connection
      * @throws Exception\InvalidException
+     *
+     * @param  \Elastica\Connection|array $params Params to create a connection
      * @return self
      */
     public static function create($params = array())

--- a/lib/Elastica/Connection/ConnectionPool.php
+++ b/lib/Elastica/Connection/ConnectionPool.php
@@ -15,23 +15,17 @@ use Exception;
 class ConnectionPool
 {
     /**
-     * Connections array
-     *
-     * @var array|\Elastica\Connection[]
+     * @var array|\Elastica\Connection[] Connections array
      */
     protected $_connections;
 
     /**
-     * Strategy for connection
-     *
-     * @var \Elastica\Connection\Strategy\StrategyInterface
+     * @var \Elastica\Connection\Strategy\StrategyInterface Strategy for connection
      */
     protected $_strategy;
 
     /**
-     * Callback function called on connection fail
-     *
-     * @var callback
+     * @var callback Function called on connection fail
      */
     protected $_callback;
 
@@ -50,7 +44,7 @@ class ConnectionPool
     }
 
     /**
-     * @param \Elastica\Connection $connection
+     * @param  \Elastica\Connection $connection
      * @return $this
      */
     public function addConnection(Connection $connection)
@@ -61,7 +55,7 @@ class ConnectionPool
     }
 
     /**
-     * @param array|\Elastica\Connection[] $connections
+     * @param  array|\Elastica\Connection[] $connections
      * @return $this
      */
     public function setConnections(array $connections)
@@ -94,8 +88,9 @@ class ConnectionPool
     }
 
     /**
-     * @return \Elastica\Connection
      * @throws \Elastica\Exception\ClientException
+     *
+     * @return \Elastica\Connection
      */
     public function getConnection()
     {
@@ -117,7 +112,6 @@ class ConnectionPool
     }
 
     /**
-     *
      * @return \Elastica\Connection\Strategy\StrategyInterface
      */
     public function getStrategy()

--- a/lib/Elastica/Connection/ConnectionPool.php
+++ b/lib/Elastica/Connection/ConnectionPool.php
@@ -51,18 +51,24 @@ class ConnectionPool
 
     /**
      * @param \Elastica\Connection $connection
+     * @return $this
      */
     public function addConnection(Connection $connection)
     {
         $this->_connections[] = $connection;
+
+        return $this;
     }
 
     /**
      * @param array|\Elastica\Connection[] $connections
+     * @return $this
      */
     public function setConnections(array $connections)
     {
         $this->_connections = $connections;
+
+        return $this;
     }
 
     /**

--- a/lib/Elastica/Connection/Strategy/RoundRobin.php
+++ b/lib/Elastica/Connection/Strategy/RoundRobin.php
@@ -10,9 +10,10 @@ namespace Elastica\Connection\Strategy;
 class RoundRobin extends Simple
 {
     /**
-     * @param  array|\Elastica\Connection[]        $connections
-     * @return \Elastica\Connection
      * @throws \Elastica\Exception\ClientException
+     *
+     * @param  array|\Elastica\Connection[] $connections
+     * @return \Elastica\Connection
      */
     public function getConnection($connections)
     {

--- a/lib/Elastica/Connection/Strategy/Simple.php
+++ b/lib/Elastica/Connection/Strategy/Simple.php
@@ -12,9 +12,10 @@ use Elastica\Exception\ClientException;
 class Simple implements StrategyInterface
 {
     /**
-     * @param  array|\Elastica\Connection[]        $connections
-     * @return \Elastica\Connection
      * @throws \Elastica\Exception\ClientException
+     *
+     * @param  array|\Elastica\Connection[] $connections
+     * @return \Elastica\Connection
      */
     public function getConnection($connections)
     {

--- a/lib/Elastica/Connection/Strategy/StrategyFactory.php
+++ b/lib/Elastica/Connection/Strategy/StrategyFactory.php
@@ -12,9 +12,10 @@ use Elastica\Exception\InvalidException;
 class StrategyFactory
 {
     /**
+     * @throws \Elastica\Exception\InvalidException
+     *
      * @param  mixed|Closure|String|StrategyInterface          $strategyName
      * @return \Elastica\Connection\Strategy\StrategyInterface
-     * @throws \Elastica\Exception\InvalidException
      */
     public static function create($strategyName)
     {

--- a/lib/Elastica/Document.php
+++ b/lib/Elastica/Document.php
@@ -106,7 +106,7 @@ class Document extends AbstractUpdateAction
      * @param  string                               $key
      * @param  mixed                                $value
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Document
+     * @return $this
      */
     public function set($key, $value)
     {
@@ -130,7 +130,7 @@ class Document extends AbstractUpdateAction
     /**
      * @param  string                               $key
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Document
+     * @return $this
      */
     public function remove($key)
     {
@@ -148,7 +148,7 @@ class Document extends AbstractUpdateAction
      * @deprecated
      * @param  string             $key   Document entry key
      * @param  mixed              $value Document entry value
-     * @return \Elastica\Document
+     * @return $this
      */
     public function add($key, $value)
     {
@@ -169,7 +169,7 @@ class Document extends AbstractUpdateAction
      * @param  string             $key      Key to add the file to
      * @param  string             $filepath Path to add the file
      * @param  string             $mimeType OPTIONAL Header mime type
-     * @return \Elastica\Document
+     * @return $this
      */
     public function addFile($key, $filepath, $mimeType = '')
     {
@@ -189,7 +189,7 @@ class Document extends AbstractUpdateAction
      *
      * @param  string             $key     Document key
      * @param  string             $content Raw file content
-     * @return \Elastica\Document
+     * @return $this
      */
     public function addFileContent($key, $content)
     {
@@ -205,7 +205,7 @@ class Document extends AbstractUpdateAction
      * @param  float              $latitude  Latitude value
      * @param  float              $longitude Longitude value
      * @link http://www.elasticsearch.org/guide/reference/mapping/geo-point-type.html
-     * @return \Elastica\Document
+     * @return $this
      */
     public function addGeoPoint($key, $latitude, $longitude)
     {
@@ -220,7 +220,7 @@ class Document extends AbstractUpdateAction
      * Overwrites the current document data with the given data
      *
      * @param  array|string       $data Data array
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setData($data)
     {
@@ -269,7 +269,7 @@ class Document extends AbstractUpdateAction
 
     /**
      * @param  bool               $value
-     * @return \Elastica\Document
+     * @return $this
      */
     public function setDocAsUpsert($value)
     {
@@ -320,7 +320,7 @@ class Document extends AbstractUpdateAction
     /**
      * @param  array|\Elastica\Document             $data
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Document
+     * @return self
      */
     public static function create($data)
     {

--- a/lib/Elastica/Document.php
+++ b/lib/Elastica/Document.php
@@ -89,9 +89,10 @@ class Document extends AbstractUpdateAction
     }
 
     /**
-     * @param  string                               $key
-     * @return mixed
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  string $key
+     * @return mixed
      */
     public function get($key)
     {
@@ -103,9 +104,10 @@ class Document extends AbstractUpdateAction
     }
 
     /**
-     * @param  string                               $key
-     * @param  mixed                                $value
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  string $key
+     * @param  mixed  $value
      * @return $this
      */
     public function set($key, $value)
@@ -128,8 +130,9 @@ class Document extends AbstractUpdateAction
     }
 
     /**
-     * @param  string                               $key
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  string $key
      * @return $this
      */
     public function remove($key)
@@ -146,8 +149,8 @@ class Document extends AbstractUpdateAction
      * Adds the given key/value pair to the document
      *
      * @deprecated
-     * @param  string             $key   Document entry key
-     * @param  mixed              $value Document entry value
+     * @param  string $key   Document entry key
+     * @param  mixed  $value Document entry value
      * @return $this
      */
     public function add($key, $value)
@@ -166,9 +169,9 @@ class Document extends AbstractUpdateAction
      * This installs the tika file analysis plugin. More infos about supported formats
      * can be found here: {@link http://tika.apache.org/0.7/formats.html}
      *
-     * @param  string             $key      Key to add the file to
-     * @param  string             $filepath Path to add the file
-     * @param  string             $mimeType OPTIONAL Header mime type
+     * @param  string $key      Key to add the file to
+     * @param  string $filepath Path to add the file
+     * @param  string $mimeType OPTIONAL Header mime type
      * @return $this
      */
     public function addFile($key, $filepath, $mimeType = '')
@@ -187,8 +190,8 @@ class Document extends AbstractUpdateAction
     /**
      * Add file content
      *
-     * @param  string             $key     Document key
-     * @param  string             $content Raw file content
+     * @param  string $key     Document key
+     * @param  string $content Raw file content
      * @return $this
      */
     public function addFileContent($key, $content)
@@ -201,9 +204,9 @@ class Document extends AbstractUpdateAction
      *
      * Geohashes are not yet supported
      *
-     * @param  string             $key       Field key
-     * @param  float              $latitude  Latitude value
-     * @param  float              $longitude Longitude value
+     * @param  string $key       Field key
+     * @param  float  $latitude  Latitude value
+     * @param  float  $longitude Longitude value
      * @link http://www.elasticsearch.org/guide/reference/mapping/geo-point-type.html
      * @return $this
      */
@@ -219,7 +222,7 @@ class Document extends AbstractUpdateAction
     /**
      * Overwrites the current document data with the given data
      *
-     * @param  array|string       $data Data array
+     * @param  array|string $data Data array
      * @return $this
      */
     public function setData($data)
@@ -240,9 +243,10 @@ class Document extends AbstractUpdateAction
     }
 
     /**
-     * @param  \Elastica\Script        $data
      * @throws NotImplementedException
      * @deprecated
+     *
+     * @param \Elastica\Script $data
      */
     public function setScript($data)
     {
@@ -268,7 +272,7 @@ class Document extends AbstractUpdateAction
     }
 
     /**
-     * @param  bool               $value
+     * @param  bool  $value
      * @return $this
      */
     public function setDocAsUpsert($value)
@@ -318,8 +322,9 @@ class Document extends AbstractUpdateAction
     }
 
     /**
-     * @param  array|\Elastica\Document             $data
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  array|\Elastica\Document $data
      * @return self
      */
     public static function create($data)

--- a/lib/Elastica/Exception/Bulk/ResponseException.php
+++ b/lib/Elastica/Exception/Bulk/ResponseException.php
@@ -15,8 +15,6 @@ use Elastica\Exception\BulkException;
 class ResponseException extends BulkException
 {
     /**
-     * Response
-     *
      * @var \Elastica\Bulk\ResponseSet ResponseSet object
      */
     protected $_responseSet;

--- a/lib/Elastica/Exception/ConnectionException.php
+++ b/lib/Elastica/Exception/ConnectionException.php
@@ -15,15 +15,11 @@ use Elastica\Response;
 class ConnectionException extends \RuntimeException implements ExceptionInterface
 {
     /**
-     * Request
-     *
      * @var \Elastica\Request Request object
      */
     protected $_request;
 
     /**
-     * Response
-     *
      * @var \Elastica\Response Response object
      */
     protected $_response;

--- a/lib/Elastica/Exception/ElasticsearchException.php
+++ b/lib/Elastica/Exception/ElasticsearchException.php
@@ -14,16 +14,12 @@ class ElasticsearchException extends \Exception implements ExceptionInterface
     const REMOTE_TRANSPORT_EXCEPTION = 'RemoteTransportException';
 
     /**
-     * Elasticsearch exception name
-     *
-     * @var string|null
+     * @var string|null Elasticsearch exception name
      */
     private $_exception;
 
     /**
-     * Whether exception was local to server node or remote
-     *
-     * @var bool
+     * @var bool Whether exception was local to server node or remote
      */
     private $_isRemote = false;
 

--- a/lib/Elastica/Exception/ResponseException.php
+++ b/lib/Elastica/Exception/ResponseException.php
@@ -15,15 +15,11 @@ use Elastica\Response;
 class ResponseException extends \RuntimeException implements ExceptionInterface
 {
     /**
-     * Request
-     *
      * @var \Elastica\Request Request object
      */
     protected $_request = null;
 
     /**
-     * Response
-     *
      * @var \Elastica\Response Response object
      */
     protected $_response = null;

--- a/lib/Elastica/Facet/AbstractFacet.php
+++ b/lib/Elastica/Facet/AbstractFacet.php
@@ -44,7 +44,7 @@ abstract class AbstractFacet extends Param
      *
      * @param  string                               $name The name of the facet.
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Facet\AbstractFacet
+     * @return $this
      */
     public function setName($name)
     {
@@ -70,7 +70,7 @@ abstract class AbstractFacet extends Param
      * Sets a filter for this facet.
      *
      * @param  \Elastica\Filter\AbstractFilter $filter A filter to apply on the facet.
-     * @return \Elastica\Facet\AbstractFacet
+     * @return $this
      */
     public function setFilter(AbstractFilter $filter)
     {
@@ -83,7 +83,7 @@ abstract class AbstractFacet extends Param
      * Elasticsearch default value.
      *
      * @param  bool                          $global Flag to either run the facet globally.
-     * @return \Elastica\Facet\AbstractFacet
+     * @return $this
      */
     public function setGlobal($global = true)
     {
@@ -94,7 +94,7 @@ abstract class AbstractFacet extends Param
      * Sets the path to the nested document
      *
      * @param  string                        $nestedPath Nested path
-     * @return \Elastica\Facet\AbstractFacet
+     * @return $this
      */
     public function setNested($nestedPath)
     {
@@ -105,7 +105,7 @@ abstract class AbstractFacet extends Param
      * Sets the scope
      *
      * @param  string                        $scope Scope
-     * @return \Elastica\Facet\AbstractFacet
+     * @return $this
      */
     public function setScope($scope)
     {
@@ -130,7 +130,7 @@ abstract class AbstractFacet extends Param
      *
      * @param  string                        $key   The key of the param to set.
      * @param  mixed                         $value The value of the param.
-     * @return \Elastica\Facet\AbstractFacet
+     * @return $this
      */
     protected function _setFacetParam($key, $value)
     {

--- a/lib/Elastica/Facet/AbstractFacet.php
+++ b/lib/Elastica/Facet/AbstractFacet.php
@@ -17,14 +17,12 @@ use Elastica\Param;
 abstract class AbstractFacet extends Param
 {
     /**
-     * Holds the name of the facet.
-     * @var string
+     * @var string Holds the name of the facet.
      */
     protected $_name = '';
 
     /**
-     * Holds all facet parameters.
-     * @var array
+     * @var array Holds all facet parameters.
      */
     protected $_facet = array();
 
@@ -42,8 +40,9 @@ abstract class AbstractFacet extends Param
      * Sets the name of the facet. It is automatically set by
      * the constructor.
      *
-     * @param  string                               $name The name of the facet.
-     * @throws \Elastica\Exception\InvalidException
+     * @throws \Elastica\Exception\InvalidException If name is empty
+     *
+     * @param  string $name The name of the facet.
      * @return $this
      */
     public function setName($name)
@@ -82,7 +81,7 @@ abstract class AbstractFacet extends Param
      * current search query. When not set, it defaults to the
      * Elasticsearch default value.
      *
-     * @param  bool                          $global Flag to either run the facet globally.
+     * @param  bool  $global Flag to either run the facet globally.
      * @return $this
      */
     public function setGlobal($global = true)
@@ -93,7 +92,7 @@ abstract class AbstractFacet extends Param
     /**
      * Sets the path to the nested document
      *
-     * @param  string                        $nestedPath Nested path
+     * @param  string $nestedPath Nested path
      * @return $this
      */
     public function setNested($nestedPath)
@@ -104,7 +103,7 @@ abstract class AbstractFacet extends Param
     /**
      * Sets the scope
      *
-     * @param  string                        $scope Scope
+     * @param  string $scope Scope
      * @return $this
      */
     public function setScope($scope)
@@ -128,8 +127,8 @@ abstract class AbstractFacet extends Param
      * Sets a param for the facet. Each facet implementation needs to take
      * care of handling their own params.
      *
-     * @param  string                        $key   The key of the param to set.
-     * @param  mixed                         $value The value of the param.
+     * @param  string $key   The key of the param to set.
+     * @param  mixed  $value The value of the param.
      * @return $this
      */
     protected function _setFacetParam($key, $value)

--- a/lib/Elastica/Facet/DateHistogram.php
+++ b/lib/Elastica/Facet/DateHistogram.php
@@ -17,7 +17,7 @@ class DateHistogram extends Histogram
      * Set the time_zone parameter
      *
      * @param  string                        $tzOffset
-     * @return \Elastica\Facet\DateHistogram
+     * @return $this
      */
     public function setTimezone($tzOffset)
     {

--- a/lib/Elastica/Facet/DateHistogram.php
+++ b/lib/Elastica/Facet/DateHistogram.php
@@ -16,7 +16,7 @@ class DateHistogram extends Histogram
     /**
      * Set the time_zone parameter
      *
-     * @param  string                        $tzOffset
+     * @param  string $tzOffset
      * @return $this
      */
     public function setTimezone($tzOffset)
@@ -30,6 +30,7 @@ class DateHistogram extends Histogram
      *
      * @see \Elastica\Facet\AbstractFacet::toArray()
      * @throws \Elastica\Exception\InvalidException When the right fields haven't been set.
+     *
      * @return array
      */
     public function toArray()

--- a/lib/Elastica/Facet/Filter.php
+++ b/lib/Elastica/Facet/Filter.php
@@ -18,7 +18,7 @@ class Filter extends AbstractFacet
      * Set the filter for the facet.
      *
      * @param  \Elastica\Filter\AbstractFilter $filter
-     * @return \Elastica\Facet\Filter
+     * @return $this
      */
     public function setFilter(AbstractFilter $filter)
     {

--- a/lib/Elastica/Facet/GeoCluster.php
+++ b/lib/Elastica/Facet/GeoCluster.php
@@ -51,6 +51,7 @@ class GeoCluster extends AbstractFacet
      *
      * @see \Elastica\Facet\AbstractFacet::toArray()
      * @throws \Elastica\Exception\InvalidException When the right fields haven't been set.
+     *
      * @return array
      */
     public function toArray()

--- a/lib/Elastica/Facet/GeoDistance.php
+++ b/lib/Elastica/Facet/GeoDistance.php
@@ -22,7 +22,7 @@ class GeoDistance extends AbstractFacet
      * array('from' => 150)
      * )
      *
-     * @param  array                       $ranges Numerical array with range definitions.
+     * @param  array $ranges Numerical array with range definitions.
      * @return $this
      */
     public function setRanges(array $ranges)
@@ -33,9 +33,9 @@ class GeoDistance extends AbstractFacet
     /**
      * Set the relative GeoPoint for the facet.
      *
-     * @param  string                      $typeField index type and field e.g foo.bar
-     * @param  float                       $latitude
-     * @param  float                       $longitude
+     * @param  string $typeField index type and field e.g foo.bar
+     * @param  float  $latitude
+     * @param  float  $longitude
      * @return $this
      */
     public function setGeoPoint($typeField, $latitude, $longitude)
@@ -52,6 +52,7 @@ class GeoDistance extends AbstractFacet
      *
      * @see \Elastica\Facet\AbstractFacet::toArray()
      * @throws \Elastica\Exception\InvalidException When the right fields haven't been set.
+     *
      * @return array
      */
     public function toArray()

--- a/lib/Elastica/Facet/GeoDistance.php
+++ b/lib/Elastica/Facet/GeoDistance.php
@@ -23,7 +23,7 @@ class GeoDistance extends AbstractFacet
      * )
      *
      * @param  array                       $ranges Numerical array with range definitions.
-     * @return \Elastica\Facet\GeoDistance
+     * @return $this
      */
     public function setRanges(array $ranges)
     {
@@ -36,7 +36,7 @@ class GeoDistance extends AbstractFacet
      * @param  string                      $typeField index type and field e.g foo.bar
      * @param  float                       $latitude
      * @param  float                       $longitude
-     * @return \Elastica\Facet\GeoDistance
+     * @return $this
      */
     public function setGeoPoint($typeField, $latitude, $longitude)
     {

--- a/lib/Elastica/Facet/Histogram.php
+++ b/lib/Elastica/Facet/Histogram.php
@@ -15,7 +15,7 @@ class Histogram extends AbstractFacet
     /**
      * Sets the field for histogram
      *
-     * @param  string                    $field The name of the field for the histogram
+     * @param  string $field The name of the field for the histogram
      * @return $this
      */
     public function setField($field)
@@ -26,7 +26,7 @@ class Histogram extends AbstractFacet
     /**
      * Set the value for interval
      *
-     * @param  string                    $interval
+     * @param  string $interval
      * @return $this
      */
     public function setInterval($interval)
@@ -37,8 +37,8 @@ class Histogram extends AbstractFacet
     /**
      * Set the fields for key_field and value_field
      *
-     * @param  string                    $keyField   Key field
-     * @param  string                    $valueField Value field
+     * @param  string $keyField   Key field
+     * @param  string $valueField Value field
      * @return $this
      */
     public function setKeyValueFields($keyField, $valueField)
@@ -49,8 +49,8 @@ class Histogram extends AbstractFacet
     /**
      * Sets the key and value for this facet by script.
      *
-     * @param  string                    $keyScript   Script to check whether it falls into the range.
-     * @param  string                    $valueScript Script to use for statistical calculations.
+     * @param  string $keyScript   Script to check whether it falls into the range.
+     * @param  string $valueScript Script to use for statistical calculations.
      * @return $this
      */
     public function setKeyValueScripts($keyScript, $valueScript)
@@ -62,7 +62,7 @@ class Histogram extends AbstractFacet
     /**
      * Set the "params" essential to the a script
      *
-     * @param  array                     $params Associative array (key/value pair)
+     * @param  array $params Associative array (key/value pair)
      * @return $this
      */
     public function setScriptParams(array $params)
@@ -76,6 +76,7 @@ class Histogram extends AbstractFacet
      *
      * @see \Elastica\Facet\AbstractFacet::toArray()
      * @throws \Elastica\Exception\InvalidException When the right fields haven't been set.
+     *
      * @return array
      */
     public function toArray()

--- a/lib/Elastica/Facet/Histogram.php
+++ b/lib/Elastica/Facet/Histogram.php
@@ -16,7 +16,7 @@ class Histogram extends AbstractFacet
      * Sets the field for histogram
      *
      * @param  string                    $field The name of the field for the histogram
-     * @return \Elastica\Facet\Histogram
+     * @return $this
      */
     public function setField($field)
     {
@@ -27,7 +27,7 @@ class Histogram extends AbstractFacet
      * Set the value for interval
      *
      * @param  string                    $interval
-     * @return \Elastica\Facet\Histogram
+     * @return $this
      */
     public function setInterval($interval)
     {
@@ -39,7 +39,7 @@ class Histogram extends AbstractFacet
      *
      * @param  string                    $keyField   Key field
      * @param  string                    $valueField Value field
-     * @return \Elastica\Facet\Histogram
+     * @return $this
      */
     public function setKeyValueFields($keyField, $valueField)
     {
@@ -51,7 +51,7 @@ class Histogram extends AbstractFacet
      *
      * @param  string                    $keyScript   Script to check whether it falls into the range.
      * @param  string                    $valueScript Script to use for statistical calculations.
-     * @return \Elastica\Facet\Histogram
+     * @return $this
      */
     public function setKeyValueScripts($keyScript, $valueScript)
     {
@@ -63,7 +63,7 @@ class Histogram extends AbstractFacet
      * Set the "params" essential to the a script
      *
      * @param  array                     $params Associative array (key/value pair)
-     * @return \Elastica\Facet\Histogram
+     * @return $this
      */
     public function setScriptParams(array $params)
     {

--- a/lib/Elastica/Facet/Query.php
+++ b/lib/Elastica/Facet/Query.php
@@ -18,7 +18,7 @@ class Query extends AbstractFacet
      * Set the query for the facet.
      *
      * @param  \Elastica\Query\AbstractQuery $query
-     * @return \Elastica\Facet\Query
+     * @return $this
      */
     public function setQuery(AbstractQuery $query)
     {

--- a/lib/Elastica/Facet/Range.php
+++ b/lib/Elastica/Facet/Range.php
@@ -17,7 +17,7 @@ class Range extends AbstractFacet
     /**
      * Sets the field for the range.
      *
-     * @param  string                $field The name of the field for range.
+     * @param  string $field The name of the field for range.
      * @return $this
      */
     public function setField($field)
@@ -28,8 +28,8 @@ class Range extends AbstractFacet
     /**
      * Sets the fields by their separate key and value fields.
      *
-     * @param  string                $keyField   The key_field param for the range.
-     * @param  string                $valueField The key_value param for the range.
+     * @param  string $keyField   The key_field param for the range.
+     * @param  string $valueField The key_value param for the range.
      * @return $this
      */
     public function setKeyValueFields($keyField, $valueField)
@@ -41,8 +41,8 @@ class Range extends AbstractFacet
     /**
      * Sets the key and value for this facet by script.
      *
-     * @param string $keyScript   Script to check whether it falls into the range.
-     * @param string $valueScript Script to use for statistical calculations.
+     * @param  string $keyScript   Script to check whether it falls into the range.
+     * @param  string $valueScript Script to use for statistical calculations.
      * @return $this
      */
     public function setKeyValueScripts($keyScript, $valueScript)
@@ -60,7 +60,7 @@ class Range extends AbstractFacet
      *     array('from' => 150)
      * )
      *
-     * @param  array                 $ranges Numerical array with range definitions.
+     * @param  array $ranges Numerical array with range definitions.
      * @return $this
      */
     public function setRanges(array $ranges)
@@ -71,8 +71,8 @@ class Range extends AbstractFacet
     /**
      * Adds a range to the range facet.
      *
-     * @param  mixed                 $from The from for the range.
-     * @param  mixed                 $to   The to for the range.
+     * @param  mixed $from The from for the range.
+     * @param  mixed $to   The to for the range.
      * @return $this
      */
     public function addRange($from = null, $to = null)
@@ -99,6 +99,7 @@ class Range extends AbstractFacet
      *
      * @see \Elastica\Facet\AbstractFacet::toArray()
      * @throws \Elastica\Exception\InvalidException When the right fields haven't been set.
+     *
      * @return array
      */
     public function toArray()

--- a/lib/Elastica/Facet/Range.php
+++ b/lib/Elastica/Facet/Range.php
@@ -18,7 +18,7 @@ class Range extends AbstractFacet
      * Sets the field for the range.
      *
      * @param  string                $field The name of the field for range.
-     * @return \Elastica\Facet\Range
+     * @return $this
      */
     public function setField($field)
     {
@@ -30,7 +30,7 @@ class Range extends AbstractFacet
      *
      * @param  string                $keyField   The key_field param for the range.
      * @param  string                $valueField The key_value param for the range.
-     * @return \Elastica\Facet\Range
+     * @return $this
      */
     public function setKeyValueFields($keyField, $valueField)
     {
@@ -43,8 +43,7 @@ class Range extends AbstractFacet
      *
      * @param string $keyScript   Script to check whether it falls into the range.
      * @param string $valueScript Script to use for statistical calculations.
-     *
-     * @return \Elastica\Facet\Range
+     * @return $this
      */
     public function setKeyValueScripts($keyScript, $valueScript)
     {
@@ -62,7 +61,7 @@ class Range extends AbstractFacet
      * )
      *
      * @param  array                 $ranges Numerical array with range definitions.
-     * @return \Elastica\Facet\Range
+     * @return $this
      */
     public function setRanges(array $ranges)
     {
@@ -74,7 +73,7 @@ class Range extends AbstractFacet
      *
      * @param  mixed                 $from The from for the range.
      * @param  mixed                 $to   The to for the range.
-     * @return \Elastica\Facet\Range
+     * @return $this
      */
     public function addRange($from = null, $to = null)
     {

--- a/lib/Elastica/Facet/Statistical.php
+++ b/lib/Elastica/Facet/Statistical.php
@@ -15,7 +15,7 @@ class Statistical extends AbstractFacet
     /**
      * Sets the field for the statistical query.
      *
-     * @param  string                      $field The field name for the statistical query.
+     * @param  string $field The field name for the statistical query.
      * @return $this
      */
     public function setField($field)
@@ -26,7 +26,7 @@ class Statistical extends AbstractFacet
     /**
      * Sets multiple fields for the statistical query.
      *
-     * @param  array                       $fields Numerical array with the fields for the statistical query.
+     * @param  array $fields Numerical array with the fields for the statistical query.
      * @return $this
      */
     public function setFields(array $fields)
@@ -37,7 +37,7 @@ class Statistical extends AbstractFacet
     /**
      * Sets a script to calculate statistical information
      *
-     * @param  string                      $script The script to do calculations on the statistical values
+     * @param  string $script The script to do calculations on the statistical values
      * @return $this
      */
     public function setScript($script)

--- a/lib/Elastica/Facet/Statistical.php
+++ b/lib/Elastica/Facet/Statistical.php
@@ -16,7 +16,7 @@ class Statistical extends AbstractFacet
      * Sets the field for the statistical query.
      *
      * @param  string                      $field The field name for the statistical query.
-     * @return \Elastica\Facet\Statistical
+     * @return $this
      */
     public function setField($field)
     {
@@ -27,7 +27,7 @@ class Statistical extends AbstractFacet
      * Sets multiple fields for the statistical query.
      *
      * @param  array                       $fields Numerical array with the fields for the statistical query.
-     * @return \Elastica\Facet\Statistical
+     * @return $this
      */
     public function setFields(array $fields)
     {
@@ -38,7 +38,7 @@ class Statistical extends AbstractFacet
      * Sets a script to calculate statistical information
      *
      * @param  string                      $script The script to do calculations on the statistical values
-     * @return \Elastica\Facet\Statistical
+     * @return $this
      */
     public function setScript($script)
     {

--- a/lib/Elastica/Facet/Terms.php
+++ b/lib/Elastica/Facet/Terms.php
@@ -28,7 +28,7 @@ class Terms extends AbstractFacet
      * Sets the field for the terms.
      *
      * @param  string                $field The field name for the terms.
-     * @return \Elastica\Facet\Terms
+     * @return $this
      */
     public function setField($field)
     {
@@ -39,7 +39,7 @@ class Terms extends AbstractFacet
      * Sets the script for the term.
      *
      * @param  string                $script The script for the term.
-     * @return \Elastica\Facet\Terms
+     * @return $this
      */
     public function setScript($script)
     {
@@ -55,7 +55,7 @@ class Terms extends AbstractFacet
      * Sets multiple fields for the terms.
      *
      * @param  array                 $fields Numerical array with the fields for the terms.
-     * @return \Elastica\Facet\Terms
+     * @return $this
      */
     public function setFields(array $fields)
     {
@@ -67,7 +67,7 @@ class Terms extends AbstractFacet
      * don't have a hit, they have a count of zero.
      *
      * @param  bool                  $allTerms Flag to fetch all terms.
-     * @return \Elastica\Facet\Terms
+     * @return $this
      */
     public function setAllTerms($allTerms)
     {
@@ -80,7 +80,7 @@ class Terms extends AbstractFacet
      *
      * @param  string                               $type The order type to set use for sorting of the terms.
      * @throws \Elastica\Exception\InvalidException When an invalid order type was set.
-     * @return \Elastica\Facet\Terms
+     * @return $this
      */
     public function setOrder($type)
     {
@@ -95,7 +95,7 @@ class Terms extends AbstractFacet
      * Set an array with terms which are omitted in the search.
      *
      * @param  array                 $exclude Numerical array which includes all terms which needs to be ignored.
-     * @return \Elastica\Facet\Terms
+     * @return $this
      */
     public function setExclude(array $exclude)
     {
@@ -106,7 +106,7 @@ class Terms extends AbstractFacet
      * Sets the amount of terms to be returned.
      *
      * @param  int                   $size The amount of terms to be returned.
-     * @return \Elastica\Facet\Terms
+     * @return $this
      */
     public function setSize($size)
     {

--- a/lib/Elastica/Facet/Terms.php
+++ b/lib/Elastica/Facet/Terms.php
@@ -27,7 +27,7 @@ class Terms extends AbstractFacet
     /**
      * Sets the field for the terms.
      *
-     * @param  string                $field The field name for the terms.
+     * @param  string $field The field name for the terms.
      * @return $this
      */
     public function setField($field)
@@ -38,7 +38,7 @@ class Terms extends AbstractFacet
     /**
      * Sets the script for the term.
      *
-     * @param  string                $script The script for the term.
+     * @param  string $script The script for the term.
      * @return $this
      */
     public function setScript($script)
@@ -54,7 +54,7 @@ class Terms extends AbstractFacet
     /**
      * Sets multiple fields for the terms.
      *
-     * @param  array                 $fields Numerical array with the fields for the terms.
+     * @param  array $fields Numerical array with the fields for the terms.
      * @return $this
      */
     public function setFields(array $fields)
@@ -66,7 +66,7 @@ class Terms extends AbstractFacet
      * Sets the flag to return all available terms. When they
      * don't have a hit, they have a count of zero.
      *
-     * @param  bool                  $allTerms Flag to fetch all terms.
+     * @param  bool  $allTerms Flag to fetch all terms.
      * @return $this
      */
     public function setAllTerms($allTerms)
@@ -78,8 +78,9 @@ class Terms extends AbstractFacet
      * Sets the ordering type for this facet. Elasticsearch
      * internal default is count.
      *
-     * @param  string                               $type The order type to set use for sorting of the terms.
      * @throws \Elastica\Exception\InvalidException When an invalid order type was set.
+     *
+     * @param  string $type The order type to set use for sorting of the terms.
      * @return $this
      */
     public function setOrder($type)
@@ -94,7 +95,7 @@ class Terms extends AbstractFacet
     /**
      * Set an array with terms which are omitted in the search.
      *
-     * @param  array                 $exclude Numerical array which includes all terms which needs to be ignored.
+     * @param  array $exclude Numerical array which includes all terms which needs to be ignored.
      * @return $this
      */
     public function setExclude(array $exclude)
@@ -105,7 +106,7 @@ class Terms extends AbstractFacet
     /**
      * Sets the amount of terms to be returned.
      *
-     * @param  int                   $size The amount of terms to be returned.
+     * @param  int   $size The amount of terms to be returned.
      * @return $this
      */
     public function setSize($size)
@@ -118,6 +119,7 @@ class Terms extends AbstractFacet
      * facet definition of the parent.
      *
      * @see \Elastica\Facet\AbstractFacet::toArray()
+     *
      * @return array
      */
     public function toArray()

--- a/lib/Elastica/Facet/TermsStats.php
+++ b/lib/Elastica/Facet/TermsStats.php
@@ -28,7 +28,7 @@ class TermsStats extends AbstractFacet
      * Sets the key field for the query.
      *
      * @param  string                     $keyField The key field name for the query.
-     * @return \Elastica\Facet\TermsStats
+     * @return $this
      */
     public function setKeyField($keyField)
     {
@@ -39,7 +39,7 @@ class TermsStats extends AbstractFacet
      * Sets a script to calculate statistical information on a per term basis
      *
      * @param  string                     $valueScript The script to do calculations on the statistical values
-     * @return \Elastica\Facet\TermsStats
+     * @return $this
      */
     public function setValueScript($valueScript)
     {
@@ -52,7 +52,7 @@ class TermsStats extends AbstractFacet
      *
      * @param  string                               $type The order type to set use for sorting of the terms.
      * @throws \Elastica\Exception\InvalidException When an invalid order type was set.
-     * @return \Elastica\Facet\TermsStats
+     * @return $this
      */
     public function setOrder($type)
     {
@@ -67,7 +67,7 @@ class TermsStats extends AbstractFacet
      * Sets a field to compute basic statistical results on
      *
      * @param  string                     $valueField The field to compute statistical values for
-     * @return \Elastica\Facet\TermsStats
+     * @return $this
      */
     public function setValueField($valueField)
     {
@@ -78,7 +78,7 @@ class TermsStats extends AbstractFacet
      * Sets the amount of terms to be returned.
      *
      * @param  int                   $size The amount of terms to be returned.
-     * @return \Elastica\Facet\Terms
+     * @return $this
      */
     public function setSize($size)
     {

--- a/lib/Elastica/Facet/TermsStats.php
+++ b/lib/Elastica/Facet/TermsStats.php
@@ -27,7 +27,7 @@ class TermsStats extends AbstractFacet
     /**
      * Sets the key field for the query.
      *
-     * @param  string                     $keyField The key field name for the query.
+     * @param  string $keyField The key field name for the query.
      * @return $this
      */
     public function setKeyField($keyField)
@@ -38,7 +38,7 @@ class TermsStats extends AbstractFacet
     /**
      * Sets a script to calculate statistical information on a per term basis
      *
-     * @param  string                     $valueScript The script to do calculations on the statistical values
+     * @param  string $valueScript The script to do calculations on the statistical values
      * @return $this
      */
     public function setValueScript($valueScript)
@@ -50,8 +50,9 @@ class TermsStats extends AbstractFacet
      * Sets the ordering type for this facet. Elasticsearch
      * internal default is count.
      *
-     * @param  string                               $type The order type to set use for sorting of the terms.
      * @throws \Elastica\Exception\InvalidException When an invalid order type was set.
+     *
+     * @param  string $type The order type to set use for sorting of the terms.
      * @return $this
      */
     public function setOrder($type)
@@ -66,7 +67,7 @@ class TermsStats extends AbstractFacet
     /**
      * Sets a field to compute basic statistical results on
      *
-     * @param  string                     $valueField The field to compute statistical values for
+     * @param  string $valueField The field to compute statistical values for
      * @return $this
      */
     public function setValueField($valueField)
@@ -77,7 +78,7 @@ class TermsStats extends AbstractFacet
     /**
      * Sets the amount of terms to be returned.
      *
-     * @param  int                   $size The amount of terms to be returned.
+     * @param  int   $size The amount of terms to be returned.
      * @return $this
      */
     public function setSize($size)
@@ -90,6 +91,7 @@ class TermsStats extends AbstractFacet
      * facet definition of the parent.
      *
      * @see \Elastica\Facet\AbstractFacet::toArray()
+     *
      * @return array
      */
     public function toArray()

--- a/lib/Elastica/Filter/AbstractFilter.php
+++ b/lib/Elastica/Filter/AbstractFilter.php
@@ -19,7 +19,7 @@ abstract class AbstractFilter extends Param
      * Sets the filter cache
      *
      * @param  boolean                         $cached Cached
-     * @return \Elastica\Filter\AbstractFilter
+     * @return $this
      */
     public function setCached($cached = true)
     {
@@ -31,7 +31,7 @@ abstract class AbstractFilter extends Param
      *
      * @param  string                               $cacheKey Cache key
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Filter\AbstractFilter
+     * @return $this
      */
     public function setCacheKey($cacheKey)
     {
@@ -48,7 +48,7 @@ abstract class AbstractFilter extends Param
      * Sets the filter name
      *
      * @param  string                          $name Name
-     * @return \Elastica\Filter\AbstractFilter
+     * @return $this
      */
     public function setName($name)
     {

--- a/lib/Elastica/Filter/AbstractFilter.php
+++ b/lib/Elastica/Filter/AbstractFilter.php
@@ -18,7 +18,7 @@ abstract class AbstractFilter extends Param
     /**
      * Sets the filter cache
      *
-     * @param  boolean                         $cached Cached
+     * @param  boolean $cached Cached
      * @return $this
      */
     public function setCached($cached = true)
@@ -29,8 +29,9 @@ abstract class AbstractFilter extends Param
     /**
      * Sets the filter cache key
      *
-     * @param  string                               $cacheKey Cache key
-     * @throws \Elastica\Exception\InvalidException
+     * @throws \Elastica\Exception\InvalidException If given key is empty
+     *
+     * @param  string $cacheKey Cache key
      * @return $this
      */
     public function setCacheKey($cacheKey)
@@ -47,7 +48,7 @@ abstract class AbstractFilter extends Param
     /**
      * Sets the filter name
      *
-     * @param  string                          $name Name
+     * @param  string $name Name
      * @return $this
      */
     public function setName($name)

--- a/lib/Elastica/Filter/AbstractGeoDistance.php
+++ b/lib/Elastica/Filter/AbstractGeoDistance.php
@@ -70,7 +70,7 @@ abstract class AbstractGeoDistance extends AbstractFilter
     }
 
     /**
-     * @param  string                               $key
+     * @param  string $key
      * @return $this
      */
     public function setKey($key)
@@ -81,9 +81,10 @@ abstract class AbstractGeoDistance extends AbstractFilter
     }
 
     /**
-     * @param  array|string                         $location
-     * @return $this
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  array|string $location
+     * @return $this
      */
     public function setLocation($location)
     {
@@ -112,7 +113,7 @@ abstract class AbstractGeoDistance extends AbstractFilter
     }
 
     /**
-     * @param  float                                $latitude
+     * @param  float $latitude
      * @return $this
      */
     public function setLatitude($latitude)
@@ -124,7 +125,7 @@ abstract class AbstractGeoDistance extends AbstractFilter
     }
 
     /**
-     * @param  float                                $longitude
+     * @param  float $longitude
      * @return $this
      */
     public function setLongitude($longitude)
@@ -136,7 +137,7 @@ abstract class AbstractGeoDistance extends AbstractFilter
     }
 
     /**
-     * @param  string                               $geohash
+     * @param  string $geohash
      * @return $this
      */
     public function setGeohash($geohash)
@@ -148,8 +149,9 @@ abstract class AbstractGeoDistance extends AbstractFilter
     }
 
     /**
-     * @return array|string
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @return array|string
      */
     protected function _getLocationData()
     {
@@ -179,6 +181,8 @@ abstract class AbstractGeoDistance extends AbstractFilter
     /**
      * @see \Elastica\Param::toArray()
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @return array
      */
     public function toArray()
     {

--- a/lib/Elastica/Filter/AbstractGeoDistance.php
+++ b/lib/Elastica/Filter/AbstractGeoDistance.php
@@ -71,7 +71,7 @@ abstract class AbstractGeoDistance extends AbstractFilter
 
     /**
      * @param  string                               $key
-     * @return \Elastica\Filter\AbstractGeoDistance current filter
+     * @return $this
      */
     public function setKey($key)
     {
@@ -82,7 +82,7 @@ abstract class AbstractGeoDistance extends AbstractFilter
 
     /**
      * @param  array|string                         $location
-     * @return \Elastica\Filter\AbstractGeoDistance
+     * @return $this
      * @throws \Elastica\Exception\InvalidException
      */
     public function setLocation($location)
@@ -113,7 +113,7 @@ abstract class AbstractGeoDistance extends AbstractFilter
 
     /**
      * @param  float                                $latitude
-     * @return \Elastica\Filter\AbstractGeoDistance current filter
+     * @return $this
      */
     public function setLatitude($latitude)
     {
@@ -125,7 +125,7 @@ abstract class AbstractGeoDistance extends AbstractFilter
 
     /**
      * @param  float                                $longitude
-     * @return \Elastica\Filter\AbstractGeoDistance current filter
+     * @return $this
      */
     public function setLongitude($longitude)
     {
@@ -137,7 +137,7 @@ abstract class AbstractGeoDistance extends AbstractFilter
 
     /**
      * @param  string                               $geohash
-     * @return \Elastica\Filter\AbstractGeoDistance current filter
+     * @return $this
      */
     public function setGeohash($geohash)
     {

--- a/lib/Elastica/Filter/AbstractGeoShape.php
+++ b/lib/Elastica/Filter/AbstractGeoShape.php
@@ -33,11 +33,14 @@ abstract class AbstractGeoShape extends AbstractFilter
     protected $_relation = self::RELATION_INTERSECT;
 
     /**
-     * @param string $relation
+     * @param  string $relation
+     * @return $this
      */
     public function setRelation($relation)
     {
         $this->_relation = $relation;
+
+        return $this;
     }
 
     /**

--- a/lib/Elastica/Filter/AbstractMulti.php
+++ b/lib/Elastica/Filter/AbstractMulti.php
@@ -21,7 +21,7 @@ abstract class AbstractMulti extends AbstractFilter
      * Add filter
      *
      * @param  \Elastica\Filter\AbstractFilter $filter
-     * @return \Elastica\Filter\AbstractMulti
+     * @return $this
      */
     public function addFilter(AbstractFilter $filter)
     {
@@ -34,7 +34,7 @@ abstract class AbstractMulti extends AbstractFilter
      * Set filters
      *
      * @param  array                          $filters
-     * @return \Elastica\Filter\AbstractMulti
+     * @return $this
      */
     public function setFilters(array $filters)
     {

--- a/lib/Elastica/Filter/AbstractMulti.php
+++ b/lib/Elastica/Filter/AbstractMulti.php
@@ -33,7 +33,7 @@ abstract class AbstractMulti extends AbstractFilter
     /**
      * Set filters
      *
-     * @param  array                          $filters
+     * @param  array $filters
      * @return $this
      */
     public function setFilters(array $filters)
@@ -57,6 +57,7 @@ abstract class AbstractMulti extends AbstractFilter
 
     /**
      * @see \Elastica\Param::toArray()
+     * @return array
      */
     public function toArray()
     {

--- a/lib/Elastica/Filter/Bool.php
+++ b/lib/Elastica/Filter/Bool.php
@@ -39,7 +39,7 @@ class Bool extends AbstractFilter
      * Adds should filter
      *
      * @param  array|\Elastica\Filter\AbstractFilter $args Filter data
-     * @return \Elastica\Filter\Bool                 Current object
+     * @return $this
      */
     public function addShould($args)
     {
@@ -50,7 +50,7 @@ class Bool extends AbstractFilter
      * Adds must filter
      *
      * @param  array|\Elastica\Filter\AbstractFilter $args Filter data
-     * @return \Elastica\Filter\Bool                 Current object
+     * @return $this
      */
     public function addMust($args)
     {
@@ -61,7 +61,7 @@ class Bool extends AbstractFilter
      * Adds mustNot filter
      *
      * @param  array|\Elastica\Filter\AbstractFilter $args Filter data
-     * @return \Elastica\Filter\Bool                 Current object
+     * @return $this
      */
     public function addMustNot($args)
     {
@@ -74,7 +74,7 @@ class Bool extends AbstractFilter
      * @param  string                                $type Filter type
      * @param  array|\Elastica\Filter\AbstractFilter $args Filter data
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Filter\Bool                 Current object
+     * @return $this
      */
     protected function _addFilter($type, $args)
     {

--- a/lib/Elastica/Filter/Bool.php
+++ b/lib/Elastica/Filter/Bool.php
@@ -71,9 +71,10 @@ class Bool extends AbstractFilter
     /**
      * Adds general filter based on type
      *
+     * @throws \Elastica\Exception\InvalidException
+     *
      * @param  string                                $type Filter type
      * @param  array|\Elastica\Filter\AbstractFilter $args Filter data
-     * @throws \Elastica\Exception\InvalidException
      * @return $this
      */
     protected function _addFilter($type, $args)
@@ -102,6 +103,7 @@ class Bool extends AbstractFilter
      * Converts bool filter to array
      *
      * @see \Elastica\Filter\AbstractFilter::toArray()
+     *
      * @return array Filter array
      */
     public function toArray()

--- a/lib/Elastica/Filter/BoolNot.php
+++ b/lib/Elastica/Filter/BoolNot.php
@@ -26,7 +26,7 @@ class BoolNot extends AbstractFilter
      * Set filter
      *
      * @param  \Elastica\Filter\AbstractFilter $filter
-     * @return \Elastica\Filter\BoolNot
+     * @return $this
      */
     public function setFilter(AbstractFilter $filter)
     {

--- a/lib/Elastica/Filter/Exists.php
+++ b/lib/Elastica/Filter/Exists.php
@@ -26,7 +26,7 @@ class Exists extends AbstractFilter
      * Set field
      *
      * @param  string                  $field
-     * @return \Elastica\Filter\Exists
+     * @return $this
      */
     public function setField($field)
     {

--- a/lib/Elastica/Filter/Exists.php
+++ b/lib/Elastica/Filter/Exists.php
@@ -25,7 +25,7 @@ class Exists extends AbstractFilter
     /**
      * Set field
      *
-     * @param  string                  $field
+     * @param  string $field
      * @return $this
      */
     public function setField($field)

--- a/lib/Elastica/Filter/GeoBoundingBox.php
+++ b/lib/Elastica/Filter/GeoBoundingBox.php
@@ -30,8 +30,8 @@ class GeoBoundingBox extends AbstractFilter
      *
      * @param  string                               $key         Key
      * @param  array                                $coordinates Array with top left coordinate as first and bottom right coordinate as second element
+     * @return $this
      * @throws \Elastica\Exception\InvalidException If $coordinates doesn't have two elements
-     * @return \Elastica\Filter\GeoBoundingBox      Current object
      */
     public function addCoordinates($key, array $coordinates)
     {

--- a/lib/Elastica/Filter/GeoBoundingBox.php
+++ b/lib/Elastica/Filter/GeoBoundingBox.php
@@ -28,10 +28,11 @@ class GeoBoundingBox extends AbstractFilter
     /**
      * Add coordinates
      *
-     * @param  string                               $key         Key
-     * @param  array                                $coordinates Array with top left coordinate as first and bottom right coordinate as second element
-     * @return $this
      * @throws \Elastica\Exception\InvalidException If $coordinates doesn't have two elements
+     *
+     * @param  string $key         Key
+     * @param  array  $coordinates Array with top left coordinate as first and bottom right coordinate as second element
+     * @return $this
      */
     public function addCoordinates($key, array $coordinates)
     {

--- a/lib/Elastica/Filter/GeoDistance.php
+++ b/lib/Elastica/Filter/GeoDistance.php
@@ -37,7 +37,7 @@ class GeoDistance extends AbstractGeoDistance
 
     /**
      * @param  string                       $distance
-     * @return \Elastica\Filter\GeoDistance current filter
+     * @return $this
      */
     public function setDistance($distance)
     {
@@ -50,7 +50,7 @@ class GeoDistance extends AbstractGeoDistance
      * See DISTANCE_TYPE_* constants
      *
      * @param  string                       $distanceType
-     * @return \Elastica\Filter\GeoDistance current filter
+     * @return $this
      */
     public function setDistanceType($distanceType)
     {
@@ -63,7 +63,7 @@ class GeoDistance extends AbstractGeoDistance
      * See OPTIMIZE_BBOX_* constants
      *
      * @param  string                       $optimizeBbox
-     * @return \Elastica\Filter\GeoDistance current filter
+     * @return $this
      */
     public function setOptimizeBbox($optimizeBbox)
     {

--- a/lib/Elastica/Filter/GeoDistance.php
+++ b/lib/Elastica/Filter/GeoDistance.php
@@ -23,10 +23,11 @@ class GeoDistance extends AbstractGeoDistance
     /**
      * Create GeoDistance object
      *
-     * @param  string                               $key      Key
-     * @param  array|string                         $location Location as array or geohash: array('lat' => 48.86, 'lon' => 2.35) OR 'drm3btev3e86'
-     * @param  string                               $distance Distance
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param string       $key      Key
+     * @param array|string $location Location as array or geohash: array('lat' => 48.86, 'lon' => 2.35) OR 'drm3btev3e86'
+     * @param string       $distance Distance
      */
     public function __construct($key, $location, $distance)
     {
@@ -36,7 +37,7 @@ class GeoDistance extends AbstractGeoDistance
     }
 
     /**
-     * @param  string                       $distance
+     * @param  string $distance
      * @return $this
      */
     public function setDistance($distance)
@@ -49,7 +50,7 @@ class GeoDistance extends AbstractGeoDistance
     /**
      * See DISTANCE_TYPE_* constants
      *
-     * @param  string                       $distanceType
+     * @param  string $distanceType
      * @return $this
      */
     public function setDistanceType($distanceType)
@@ -62,7 +63,7 @@ class GeoDistance extends AbstractGeoDistance
     /**
      * See OPTIMIZE_BBOX_* constants
      *
-     * @param  string                       $optimizeBbox
+     * @param  string $optimizeBbox
      * @return $this
      */
     public function setOptimizeBbox($optimizeBbox)

--- a/lib/Elastica/Filter/GeoDistanceRange.php
+++ b/lib/Elastica/Filter/GeoDistanceRange.php
@@ -45,7 +45,7 @@ class GeoDistanceRange extends AbstractGeoDistance
     }
 
     /**
-     * @param  array                             $ranges
+     * @param  array $ranges
      * @return $this
      */
     public function setRanges(array $ranges)
@@ -60,10 +60,11 @@ class GeoDistanceRange extends AbstractGeoDistance
     }
 
     /**
-     * @param  string                               $key
-     * @param  mixed                                $value
-     * @return $this
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  string $key
+     * @param  mixed  $value
+     * @return $this
      */
     public function setRange($key, $value)
     {

--- a/lib/Elastica/Filter/GeoDistanceRange.php
+++ b/lib/Elastica/Filter/GeoDistanceRange.php
@@ -46,7 +46,7 @@ class GeoDistanceRange extends AbstractGeoDistance
 
     /**
      * @param  array                             $ranges
-     * @return \Elastica\Filter\GeoDistanceRange
+     * @return $this
      */
     public function setRanges(array $ranges)
     {
@@ -62,7 +62,7 @@ class GeoDistanceRange extends AbstractGeoDistance
     /**
      * @param  string                               $key
      * @param  mixed                                $value
-     * @return \Elastica\Filter\GeoDistanceRange
+     * @return $this
      * @throws \Elastica\Exception\InvalidException
      */
     public function setRange($key, $value)

--- a/lib/Elastica/Filter/GeoPolygon.php
+++ b/lib/Elastica/Filter/GeoPolygon.php
@@ -42,6 +42,7 @@ class GeoPolygon extends AbstractFilter
      * Converts filter to array
      *
      * @see \Elastica\Filter\AbstractFilter::toArray()
+     *
      * @return array
      */
     public function toArray()

--- a/lib/Elastica/Filter/GeoShapePreIndexed.php
+++ b/lib/Elastica/Filter/GeoShapePreIndexed.php
@@ -64,6 +64,7 @@ class GeoShapePreIndexed extends AbstractGeoShape
      * Converts filter to array
      *
      * @see \Elastica\Filter\AbstractFilter::toArray()
+     *
      * @return array
      */
     public function toArray()

--- a/lib/Elastica/Filter/GeoShapeProvided.php
+++ b/lib/Elastica/Filter/GeoShapeProvided.php
@@ -55,6 +55,7 @@ class GeoShapeProvided extends AbstractGeoShape
      * Converts filter to array
      *
      * @see \Elastica\Filter\AbstractFilter::toArray()
+     *
      * @return array
      */
     public function toArray()

--- a/lib/Elastica/Filter/GeohashCell.php
+++ b/lib/Elastica/Filter/GeohashCell.php
@@ -24,7 +24,7 @@ class GeohashCell extends AbstractGeoDistance
 
     /**
      * Set the precision for this filter
-     * @param  string|int                   $precision Integer length of geohash prefix or distance (3, or "50m")
+     * @param  string|int $precision Integer length of geohash prefix or distance (3, or "50m")
      * @return $this
      */
     public function setPrecision($precision)
@@ -34,7 +34,7 @@ class GeohashCell extends AbstractGeoDistance
 
     /**
      * Set the neighbors option for this filter
-     * @param  bool                         $neighbors If true, filters cells next to the given cell.
+     * @param  bool  $neighbors If true, filters cells next to the given cell.
      * @return $this
      */
     public function setNeighbors($neighbors)

--- a/lib/Elastica/Filter/GeohashCell.php
+++ b/lib/Elastica/Filter/GeohashCell.php
@@ -25,7 +25,7 @@ class GeohashCell extends AbstractGeoDistance
     /**
      * Set the precision for this filter
      * @param  string|int                   $precision Integer length of geohash prefix or distance (3, or "50m")
-     * @return \Elastica\Filter\GeohashCell
+     * @return $this
      */
     public function setPrecision($precision)
     {
@@ -35,7 +35,7 @@ class GeohashCell extends AbstractGeoDistance
     /**
      * Set the neighbors option for this filter
      * @param  bool                         $neighbors If true, filters cells next to the given cell.
-     * @return \Elastica\Filter\GeohashCell
+     * @return $this
      */
     public function setNeighbors($neighbors)
     {

--- a/lib/Elastica/Filter/HasChild.php
+++ b/lib/Elastica/Filter/HasChild.php
@@ -56,7 +56,7 @@ class HasChild extends AbstractFilter
     /**
      * Set type of the child document
      *
-     * @param  string|\Elastica\Type      $type Child document type
+     * @param  string|\Elastica\Type $type Child document type
      * @return $this
      */
     public function setType($type)
@@ -70,7 +70,7 @@ class HasChild extends AbstractFilter
 
     /**
      * Set minimum number of children are required to match for the parent doc to be considered a match
-     * @param  int                       $count
+     * @param  int   $count
      * @return $this
      */
     public function setMinimumChildrenCount($count)
@@ -80,7 +80,7 @@ class HasChild extends AbstractFilter
 
     /**
      * Set maximum number of children are required to match for the parent doc to be considered a match
-     * @param  int                       $count
+     * @param  int   $count
      * @return $this
      */
     public function setMaximumChildrenCount($count)

--- a/lib/Elastica/Filter/HasChild.php
+++ b/lib/Elastica/Filter/HasChild.php
@@ -32,7 +32,7 @@ class HasChild extends AbstractFilter
      * Sets query object
      *
      * @param  string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
-     * @return \Elastica\Filter\HasChild                            Current object
+     * @return $this
      */
     public function setQuery($query)
     {
@@ -46,7 +46,7 @@ class HasChild extends AbstractFilter
      * Sets the filter object
      *
      * @param  \Elastica\Filter\AbstractFilter $filter
-     * @return \Elastica\Filter\HasChild       Current object
+     * @return $this
      */
     public function setFilter($filter)
     {
@@ -57,7 +57,7 @@ class HasChild extends AbstractFilter
      * Set type of the child document
      *
      * @param  string|\Elastica\Type      $type Child document type
-     * @return \Elastica\Filter\HasParent Current object
+     * @return $this
      */
     public function setType($type)
     {
@@ -71,7 +71,7 @@ class HasChild extends AbstractFilter
     /**
      * Set minimum number of children are required to match for the parent doc to be considered a match
      * @param  int                       $count
-     * @return \Elastica\Filter\HasChild
+     * @return $this
      */
     public function setMinimumChildrenCount($count)
     {
@@ -81,7 +81,7 @@ class HasChild extends AbstractFilter
     /**
      * Set maximum number of children are required to match for the parent doc to be considered a match
      * @param  int                       $count
-     * @return \Elastica\Filter\HasChild
+     * @return $this
      */
     public function setMaximumChildrenCount($count)
     {

--- a/lib/Elastica/Filter/HasParent.php
+++ b/lib/Elastica/Filter/HasParent.php
@@ -31,7 +31,7 @@ class HasParent extends AbstractFilter
      * Sets query object
      *
      * @param  string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
-     * @return \Elastica\Filter\HasParent                           Current object
+     * @return $this
      */
     public function setQuery($query)
     {
@@ -45,7 +45,7 @@ class HasParent extends AbstractFilter
      * Sets filter object
      *
      * @param  \Elastica\Filter\AbstractFilter $filter
-     * @return \Elastica\Filter\HasParent      Current object
+     * @return $this
      */
     public function setFilter($filter)
     {
@@ -56,7 +56,7 @@ class HasParent extends AbstractFilter
      * Set type of the parent document
      *
      * @param  string|\Elastica\Type      $type Parent document type
-     * @return \Elastica\Filter\HasParent Current object
+     * @return $this
      */
     public function setType($type)
     {

--- a/lib/Elastica/Filter/HasParent.php
+++ b/lib/Elastica/Filter/HasParent.php
@@ -55,7 +55,7 @@ class HasParent extends AbstractFilter
     /**
      * Set type of the parent document
      *
-     * @param  string|\Elastica\Type      $type Parent document type
+     * @param  string|\Elastica\Type $type Parent document type
      * @return $this
      */
     public function setType($type)

--- a/lib/Elastica/Filter/Ids.php
+++ b/lib/Elastica/Filter/Ids.php
@@ -29,7 +29,7 @@ class Ids extends AbstractFilter
     /**
      * Adds one more filter to the and filter
      *
-     * @param  string               $id Adds id to filter
+     * @param  string $id Adds id to filter
      * @return $this
      */
     public function addId($id)
@@ -78,7 +78,7 @@ class Ids extends AbstractFilter
     /**
      * Sets the ids to filter
      *
-     * @param  array|string         $ids List of ids
+     * @param  array|string $ids List of ids
      * @return $this
      */
     public function setIds($ids)

--- a/lib/Elastica/Filter/Ids.php
+++ b/lib/Elastica/Filter/Ids.php
@@ -30,7 +30,7 @@ class Ids extends AbstractFilter
      * Adds one more filter to the and filter
      *
      * @param  string               $id Adds id to filter
-     * @return \Elastica\Filter\Ids Current object
+     * @return $this
      */
     public function addId($id)
     {
@@ -41,7 +41,7 @@ class Ids extends AbstractFilter
      * Adds one more type to query
      *
      * @param  string|\Elastica\Type $type Type name or object
-     * @return \Elastica\Filter\Ids  Current object
+     * @return $this
      */
     public function addType($type)
     {
@@ -60,7 +60,7 @@ class Ids extends AbstractFilter
      * Set type
      *
      * @param  string|\Elastica\Type $type Type name or object
-     * @return \Elastica\Filter\Ids  Current object
+     * @return $this
      */
     public function setType($type)
     {
@@ -79,7 +79,7 @@ class Ids extends AbstractFilter
      * Sets the ids to filter
      *
      * @param  array|string         $ids List of ids
-     * @return \Elastica\Filter\Ids Current object
+     * @return $this
      */
     public function setIds($ids)
     {

--- a/lib/Elastica/Filter/Indices.php
+++ b/lib/Elastica/Filter/Indices.php
@@ -23,7 +23,7 @@ class Indices extends AbstractFilter
     /**
      * Set the indices on which this filter should be applied
      * @param  mixed[] $indices
-     * @return Indices
+     * @return $this
      */
     public function setIndices(array $indices)
     {
@@ -38,7 +38,7 @@ class Indices extends AbstractFilter
     /**
      * Adds one more index on which this filter should be applied
      * @param  string|\Elastica\Index $index
-     * @return Indices
+     * @return $this
      */
     public function addIndex($index)
     {
@@ -52,7 +52,7 @@ class Indices extends AbstractFilter
     /**
      * Set the filter to be applied to docs in the specified indices
      * @param  AbstractFilter $filter
-     * @return Indices
+     * @return $this
      */
     public function setFilter(AbstractFilter $filter)
     {
@@ -62,7 +62,7 @@ class Indices extends AbstractFilter
     /**
      * Set the filter to be applied to docs in indices which do not match those specified in the "indices" parameter
      * @param  AbstractFilter $filter
-     * @return Indices
+     * @return $this
      */
     public function setNoMatchFilter(AbstractFilter $filter)
     {

--- a/lib/Elastica/Filter/Limit.php
+++ b/lib/Elastica/Filter/Limit.php
@@ -16,7 +16,6 @@ class Limit extends AbstractFilter
      * Construct limit filter
      *
      * @param  int                    $limit Limit
-     * @return \Elastica\Filter\Limit
      */
     public function __construct($limit)
     {
@@ -27,7 +26,7 @@ class Limit extends AbstractFilter
      * Set the limit
      *
      * @param  int                    $limit Limit
-     * @return \Elastica\Filter\Limit
+     * @return $this
      */
     public function setLimit($limit)
     {

--- a/lib/Elastica/Filter/Limit.php
+++ b/lib/Elastica/Filter/Limit.php
@@ -15,7 +15,7 @@ class Limit extends AbstractFilter
     /**
      * Construct limit filter
      *
-     * @param  int                    $limit Limit
+     * @param int $limit Limit
      */
     public function __construct($limit)
     {
@@ -25,7 +25,7 @@ class Limit extends AbstractFilter
     /**
      * Set the limit
      *
-     * @param  int                    $limit Limit
+     * @param  int   $limit Limit
      * @return $this
      */
     public function setLimit($limit)

--- a/lib/Elastica/Filter/Missing.php
+++ b/lib/Elastica/Filter/Missing.php
@@ -27,7 +27,7 @@ class Missing extends AbstractFilter
     /**
      * Set field
      *
-     * @param  string                   $field
+     * @param  string $field
      * @return $this
      */
     public function setField($field)
@@ -37,7 +37,7 @@ class Missing extends AbstractFilter
 
     /**
      * Set "existence" parameter
-     * @param  bool                     $existence
+     * @param  bool  $existence
      * @return $this
      */
     public function setExistence($existence)
@@ -47,7 +47,7 @@ class Missing extends AbstractFilter
 
     /**
      * Set "null_value" parameter
-     * @param  bool                     $nullValue
+     * @param  bool  $nullValue
      * @return $this
      */
     public function setNullValue($nullValue)

--- a/lib/Elastica/Filter/Missing.php
+++ b/lib/Elastica/Filter/Missing.php
@@ -28,7 +28,7 @@ class Missing extends AbstractFilter
      * Set field
      *
      * @param  string                   $field
-     * @return \Elastica\Filter\Missing
+     * @return $this
      */
     public function setField($field)
     {
@@ -38,7 +38,7 @@ class Missing extends AbstractFilter
     /**
      * Set "existence" parameter
      * @param  bool                     $existence
-     * @return \Elastica\Filter\Missing
+     * @return $this
      */
     public function setExistence($existence)
     {
@@ -48,7 +48,7 @@ class Missing extends AbstractFilter
     /**
      * Set "null_value" parameter
      * @param  bool                     $nullValue
-     * @return \Elastica\Filter\Missing
+     * @return $this
      */
     public function setNullValue($nullValue)
     {

--- a/lib/Elastica/Filter/Nested.php
+++ b/lib/Elastica/Filter/Nested.php
@@ -17,7 +17,7 @@ class Nested extends AbstractFilter
     /**
      * Adds field to mlt filter
      *
-     * @param  string                  $path Nested object path
+     * @param  string $path Nested object path
      * @return $this
      */
     public function setPath($path)
@@ -50,7 +50,7 @@ class Nested extends AbstractFilter
     /**
      * Set join option
      *
-     * @param  bool                    $join
+     * @param  bool  $join
      * @return $this
      */
     public function setJoin($join)

--- a/lib/Elastica/Filter/Nested.php
+++ b/lib/Elastica/Filter/Nested.php
@@ -18,7 +18,7 @@ class Nested extends AbstractFilter
      * Adds field to mlt filter
      *
      * @param  string                  $path Nested object path
-     * @return \Elastica\Filter\Nested
+     * @return $this
      */
     public function setPath($path)
     {
@@ -29,7 +29,7 @@ class Nested extends AbstractFilter
      * Sets nested query
      *
      * @param  \Elastica\Query\AbstractQuery $query
-     * @return \Elastica\Filter\Nested
+     * @return $this
      */
     public function setQuery(AbstractQuery $query)
     {
@@ -40,7 +40,7 @@ class Nested extends AbstractFilter
      * Sets nested filter
      *
      * @param  \Elastica\Filter\AbstractFilter $filter
-     * @return \Elastica\Filter\Nested
+     * @return $this
      */
     public function setFilter(AbstractFilter $filter)
     {
@@ -51,7 +51,7 @@ class Nested extends AbstractFilter
      * Set join option
      *
      * @param  bool                    $join
-     * @return \Elastica\Filter\Nested
+     * @return $this
      */
     public function setJoin($join)
     {

--- a/lib/Elastica/Filter/Prefix.php
+++ b/lib/Elastica/Filter/Prefix.php
@@ -41,7 +41,7 @@ class Prefix extends AbstractFilter
     /**
      * Sets the name of the prefix field.
      *
-     * @param  string                  $field Field name
+     * @param  string $field Field name
      * @return $this
      */
     public function setField($field)
@@ -54,7 +54,7 @@ class Prefix extends AbstractFilter
     /**
      * Sets the prefix string.
      *
-     * @param  string                  $prefix Prefix string
+     * @param  string $prefix Prefix string
      * @return $this
      */
     public function setPrefix($prefix)

--- a/lib/Elastica/Filter/Prefix.php
+++ b/lib/Elastica/Filter/Prefix.php
@@ -42,7 +42,7 @@ class Prefix extends AbstractFilter
      * Sets the name of the prefix field.
      *
      * @param  string                  $field Field name
-     * @return \Elastica\Filter\Prefix
+     * @return $this
      */
     public function setField($field)
     {
@@ -55,7 +55,7 @@ class Prefix extends AbstractFilter
      * Sets the prefix string.
      *
      * @param  string                  $prefix Prefix string
-     * @return \Elastica\Filter\Prefix
+     * @return $this
      */
     public function setPrefix($prefix)
     {

--- a/lib/Elastica/Filter/Query.php
+++ b/lib/Elastica/Filter/Query.php
@@ -37,7 +37,7 @@ class Query extends AbstractFilter
      * Set query
      *
      * @param  array|\Elastica\Query\AbstractQuery  $query
-     * @return \Elastica\Filter\Query               Query object
+     * @return $this
      * @throws \Elastica\Exception\InvalidException Invalid param
      */
     public function setQuery($query)

--- a/lib/Elastica/Filter/Query.php
+++ b/lib/Elastica/Filter/Query.php
@@ -36,9 +36,10 @@ class Query extends AbstractFilter
     /**
      * Set query
      *
-     * @param  array|\Elastica\Query\AbstractQuery  $query
+     * @throws \Elastica\Exception\InvalidException If parameter is invalid
+     *
+     * @param  array|\Elastica\Query\AbstractQuery $query
      * @return $this
-     * @throws \Elastica\Exception\InvalidException Invalid param
      */
     public function setQuery($query)
     {

--- a/lib/Elastica/Filter/Range.php
+++ b/lib/Elastica/Filter/Range.php
@@ -35,8 +35,8 @@ class Range extends AbstractFilter
     /**
      * Ads a field with arguments to the range query
      *
-     * @param  string                 $fieldName Field name
-     * @param  array                  $args      Field arguments
+     * @param  string $fieldName Field name
+     * @param  array  $args      Field arguments
      * @return $this
      */
     public function addField($fieldName, array $args)
@@ -49,7 +49,7 @@ class Range extends AbstractFilter
     /**
      * Set execution mode
      *
-     * @param  string                 $execution Options: "index" or "fielddata"
+     * @param  string $execution Options: "index" or "fielddata"
      * @return $this
      */
     public function setExecution($execution)
@@ -66,6 +66,7 @@ class Range extends AbstractFilter
     public function toArray()
     {
         $this->setParams(array_merge($this->getParams(), $this->_fields));
+
         return parent::toArray();
     }
 }

--- a/lib/Elastica/Filter/Range.php
+++ b/lib/Elastica/Filter/Range.php
@@ -37,7 +37,7 @@ class Range extends AbstractFilter
      *
      * @param  string                 $fieldName Field name
      * @param  array                  $args      Field arguments
-     * @return \Elastica\Filter\Range
+     * @return $this
      */
     public function addField($fieldName, array $args)
     {
@@ -50,7 +50,7 @@ class Range extends AbstractFilter
      * Set execution mode
      *
      * @param  string                 $execution Options: "index" or "fielddata"
-     * @return \Elastica\Filter\Range
+     * @return $this
      */
     public function setExecution($execution)
     {

--- a/lib/Elastica/Filter/Regexp.php
+++ b/lib/Elastica/Filter/Regexp.php
@@ -52,7 +52,7 @@ class Regexp extends AbstractFilter
      * Sets the name of the regexp field.
      *
      * @param  string                  $field Field name
-     * @return \Elastica\Filter\Regexp
+     * @return $this
      */
     public function setField($field)
     {
@@ -65,7 +65,7 @@ class Regexp extends AbstractFilter
      * Sets the regular expression query string.
      *
      * @param  string                  $regexp Regular expression
-     * @return \Elastica\Filter\Regexp
+     * @return $this
      */
     public function setRegexp($regexp)
     {
@@ -78,7 +78,7 @@ class Regexp extends AbstractFilter
      * Sets the regular expression query options.
      *
      * @param  array                        $options Regular expression options
-     * @return \Elastica\Filter\Regexp
+     * @return $this
      */
     public function setOptions($options)
     {

--- a/lib/Elastica/Filter/Regexp.php
+++ b/lib/Elastica/Filter/Regexp.php
@@ -36,10 +36,11 @@ class Regexp extends AbstractFilter
     /**
      * Create Regexp object
      *
-     * @param  string $field     Field name
-     * @param  string $regexp    Regular expression
-     * @param  array  $options   Regular expression options
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param string $field   Field name
+     * @param string $regexp  Regular expression
+     * @param array  $options Regular expression options
      */
     public function __construct($field = '', $regexp = '', $options = array())
     {
@@ -51,7 +52,7 @@ class Regexp extends AbstractFilter
     /**
      * Sets the name of the regexp field.
      *
-     * @param  string                  $field Field name
+     * @param  string $field Field name
      * @return $this
      */
     public function setField($field)
@@ -64,7 +65,7 @@ class Regexp extends AbstractFilter
     /**
      * Sets the regular expression query string.
      *
-     * @param  string                  $regexp Regular expression
+     * @param  string $regexp Regular expression
      * @return $this
      */
     public function setRegexp($regexp)
@@ -77,7 +78,7 @@ class Regexp extends AbstractFilter
     /**
      * Sets the regular expression query options.
      *
-     * @param  array                        $options Regular expression options
+     * @param  array $options Regular expression options
      * @return $this
      */
     public function setOptions($options)

--- a/lib/Elastica/Filter/Script.php
+++ b/lib/Elastica/Filter/Script.php
@@ -38,7 +38,7 @@ class Script extends AbstractFilter
      * Sets script object
      *
      * @param  \Elastica\Script|string|array $script
-     * @return \Elastica\Filter\Script
+     * @return $this
      */
     public function setScript($script)
     {

--- a/lib/Elastica/Filter/Term.php
+++ b/lib/Elastica/Filter/Term.php
@@ -25,7 +25,7 @@ class Term extends AbstractFilter
     /**
      * Sets/overwrites key and term directly
      *
-     * @param  array                 $term Key value pair
+     * @param  array $term Key value pair
      * @return $this
      */
     public function setRawTerm(array $term)
@@ -36,8 +36,8 @@ class Term extends AbstractFilter
     /**
      * Adds a term to the term query
      *
-     * @param  string                $key   Key to query
-     * @param  string|array          $value Values(s) for the query. Boost can be set with array
+     * @param  string       $key   Key to query
+     * @param  string|array $value Values(s) for the query. Boost can be set with array
      * @return $this
      */
     public function setTerm($key, $value)

--- a/lib/Elastica/Filter/Term.php
+++ b/lib/Elastica/Filter/Term.php
@@ -26,7 +26,7 @@ class Term extends AbstractFilter
      * Sets/overwrites key and term directly
      *
      * @param  array                 $term Key value pair
-     * @return \Elastica\Filter\Term Filter object
+     * @return $this
      */
     public function setRawTerm(array $term)
     {
@@ -38,7 +38,7 @@ class Term extends AbstractFilter
      *
      * @param  string                $key   Key to query
      * @param  string|array          $value Values(s) for the query. Boost can be set with array
-     * @return \Elastica\Filter\Term Filter object
+     * @return $this
      */
     public function setTerm($key, $value)
     {

--- a/lib/Elastica/Filter/Terms.php
+++ b/lib/Elastica/Filter/Terms.php
@@ -49,8 +49,8 @@ class Terms extends AbstractFilter
     /**
      * Sets key and terms for the filter
      *
-     * @param  string                 $key   Terms key
-     * @param  array                  $terms Terms for the query.
+     * @param  string $key   Terms key
+     * @param  array  $terms Terms for the query.
      * @return $this
      */
     public function setTerms($key, array $terms)
@@ -104,7 +104,7 @@ class Terms extends AbstractFilter
     /**
      * Adds an additional term to the query
      *
-     * @param  string                 $term Filter term
+     * @param  string $term Filter term
      * @return $this
      */
     public function addTerm($term)
@@ -119,7 +119,8 @@ class Terms extends AbstractFilter
      *
      * @see \Elastica\Filter\AbstractFilter::toArray()
      * @throws \Elastica\Exception\InvalidException
-     * @return array                                data array
+     *
+     * @return array
      */
     public function toArray()
     {
@@ -134,7 +135,7 @@ class Terms extends AbstractFilter
     /**
      * Set execution mode
      *
-     * @param  string                 $execution Options: "bool", "and", "or", "plain" or "fielddata"
+     * @param  string $execution Options: "bool", "and", "or", "plain" or "fielddata"
      * @return $this
      */
     public function setExecution($execution)

--- a/lib/Elastica/Filter/Terms.php
+++ b/lib/Elastica/Filter/Terms.php
@@ -51,7 +51,7 @@ class Terms extends AbstractFilter
      *
      * @param  string                 $key   Terms key
      * @param  array                  $terms Terms for the query.
-     * @return \Elastica\Filter\Terms
+     * @return $this
      */
     public function setTerms($key, array $terms)
     {
@@ -68,7 +68,7 @@ class Terms extends AbstractFilter
      * @param  string                       $id      id of the document from which to fetch the terms values
      * @param  string                       $path    the field from which to fetch the values for the filter
      * @param  string|array|\Elastica\Index $options An array of options or the index from which to fetch the terms values. Defaults to the current index.
-     * @return \Elastica\Filter\Terms       Filter object
+     * @return $this
      */
     public function setLookup($key, $type, $id, $path, $options = array())
     {
@@ -105,7 +105,7 @@ class Terms extends AbstractFilter
      * Adds an additional term to the query
      *
      * @param  string                 $term Filter term
-     * @return \Elastica\Filter\Terms Filter object
+     * @return $this
      */
     public function addTerm($term)
     {
@@ -135,7 +135,7 @@ class Terms extends AbstractFilter
      * Set execution mode
      *
      * @param  string                 $execution Options: "bool", "and", "or", "plain" or "fielddata"
-     * @return \Elastica\Filter\Terms
+     * @return $this
      */
     public function setExecution($execution)
     {

--- a/lib/Elastica/Filter/Type.php
+++ b/lib/Elastica/Filter/Type.php
@@ -23,7 +23,6 @@ class Type extends AbstractFilter
      * Construct Type Filter
      *
      * @param  string                $typeName Type name
-     * @return \Elastica\Filter\Type
      */
     public function __construct($typeName = null)
     {
@@ -36,7 +35,7 @@ class Type extends AbstractFilter
      * Ads a field with arguments to the range query
      *
      * @param  string                $typeName Type name
-     * @return \Elastica\Filter\Type current object
+     * @return $this
      */
     public function setType($typeName)
     {

--- a/lib/Elastica/Filter/Type.php
+++ b/lib/Elastica/Filter/Type.php
@@ -22,7 +22,7 @@ class Type extends AbstractFilter
     /**
      * Construct Type Filter
      *
-     * @param  string                $typeName Type name
+     * @param string $typeName Type name
      */
     public function __construct($typeName = null)
     {
@@ -34,7 +34,7 @@ class Type extends AbstractFilter
     /**
      * Ads a field with arguments to the range query
      *
-     * @param  string                $typeName Type name
+     * @param  string $typeName Type name
      * @return $this
      */
     public function setType($typeName)
@@ -48,6 +48,7 @@ class Type extends AbstractFilter
      * Convert object to array
      *
      * @see \Elastica\Filter\AbstractFilter::toArray()
+     *
      * @return array Filter array
      */
     public function toArray()

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -38,9 +38,10 @@ class Index implements SearchableInterface
      *
      * All the communication to and from an index goes of this object
      *
-     * @param  \Elastica\Client                     $client Client object
-     * @param  string                               $name   Index name
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param \Elastica\Client $client Client object
+     * @param string           $name   Index name
      */
     public function __construct(Client $client, $name)
     {
@@ -203,14 +204,15 @@ class Index implements SearchableInterface
     /**
      * Creates a new index with the given arguments
      *
-     * @param  array                                 $args    OPTIONAL Arguments to use
-     * @param  bool|array                            $options OPTIONAL
-     *                                                        bool=> Deletes index first if already exists (default = false).
-     *                                                        array => Associative array of options (option=>value)
      * @throws \Elastica\Exception\InvalidException
      * @throws \Elastica\Exception\ResponseException
-     * @return array                                 Server response
      * @link http://www.elasticsearch.org/guide/reference/api/admin-indices-create-index.html
+     *
+     * @param  array      $args    OPTIONAL Arguments to use
+     * @param  bool|array $options OPTIONAL
+     *                             bool=> Deletes index first if already exists (default = false).
+     *                             array => Associative array of options (option=>value)
+     * @return array      Server response
      */
     public function create(array $args = array(), $options = null)
     {

--- a/lib/Elastica/JSON.php
+++ b/lib/Elastica/JSON.php
@@ -14,10 +14,11 @@ class JSON
     /**
      * Parse JSON string to an array
      *
-     * @param  string $json JSON string to parse
-     * @return array  PHP array representation of JSON string
      * @link http://php.net/manual/en/function.json-decode.php
      * @link http://www.php.net/manual/en/function.json-last-error.php
+     *
+     * @param  string $json JSON string to parse
+     * @return array  PHP array representation of JSON string
      */
     public static function parse(/* inherit from json_decode */)
     {
@@ -45,9 +46,10 @@ class JSON
     /**
      * Convert input to JSON string with standard options
      *
+     * @link http://php.net/manual/en/function.json-encode.php
+     *
      * @param  mixed check args for PHP function json_encode
      * @return string Valid JSON representation of $input
-     * @link http://php.net/manual/en/function.json-encode.php
      */
     public static function stringify(/* inherit from json_encode */)
     {

--- a/lib/Elastica/Log.php
+++ b/lib/Elastica/Log.php
@@ -61,7 +61,7 @@ class Log extends AbstractLogger
      * Enable/disable log or set log path
      *
      * @param  bool|string   $log Enables log or sets log path
-     * @return \Elastica\Log
+     * @return $this
      */
     public function setLog($log)
     {

--- a/lib/Elastica/Log.php
+++ b/lib/Elastica/Log.php
@@ -60,7 +60,7 @@ class Log extends AbstractLogger
     /**
      * Enable/disable log or set log path
      *
-     * @param  bool|string   $log Enables log or sets log path
+     * @param  bool|string $log Enables log or sets log path
      * @return $this
      */
     public function setLog($log)

--- a/lib/Elastica/Multi/ResultSet.php
+++ b/lib/Elastica/Multi/ResultSet.php
@@ -51,9 +51,10 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     }
 
     /**
-     * @param  \Elastica\Response                   $response
-     * @param  array|\Elastica\Search[]             $searches
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param \Elastica\Response       $response
+     * @param array|\Elastica\Search[] $searches
      */
     protected function _init(Response $response, array $searches)
     {

--- a/lib/Elastica/Multi/Search.php
+++ b/lib/Elastica/Multi/Search.php
@@ -51,7 +51,7 @@ class Search
     }
 
     /**
-     * @param  \Elastica\Client       $client
+     * @param  \Elastica\Client $client
      * @return $this
      */
     public function setClient(Client $client)
@@ -72,8 +72,8 @@ class Search
     }
 
     /**
-     * @param  \Elastica\Search       $search
-     * @param  string                 $key    Optional key
+     * @param  \Elastica\Search $search
+     * @param  string           $key    Optional key
      * @return $this
      */
     public function addSearch(BaseSearch $search, $key = null)
@@ -121,7 +121,7 @@ class Search
     }
 
     /**
-     * @param  string                 $searchType
+     * @param  string $searchType
      * @return $this
      */
     public function setSearchType($searchType)

--- a/lib/Elastica/Multi/Search.php
+++ b/lib/Elastica/Multi/Search.php
@@ -52,7 +52,7 @@ class Search
 
     /**
      * @param  \Elastica\Client       $client
-     * @return \Elastica\Multi\Search
+     * @return $this
      */
     public function setClient(Client $client)
     {
@@ -62,7 +62,7 @@ class Search
     }
 
     /**
-     * @return \Elastica\Multi\Search
+     * @return $this
      */
     public function clearSearches()
     {
@@ -74,7 +74,7 @@ class Search
     /**
      * @param  \Elastica\Search       $search
      * @param  string                 $key    Optional key
-     * @return \Elastica\Multi\Search
+     * @return $this
      */
     public function addSearch(BaseSearch $search, $key = null)
     {
@@ -89,7 +89,7 @@ class Search
 
     /**
      * @param  array|\Elastica\Search[] $searches
-     * @return \Elastica\Multi\Search
+     * @return $this
      */
     public function addSearches(array $searches)
     {
@@ -102,7 +102,7 @@ class Search
 
     /**
      * @param  array|\Elastica\Search[] $searches
-     * @return \Elastica\Multi\Search
+     * @return $this
      */
     public function setSearches(array $searches)
     {
@@ -122,7 +122,7 @@ class Search
 
     /**
      * @param  string                 $searchType
-     * @return \Elastica\Multi\Search
+     * @return $this
      */
     public function setSearchType($searchType)
     {

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -64,7 +64,7 @@ class Param
      *
      * @param  string          $key
      * @param  mixed           $value
-     * @return \Elastica\Param
+     * @return $this
      */
     protected function _setRawParam($key, $value)
     {

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -62,8 +62,8 @@ class Param
     /**
      * Sets params not inside params array
      *
-     * @param  string          $key
-     * @param  mixed           $value
+     * @param  string $key
+     * @param  mixed  $value
      * @return $this
      */
     protected function _setRawParam($key, $value)
@@ -76,8 +76,8 @@ class Param
     /**
      * Sets (overwrites) the value at the given key
      *
-     * @param  string          $key   Key to set
-     * @param  mixed           $value Key Value
+     * @param  string $key   Key to set
+     * @param  mixed  $value Key Value
      * @return $this
      */
     public function setParam($key, $value)
@@ -90,7 +90,7 @@ class Param
     /**
      * Sets (overwrites) all params of this object
      *
-     * @param  array           $params Parameter list
+     * @param  array $params Parameter list
      * @return $this
      */
     public function setParams(array $params)
@@ -105,8 +105,8 @@ class Param
      *
      * This function can be used to add an array of params
      *
-     * @param  string          $key   Param key
-     * @param  mixed           $value Value to set
+     * @param  string $key   Param key
+     * @param  mixed  $value Value to set
      * @return $this
      */
     public function addParam($key, $value)
@@ -127,9 +127,10 @@ class Param
     /**
      * Returns a specific param
      *
-     * @param  string                               $key Key to return
-     * @return mixed                                Key value
      * @throws \Elastica\Exception\InvalidException If requested key is not set
+     *
+     * @param  string $key Key to return
+     * @return mixed  Key value
      */
     public function getParam($key)
     {

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -62,7 +62,7 @@ class Query extends Param
      *
      * @param  mixed                                       $query
      * @throws \Elastica\Exception\NotImplementedException
-     * @return \Elastica\Query
+     * @return self
      */
     public static function create($query)
     {
@@ -98,7 +98,7 @@ class Query extends Param
      * Sets query as raw array. Will overwrite all already set arguments
      *
      * @param  array           $query Query array
-     * @return \Elastica\Query Query object
+     * @return $this
      */
     public function setRawQuery(array $query)
     {
@@ -111,7 +111,7 @@ class Query extends Param
      * Sets the query
      *
      * @param  \Elastica\Query\AbstractQuery $query Query object
-     * @return \Elastica\Query               Query object
+     * @return $this
      */
     public function setQuery(AbstractQuery $query)
     {
@@ -132,7 +132,7 @@ class Query extends Param
      * Set Filter
      *
      * @param  \Elastica\Filter\AbstractFilter $filter Filter object
-     * @return \Elastica\Query                 Current object
+     * @return $this
      * @link    https://github.com/elasticsearch/elasticsearch/issues/7422
      * @deprecated
      */
@@ -147,7 +147,7 @@ class Query extends Param
      * Sets the start from which the search results should be returned
      *
      * @param  int             $from
-     * @return \Elastica\Query Query object
+     * @return $this
      */
     public function setFrom($from)
     {
@@ -159,7 +159,7 @@ class Query extends Param
      * Replaces existing values
      *
      * @param  array           $sortArgs Sorting arguments
-     * @return \Elastica\Query Query object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/sort.html
      */
     public function setSort(array $sortArgs)
@@ -171,7 +171,7 @@ class Query extends Param
      * Adds a sort param to the query
      *
      * @param  mixed           $sort Sort parameter
-     * @return \Elastica\Query Query object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/sort.html
      */
     public function addSort($sort)
@@ -183,7 +183,7 @@ class Query extends Param
      * Sets highlight arguments for the query
      *
      * @param  array           $highlightArgs Set all highlight arguments
-     * @return \Elastica\Query Query object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/highlighting.html
      */
     public function setHighlight(array $highlightArgs)
@@ -195,7 +195,7 @@ class Query extends Param
      * Adds a highlight argument
      *
      * @param  mixed           $highlight Add highlight argument
-     * @return \Elastica\Query Query object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/highlighting.html
      */
     public function addHighlight($highlight)
@@ -207,7 +207,7 @@ class Query extends Param
      * Sets maximum number of results for this query
      *
      * @param  int             $size OPTIONAL Maximal number of results for query (default = 10)
-     * @return \Elastica\Query Query object
+     * @return $this
      */
     public function setSize($size = 10)
     {
@@ -219,7 +219,7 @@ class Query extends Param
      *
      * @deprecated Use the setSize() method, this method will be removed in future releases
      * @param  int             $limit OPTIONAL Maximal number of results for query (default = 10)
-     * @return \Elastica\Query Query object
+     * @return $this
      */
     public function setLimit($limit = 10)
     {
@@ -230,7 +230,7 @@ class Query extends Param
      * Enables explain on the query
      *
      * @param  bool            $explain OPTIONAL Enabled or disable explain (default = true)
-     * @return \Elastica\Query Current object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/explain.html
      */
     public function setExplain($explain = true)
@@ -242,7 +242,7 @@ class Query extends Param
      * Enables version on the query
      *
      * @param  bool            $version OPTIONAL Enabled or disable version (default = true)
-     * @return \Elastica\Query Current object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/version.html
      */
     public function setVersion($version = true)
@@ -256,7 +256,7 @@ class Query extends Param
      * so the fields array must a sequence(list) type of array
      *
      * @param  array           $fields Fields to be returned
-     * @return \Elastica\Query Current object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/fields.html
      */
     public function setFields(array $fields)
@@ -268,7 +268,7 @@ class Query extends Param
      * Set script fields
      *
      * @param  array|\Elastica\ScriptFields $scriptFields Script fields
-     * @return \Elastica\Query              Current object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/script-fields.html
      */
     public function setScriptFields($scriptFields)
@@ -285,7 +285,7 @@ class Query extends Param
      *
      * @param  string           $name
      * @param  \Elastica\Script $script Script object
-     * @return \Elastica\Query  Query object
+     * @return $this
      */
     public function addScriptField($name, Script $script)
     {
@@ -298,7 +298,7 @@ class Query extends Param
      * Sets all facets for this query object. Replaces existing facets
      *
      * @param  array           $facets List of facet objects
-     * @return \Elastica\Query Query object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/facets/
      */
     public function setFacets(array $facets)
@@ -315,7 +315,7 @@ class Query extends Param
      * Adds a Facet to the query
      *
      * @param  \Elastica\Facet\AbstractFacet $facet Facet object
-     * @return \Elastica\Query               Query object
+     * @return $this
      */
     public function addFacet(AbstractFacet $facet)
     {
@@ -328,7 +328,7 @@ class Query extends Param
      * Adds an Aggregation to the query
      *
      * @param  AbstractAggregation $agg
-     * @return \Elastica\Query     Query object
+     * @return $this
      */
     public function addAggregation(AbstractAggregation $agg)
     {
@@ -367,7 +367,7 @@ class Query extends Param
      *
      * @param  int                                  $minScore Minimum score to filter documents by
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Query                      Query object
+     * @return $this
      */
     public function setMinScore($minScore)
     {
@@ -382,6 +382,7 @@ class Query extends Param
      * Add a suggest term
      *
      * @param \Elastica\Suggest $suggest suggestion object
+     * @return $this
      */
     public function setSuggest(Suggest $suggest)
     {
@@ -399,7 +400,7 @@ class Query extends Param
      * Add a Rescore
      *
      * @param  \Elastica\Rescore\AbstractRescore $rescore suggestion object
-     * @return \Elastica\Query                   Current object
+     * @return $this
      */
     public function setRescore($rescore)
     {
@@ -410,7 +411,7 @@ class Query extends Param
      * Sets the _source field to be returned with every hit
      *
      * @param  array           $fields Fields to be returned
-     * @return \Elastica\Query Current object
+     * @return $this
      * @link   http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-source-filtering.html
      */
     public function setSource(array $fields)
@@ -422,7 +423,7 @@ class Query extends Param
      * Sets post_filter argument for the query. The filter is applied after the query has executed
      *
      * @param  array|\Elastica\Filter\AbstractFilter $filter
-     * @return \Elastica\Query                       Current object
+     * @return $this
      * @link    http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-post-filter.html
      */
     public function setPostFilter($filter)

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -60,8 +60,9 @@ class Query extends Param
      *
      * If query is empty,
      *
-     * @param  mixed                                       $query
      * @throws \Elastica\Exception\NotImplementedException
+     *
+     * @param  mixed $query
      * @return self
      */
     public static function create($query)
@@ -97,7 +98,7 @@ class Query extends Param
     /**
      * Sets query as raw array. Will overwrite all already set arguments
      *
-     * @param  array           $query Query array
+     * @param  array $query Query array
      * @return $this
      */
     public function setRawQuery(array $query)
@@ -146,7 +147,7 @@ class Query extends Param
     /**
      * Sets the start from which the search results should be returned
      *
-     * @param  int             $from
+     * @param  int   $from
      * @return $this
      */
     public function setFrom($from)
@@ -158,7 +159,7 @@ class Query extends Param
      * Sets sort arguments for the query
      * Replaces existing values
      *
-     * @param  array           $sortArgs Sorting arguments
+     * @param  array $sortArgs Sorting arguments
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/sort.html
      */
@@ -170,7 +171,7 @@ class Query extends Param
     /**
      * Adds a sort param to the query
      *
-     * @param  mixed           $sort Sort parameter
+     * @param  mixed $sort Sort parameter
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/sort.html
      */
@@ -182,7 +183,7 @@ class Query extends Param
     /**
      * Sets highlight arguments for the query
      *
-     * @param  array           $highlightArgs Set all highlight arguments
+     * @param  array $highlightArgs Set all highlight arguments
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/highlighting.html
      */
@@ -194,7 +195,7 @@ class Query extends Param
     /**
      * Adds a highlight argument
      *
-     * @param  mixed           $highlight Add highlight argument
+     * @param  mixed $highlight Add highlight argument
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/highlighting.html
      */
@@ -206,7 +207,7 @@ class Query extends Param
     /**
      * Sets maximum number of results for this query
      *
-     * @param  int             $size OPTIONAL Maximal number of results for query (default = 10)
+     * @param  int   $size OPTIONAL Maximal number of results for query (default = 10)
      * @return $this
      */
     public function setSize($size = 10)
@@ -218,7 +219,7 @@ class Query extends Param
      * Alias for setSize
      *
      * @deprecated Use the setSize() method, this method will be removed in future releases
-     * @param  int             $limit OPTIONAL Maximal number of results for query (default = 10)
+     * @param  int   $limit OPTIONAL Maximal number of results for query (default = 10)
      * @return $this
      */
     public function setLimit($limit = 10)
@@ -229,7 +230,7 @@ class Query extends Param
     /**
      * Enables explain on the query
      *
-     * @param  bool            $explain OPTIONAL Enabled or disable explain (default = true)
+     * @param  bool  $explain OPTIONAL Enabled or disable explain (default = true)
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/explain.html
      */
@@ -241,7 +242,7 @@ class Query extends Param
     /**
      * Enables version on the query
      *
-     * @param  bool            $version OPTIONAL Enabled or disable version (default = true)
+     * @param  bool  $version OPTIONAL Enabled or disable version (default = true)
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/version.html
      */
@@ -255,7 +256,7 @@ class Query extends Param
      * NOTICE php will encode modified(or named keys) array into object format in json format request
      * so the fields array must a sequence(list) type of array
      *
-     * @param  array           $fields Fields to be returned
+     * @param  array $fields Fields to be returned
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/fields.html
      */
@@ -297,7 +298,7 @@ class Query extends Param
     /**
      * Sets all facets for this query object. Replaces existing facets
      *
-     * @param  array           $facets List of facet objects
+     * @param  array $facets List of facet objects
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/api/search/facets/
      */
@@ -365,8 +366,9 @@ class Query extends Param
     /**
      * Allows filtering of documents based on a minimum score
      *
-     * @param  int                                  $minScore Minimum score to filter documents by
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  int   $minScore Minimum score to filter documents by
      * @return $this
      */
     public function setMinScore($minScore)
@@ -381,7 +383,7 @@ class Query extends Param
     /**
      * Add a suggest term
      *
-     * @param \Elastica\Suggest $suggest suggestion object
+     * @param  \Elastica\Suggest $suggest suggestion object
      * @return $this
      */
     public function setSuggest(Suggest $suggest)
@@ -392,7 +394,7 @@ class Query extends Param
         ));
 
         $this->_suggest = 1;
-        
+
         return $this;
     }
 
@@ -410,7 +412,7 @@ class Query extends Param
     /**
      * Sets the _source field to be returned with every hit
      *
-     * @param  array           $fields Fields to be returned
+     * @param  array $fields Fields to be returned
      * @return $this
      * @link   http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/search-request-source-filtering.html
      */

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -389,7 +389,10 @@ class Query extends Param
             $this->getParams(),
             $suggest->toArray()
         ));
+
         $this->_suggest = 1;
+        
+        return $this;
     }
 
     /**

--- a/lib/Elastica/Query/Bool.php
+++ b/lib/Elastica/Query/Bool.php
@@ -50,10 +50,11 @@ class Bool extends AbstractQuery
     /**
      * Adds a query to the current object
      *
-     * @param  string                               $type Query type
-     * @param  \Elastica\Query\AbstractQuery|array  $args Query
-     * @return $this
      * @throws \Elastica\Exception\InvalidException If not valid query
+     *
+     * @param  string                              $type Query type
+     * @param  \Elastica\Query\AbstractQuery|array $args Query
+     * @return $this
      */
     protected function _addQuery($type, $args)
     {
@@ -71,7 +72,7 @@ class Bool extends AbstractQuery
     /**
      * Sets boost value of this query
      *
-     * @param  float                $boost Boost value
+     * @param  float $boost Boost value
      * @return $this
      */
     public function setBoost($boost)
@@ -82,7 +83,7 @@ class Bool extends AbstractQuery
     /**
      * Set the minimum number of of should match
      *
-     * @param  int                  $minimumNumberShouldMatch Should match minimum
+     * @param  int   $minimumNumberShouldMatch Should match minimum
      * @return $this
      */
     public function setMinimumNumberShouldMatch($minimumNumberShouldMatch)

--- a/lib/Elastica/Query/Bool.php
+++ b/lib/Elastica/Query/Bool.php
@@ -18,7 +18,7 @@ class Bool extends AbstractQuery
      * Add should part to query
      *
      * @param  \Elastica\Query\AbstractQuery|array $args Should query
-     * @return \Elastica\Query\Bool                Current object
+     * @return $this
      */
     public function addShould($args)
     {
@@ -29,7 +29,7 @@ class Bool extends AbstractQuery
      * Add must part to query
      *
      * @param  \Elastica\Query\AbstractQuery|array $args Must query
-     * @return \Elastica\Query\Bool                Current object
+     * @return $this
      */
     public function addMust($args)
     {
@@ -40,7 +40,7 @@ class Bool extends AbstractQuery
      * Add must not part to query
      *
      * @param  \Elastica\Query\AbstractQuery|array $args Must not query
-     * @return \Elastica\Query\Bool                Current object
+     * @return $this
      */
     public function addMustNot($args)
     {
@@ -52,7 +52,7 @@ class Bool extends AbstractQuery
      *
      * @param  string                               $type Query type
      * @param  \Elastica\Query\AbstractQuery|array  $args Query
-     * @return \Elastica\Query\Bool
+     * @return $this
      * @throws \Elastica\Exception\InvalidException If not valid query
      */
     protected function _addQuery($type, $args)
@@ -72,7 +72,7 @@ class Bool extends AbstractQuery
      * Sets boost value of this query
      *
      * @param  float                $boost Boost value
-     * @return \Elastica\Query\Bool Current object
+     * @return $this
      */
     public function setBoost($boost)
     {
@@ -83,7 +83,7 @@ class Bool extends AbstractQuery
      * Set the minimum number of of should match
      *
      * @param  int                  $minimumNumberShouldMatch Should match minimum
-     * @return \Elastica\Query\Bool Current object
+     * @return $this
      */
     public function setMinimumNumberShouldMatch($minimumNumberShouldMatch)
     {

--- a/lib/Elastica/Query/Boosting.php
+++ b/lib/Elastica/Query/Boosting.php
@@ -15,7 +15,7 @@ class Boosting extends AbstractQuery
     /**
      * Set the positive query for this Boosting Query
      * @param  AbstractQuery            $query
-     * @return \Elastica\Query\Boosting
+     * @return $this
      */
     public function setPositiveQuery(AbstractQuery $query)
     {
@@ -25,7 +25,7 @@ class Boosting extends AbstractQuery
     /**
      * Set the negative query for this Boosting Query
      * @param  AbstractQuery            $query
-     * @return \Elastica\Query\Boosting
+     * @return $this
      */
     public function setNegativeQuery(AbstractQuery $query)
     {
@@ -35,7 +35,7 @@ class Boosting extends AbstractQuery
     /**
      * Set the negative_boost parameter for this Boosting Query
      * @param  Float                    $negativeBoost
-     * @return \Elastica\Query\Boosting
+     * @return $this
      */
     public function setNegativeBoost($negativeBoost)
     {

--- a/lib/Elastica/Query/Boosting.php
+++ b/lib/Elastica/Query/Boosting.php
@@ -14,7 +14,7 @@ class Boosting extends AbstractQuery
 
     /**
      * Set the positive query for this Boosting Query
-     * @param  AbstractQuery            $query
+     * @param  AbstractQuery $query
      * @return $this
      */
     public function setPositiveQuery(AbstractQuery $query)
@@ -24,7 +24,7 @@ class Boosting extends AbstractQuery
 
     /**
      * Set the negative query for this Boosting Query
-     * @param  AbstractQuery            $query
+     * @param  AbstractQuery $query
      * @return $this
      */
     public function setNegativeQuery(AbstractQuery $query)
@@ -34,7 +34,7 @@ class Boosting extends AbstractQuery
 
     /**
      * Set the negative_boost parameter for this Boosting Query
-     * @param  Float                    $negativeBoost
+     * @param  Float $negativeBoost
      * @return $this
      */
     public function setNegativeBoost($negativeBoost)

--- a/lib/Elastica/Query/Builder.php
+++ b/lib/Elastica/Query/Builder.php
@@ -28,7 +28,7 @@ class Builder extends AbstractQuery
      *
      * @param string $string JSON encoded string to use as query.
      *
-     * @return \Elastica\Query\Builder
+     * @return self
      */
     public static function factory($string = null)
     {
@@ -77,7 +77,7 @@ class Builder extends AbstractQuery
      *
      * @param boolean $bool Defaults to true.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function allowLeadingWildcard($bool = true)
     {
@@ -89,7 +89,7 @@ class Builder extends AbstractQuery
      *
      * @param boolean $bool Defaults to true.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function analyzeWildcard($bool = true)
     {
@@ -101,7 +101,7 @@ class Builder extends AbstractQuery
      *
      * @param string $analyzer Analyzer to use.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function analyzer($analyzer)
     {
@@ -113,7 +113,7 @@ class Builder extends AbstractQuery
      *
      * @param boolean $bool Defaults to true.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function autoGeneratePhraseQueries($bool = true)
     {
@@ -132,7 +132,7 @@ class Builder extends AbstractQuery
      *
      * The occurrence types are: must, should, must_not.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function bool()
     {
@@ -144,7 +144,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function boolClose()
     {
@@ -156,7 +156,7 @@ class Builder extends AbstractQuery
      *
      * @param float $boost Defaults to 1.0.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function boost($boost = 1.0)
     {
@@ -166,7 +166,7 @@ class Builder extends AbstractQuery
     /**
      * Close a previously opened brace.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function close()
     {
@@ -183,7 +183,7 @@ class Builder extends AbstractQuery
      *
      * Maps to Lucene ConstantScoreQuery.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function constantScore()
     {
@@ -195,7 +195,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function constantScoreClose()
     {
@@ -207,7 +207,7 @@ class Builder extends AbstractQuery
      *
      * @param string $field Defaults to _all.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function defaultField($field = '_all')
     {
@@ -223,7 +223,7 @@ class Builder extends AbstractQuery
      *
      * @param string $operator Defaults to OR.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function defaultOperator($operator = 'OR')
     {
@@ -238,7 +238,7 @@ class Builder extends AbstractQuery
      * produced by any subquery, plus a tie breaking increment for any additional
      * matching subqueries.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function disMax()
     {
@@ -250,7 +250,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function disMaxClose()
     {
@@ -262,7 +262,7 @@ class Builder extends AbstractQuery
      *
      * @param boolean $bool Defaults to true.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function enablePositionIncrements($bool = true)
     {
@@ -274,7 +274,7 @@ class Builder extends AbstractQuery
      *
      * @param boolean $value Turn on / off explain.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function explain($value = true)
     {
@@ -292,7 +292,7 @@ class Builder extends AbstractQuery
      * Elasticsearch supports more advanced facet implementations, such as
      * statistical or date histogram facets.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function facets()
     {
@@ -304,7 +304,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function facetsClose()
     {
@@ -316,8 +316,7 @@ class Builder extends AbstractQuery
      *
      * @param string $name  Field to add.
      * @param mixed  $value Value to set.
-     *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function field($name, $value)
     {
@@ -351,7 +350,7 @@ class Builder extends AbstractQuery
      *     ->rangeClose()
      *     ->queryClose();
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function fieldClose()
     {
@@ -363,7 +362,7 @@ class Builder extends AbstractQuery
      *
      * @param string $name Field name.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function fieldOpen($name)
     {
@@ -378,7 +377,7 @@ class Builder extends AbstractQuery
      *
      * @param array $fields Array of fields to return.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function fields(array $fields)
     {
@@ -396,7 +395,7 @@ class Builder extends AbstractQuery
     /**
      * Open a 'filter' block.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function filter()
     {
@@ -406,7 +405,7 @@ class Builder extends AbstractQuery
     /**
      * Close a filter block.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function filterClose()
     {
@@ -416,7 +415,7 @@ class Builder extends AbstractQuery
     /**
      *  Query.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function filteredQuery()
     {
@@ -428,7 +427,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function filteredQueryClose()
     {
@@ -440,7 +439,7 @@ class Builder extends AbstractQuery
      *
      * @param integer $value Result number to start from.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function from($value = 0)
     {
@@ -452,7 +451,7 @@ class Builder extends AbstractQuery
      *
      * @param float $value Defaults to 0.5.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function fuzzyMinSim($value = 0.5)
     {
@@ -464,7 +463,7 @@ class Builder extends AbstractQuery
      *
      * @param integer $value Defaults to 0.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function fuzzyPrefixLength($value = 0)
     {
@@ -478,7 +477,7 @@ class Builder extends AbstractQuery
      *
      * @param mixed $value Value to be gt.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function gt($value)
     {
@@ -492,7 +491,7 @@ class Builder extends AbstractQuery
      *
      * @param mixed $value Value to be gte to.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function gte($value)
     {
@@ -504,7 +503,7 @@ class Builder extends AbstractQuery
      *
      * @param boolean $bool Defaults to true.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function lowercaseExpandedTerms($bool = true)
     {
@@ -518,7 +517,7 @@ class Builder extends AbstractQuery
      *
      * @param mixed $value Value to be lt.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function lt($value)
     {
@@ -532,7 +531,7 @@ class Builder extends AbstractQuery
      *
      * @param mixed $value Value to be lte to.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function lte($value)
     {
@@ -548,7 +547,7 @@ class Builder extends AbstractQuery
      *
      * @param float $boost Boost to use.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function matchAll($boost = null)
     {
@@ -566,7 +565,7 @@ class Builder extends AbstractQuery
      *
      * @param integer $minimum Minimum number that should match.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function minimumNumberShouldMatch($minimum)
     {
@@ -576,7 +575,7 @@ class Builder extends AbstractQuery
     /**
      * The clause (query) must appear in matching documents.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function must()
     {
@@ -588,7 +587,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function mustClose()
     {
@@ -601,7 +600,7 @@ class Builder extends AbstractQuery
      * Note that it is not possible to search on documents that only consists of
      * a must_not clauses.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function mustNot()
     {
@@ -613,7 +612,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function mustNotClose()
     {
@@ -623,7 +622,7 @@ class Builder extends AbstractQuery
     /**
      * Add an opening brace.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function open()
     {
@@ -639,7 +638,7 @@ class Builder extends AbstractQuery
      *
      * @param integer $value Defaults to 0.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function phraseSlop($value = 0)
     {
@@ -649,7 +648,7 @@ class Builder extends AbstractQuery
     /**
      *  Query.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function prefix()
     {
@@ -661,7 +660,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function prefixClose()
     {
@@ -673,7 +672,7 @@ class Builder extends AbstractQuery
      *
      * @param array $queries Array of queries.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function queries(array $queries)
     {
@@ -691,7 +690,7 @@ class Builder extends AbstractQuery
     /**
      * Open a query block.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function query()
     {
@@ -703,7 +702,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function queryClose()
     {
@@ -715,7 +714,7 @@ class Builder extends AbstractQuery
      *
      * A query that uses a query parser in order to parse its content
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function queryString()
     {
@@ -727,7 +726,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function queryStringClose()
     {
@@ -737,7 +736,7 @@ class Builder extends AbstractQuery
     /**
      * Open a range block.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function range()
     {
@@ -749,7 +748,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function rangeClose()
     {
@@ -762,7 +761,7 @@ class Builder extends AbstractQuery
      * A boolean query with no must clauses, one or more should clauses must
      * match a document.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function should()
     {
@@ -774,7 +773,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function shouldClose()
     {
@@ -786,7 +785,7 @@ class Builder extends AbstractQuery
      *
      * @param integer $value Number of records to return.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function size($value = 10)
     {
@@ -796,7 +795,7 @@ class Builder extends AbstractQuery
     /**
      * Allows to add one or more sort on specific fields.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function sort()
     {
@@ -808,7 +807,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function sortClose()
     {
@@ -821,7 +820,7 @@ class Builder extends AbstractQuery
      * @param string  $name    Field to sort.
      * @param boolean $reverse Reverse direction.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function sortField($name, $reverse = false)
     {
@@ -839,7 +838,7 @@ class Builder extends AbstractQuery
      * @param array $fields Associative array where the keys are field names to sort on, and the
      *                      values are the sort order: "asc" or "desc"
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function sortFields(array $fields)
     {
@@ -861,7 +860,7 @@ class Builder extends AbstractQuery
      *
      * The term query maps to Lucene TermQuery.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function term()
     {
@@ -873,7 +872,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function termClose()
     {
@@ -883,7 +882,7 @@ class Builder extends AbstractQuery
     /**
      * Open a 'text_phrase' block.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function textPhrase()
     {
@@ -893,7 +892,7 @@ class Builder extends AbstractQuery
     /**
      * Close a 'text_phrase' block.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function textPhraseClose()
     {
@@ -905,7 +904,7 @@ class Builder extends AbstractQuery
      *
      * @param float $multiplier Multiplier to use.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function tieBreakerMultiplier($multiplier)
     {
@@ -915,7 +914,7 @@ class Builder extends AbstractQuery
     /**
      *  Query.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function wildcard()
     {
@@ -927,7 +926,7 @@ class Builder extends AbstractQuery
      *
      * Alias of close() for ease of reading in source.
      *
-     * @return \Elastica\Query\Builder
+     * @return $this
      */
     public function wildcardClose()
     {

--- a/lib/Elastica/Query/Builder.php
+++ b/lib/Elastica/Query/Builder.php
@@ -314,8 +314,8 @@ class Builder extends AbstractQuery
     /**
      * Add a specific field / value entry.
      *
-     * @param string $name  Field to add.
-     * @param mixed  $value Value to set.
+     * @param  string $name  Field to add.
+     * @param  mixed  $value Value to set.
      * @return $this
      */
     public function field($name, $value)

--- a/lib/Elastica/Query/Common.php
+++ b/lib/Elastica/Query/Common.php
@@ -36,7 +36,7 @@ class Common extends AbstractQuery
 
     /**
      * Set the field on which to query
-     * @param  string                 $field the field on which to query
+     * @param  string $field the field on which to query
      * @return $this
      */
     public function setField($field)
@@ -48,7 +48,7 @@ class Common extends AbstractQuery
 
     /**
      * Set the query string for this query
-     * @param  string                 $query
+     * @param  string $query
      * @return $this
      */
     public function setQuery($query)
@@ -58,7 +58,7 @@ class Common extends AbstractQuery
 
     /**
      * Set the frequency below which terms will be put in the low frequency group
-     * @param  float                  $frequency percentage in decimal form (.001 == 0.1%)
+     * @param  float $frequency percentage in decimal form (.001 == 0.1%)
      * @return $this
      */
     public function setCutoffFrequency($frequency)
@@ -68,7 +68,7 @@ class Common extends AbstractQuery
 
     /**
      * Set the logic operator for low frequency terms
-     * @param  string                 $operator see OPERATOR_* class constants for options
+     * @param  string $operator see OPERATOR_* class constants for options
      * @return $this
      */
     public function setLowFrequencyOperator($operator)
@@ -78,7 +78,7 @@ class Common extends AbstractQuery
 
     /**
      * Set the logic operator for high frequency terms
-     * @param  string                 $operator see OPERATOR_* class constants for options
+     * @param  string $operator see OPERATOR_* class constants for options
      * @return $this
      */
     public function setHighFrequencyOperator($operator)
@@ -88,7 +88,7 @@ class Common extends AbstractQuery
 
     /**
      * Set the minimum_should_match parameter
-     * @param  int|string             $minimum minimum number of low frequency terms which must be present
+     * @param  int|string $minimum minimum number of low frequency terms which must be present
      * @return $this
      * @link Possible values for minimum_should_match http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
      */
@@ -99,7 +99,7 @@ class Common extends AbstractQuery
 
     /**
      * Set the boost for this query
-     * @param  float                  $boost
+     * @param  float $boost
      * @return $this
      */
     public function setBoost($boost)
@@ -109,7 +109,7 @@ class Common extends AbstractQuery
 
     /**
      * Set the analyzer for this query
-     * @param  string                 $analyzer
+     * @param  string $analyzer
      * @return $this
      */
     public function setAnalyzer($analyzer)
@@ -119,7 +119,7 @@ class Common extends AbstractQuery
 
     /**
      * Enable / disable computation of score factor based on the fraction of all query terms contained in the document
-     * @param  bool                   $disable disable_coord is false by default
+     * @param  bool  $disable disable_coord is false by default
      * @return $this
      */
     public function setDisableCoord($disable = true)
@@ -129,8 +129,8 @@ class Common extends AbstractQuery
 
     /**
      * Set a parameter in the body of this query
-     * @param  string                 $key   parameter key
-     * @param  mixed                  $value parameter value
+     * @param  string $key   parameter key
+     * @param  mixed  $value parameter value
      * @return $this
      */
     public function setQueryParam($key, $value)

--- a/lib/Elastica/Query/Common.php
+++ b/lib/Elastica/Query/Common.php
@@ -37,7 +37,7 @@ class Common extends AbstractQuery
     /**
      * Set the field on which to query
      * @param  string                 $field the field on which to query
-     * @return \Elastica\Query\Common
+     * @return $this
      */
     public function setField($field)
     {
@@ -49,7 +49,7 @@ class Common extends AbstractQuery
     /**
      * Set the query string for this query
      * @param  string                 $query
-     * @return \Elastica\Query\Common
+     * @return $this
      */
     public function setQuery($query)
     {
@@ -59,7 +59,7 @@ class Common extends AbstractQuery
     /**
      * Set the frequency below which terms will be put in the low frequency group
      * @param  float                  $frequency percentage in decimal form (.001 == 0.1%)
-     * @return \Elastica\Query\Common
+     * @return $this
      */
     public function setCutoffFrequency($frequency)
     {
@@ -69,7 +69,7 @@ class Common extends AbstractQuery
     /**
      * Set the logic operator for low frequency terms
      * @param  string                 $operator see OPERATOR_* class constants for options
-     * @return \Elastica\Query\Common
+     * @return $this
      */
     public function setLowFrequencyOperator($operator)
     {
@@ -79,7 +79,7 @@ class Common extends AbstractQuery
     /**
      * Set the logic operator for high frequency terms
      * @param  string                 $operator see OPERATOR_* class constants for options
-     * @return \Elastica\Query\Common
+     * @return $this
      */
     public function setHighFrequencyOperator($operator)
     {
@@ -89,7 +89,7 @@ class Common extends AbstractQuery
     /**
      * Set the minimum_should_match parameter
      * @param  int|string             $minimum minimum number of low frequency terms which must be present
-     * @return \Elastica\Query\Common
+     * @return $this
      * @link Possible values for minimum_should_match http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
      */
     public function setMinimumShouldMatch($minimum)
@@ -100,7 +100,7 @@ class Common extends AbstractQuery
     /**
      * Set the boost for this query
      * @param  float                  $boost
-     * @return \Elastica\Query\Common
+     * @return $this
      */
     public function setBoost($boost)
     {
@@ -110,7 +110,7 @@ class Common extends AbstractQuery
     /**
      * Set the analyzer for this query
      * @param  string                 $analyzer
-     * @return \Elastica\Query\Common
+     * @return $this
      */
     public function setAnalyzer($analyzer)
     {
@@ -120,7 +120,7 @@ class Common extends AbstractQuery
     /**
      * Enable / disable computation of score factor based on the fraction of all query terms contained in the document
      * @param  bool                   $disable disable_coord is false by default
-     * @return \Elastica\Query\Common
+     * @return $this
      */
     public function setDisableCoord($disable = true)
     {
@@ -131,7 +131,7 @@ class Common extends AbstractQuery
      * Set a parameter in the body of this query
      * @param  string                 $key   parameter key
      * @param  mixed                  $value parameter value
-     * @return \Elastica\Query\Common
+     * @return $this
      */
     public function setQueryParam($key, $value)
     {

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -30,7 +30,7 @@ class ConstantScore extends AbstractQuery
      * Set filter
      *
      * @param  array|\Elastica\Filter\AbstractFilter $filter
-     * @return \Elastica\Query\ConstantScore         Query object
+     * @return $this
      */
     public function setFilter($filter)
     {
@@ -45,7 +45,7 @@ class ConstantScore extends AbstractQuery
      * Set query
      *
      * @param  array|\Elastica\Query\AbstractQuery $query
-     * @return \Elastica\Query\ConstantScore       Query object
+     * @return $this
      */
     public function setQuery($query)
     {
@@ -60,7 +60,7 @@ class ConstantScore extends AbstractQuery
      * Set boost
      *
      * @param  float                         $boost
-     * @return \Elastica\Query\ConstantScore
+     * @return $this
      */
     public function setBoost($boost)
     {

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -59,7 +59,7 @@ class ConstantScore extends AbstractQuery
     /**
      * Set boost
      *
-     * @param  float                         $boost
+     * @param  float $boost
      * @return $this
      */
     public function setBoost($boost)

--- a/lib/Elastica/Query/DisMax.php
+++ b/lib/Elastica/Query/DisMax.php
@@ -17,9 +17,10 @@ class DisMax extends AbstractQuery
     /**
      * Adds a query to the current object
      *
-     * @param  \Elastica\Query\AbstractQuery|array  $args Query
-     * @return $this
      * @throws \Elastica\Exception\InvalidException If not valid query
+     *
+     * @param  \Elastica\Query\AbstractQuery|array $args Query
+     * @return $this
      */
     public function addQuery($args)
     {
@@ -37,7 +38,7 @@ class DisMax extends AbstractQuery
     /**
      * Set boost
      *
-     * @param  float                  $boost
+     * @param  float $boost
      * @return $this
      */
     public function setBoost($boost)
@@ -50,7 +51,7 @@ class DisMax extends AbstractQuery
      *
      * If not set, defaults to 0.0
      *
-     * @param  float                  $tieBreaker
+     * @param  float $tieBreaker
      * @return $this
      */
     public function setTieBreaker($tieBreaker = 0.0)

--- a/lib/Elastica/Query/DisMax.php
+++ b/lib/Elastica/Query/DisMax.php
@@ -18,7 +18,7 @@ class DisMax extends AbstractQuery
      * Adds a query to the current object
      *
      * @param  \Elastica\Query\AbstractQuery|array  $args Query
-     * @return \Elastica\Query\DisMax
+     * @return $this
      * @throws \Elastica\Exception\InvalidException If not valid query
      */
     public function addQuery($args)
@@ -38,7 +38,7 @@ class DisMax extends AbstractQuery
      * Set boost
      *
      * @param  float                  $boost
-     * @return \Elastica\Query\DisMax
+     * @return $this
      */
     public function setBoost($boost)
     {
@@ -51,7 +51,7 @@ class DisMax extends AbstractQuery
      * If not set, defaults to 0.0
      *
      * @param  float                  $tieBreaker
-     * @return \Elastica\Query\DisMax
+     * @return $this
      */
     public function setTieBreaker($tieBreaker = 0.0)
     {

--- a/lib/Elastica/Query/Filtered.php
+++ b/lib/Elastica/Query/Filtered.php
@@ -31,7 +31,7 @@ class Filtered extends AbstractQuery
      * Sets a query
      *
      * @param  \Elastica\Query\AbstractQuery $query Query object
-     * @return \Elastica\Query\Filtered      Current object
+     * @return $this
      */
     public function setQuery(AbstractQuery $query = null)
     {
@@ -42,7 +42,7 @@ class Filtered extends AbstractQuery
      * Sets the filter
      *
      * @param  \Elastica\Filter\AbstractFilter $filter Filter object
-     * @return \Elastica\Query\Filtered        Current object
+     * @return $this
      */
     public function setFilter(AbstractFilter $filter = null)
     {

--- a/lib/Elastica/Query/FunctionScore.php
+++ b/lib/Elastica/Query/FunctionScore.php
@@ -34,7 +34,7 @@ class FunctionScore extends AbstractQuery
 
     /**
      * Set the child query for this function_score query
-     * @param  AbstractQuery                 $query
+     * @param  AbstractQuery $query
      * @return $this
      */
     public function setQuery(AbstractQuery $query)
@@ -43,7 +43,7 @@ class FunctionScore extends AbstractQuery
     }
 
     /**
-     * @param  AbstractFilter  $filter
+     * @param  AbstractFilter $filter
      * @return $this
      */
     public function setFilter(AbstractFilter $filter)
@@ -53,10 +53,10 @@ class FunctionScore extends AbstractQuery
 
     /**
      * Add a function to the function_score query
-     * @param  string                        $functionType   valid values are DECAY_* constants and script_score
-     * @param  array|float                   $functionParams the body of the function. See documentation for proper syntax.
-     * @param  AbstractFilter                $filter         optional filter to apply to the function
-     * @param  float                         $weight         function weight
+     * @param  string         $functionType   valid values are DECAY_* constants and script_score
+     * @param  array|float    $functionParams the body of the function. See documentation for proper syntax.
+     * @param  AbstractFilter $filter         optional filter to apply to the function
+     * @param  float          $weight         function weight
      * @return $this
      */
     public function addFunction($functionType, $functionParams, AbstractFilter $filter = null, $weight = null)
@@ -78,9 +78,9 @@ class FunctionScore extends AbstractQuery
 
     /**
      * Add a script_score function to the query
-     * @param  Script                        $script a Script object
-     * @param  AbstractFilter                $filter an optional filter to apply to the function
-     * @param  float                         $weight the weight of the function
+     * @param  Script         $script a Script object
+     * @param  AbstractFilter $filter an optional filter to apply to the function
+     * @param  float          $weight the weight of the function
      * @return $this
      */
     public function addScriptScoreFunction(Script $script, AbstractFilter $filter = null, $weight = null)
@@ -90,15 +90,15 @@ class FunctionScore extends AbstractQuery
 
     /**
      * Add a decay function to the query
-     * @param  string                        $function    see DECAY_* constants for valid options
-     * @param  string                        $field       the document field on which to perform the decay function
-     * @param  string                        $origin      the origin value for this decay function
-     * @param  string                        $scale       a scale to define the rate of decay for this function
-     * @param  string                        $offset      If defined, this function will only be computed for documents with a distance from the origin greater than this value
-     * @param  float                         $decay       optionally defines how documents are scored at the distance given by the $scale parameter
-     * @param  float                         $scaleWeight optional factor by which to multiply the score at the value provided by the $scale parameter
-     * @param  float                         $weight      optional factor by which to multiply the score at the value provided by the $scale parameter
-     * @param  AbstractFilter                $filter      a filter associated with this function
+     * @param  string         $function    see DECAY_* constants for valid options
+     * @param  string         $field       the document field on which to perform the decay function
+     * @param  string         $origin      the origin value for this decay function
+     * @param  string         $scale       a scale to define the rate of decay for this function
+     * @param  string         $offset      If defined, this function will only be computed for documents with a distance from the origin greater than this value
+     * @param  float          $decay       optionally defines how documents are scored at the distance given by the $scale parameter
+     * @param  float          $scaleWeight optional factor by which to multiply the score at the value provided by the $scale parameter
+     * @param  float          $weight      optional factor by which to multiply the score at the value provided by the $scale parameter
+     * @param  AbstractFilter $filter      a filter associated with this function
      * @return $this
      */
     public function addDecayFunction(
@@ -165,7 +165,7 @@ class FunctionScore extends AbstractQuery
 
     /**
      * Set an overall boost value for this query
-     * @param  float                         $boost
+     * @param  float $boost
      * @return $this
      */
     public function setBoost($boost)
@@ -175,7 +175,7 @@ class FunctionScore extends AbstractQuery
 
     /**
      * Restrict the combined boost of the function_score query and its child query
-     * @param  float                         $maxBoost
+     * @param  float $maxBoost
      * @return $this
      */
     public function setMaxBoost($maxBoost)
@@ -185,7 +185,7 @@ class FunctionScore extends AbstractQuery
 
     /**
      * The boost mode determines how the score of this query is combined with that of the child query
-     * @param  string                        $mode see BOOST_MODE_* constants for valid options. Default is multiply.
+     * @param  string $mode see BOOST_MODE_* constants for valid options. Default is multiply.
      * @return $this
      */
     public function setBoostMode($mode)
@@ -195,7 +195,7 @@ class FunctionScore extends AbstractQuery
 
     /**
      * If set, this query will return results in random order.
-     * @param  int                           $seed Set a seed value to return results in the same random order for consistent pagination.
+     * @param  int   $seed Set a seed value to return results in the same random order for consistent pagination.
      * @return $this
      */
     public function setRandomScore($seed = null)
@@ -210,7 +210,7 @@ class FunctionScore extends AbstractQuery
 
     /**
      * Set the score method
-     * @param  string                        $mode see SCORE_MODE_* constants for valid options. Default is multiply.
+     * @param  string $mode see SCORE_MODE_* constants for valid options. Default is multiply.
      * @return $this
      */
     public function setScoreMode($mode)

--- a/lib/Elastica/Query/FunctionScore.php
+++ b/lib/Elastica/Query/FunctionScore.php
@@ -35,7 +35,7 @@ class FunctionScore extends AbstractQuery
     /**
      * Set the child query for this function_score query
      * @param  AbstractQuery                 $query
-     * @return \Elastica\Query\FunctionScore
+     * @return $this
      */
     public function setQuery(AbstractQuery $query)
     {
@@ -44,7 +44,7 @@ class FunctionScore extends AbstractQuery
 
     /**
      * @param  AbstractFilter  $filter
-     * @return \Elastica\Param
+     * @return $this
      */
     public function setFilter(AbstractFilter $filter)
     {
@@ -57,7 +57,7 @@ class FunctionScore extends AbstractQuery
      * @param  array|float                   $functionParams the body of the function. See documentation for proper syntax.
      * @param  AbstractFilter                $filter         optional filter to apply to the function
      * @param  float                         $weight         function weight
-     * @return \Elastica\Query\FunctionScore
+     * @return $this
      */
     public function addFunction($functionType, $functionParams, AbstractFilter $filter = null, $weight = null)
     {
@@ -81,7 +81,7 @@ class FunctionScore extends AbstractQuery
      * @param  Script                        $script a Script object
      * @param  AbstractFilter                $filter an optional filter to apply to the function
      * @param  float                         $weight the weight of the function
-     * @return \Elastica\Query\FunctionScore
+     * @return $this
      */
     public function addScriptScoreFunction(Script $script, AbstractFilter $filter = null, $weight = null)
     {
@@ -99,7 +99,7 @@ class FunctionScore extends AbstractQuery
      * @param  float                         $scaleWeight optional factor by which to multiply the score at the value provided by the $scale parameter
      * @param  float                         $weight      optional factor by which to multiply the score at the value provided by the $scale parameter
      * @param  AbstractFilter                $filter      a filter associated with this function
-     * @return \Elastica\Query\FunctionScore
+     * @return $this
      */
     public function addDecayFunction(
         $function,
@@ -166,7 +166,7 @@ class FunctionScore extends AbstractQuery
     /**
      * Set an overall boost value for this query
      * @param  float                         $boost
-     * @return \Elastica\Query\FunctionScore
+     * @return $this
      */
     public function setBoost($boost)
     {
@@ -176,7 +176,7 @@ class FunctionScore extends AbstractQuery
     /**
      * Restrict the combined boost of the function_score query and its child query
      * @param  float                         $maxBoost
-     * @return \Elastica\Query\FunctionScore
+     * @return $this
      */
     public function setMaxBoost($maxBoost)
     {
@@ -186,7 +186,7 @@ class FunctionScore extends AbstractQuery
     /**
      * The boost mode determines how the score of this query is combined with that of the child query
      * @param  string                        $mode see BOOST_MODE_* constants for valid options. Default is multiply.
-     * @return \Elastica\Query\FunctionScore
+     * @return $this
      */
     public function setBoostMode($mode)
     {
@@ -196,7 +196,7 @@ class FunctionScore extends AbstractQuery
     /**
      * If set, this query will return results in random order.
      * @param  int                           $seed Set a seed value to return results in the same random order for consistent pagination.
-     * @return \Elastica\Query\FunctionScore
+     * @return $this
      */
     public function setRandomScore($seed = null)
     {
@@ -211,7 +211,7 @@ class FunctionScore extends AbstractQuery
     /**
      * Set the score method
      * @param  string                        $mode see SCORE_MODE_* constants for valid options. Default is multiply.
-     * @return \Elastica\Query\FunctionScore
+     * @return $this
      */
     public function setScoreMode($mode)
     {

--- a/lib/Elastica/Query/Fuzzy.php
+++ b/lib/Elastica/Query/Fuzzy.php
@@ -17,8 +17,8 @@ class Fuzzy extends AbstractQuery
     /**
      * Construct a fuzzy query
      *
-     * @param  string                $fieldName Field name
-     * @param  string                $value     String to search for
+     * @param string $fieldName Field name
+     * @param string $value     String to search for
      */
     public function __construct($fieldName = null, $value = null)
     {
@@ -30,8 +30,8 @@ class Fuzzy extends AbstractQuery
     /**
      * Set field for fuzzy query
      *
-     * @param  string                $fieldName Field name
-     * @param  string                $value     String to search for
+     * @param  string $fieldName Field name
+     * @param  string $value     String to search for
      * @return $this
      */
     public function setField($fieldName, $value)
@@ -49,8 +49,8 @@ class Fuzzy extends AbstractQuery
     /**
      * Set optional parameters on the existing query
      *
-     * @param  string                $param option name
-     * @param  mixed                 $value Value of the parameter
+     * @param  string $param option name
+     * @param  mixed  $value Value of the parameter
      * @return $this
      */
     public function setFieldOption($param, $value)

--- a/lib/Elastica/Query/Fuzzy.php
+++ b/lib/Elastica/Query/Fuzzy.php
@@ -19,7 +19,6 @@ class Fuzzy extends AbstractQuery
      *
      * @param  string                $fieldName Field name
      * @param  string                $value     String to search for
-     * @return \Elastica\Query\Fuzzy Current object
      */
     public function __construct($fieldName = null, $value = null)
     {
@@ -33,7 +32,7 @@ class Fuzzy extends AbstractQuery
      *
      * @param  string                $fieldName Field name
      * @param  string                $value     String to search for
-     * @return \Elastica\Query\Fuzzy Current object
+     * @return $this
      */
     public function setField($fieldName, $value)
     {
@@ -52,7 +51,7 @@ class Fuzzy extends AbstractQuery
      *
      * @param  string                $param option name
      * @param  mixed                 $value Value of the parameter
-     * @return \Elastica\Query\Fuzzy Current object
+     * @return $this
      */
     public function setFieldOption($param, $value)
     {

--- a/lib/Elastica/Query/Fuzzy.php
+++ b/lib/Elastica/Query/Fuzzy.php
@@ -64,7 +64,7 @@ class Fuzzy extends AbstractQuery
         $keyArray = array_keys($params);
         $params[$keyArray[0]][$param] = $value;
 
-        return $this->setparam($keyArray[0], $params[$keyArray[0]]);
+        return $this->setParam($keyArray[0], $params[$keyArray[0]]);
     }
 
     /**

--- a/lib/Elastica/Query/FuzzyLikeThis.php
+++ b/lib/Elastica/Query/FuzzyLikeThis.php
@@ -72,7 +72,7 @@ class FuzzyLikeThis extends AbstractQuery
      * Adds field to flt query
      *
      * @param  array                         $fields Field names
-     * @return \Elastica\Query\FuzzyLikeThis Current object
+     * @return $this
      */
     public function addFields(array $fields)
     {
@@ -85,7 +85,7 @@ class FuzzyLikeThis extends AbstractQuery
      * Set the "like_text" value
      *
      * @param  string                        $text
-     * @return \Elastica\Query\FuzzyLikeThis This current object
+     * @return $this
      */
     public function setLikeText($text)
     {
@@ -99,7 +99,7 @@ class FuzzyLikeThis extends AbstractQuery
      * Set the "ignore_tf" value (ignore term frequency)
      *
      * @param  bool                          $ignoreTF
-     * @return \Elastica\Query\FuzzyLikeThis Current object
+     * @return $this
      */
     public function setIgnoreTF($ignoreTF)
     {
@@ -112,7 +112,7 @@ class FuzzyLikeThis extends AbstractQuery
      * Set the minimum similarity
      *
      * @param  int                           $value
-     * @return \Elastica\Query\FuzzyLikeThis This current object
+     * @return $this
      */
     public function setMinSimilarity($value)
     {
@@ -126,7 +126,7 @@ class FuzzyLikeThis extends AbstractQuery
      * Set boost
      *
      * @param  float                         $value Boost value
-     * @return \Elastica\Query\FuzzyLikeThis Query object
+     * @return $this
      */
     public function setBoost($value)
     {
@@ -139,7 +139,7 @@ class FuzzyLikeThis extends AbstractQuery
      * Set Prefix Length
      *
      * @param  int                           $value Prefix length
-     * @return \Elastica\Query\FuzzyLikeThis
+     * @return $this
      */
     public function setPrefixLength($value)
     {
@@ -152,7 +152,7 @@ class FuzzyLikeThis extends AbstractQuery
      * Set max_query_terms
      *
      * @param  int                           $value Max query terms value
-     * @return \Elastica\Query\FuzzyLikeThis
+     * @return $this
      */
     public function setMaxQueryTerms($value)
     {
@@ -165,7 +165,7 @@ class FuzzyLikeThis extends AbstractQuery
      * Set analyzer
      *
      * @param  string                        $text Analyzer text
-     * @return \Elastica\Query\FuzzyLikeThis
+     * @return $this
      */
     public function setAnalyzer($text)
     {

--- a/lib/Elastica/Query/FuzzyLikeThis.php
+++ b/lib/Elastica/Query/FuzzyLikeThis.php
@@ -71,7 +71,7 @@ class FuzzyLikeThis extends AbstractQuery
     /**
      * Adds field to flt query
      *
-     * @param  array                         $fields Field names
+     * @param  array $fields Field names
      * @return $this
      */
     public function addFields(array $fields)
@@ -84,7 +84,7 @@ class FuzzyLikeThis extends AbstractQuery
     /**
      * Set the "like_text" value
      *
-     * @param  string                        $text
+     * @param  string $text
      * @return $this
      */
     public function setLikeText($text)
@@ -98,7 +98,7 @@ class FuzzyLikeThis extends AbstractQuery
     /**
      * Set the "ignore_tf" value (ignore term frequency)
      *
-     * @param  bool                          $ignoreTF
+     * @param  bool  $ignoreTF
      * @return $this
      */
     public function setIgnoreTF($ignoreTF)
@@ -111,7 +111,7 @@ class FuzzyLikeThis extends AbstractQuery
     /**
      * Set the minimum similarity
      *
-     * @param  int                           $value
+     * @param  int   $value
      * @return $this
      */
     public function setMinSimilarity($value)
@@ -125,7 +125,7 @@ class FuzzyLikeThis extends AbstractQuery
     /**
      * Set boost
      *
-     * @param  float                         $value Boost value
+     * @param  float $value Boost value
      * @return $this
      */
     public function setBoost($value)
@@ -138,7 +138,7 @@ class FuzzyLikeThis extends AbstractQuery
     /**
      * Set Prefix Length
      *
-     * @param  int                           $value Prefix length
+     * @param  int   $value Prefix length
      * @return $this
      */
     public function setPrefixLength($value)
@@ -151,7 +151,7 @@ class FuzzyLikeThis extends AbstractQuery
     /**
      * Set max_query_terms
      *
-     * @param  int                           $value Max query terms value
+     * @param  int   $value Max query terms value
      * @return $this
      */
     public function setMaxQueryTerms($value)
@@ -164,7 +164,7 @@ class FuzzyLikeThis extends AbstractQuery
     /**
      * Set analyzer
      *
-     * @param  string                        $text Analyzer text
+     * @param  string $text Analyzer text
      * @return $this
      */
     public function setAnalyzer($text)

--- a/lib/Elastica/Query/HasChild.php
+++ b/lib/Elastica/Query/HasChild.php
@@ -30,7 +30,7 @@ class HasChild extends AbstractQuery
      * Sets query object
      *
      * @param  string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
-     * @return \Elastica\Query\HasChild
+     * @return $this
      */
     public function setQuery($query)
     {
@@ -44,7 +44,7 @@ class HasChild extends AbstractQuery
      * Set type of the parent document
      *
      * @param  string                   $type Parent document type
-     * @return \Elastica\Query\HasChild Current object
+     * @return $this
      */
     public function setType($type)
     {
@@ -55,7 +55,7 @@ class HasChild extends AbstractQuery
      * Sets the scope
      *
      * @param  string                   $scope Scope
-     * @return \Elastica\Query\HasChild Current object
+     * @return $this
      */
     public function setScope($scope)
     {

--- a/lib/Elastica/Query/HasChild.php
+++ b/lib/Elastica/Query/HasChild.php
@@ -43,7 +43,7 @@ class HasChild extends AbstractQuery
     /**
      * Set type of the parent document
      *
-     * @param  string                   $type Parent document type
+     * @param  string $type Parent document type
      * @return $this
      */
     public function setType($type)
@@ -54,7 +54,7 @@ class HasChild extends AbstractQuery
     /**
      * Sets the scope
      *
-     * @param  string                   $scope Scope
+     * @param  string $scope Scope
      * @return $this
      */
     public function setScope($scope)

--- a/lib/Elastica/Query/HasParent.php
+++ b/lib/Elastica/Query/HasParent.php
@@ -29,7 +29,7 @@ class HasParent extends AbstractQuery
      * Sets query object
      *
      * @param  string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
-     * @return \Elastica\Filter\HasParent
+     * @return $this
      */
     public function setQuery($query)
     {
@@ -43,7 +43,7 @@ class HasParent extends AbstractQuery
      * Set type of the parent document
      *
      * @param  string                     $type Parent document type
-     * @return \Elastica\Filter\HasParent Current object
+     * @return $this
      */
     public function setType($type)
     {
@@ -54,7 +54,7 @@ class HasParent extends AbstractQuery
      * Sets the scope
      *
      * @param  string                     $scope Scope
-     * @return \Elastica\Filter\HasParent Current object
+     * @return $this
      */
     public function setScope($scope)
     {

--- a/lib/Elastica/Query/HasParent.php
+++ b/lib/Elastica/Query/HasParent.php
@@ -42,7 +42,7 @@ class HasParent extends AbstractQuery
     /**
      * Set type of the parent document
      *
-     * @param  string                     $type Parent document type
+     * @param  string $type Parent document type
      * @return $this
      */
     public function setType($type)
@@ -53,7 +53,7 @@ class HasParent extends AbstractQuery
     /**
      * Sets the scope
      *
-     * @param  string                     $scope Scope
+     * @param  string $scope Scope
      * @return $this
      */
     public function setScope($scope)

--- a/lib/Elastica/Query/Ids.php
+++ b/lib/Elastica/Query/Ids.php
@@ -38,7 +38,7 @@ class Ids extends AbstractQuery
     /**
      * Adds one more filter to the and filter
      *
-     * @param  string              $id Adds id to filter
+     * @param  string $id Adds id to filter
      * @return $this
      */
     public function addId($id)
@@ -91,7 +91,7 @@ class Ids extends AbstractQuery
     /**
      * Sets the ids to filter
      *
-     * @param  array|string        $ids List of ids
+     * @param  array|string $ids List of ids
      * @return $this
      */
     public function setIds($ids)

--- a/lib/Elastica/Query/Ids.php
+++ b/lib/Elastica/Query/Ids.php
@@ -39,7 +39,7 @@ class Ids extends AbstractQuery
      * Adds one more filter to the and filter
      *
      * @param  string              $id Adds id to filter
-     * @return \Elastica\Query\Ids Current object
+     * @return $this
      */
     public function addId($id)
     {
@@ -52,7 +52,7 @@ class Ids extends AbstractQuery
      * Adds one more type to query
      *
      * @param  string|\Elastica\Type $type Type name or object
-     * @return \Elastica\Query\Ids   Current object
+     * @return $this
      */
     public function addType($type)
     {
@@ -72,7 +72,7 @@ class Ids extends AbstractQuery
      * Set type
      *
      * @param  string|\Elastica\Type $type Type name or object
-     * @return \Elastica\Query\Ids   Current object
+     * @return $this
      */
     public function setType($type)
     {
@@ -92,7 +92,7 @@ class Ids extends AbstractQuery
      * Sets the ids to filter
      *
      * @param  array|string        $ids List of ids
-     * @return \Elastica\Query\Ids Current object
+     * @return $this
      */
     public function setIds($ids)
     {

--- a/lib/Elastica/Query/Match.php
+++ b/lib/Elastica/Query/Match.php
@@ -21,7 +21,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  mixed                 $values
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setField($field, $values)
     {
@@ -34,7 +34,7 @@ class Match extends AbstractQuery
      * @param  string                $field
      * @param  string                $key
      * @param  string                $value
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldParam($field, $key, $value)
     {
@@ -52,7 +52,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  string                $query
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldQuery($field, $query)
     {
@@ -64,7 +64,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  string                $type
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldType($field, $type)
     {
@@ -76,7 +76,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  string                $operator
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldOperator($field, $operator)
     {
@@ -88,7 +88,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  string                $analyzer
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldAnalyzer($field, $analyzer)
     {
@@ -102,7 +102,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  float                 $boost
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldBoost($field, $boost = 1.0)
     {
@@ -114,7 +114,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  int|string            $minimumShouldMatch
-     * @return \Elastica\Query\Match
+     * @return $this
      * @link Possible values for minimum_should_match http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
      */
     public function setFieldMinimumShouldMatch($field, $minimumShouldMatch)
@@ -127,7 +127,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  mixed                 $fuzziness
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldFuzziness($field, $fuzziness)
     {
@@ -139,7 +139,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  string                $fuzzyRewrite
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldFuzzyRewrite($field, $fuzzyRewrite)
     {
@@ -151,7 +151,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  int                   $prefixLength
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldPrefixLength($field, $prefixLength)
     {
@@ -163,7 +163,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  int                   $maxExpansions
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldMaxExpansions($field, $maxExpansions)
     {
@@ -177,7 +177,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  string                $zeroTermQuery
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldZeroTermsQuery($field, $zeroTermQuery = 'none')
     {
@@ -189,7 +189,7 @@ class Match extends AbstractQuery
      *
      * @param  string                $field
      * @param  float                 $cutoffFrequency
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFieldCutoffFrequency($field, $cutoffFrequency)
     {

--- a/lib/Elastica/Query/Match.php
+++ b/lib/Elastica/Query/Match.php
@@ -19,8 +19,8 @@ class Match extends AbstractQuery
     /**
      * Sets a param for the message array
      *
-     * @param  string                $field
-     * @param  mixed                 $values
+     * @param  string $field
+     * @param  mixed  $values
      * @return $this
      */
     public function setField($field, $values)
@@ -31,9 +31,9 @@ class Match extends AbstractQuery
     /**
      * Sets a param for the given field
      *
-     * @param  string                $field
-     * @param  string                $key
-     * @param  string                $value
+     * @param  string $field
+     * @param  string $key
+     * @param  string $value
      * @return $this
      */
     public function setFieldParam($field, $key, $value)
@@ -50,8 +50,8 @@ class Match extends AbstractQuery
     /**
      * Sets the query string
      *
-     * @param  string                $field
-     * @param  string                $query
+     * @param  string $field
+     * @param  string $query
      * @return $this
      */
     public function setFieldQuery($field, $query)
@@ -62,8 +62,8 @@ class Match extends AbstractQuery
     /**
      * Set field type
      *
-     * @param  string                $field
-     * @param  string                $type
+     * @param  string $field
+     * @param  string $type
      * @return $this
      */
     public function setFieldType($field, $type)
@@ -74,8 +74,8 @@ class Match extends AbstractQuery
     /**
      * Set field operator
      *
-     * @param  string                $field
-     * @param  string                $operator
+     * @param  string $field
+     * @param  string $operator
      * @return $this
      */
     public function setFieldOperator($field, $operator)
@@ -86,8 +86,8 @@ class Match extends AbstractQuery
     /**
      * Set field analyzer
      *
-     * @param  string                $field
-     * @param  string                $analyzer
+     * @param  string $field
+     * @param  string $analyzer
      * @return $this
      */
     public function setFieldAnalyzer($field, $analyzer)
@@ -100,8 +100,8 @@ class Match extends AbstractQuery
      *
      * If not set, defaults to 1.0.
      *
-     * @param  string                $field
-     * @param  float                 $boost
+     * @param  string $field
+     * @param  float  $boost
      * @return $this
      */
     public function setFieldBoost($field, $boost = 1.0)
@@ -112,8 +112,8 @@ class Match extends AbstractQuery
     /**
      * Set field minimum should match
      *
-     * @param  string                $field
-     * @param  int|string            $minimumShouldMatch
+     * @param  string     $field
+     * @param  int|string $minimumShouldMatch
      * @return $this
      * @link Possible values for minimum_should_match http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
      */
@@ -125,8 +125,8 @@ class Match extends AbstractQuery
     /**
      * Set field fuzziness
      *
-     * @param  string                $field
-     * @param  mixed                 $fuzziness
+     * @param  string $field
+     * @param  mixed  $fuzziness
      * @return $this
      */
     public function setFieldFuzziness($field, $fuzziness)
@@ -137,8 +137,8 @@ class Match extends AbstractQuery
     /**
      * Set field fuzzy rewrite
      *
-     * @param  string                $field
-     * @param  string                $fuzzyRewrite
+     * @param  string $field
+     * @param  string $fuzzyRewrite
      * @return $this
      */
     public function setFieldFuzzyRewrite($field, $fuzzyRewrite)
@@ -149,8 +149,8 @@ class Match extends AbstractQuery
     /**
      * Set field prefix length
      *
-     * @param  string                $field
-     * @param  int                   $prefixLength
+     * @param  string $field
+     * @param  int    $prefixLength
      * @return $this
      */
     public function setFieldPrefixLength($field, $prefixLength)
@@ -161,8 +161,8 @@ class Match extends AbstractQuery
     /**
      * Set field max expansions
      *
-     * @param  string                $field
-     * @param  int                   $maxExpansions
+     * @param  string $field
+     * @param  int    $maxExpansions
      * @return $this
      */
     public function setFieldMaxExpansions($field, $maxExpansions)
@@ -175,8 +175,8 @@ class Match extends AbstractQuery
      *
      * If not set, default to 'none'
      *
-     * @param  string                $field
-     * @param  string                $zeroTermQuery
+     * @param  string $field
+     * @param  string $zeroTermQuery
      * @return $this
      */
     public function setFieldZeroTermsQuery($field, $zeroTermQuery = 'none')
@@ -187,8 +187,8 @@ class Match extends AbstractQuery
     /**
      * Set cutoff frequency
      *
-     * @param  string                $field
-     * @param  float                 $cutoffFrequency
+     * @param  string $field
+     * @param  float  $cutoffFrequency
      * @return $this
      */
     public function setFieldCutoffFrequency($field, $cutoffFrequency)

--- a/lib/Elastica/Query/MoreLikeThis.php
+++ b/lib/Elastica/Query/MoreLikeThis.php
@@ -15,7 +15,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Adds field to mlt query
      *
-     * @param  array                        $fields Field names
+     * @param  array $fields Field names
      * @return $this
      */
     public function setFields(array $fields)
@@ -26,7 +26,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set the "like_text" value
      *
-     * @param  string                       $likeText
+     * @param  string $likeText
      * @return $this
      */
     public function setLikeText($likeText)
@@ -39,7 +39,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set boost
      *
-     * @param  float                        $boost Boost value
+     * @param  float $boost Boost value
      * @return $this
      */
     public function setBoost($boost)
@@ -50,7 +50,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set max_query_terms
      *
-     * @param  int                          $maxQueryTerms Max query terms value
+     * @param  int   $maxQueryTerms Max query terms value
      * @return $this
      */
     public function setMaxQueryTerms($maxQueryTerms)
@@ -61,7 +61,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set percent terms to match
      *
-     * @param  float                        $percentTermsToMatch Percentage
+     * @param  float $percentTermsToMatch Percentage
      * @return $this
      */
     public function setPercentTermsToMatch($percentTermsToMatch)
@@ -72,7 +72,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set min term frequency
      *
-     * @param  int                          $minTermFreq
+     * @param  int   $minTermFreq
      * @return $this
      */
     public function setMinTermFrequency($minTermFreq)
@@ -83,7 +83,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * set min document frequency
      *
-     * @param  int                          $minDocFreq
+     * @param  int   $minDocFreq
      * @return $this
      */
     public function setMinDocFrequency($minDocFreq)
@@ -94,7 +94,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * set max document frequency
      *
-     * @param  int                          $maxDocFreq
+     * @param  int   $maxDocFreq
      * @return $this
      */
     public function setMaxDocFrequency($maxDocFreq)
@@ -105,7 +105,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set min word length
      *
-     * @param  int                          $minWordLength
+     * @param  int   $minWordLength
      * @return $this
      */
     public function setMinWordLength($minWordLength)
@@ -116,7 +116,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set max word length
      *
-     * @param  int                          $maxWordLength
+     * @param  int   $maxWordLength
      * @return $this
      */
     public function setMaxWordLength($maxWordLength)
@@ -127,7 +127,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set boost terms
      *
-     * @param  bool                         $boostTerms
+     * @param  bool  $boostTerms
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/query-dsl/mlt-query.html
      */
@@ -139,7 +139,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set analyzer
      *
-     * @param  string                       $analyzer
+     * @param  string $analyzer
      * @return $this
      */
     public function setAnalyzer($analyzer)
@@ -152,7 +152,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set stop words
      *
-     * @param  array                        $stopWords
+     * @param  array $stopWords
      * @return $this
      */
     public function setStopWords(array $stopWords)

--- a/lib/Elastica/Query/MoreLikeThis.php
+++ b/lib/Elastica/Query/MoreLikeThis.php
@@ -16,7 +16,7 @@ class MoreLikeThis extends AbstractQuery
      * Adds field to mlt query
      *
      * @param  array                        $fields Field names
-     * @return \Elastica\Query\MoreLikeThis Current object
+     * @return $this
      */
     public function setFields(array $fields)
     {
@@ -27,7 +27,7 @@ class MoreLikeThis extends AbstractQuery
      * Set the "like_text" value
      *
      * @param  string                       $likeText
-     * @return \Elastica\Query\MoreLikeThis This current object
+     * @return $this
      */
     public function setLikeText($likeText)
     {
@@ -40,7 +40,7 @@ class MoreLikeThis extends AbstractQuery
      * Set boost
      *
      * @param  float                        $boost Boost value
-     * @return \Elastica\Query\MoreLikeThis Query object
+     * @return $this
      */
     public function setBoost($boost)
     {
@@ -51,7 +51,7 @@ class MoreLikeThis extends AbstractQuery
      * Set max_query_terms
      *
      * @param  int                          $maxQueryTerms Max query terms value
-     * @return \Elastica\Query\MoreLikeThis
+     * @return $this
      */
     public function setMaxQueryTerms($maxQueryTerms)
     {
@@ -62,7 +62,7 @@ class MoreLikeThis extends AbstractQuery
      * Set percent terms to match
      *
      * @param  float                        $percentTermsToMatch Percentage
-     * @return \Elastica\Query\MoreLikeThis
+     * @return $this
      */
     public function setPercentTermsToMatch($percentTermsToMatch)
     {
@@ -73,7 +73,7 @@ class MoreLikeThis extends AbstractQuery
      * Set min term frequency
      *
      * @param  int                          $minTermFreq
-     * @return \Elastica\Query\MoreLikeThis
+     * @return $this
      */
     public function setMinTermFrequency($minTermFreq)
     {
@@ -84,7 +84,7 @@ class MoreLikeThis extends AbstractQuery
      * set min document frequency
      *
      * @param  int                          $minDocFreq
-     * @return \Elastica\Query\MoreLikeThis
+     * @return $this
      */
     public function setMinDocFrequency($minDocFreq)
     {
@@ -95,7 +95,7 @@ class MoreLikeThis extends AbstractQuery
      * set max document frequency
      *
      * @param  int                          $maxDocFreq
-     * @return \Elastica\Query\MoreLikeThis
+     * @return $this
      */
     public function setMaxDocFrequency($maxDocFreq)
     {
@@ -106,7 +106,7 @@ class MoreLikeThis extends AbstractQuery
      * Set min word length
      *
      * @param  int                          $minWordLength
-     * @return \Elastica\Query\MoreLikeThis
+     * @return $this
      */
     public function setMinWordLength($minWordLength)
     {
@@ -117,7 +117,7 @@ class MoreLikeThis extends AbstractQuery
      * Set max word length
      *
      * @param  int                          $maxWordLength
-     * @return \Elastica\Query\MoreLikeThis
+     * @return $this
      */
     public function setMaxWordLength($maxWordLength)
     {
@@ -128,7 +128,7 @@ class MoreLikeThis extends AbstractQuery
      * Set boost terms
      *
      * @param  bool                         $boostTerms
-     * @return \Elastica\Query\MoreLikeThis
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/query-dsl/mlt-query.html
      */
     public function setBoostTerms($boostTerms)
@@ -140,7 +140,7 @@ class MoreLikeThis extends AbstractQuery
      * Set analyzer
      *
      * @param  string                       $analyzer
-     * @return \Elastica\Query\MoreLikeThis
+     * @return $this
      */
     public function setAnalyzer($analyzer)
     {
@@ -153,7 +153,7 @@ class MoreLikeThis extends AbstractQuery
      * Set stop words
      *
      * @param  array                        $stopWords
-     * @return \Elastica\Query\MoreLikeThis
+     * @return $this
      */
     public function setStopWords(array $stopWords)
     {

--- a/lib/Elastica/Query/MultiMatch.php
+++ b/lib/Elastica/Query/MultiMatch.php
@@ -29,7 +29,7 @@ class MultiMatch extends AbstractQuery
     /**
      * Sets the query
      *
-     * @param  string                     $query Query
+     * @param  string $query Query
      * @return $this
      */
     public function setQuery($query = '')
@@ -40,7 +40,7 @@ class MultiMatch extends AbstractQuery
     /**
      * Sets Fields to be used in the query.
      *
-     * @param  array                      $fields Fields
+     * @param  array $fields Fields
      * @return $this
      */
     public function setFields($fields = array())
@@ -53,7 +53,7 @@ class MultiMatch extends AbstractQuery
      *
      * If not set, defaults to true.
      *
-     * @param  boolean                    $useDisMax
+     * @param  boolean $useDisMax
      * @return $this
      */
     public function setUseDisMax($useDisMax = true)
@@ -66,7 +66,7 @@ class MultiMatch extends AbstractQuery
      *
      * If not set, defaults to 0.0.
      *
-     * @param  float                      $tieBreaker
+     * @param  float $tieBreaker
      * @return $this
      */
     public function setTieBreaker($tieBreaker = 0.0)
@@ -79,7 +79,7 @@ class MultiMatch extends AbstractQuery
      *
      * If not set, defaults to 'or'
      *
-     * @param  string                     $operator
+     * @param  string $operator
      * @return $this
      */
     public function setOperator($operator = 'or')
@@ -90,7 +90,7 @@ class MultiMatch extends AbstractQuery
     /**
      * Set field minimum should match for Match Query
      *
-     * @param  int                   $minimumShouldMatch
+     * @param  int   $minimumShouldMatch
      * @return $this
      */
     public function setMinimumShouldMatch($minimumShouldMatch)
@@ -103,7 +103,7 @@ class MultiMatch extends AbstractQuery
      *
      * If not set, default to 'none'
      *
-     * @param  string                $zeroTermQuery
+     * @param  string $zeroTermQuery
      * @return $this
      */
     public function setZeroTermsQuery($zeroTermQuery = 'none')
@@ -114,7 +114,7 @@ class MultiMatch extends AbstractQuery
     /**
      * Set cutoff frequency for Match Query
      *
-     * @param  float                 $cutoffFrequency
+     * @param  float $cutoffFrequency
      * @return $this
      */
     public function setCutoffFrequency($cutoffFrequency)
@@ -125,8 +125,8 @@ class MultiMatch extends AbstractQuery
     /**
      * Set type
      *
-     * @param  string                $field
-     * @param  string                $type
+     * @param  string $field
+     * @param  string $type
      * @return $this
      */
     public function setType($type)
@@ -137,7 +137,7 @@ class MultiMatch extends AbstractQuery
     /**
      * Set fuzziness
      *
-     * @param  float                 $fuzziness
+     * @param  float $fuzziness
      * @return $this
      */
     public function setFuzziness($fuzziness)
@@ -148,7 +148,7 @@ class MultiMatch extends AbstractQuery
     /**
      * Set prefix length
      *
-     * @param  int                   $prefixLength
+     * @param  int   $prefixLength
      * @return $this
      */
     public function setPrefixLength($prefixLength)
@@ -159,7 +159,7 @@ class MultiMatch extends AbstractQuery
     /**
      * Set max expansions
      *
-     * @param  int                   $maxExpansions
+     * @param  int   $maxExpansions
      * @return $this
      */
     public function setMaxExpansions($maxExpansions)
@@ -170,7 +170,7 @@ class MultiMatch extends AbstractQuery
     /**
      * Set analyzer
      *
-     * @param  string                $analyzer
+     * @param  string $analyzer
      * @return $this
      */
     public function setAnalyzer($analyzer)

--- a/lib/Elastica/Query/MultiMatch.php
+++ b/lib/Elastica/Query/MultiMatch.php
@@ -30,7 +30,7 @@ class MultiMatch extends AbstractQuery
      * Sets the query
      *
      * @param  string                     $query Query
-     * @return \Elastica\Query\MultiMatch Current object
+     * @return $this
      */
     public function setQuery($query = '')
     {
@@ -41,7 +41,7 @@ class MultiMatch extends AbstractQuery
      * Sets Fields to be used in the query.
      *
      * @param  array                      $fields Fields
-     * @return \Elastica\Query\MultiMatch Current object
+     * @return $this
      */
     public function setFields($fields = array())
     {
@@ -54,7 +54,7 @@ class MultiMatch extends AbstractQuery
      * If not set, defaults to true.
      *
      * @param  boolean                    $useDisMax
-     * @return \Elastica\Query\MultiMatch Current object
+     * @return $this
      */
     public function setUseDisMax($useDisMax = true)
     {
@@ -67,7 +67,7 @@ class MultiMatch extends AbstractQuery
      * If not set, defaults to 0.0.
      *
      * @param  float                      $tieBreaker
-     * @return \Elastica\Query\MultiMatch Current object
+     * @return $this
      */
     public function setTieBreaker($tieBreaker = 0.0)
     {
@@ -80,7 +80,7 @@ class MultiMatch extends AbstractQuery
      * If not set, defaults to 'or'
      *
      * @param  string                     $operator
-     * @return \Elastica\Query\MultiMatch Current object
+     * @return $this
      */
     public function setOperator($operator = 'or')
     {
@@ -91,7 +91,7 @@ class MultiMatch extends AbstractQuery
      * Set field minimum should match for Match Query
      *
      * @param  int                   $minimumShouldMatch
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setMinimumShouldMatch($minimumShouldMatch)
     {
@@ -104,7 +104,7 @@ class MultiMatch extends AbstractQuery
      * If not set, default to 'none'
      *
      * @param  string                $zeroTermQuery
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setZeroTermsQuery($zeroTermQuery = 'none')
     {
@@ -115,7 +115,7 @@ class MultiMatch extends AbstractQuery
      * Set cutoff frequency for Match Query
      *
      * @param  float                 $cutoffFrequency
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setCutoffFrequency($cutoffFrequency)
     {
@@ -127,7 +127,7 @@ class MultiMatch extends AbstractQuery
      *
      * @param  string                $field
      * @param  string                $type
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setType($type)
     {
@@ -138,7 +138,7 @@ class MultiMatch extends AbstractQuery
      * Set fuzziness
      *
      * @param  float                 $fuzziness
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setFuzziness($fuzziness)
     {
@@ -149,7 +149,7 @@ class MultiMatch extends AbstractQuery
      * Set prefix length
      *
      * @param  int                   $prefixLength
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setPrefixLength($prefixLength)
     {
@@ -160,7 +160,7 @@ class MultiMatch extends AbstractQuery
      * Set max expansions
      *
      * @param  int                   $maxExpansions
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setMaxExpansions($maxExpansions)
     {
@@ -171,7 +171,7 @@ class MultiMatch extends AbstractQuery
      * Set analyzer
      *
      * @param  string                $analyzer
-     * @return \Elastica\Query\Match
+     * @return $this
      */
     public function setAnalyzer($analyzer)
     {

--- a/lib/Elastica/Query/Nested.php
+++ b/lib/Elastica/Query/Nested.php
@@ -16,7 +16,7 @@ class Nested extends AbstractQuery
      * Adds field to mlt query
      *
      * @param  string                 $path Nested object path
-     * @return \Elastica\Query\Nested
+     * @return $this
      */
     public function setPath($path)
     {
@@ -27,7 +27,7 @@ class Nested extends AbstractQuery
      * Sets nested query
      *
      * @param  \Elastica\Query\AbstractQuery $query
-     * @return \Elastica\Query\Nested
+     * @return $this
      */
     public function setQuery(AbstractQuery $query)
     {
@@ -38,7 +38,7 @@ class Nested extends AbstractQuery
      * Set score method
      *
      * @param  string                 $scoreMode Options: avg, total, max and none.
-     * @return \Elastica\Query\Nested
+     * @return $this
      */
     public function setScoreMode($scoreMode)
     {

--- a/lib/Elastica/Query/Nested.php
+++ b/lib/Elastica/Query/Nested.php
@@ -15,7 +15,7 @@ class Nested extends AbstractQuery
     /**
      * Adds field to mlt query
      *
-     * @param  string                 $path Nested object path
+     * @param  string $path Nested object path
      * @return $this
      */
     public function setPath($path)
@@ -37,7 +37,7 @@ class Nested extends AbstractQuery
     /**
      * Set score method
      *
-     * @param  string                 $scoreMode Options: avg, total, max and none.
+     * @param  string $scoreMode Options: avg, total, max and none.
      * @return $this
      */
     public function setScoreMode($scoreMode)

--- a/lib/Elastica/Query/Prefix.php
+++ b/lib/Elastica/Query/Prefix.php
@@ -25,7 +25,7 @@ class Prefix extends AbstractQuery
      * setRawPrefix can be used instead of setPrefix if some more special
      * values for a prefix have to be set.
      *
-     * @param  array                  $prefix Prefix array
+     * @param  array $prefix Prefix array
      * @return $this
      */
     public function setRawPrefix(array $prefix)
@@ -36,9 +36,9 @@ class Prefix extends AbstractQuery
     /**
      * Adds a prefix to the prefix query
      *
-     * @param  string                 $key   Key to query
-     * @param  string|array           $value Values(s) for the query. Boost can be set with array
-     * @param  float                  $boost OPTIONAL Boost value (default = 1.0)
+     * @param  string       $key   Key to query
+     * @param  string|array $value Values(s) for the query. Boost can be set with array
+     * @param  float        $boost OPTIONAL Boost value (default = 1.0)
      * @return $this
      */
     public function setPrefix($key, $value, $boost = 1.0)

--- a/lib/Elastica/Query/Prefix.php
+++ b/lib/Elastica/Query/Prefix.php
@@ -26,7 +26,7 @@ class Prefix extends AbstractQuery
      * values for a prefix have to be set.
      *
      * @param  array                  $prefix Prefix array
-     * @return \Elastica\Query\Prefix Current object
+     * @return $this
      */
     public function setRawPrefix(array $prefix)
     {
@@ -39,7 +39,7 @@ class Prefix extends AbstractQuery
      * @param  string                 $key   Key to query
      * @param  string|array           $value Values(s) for the query. Boost can be set with array
      * @param  float                  $boost OPTIONAL Boost value (default = 1.0)
-     * @return \Elastica\Query\Prefix Current object
+     * @return $this
      */
     public function setPrefix($key, $value, $boost = 1.0)
     {

--- a/lib/Elastica/Query/QueryString.php
+++ b/lib/Elastica/Query/QueryString.php
@@ -34,8 +34,9 @@ class QueryString extends AbstractQuery
     /**
      * Sets a new query string for the object
      *
-     * @param  string                               $query Query string
-     * @throws \Elastica\Exception\InvalidException
+     * @throws \Elastica\Exception\InvalidException If given parameter is not a string
+     *
+     * @param  string $query Query string
      * @return $this
      */
     public function setQuery($query = '')
@@ -52,7 +53,7 @@ class QueryString extends AbstractQuery
      *
      * If no field is set, _all is chosen
      *
-     * @param  string                      $field Field
+     * @param  string $field Field
      * @return $this
      */
     public function setDefaultField($field)
@@ -65,7 +66,7 @@ class QueryString extends AbstractQuery
      *
      * If no operator is set, OR is chosen
      *
-     * @param  string                      $operator Operator
+     * @param  string $operator Operator
      * @return $this
      */
     public function setDefaultOperator($operator)
@@ -76,7 +77,7 @@ class QueryString extends AbstractQuery
     /**
      * Sets the analyzer to analyze the query with.
      *
-     * @param  string                      $analyzer Analyser to use
+     * @param  string $analyzer Analyser to use
      * @return $this
      */
     public function setAnalyzer($analyzer)
@@ -89,7 +90,7 @@ class QueryString extends AbstractQuery
      *
      * If not set, defaults to true.
      *
-     * @param  bool                        $allow
+     * @param  bool  $allow
      * @return $this
      */
     public function setAllowLeadingWildcard($allow = true)
@@ -102,7 +103,7 @@ class QueryString extends AbstractQuery
      *
      * If not set, defaults to true.
      *
-     * @param  bool                        $lowercase
+     * @param  bool  $lowercase
      * @return $this
      */
     public function setLowercaseExpandedTerms($lowercase = true)
@@ -115,7 +116,7 @@ class QueryString extends AbstractQuery
      *
      * If not set, defaults to true.
      *
-     * @param  bool                        $enabled
+     * @param  bool  $enabled
      * @return $this
      */
     public function setEnablePositionIncrements($enabled = true)
@@ -128,7 +129,7 @@ class QueryString extends AbstractQuery
      *
      * If not set, defaults to 0.
      *
-     * @param  int                         $length
+     * @param  int   $length
      * @return $this
      */
     public function setFuzzyPrefixLength($length = 0)
@@ -141,7 +142,7 @@ class QueryString extends AbstractQuery
      *
      * If not set, defaults to 0.5
      *
-     * @param  float                       $minSim
+     * @param  float $minSim
      * @return $this
      */
     public function setFuzzyMinSim($minSim = 0.5)
@@ -155,7 +156,7 @@ class QueryString extends AbstractQuery
      * If zero, exact phrases are required.
      * If not set, defaults to zero.
      *
-     * @param  int                         $phraseSlop
+     * @param  int   $phraseSlop
      * @return $this
      */
     public function setPhraseSlop($phraseSlop = 0)
@@ -168,7 +169,7 @@ class QueryString extends AbstractQuery
      *
      * If not set, defaults to 1.0.
      *
-     * @param  float                       $boost
+     * @param  float $boost
      * @return $this
      */
     public function setBoost($boost = 1.0)
@@ -181,7 +182,7 @@ class QueryString extends AbstractQuery
      *
      * If not set, defaults to true
      *
-     * @param  bool                        $analyze
+     * @param  bool  $analyze
      * @return $this
      */
     public function setAnalyzeWildcard($analyze = true)
@@ -194,7 +195,7 @@ class QueryString extends AbstractQuery
      *
      * If not set, defaults to true.
      *
-     * @param  bool                        $autoGenerate
+     * @param  bool  $autoGenerate
      * @return $this
      */
     public function setAutoGeneratePhraseQueries($autoGenerate = true)
@@ -203,12 +204,11 @@ class QueryString extends AbstractQuery
     }
 
     /**
-     * Sets the fields
+     * Sets the fields. If no fields are set, _all is chosen
      *
-     * If no fields are set, _all is chosen
+     * @throws \Elastica\Exception\InvalidException If given parameter is not an array
      *
-     * @param  array                                $fields Fields
-     * @throws \Elastica\Exception\InvalidException
+     * @param  array $fields Fields
      * @return $this
      */
     public function setFields(array $fields)
@@ -223,7 +223,7 @@ class QueryString extends AbstractQuery
     /**
      * Whether to use bool or dis_max queries to internally combine results for multi field search.
      *
-     * @param  bool                        $value Determines whether to use
+     * @param  bool  $value Determines whether to use
      * @return $this
      */
     public function setUseDisMax($value = true)
@@ -236,7 +236,7 @@ class QueryString extends AbstractQuery
      *
      * If not set, defaults to 0.
      *
-     * @param  int                         $tieBreaker
+     * @param  int   $tieBreaker
      * @return $this
      */
     public function setTieBreaker($tieBreaker = 0)
@@ -247,7 +247,7 @@ class QueryString extends AbstractQuery
     /**
      * Set a re-write condition. See https://github.com/elasticsearch/elasticsearch/issues/1186 for additional information
      *
-     * @param  string                      $rewrite
+     * @param  string $rewrite
      * @return $this
      */
     public function setRewrite($rewrite = "")

--- a/lib/Elastica/Query/QueryString.php
+++ b/lib/Elastica/Query/QueryString.php
@@ -36,7 +36,7 @@ class QueryString extends AbstractQuery
      *
      * @param  string                               $query Query string
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Query\QueryString          Current object
+     * @return $this
      */
     public function setQuery($query = '')
     {
@@ -53,7 +53,7 @@ class QueryString extends AbstractQuery
      * If no field is set, _all is chosen
      *
      * @param  string                      $field Field
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setDefaultField($field)
     {
@@ -66,7 +66,7 @@ class QueryString extends AbstractQuery
      * If no operator is set, OR is chosen
      *
      * @param  string                      $operator Operator
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setDefaultOperator($operator)
     {
@@ -77,7 +77,7 @@ class QueryString extends AbstractQuery
      * Sets the analyzer to analyze the query with.
      *
      * @param  string                      $analyzer Analyser to use
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setAnalyzer($analyzer)
     {
@@ -90,7 +90,7 @@ class QueryString extends AbstractQuery
      * If not set, defaults to true.
      *
      * @param  bool                        $allow
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setAllowLeadingWildcard($allow = true)
     {
@@ -103,7 +103,7 @@ class QueryString extends AbstractQuery
      * If not set, defaults to true.
      *
      * @param  bool                        $lowercase
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setLowercaseExpandedTerms($lowercase = true)
     {
@@ -116,7 +116,7 @@ class QueryString extends AbstractQuery
      * If not set, defaults to true.
      *
      * @param  bool                        $enabled
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setEnablePositionIncrements($enabled = true)
     {
@@ -129,7 +129,7 @@ class QueryString extends AbstractQuery
      * If not set, defaults to 0.
      *
      * @param  int                         $length
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setFuzzyPrefixLength($length = 0)
     {
@@ -142,7 +142,7 @@ class QueryString extends AbstractQuery
      * If not set, defaults to 0.5
      *
      * @param  float                       $minSim
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setFuzzyMinSim($minSim = 0.5)
     {
@@ -156,7 +156,7 @@ class QueryString extends AbstractQuery
      * If not set, defaults to zero.
      *
      * @param  int                         $phraseSlop
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setPhraseSlop($phraseSlop = 0)
     {
@@ -169,7 +169,7 @@ class QueryString extends AbstractQuery
      * If not set, defaults to 1.0.
      *
      * @param  float                       $boost
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setBoost($boost = 1.0)
     {
@@ -182,7 +182,7 @@ class QueryString extends AbstractQuery
      * If not set, defaults to true
      *
      * @param  bool                        $analyze
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setAnalyzeWildcard($analyze = true)
     {
@@ -195,7 +195,7 @@ class QueryString extends AbstractQuery
      * If not set, defaults to true.
      *
      * @param  bool                        $autoGenerate
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setAutoGeneratePhraseQueries($autoGenerate = true)
     {
@@ -209,7 +209,7 @@ class QueryString extends AbstractQuery
      *
      * @param  array                                $fields Fields
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Query\QueryString          Current object
+     * @return $this
      */
     public function setFields(array $fields)
     {
@@ -224,7 +224,7 @@ class QueryString extends AbstractQuery
      * Whether to use bool or dis_max queries to internally combine results for multi field search.
      *
      * @param  bool                        $value Determines whether to use
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setUseDisMax($value = true)
     {
@@ -237,7 +237,7 @@ class QueryString extends AbstractQuery
      * If not set, defaults to 0.
      *
      * @param  int                         $tieBreaker
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setTieBreaker($tieBreaker = 0)
     {
@@ -248,7 +248,7 @@ class QueryString extends AbstractQuery
      * Set a re-write condition. See https://github.com/elasticsearch/elasticsearch/issues/1186 for additional information
      *
      * @param  string                      $rewrite
-     * @return \Elastica\Query\QueryString Current object
+     * @return $this
      */
     public function setRewrite($rewrite = "")
     {

--- a/lib/Elastica/Query/Range.php
+++ b/lib/Elastica/Query/Range.php
@@ -28,8 +28,8 @@ class Range extends AbstractQuery
     /**
      * Adds a range field to the query
      *
-     * @param  string                $fieldName Field name
-     * @param  array                 $args      Field arguments
+     * @param  string $fieldName Field name
+     * @param  array  $args      Field arguments
      * @return $this
      */
     public function addField($fieldName, array $args)

--- a/lib/Elastica/Query/Range.php
+++ b/lib/Elastica/Query/Range.php
@@ -30,7 +30,7 @@ class Range extends AbstractQuery
      *
      * @param  string                $fieldName Field name
      * @param  array                 $args      Field arguments
-     * @return \Elastica\Query\Range Current object
+     * @return $this
      */
     public function addField($fieldName, array $args)
     {

--- a/lib/Elastica/Query/Regexp.php
+++ b/lib/Elastica/Query/Regexp.php
@@ -29,9 +29,9 @@ class Regexp extends AbstractQuery
     /**
      * Sets the query expression for a key with its boost value
      *
-     * @param  string                 $key
-     * @param  string                 $value
-     * @param  float                  $boost
+     * @param  string $key
+     * @param  string $value
+     * @param  float  $boost
      * @return $this
      */
     public function setValue($key, $value, $boost = 1.0)

--- a/lib/Elastica/Query/Regexp.php
+++ b/lib/Elastica/Query/Regexp.php
@@ -32,7 +32,7 @@ class Regexp extends AbstractQuery
      * @param  string                 $key
      * @param  string                 $value
      * @param  float                  $boost
-     * @return \Elastica\Query\Regexp
+     * @return $this
      */
     public function setValue($key, $value, $boost = 1.0)
     {

--- a/lib/Elastica/Query/Simple.php
+++ b/lib/Elastica/Query/Simple.php
@@ -32,7 +32,7 @@ class Simple extends AbstractQuery
     /**
      * Sets new query array
      *
-     * @param  array                  $query Query array
+     * @param  array $query Query array
      * @return $this
      */
     public function setQuery(array $query)

--- a/lib/Elastica/Query/Simple.php
+++ b/lib/Elastica/Query/Simple.php
@@ -33,7 +33,7 @@ class Simple extends AbstractQuery
      * Sets new query array
      *
      * @param  array                  $query Query array
-     * @return \Elastica\Query\Simple Current object
+     * @return $this
      */
     public function setQuery(array $query)
     {

--- a/lib/Elastica/Query/SimpleQueryString.php
+++ b/lib/Elastica/Query/SimpleQueryString.php
@@ -27,7 +27,7 @@ class SimpleQueryString extends AbstractQuery
     /**
      * Set the querystring for this query
      * @param  string                            $query see ES documentation for querystring syntax
-     * @return \Elastica\Query\SimpleQueryString
+     * @return $this
      */
     public function setQuery($query)
     {
@@ -36,7 +36,7 @@ class SimpleQueryString extends AbstractQuery
 
     /**
      * @param  string[]                          $fields the fields on which to perform this query. Defaults to index.query.default_field.
-     * @return \Elastica\Query\SimpleQueryString
+     * @return $this
      */
     public function setFields(array $fields)
     {
@@ -46,7 +46,7 @@ class SimpleQueryString extends AbstractQuery
     /**
      * Set the default operator to use if no explicit operator is defined in the query string
      * @param  string                            $operator see OPERATOR_* constants for options
-     * @return \Elastica\Query\SimpleQueryString
+     * @return $this
      */
     public function setDefaultOperator($operator)
     {
@@ -56,7 +56,7 @@ class SimpleQueryString extends AbstractQuery
     /**
      * Set the analyzer used to analyze each term of the query
      * @param  string                            $analyzer
-     * @return \Elastica\Query\SimpleQueryString
+     * @return $this
      */
     public function setAnalyzer($analyzer)
     {

--- a/lib/Elastica/Query/SimpleQueryString.php
+++ b/lib/Elastica/Query/SimpleQueryString.php
@@ -26,7 +26,7 @@ class SimpleQueryString extends AbstractQuery
 
     /**
      * Set the querystring for this query
-     * @param  string                            $query see ES documentation for querystring syntax
+     * @param  string $query see ES documentation for querystring syntax
      * @return $this
      */
     public function setQuery($query)
@@ -35,7 +35,7 @@ class SimpleQueryString extends AbstractQuery
     }
 
     /**
-     * @param  string[]                          $fields the fields on which to perform this query. Defaults to index.query.default_field.
+     * @param  string[] $fields the fields on which to perform this query. Defaults to index.query.default_field.
      * @return $this
      */
     public function setFields(array $fields)
@@ -45,7 +45,7 @@ class SimpleQueryString extends AbstractQuery
 
     /**
      * Set the default operator to use if no explicit operator is defined in the query string
-     * @param  string                            $operator see OPERATOR_* constants for options
+     * @param  string $operator see OPERATOR_* constants for options
      * @return $this
      */
     public function setDefaultOperator($operator)
@@ -55,7 +55,7 @@ class SimpleQueryString extends AbstractQuery
 
     /**
      * Set the analyzer used to analyze each term of the query
-     * @param  string                            $analyzer
+     * @param  string $analyzer
      * @return $this
      */
     public function setAnalyzer($analyzer)

--- a/lib/Elastica/Query/Term.php
+++ b/lib/Elastica/Query/Term.php
@@ -27,7 +27,7 @@ class Term extends AbstractQuery
      * values for a term have to be set.
      *
      * @param  array                $term Term array
-     * @return \Elastica\Query\Term Current object
+     * @return $this
      */
     public function setRawTerm(array $term)
     {
@@ -40,7 +40,7 @@ class Term extends AbstractQuery
      * @param  string               $key   Key to query
      * @param  string|array         $value Values(s) for the query. Boost can be set with array
      * @param  float                $boost OPTIONAL Boost value (default = 1.0)
-     * @return \Elastica\Query\Term Current object
+     * @return $this
      */
     public function setTerm($key, $value, $boost = 1.0)
     {

--- a/lib/Elastica/Query/Term.php
+++ b/lib/Elastica/Query/Term.php
@@ -26,7 +26,7 @@ class Term extends AbstractQuery
      * Set term can be used instead of addTerm if some more special
      * values for a term have to be set.
      *
-     * @param  array                $term Term array
+     * @param  array $term Term array
      * @return $this
      */
     public function setRawTerm(array $term)
@@ -37,9 +37,9 @@ class Term extends AbstractQuery
     /**
      * Adds a term to the term query
      *
-     * @param  string               $key   Key to query
-     * @param  string|array         $value Values(s) for the query. Boost can be set with array
-     * @param  float                $boost OPTIONAL Boost value (default = 1.0)
+     * @param  string       $key   Key to query
+     * @param  string|array $value Values(s) for the query. Boost can be set with array
+     * @param  float        $boost OPTIONAL Boost value (default = 1.0)
      * @return $this
      */
     public function setTerm($key, $value, $boost = 1.0)

--- a/lib/Elastica/Query/Terms.php
+++ b/lib/Elastica/Query/Terms.php
@@ -49,8 +49,8 @@ class Terms extends AbstractQuery
     /**
      * Sets key and terms for the query
      *
-     * @param  string                $key   Terms key
-     * @param  array                 $terms Terms for the query.
+     * @param  string $key   Terms key
+     * @param  array  $terms Terms for the query.
      * @return $this
      */
     public function setTerms($key, array $terms)
@@ -64,7 +64,7 @@ class Terms extends AbstractQuery
     /**
      * Adds a single term to the list
      *
-     * @param  string                $term Term
+     * @param  string $term Term
      * @return $this
      */
     public function addTerm($term)
@@ -77,7 +77,7 @@ class Terms extends AbstractQuery
     /**
      * Sets the minimum matching values
      *
-     * @param  int                   $minimum Minimum value
+     * @param  int   $minimum Minimum value
      * @return $this
      */
     public function setMinimumMatch($minimum)
@@ -89,8 +89,9 @@ class Terms extends AbstractQuery
      * Converts the terms object to an array
      *
      * @see \Elastica\Query\AbstractQuery::toArray()
-     * @throws \Elastica\Exception\InvalidException
-     * @return array                                Query array
+     * @throws \Elastica\Exception\InvalidException If term key is empty
+     *
+     * @return array Query array
      */
     public function toArray()
     {

--- a/lib/Elastica/Query/Terms.php
+++ b/lib/Elastica/Query/Terms.php
@@ -51,7 +51,7 @@ class Terms extends AbstractQuery
      *
      * @param  string                $key   Terms key
      * @param  array                 $terms Terms for the query.
-     * @return \Elastica\Query\Terms
+     * @return $this
      */
     public function setTerms($key, array $terms)
     {
@@ -65,7 +65,7 @@ class Terms extends AbstractQuery
      * Adds a single term to the list
      *
      * @param  string                $term Term
-     * @return \Elastica\Query\Terms
+     * @return $this
      */
     public function addTerm($term)
     {
@@ -78,7 +78,7 @@ class Terms extends AbstractQuery
      * Sets the minimum matching values
      *
      * @param  int                   $minimum Minimum value
-     * @return \Elastica\Query\Terms
+     * @return $this
      */
     public function setMinimumMatch($minimum)
     {

--- a/lib/Elastica/Query/TopChildren.php
+++ b/lib/Elastica/Query/TopChildren.php
@@ -30,7 +30,7 @@ class TopChildren extends AbstractQuery
      * Sets query object
      *
      * @param  string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
-     * @return \Elastica\Query\TopChildren
+     * @return $this
      */
     public function setQuery($query)
     {
@@ -44,7 +44,7 @@ class TopChildren extends AbstractQuery
      * Set type of the parent document
      *
      * @param  string                      $type Parent document type
-     * @return \Elastica\Query\TopChildren Current object
+     * @return $this
      */
     public function setType($type)
     {

--- a/lib/Elastica/Query/TopChildren.php
+++ b/lib/Elastica/Query/TopChildren.php
@@ -43,7 +43,7 @@ class TopChildren extends AbstractQuery
     /**
      * Set type of the parent document
      *
-     * @param  string                      $type Parent document type
+     * @param  string $type Parent document type
      * @return $this
      */
     public function setType($type)

--- a/lib/Elastica/Query/Wildcard.php
+++ b/lib/Elastica/Query/Wildcard.php
@@ -32,7 +32,7 @@ class Wildcard extends AbstractQuery
      * @param  string                   $key
      * @param  string                   $value
      * @param  float                    $boost
-     * @return \Elastica\Query\Wildcard
+     * @return $this
      */
     public function setValue($key, $value, $boost = 1.0)
     {

--- a/lib/Elastica/Query/Wildcard.php
+++ b/lib/Elastica/Query/Wildcard.php
@@ -29,9 +29,9 @@ class Wildcard extends AbstractQuery
     /**
      * Sets the query expression for a key with its boost value
      *
-     * @param  string                   $key
-     * @param  string                   $value
-     * @param  float                    $boost
+     * @param  string $key
+     * @param  string $value
+     * @param  float  $boost
      * @return $this
      */
     public function setValue($key, $value, $boost = 1.0)

--- a/lib/Elastica/QueryBuilder.php
+++ b/lib/Elastica/QueryBuilder.php
@@ -44,10 +44,11 @@ class QueryBuilder
     /**
      * Returns Facade for custom DSL object
      *
-     * @param $dsl
-     * @param  array                 $arguments
-     * @return Facade
      * @throws QueryBuilderException
+     *
+     * @param $dsl
+     * @param  array  $arguments
+     * @return Facade
      */
     public function __call($dsl, array $arguments)
     {

--- a/lib/Elastica/QueryBuilder/Facade.php
+++ b/lib/Elastica/QueryBuilder/Facade.php
@@ -37,10 +37,11 @@ class Facade
     /**
      * Executes DSL methods
      *
-     * @param $name
-     * @param  array                 $arguments
-     * @return mixed
      * @throws QueryBuilderException
+     *
+     * @param  string $name
+     * @param  array  $arguments
+     * @return mixed
      */
     public function __call($name, array $arguments)
     {

--- a/lib/Elastica/Request.php
+++ b/lib/Elastica/Request.php
@@ -49,7 +49,7 @@ class Request extends Param
     /**
      * Sets the request method. Use one of the for consts
      *
-     * @param  string            $method Request method
+     * @param  string $method Request method
      * @return $this
      */
     public function setMethod($method)
@@ -70,7 +70,7 @@ class Request extends Param
     /**
      * Sets the request data
      *
-     * @param  array             $data Request data
+     * @param  array $data Request data
      * @return $this
      */
     public function setData($data)
@@ -91,7 +91,7 @@ class Request extends Param
     /**
      * Sets the request path
      *
-     * @param  string            $path Request path
+     * @param  string $path Request path
      * @return $this
      */
     public function setPath($path)
@@ -120,7 +120,7 @@ class Request extends Param
     }
 
     /**
-     * @param  array             $query
+     * @param  array $query
      * @return $this
      */
     public function setQuery(array $query = array())
@@ -142,7 +142,8 @@ class Request extends Param
     /**
      * Return Connection Object
      *
-     * @throws Exception\InvalidException
+     * @throws Exception\InvalidException If no valid connection was setted
+     *
      * @return \Elastica\Connection
      */
     public function getConnection()

--- a/lib/Elastica/Request.php
+++ b/lib/Elastica/Request.php
@@ -50,7 +50,7 @@ class Request extends Param
      * Sets the request method. Use one of the for consts
      *
      * @param  string            $method Request method
-     * @return \Elastica\Request Current object
+     * @return $this
      */
     public function setMethod($method)
     {
@@ -71,7 +71,7 @@ class Request extends Param
      * Sets the request data
      *
      * @param  array             $data Request data
-     * @return \Elastica\Request
+     * @return $this
      */
     public function setData($data)
     {
@@ -92,7 +92,7 @@ class Request extends Param
      * Sets the request path
      *
      * @param  string            $path Request path
-     * @return \Elastica\Request Current object
+     * @return $this
      */
     public function setPath($path)
     {
@@ -121,7 +121,7 @@ class Request extends Param
 
     /**
      * @param  array             $query
-     * @return \Elastica\Request
+     * @return $this
      */
     public function setQuery(array $query = array())
     {
@@ -130,7 +130,7 @@ class Request extends Param
 
     /**
      * @param  \Elastica\Connection $connection
-     * @return \Elastica\Request
+     * @return $this
      */
     public function setConnection(Connection $connection)
     {

--- a/lib/Elastica/Rescore/AbstractRescore.php
+++ b/lib/Elastica/Rescore/AbstractRescore.php
@@ -28,7 +28,7 @@ abstract class AbstractRescore extends Param
      * Sets window_size
      *
      * @param  int               $size
-     * @return \Elastica\Rescore
+     * @return $this
      */
     public function setWindowSize($size)
     {

--- a/lib/Elastica/Rescore/AbstractRescore.php
+++ b/lib/Elastica/Rescore/AbstractRescore.php
@@ -27,7 +27,7 @@ abstract class AbstractRescore extends Param
     /**
      * Sets window_size
      *
-     * @param  int               $size
+     * @param  int   $size
      * @return $this
      */
     public function setWindowSize($size)

--- a/lib/Elastica/Rescore/Query.php
+++ b/lib/Elastica/Rescore/Query.php
@@ -47,7 +47,7 @@ class Query extends AbstractRescore
      * Sets rescoreQuery object
      *
      * @param  string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
-     * @return \Elastica\Query\Rescore
+     * @return $this
      */
     public function setRescoreQuery($rescoreQuery)
     {
@@ -64,7 +64,7 @@ class Query extends AbstractRescore
      * Sets query_weight
      *
      * @param  float                   $weight
-     * @return \Elastica\Query\Rescore
+     * @return $this
      */
     public function setQueryWeight($weight)
     {
@@ -78,7 +78,7 @@ class Query extends AbstractRescore
      * Sets rescore_query_weight
      *
      * @param  float                   $size
-     * @return \Elastica\Query\Rescore
+     * @return $this
      */
     public function setRescoreQueryWeight($weight)
     {

--- a/lib/Elastica/Rescore/Query.php
+++ b/lib/Elastica/Rescore/Query.php
@@ -63,7 +63,7 @@ class Query extends AbstractRescore
     /**
      * Sets query_weight
      *
-     * @param  float                   $weight
+     * @param  float $weight
      * @return $this
      */
     public function setQueryWeight($weight)
@@ -77,7 +77,7 @@ class Query extends AbstractRescore
     /**
      * Sets rescore_query_weight
      *
-     * @param  float                   $size
+     * @param  float $size
      * @return $this
      */
     public function setRescoreQueryWeight($weight)

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -221,7 +221,7 @@ class Response
      * from the \Elastica\Client::_callService .
      *
      * @param  array              $transferInfo The curl transfer information.
-     * @return \Elastica\Response Current object
+     * @return $this
      */
     public function setTransferInfo(array $transferInfo)
     {
@@ -244,7 +244,7 @@ class Response
      * Sets the query time
      *
      * @param  float              $queryTime Query time
-     * @return \Elastica\Response Current object
+     * @return $this
      */
     public function setQueryTime($queryTime)
     {

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -220,7 +220,7 @@ class Response
      * Sets the transfer info of the curl request. This function is called
      * from the \Elastica\Client::_callService .
      *
-     * @param  array              $transferInfo The curl transfer information.
+     * @param  array $transferInfo The curl transfer information.
      * @return $this
      */
     public function setTransferInfo(array $transferInfo)
@@ -243,7 +243,7 @@ class Response
     /**
      * Sets the query time
      *
-     * @param  float              $queryTime Query time
+     * @param  float $queryTime Query time
      * @return $this
      */
     public function setQueryTime($queryTime)
@@ -257,7 +257,8 @@ class Response
      * Time request took
      *
      * @throws \Elastica\Exception\NotFoundException
-     * @return int                                   Time request took
+     *
+     * @return int Time request took
      */
     public function getEngineTime()
     {
@@ -274,6 +275,7 @@ class Response
      * Get the _shard statistics for the response
      *
      * @throws \Elastica\Exception\NotFoundException
+     *
      * @return array
      */
     public function getShardsStatistics()
@@ -291,6 +293,7 @@ class Response
      * Get the _scroll value for the response
      *
      * @throws \Elastica\Exception\NotFoundException
+     *
      * @return string
      */
     public function getScrollId()

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -200,9 +200,11 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
 
     /**
      * Retrieve a specific aggregation from this result set
-     * @param  string                     $name the name of the desired aggregation
-     * @return array
+     *
      * @throws Exception\InvalidException if an aggregation by the given name cannot be found
+     *
+     * @param  string $name the name of the desired aggregation
+     * @return array
      */
     public function getAggregation($name)
     {
@@ -371,9 +373,9 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     /**
      * Offset to retrieve
      * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     * @throws Exception\InvalidException If offset doesn't exist
      *
-     * @param  integer                    $offset
-     * @throws Exception\InvalidException
+     * @param  integer     $offset
      * @return Result|null
      */
     public function offsetGet($offset)
@@ -388,10 +390,10 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     /**
      * Offset to set
      * @link http://php.net/manual/en/arrayaccess.offsetset.php
-     *
-     * @param  integer                    $offset
-     * @param  Result                     $value
      * @throws Exception\InvalidException
+     *
+     * @param integer $offset
+     * @param Result  $value
      */
     public function offsetSet($offset, $value)
     {

--- a/lib/Elastica/ScanAndScroll.php
+++ b/lib/Elastica/ScanAndScroll.php
@@ -110,6 +110,7 @@ class ScanAndScroll implements \Iterator
      * Start the initial scan search
      * @link http://php.net/manual/en/iterator.rewind.php
      * @throws \Elastica\Exception\InvalidException
+     *
      * @return void
      */
     public function rewind()
@@ -129,7 +130,6 @@ class ScanAndScroll implements \Iterator
     /**
      * Perform next scroll search
      * @throws \Elastica\Exception\InvalidException
-     * @return void
      */
     protected function _scroll()
     {

--- a/lib/Elastica/Script.php
+++ b/lib/Elastica/Script.php
@@ -91,8 +91,9 @@ class Script extends AbstractUpdateAction
     }
 
     /**
-     * @param  string|array|\Elastica\Script        $data
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  string|array|\Elastica\Script $data
      * @return self
      */
     public static function create($data)
@@ -111,8 +112,9 @@ class Script extends AbstractUpdateAction
     }
 
     /**
-     * @param  array                                $data
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  array $data
      * @return self
      */
     protected static function _createFromArray(array $data)

--- a/lib/Elastica/Script.php
+++ b/lib/Elastica/Script.php
@@ -93,7 +93,7 @@ class Script extends AbstractUpdateAction
     /**
      * @param  string|array|\Elastica\Script        $data
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Script
+     * @return self
      */
     public static function create($data)
     {
@@ -113,7 +113,7 @@ class Script extends AbstractUpdateAction
     /**
      * @param  array                                $data
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Script
+     * @return self
      */
     protected static function _createFromArray(array $data)
     {

--- a/lib/Elastica/Script.php
+++ b/lib/Elastica/Script.php
@@ -38,9 +38,11 @@ class Script extends AbstractUpdateAction
     public function __construct($script, array $params = null, $lang = null, $id = null)
     {
         $this->setScript($script);
+
         if ($params) {
             $this->setParams($params);
         }
+
         if ($lang) {
             $this->setLang($lang);
         }
@@ -51,11 +53,14 @@ class Script extends AbstractUpdateAction
     }
 
     /**
-     * @param string $lang
+     * @param  string $lang
+     * @return $this
      */
     public function setLang($lang)
     {
         $this->_lang = $lang;
+
+        return $this;
     }
 
     /**
@@ -67,11 +72,14 @@ class Script extends AbstractUpdateAction
     }
 
     /**
-     * @param string $script
+     * @param  string $script
+     * @return $this
      */
     public function setScript($script)
     {
         $this->_script = $script;
+
+        return $this;
     }
 
     /**
@@ -118,6 +126,7 @@ class Script extends AbstractUpdateAction
         if (isset($data['lang'])) {
             $script->setLang($data['lang']);
         }
+
         if (isset($data['params'])) {
             if (!is_array($data['params'])) {
                 throw new InvalidException("\$data['params'] should be array");
@@ -136,9 +145,11 @@ class Script extends AbstractUpdateAction
         $array = array(
             'script' => $this->_script,
         );
+
         if (!empty($this->_params)) {
             $array['params'] = $this->_params;
         }
+
         if ($this->_lang) {
             $array['lang'] = $this->_lang;
         }

--- a/lib/Elastica/ScriptFields.php
+++ b/lib/Elastica/ScriptFields.php
@@ -28,7 +28,7 @@ class ScriptFields extends Param
      * @param  string                               $name   Name of the Script field
      * @param  \Elastica\Script                     $script
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\ScriptFields
+     * @return $this
      */
     public function addScript($name, Script $script)
     {
@@ -42,7 +42,7 @@ class ScriptFields extends Param
 
     /**
      * @param  \Elastica\Script[]|array $scripts Associative array of string => Elastica\Script
-     * @return \Elastica\ScriptFields
+     * @return $this
      */
     public function setScripts(array $scripts)
     {

--- a/lib/Elastica/ScriptFields.php
+++ b/lib/Elastica/ScriptFields.php
@@ -25,9 +25,10 @@ class ScriptFields extends Param
     }
 
     /**
-     * @param  string                               $name   Name of the Script field
-     * @param  \Elastica\Script                     $script
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  string           $name   Name of the Script field
+     * @param  \Elastica\Script $script
      * @return $this
      */
     public function addScript($name, Script $script)

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -83,8 +83,9 @@ class Search
     /**
      * Adds a index to the list
      *
-     * @param  \Elastica\Index|string               $index Index object or string
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  \Elastica\Index|string $index Index object or string
      * @return $this
      */
     public function addIndex($index)
@@ -105,7 +106,7 @@ class Search
     /**
      * Add array of indices at once
      *
-     * @param  array            $indices
+     * @param  array $indices
      * @return $this
      */
     public function addIndices(array $indices = array())
@@ -120,9 +121,10 @@ class Search
     /**
      * Adds a type to the current search
      *
-     * @param  \Elastica\Type|string                $type Type name or object
-     * @return $this
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  \Elastica\Type|string $type Type name or object
+     * @return $this
      */
     public function addType($type)
     {
@@ -142,7 +144,7 @@ class Search
     /**
      * Add array of types
      *
-     * @param  array            $types
+     * @param  array $types
      * @return $this
      */
     public function addTypes(array $types = array())
@@ -166,8 +168,8 @@ class Search
     }
 
     /**
-     * @param  string           $key
-     * @param  mixed            $value
+     * @param  string $key
+     * @param  mixed  $value
      * @return $this
      */
     public function setOption($key, $value)
@@ -180,7 +182,7 @@ class Search
     }
 
     /**
-     * @param  array            $options
+     * @param  array $options
      * @return $this
      */
     public function setOptions(array $options)
@@ -205,8 +207,8 @@ class Search
     }
 
     /**
-     * @param  string           $key
-     * @param  mixed            $value
+     * @param  string $key
+     * @param  mixed  $value
      * @return $this
      */
     public function addOption($key, $value)
@@ -232,9 +234,10 @@ class Search
     }
 
     /**
-     * @param  string                               $key
-     * @return mixed
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  string $key
+     * @return mixed
      */
     public function getOption($key)
     {
@@ -254,9 +257,10 @@ class Search
     }
 
     /**
-     * @param  string                               $key
-     * @return bool
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  string $key
+     * @return bool
      */
     protected function _validateOption($key)
     {
@@ -408,9 +412,10 @@ class Search
     /**
      * Search in the set indices, types
      *
-     * @param  mixed                                $query
-     * @param  int|array                            $options OPTIONAL Limit or associative array of options (option=>value)
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  mixed               $query
+     * @param  int|array           $options OPTIONAL Limit or associative array of options (option=>value)
      * @return \Elastica\ResultSet
      */
     public function search($query = '', $options = null)

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -85,7 +85,7 @@ class Search
      *
      * @param  \Elastica\Index|string               $index Index object or string
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Search                     Current object
+     * @return $this
      */
     public function addIndex($index)
     {
@@ -106,7 +106,7 @@ class Search
      * Add array of indices at once
      *
      * @param  array            $indices
-     * @return \Elastica\Search
+     * @return $this
      */
     public function addIndices(array $indices = array())
     {
@@ -121,7 +121,7 @@ class Search
      * Adds a type to the current search
      *
      * @param  \Elastica\Type|string                $type Type name or object
-     * @return \Elastica\Search                     Search object
+     * @return $this
      * @throws \Elastica\Exception\InvalidException
      */
     public function addType($type)
@@ -143,7 +143,7 @@ class Search
      * Add array of types
      *
      * @param  array            $types
-     * @return \Elastica\Search
+     * @return $this
      */
     public function addTypes(array $types = array())
     {
@@ -156,7 +156,7 @@ class Search
 
     /**
      * @param  string|array|\Elastica\Query|\Elastica\Suggest|\Elastica\Query\AbstractQuery|\Elastica\Filter\AbstractFilter $query|
-     * @return \Elastica\Search
+     * @return $this
      */
     public function setQuery($query)
     {
@@ -168,7 +168,7 @@ class Search
     /**
      * @param  string           $key
      * @param  mixed            $value
-     * @return \Elastica\Search
+     * @return $this
      */
     public function setOption($key, $value)
     {
@@ -181,7 +181,7 @@ class Search
 
     /**
      * @param  array            $options
-     * @return \Elastica\Search
+     * @return $this
      */
     public function setOptions(array $options)
     {
@@ -195,7 +195,7 @@ class Search
     }
 
     /**
-     * @return \Elastica\Search
+     * @return $this
      */
     public function clearOptions()
     {
@@ -207,7 +207,7 @@ class Search
     /**
      * @param  string           $key
      * @param  mixed            $value
-     * @return \Elastica\Search
+     * @return $this
      */
     public function addOption($key, $value)
     {
@@ -366,7 +366,7 @@ class Search
      * Creates new search object
      *
      * @param  \Elastica\SearchableInterface $searchObject
-     * @return \Elastica\Search
+     * @return Search
      */
     public static function create(SearchableInterface $searchObject)
     {
@@ -467,7 +467,7 @@ class Search
     /**
      * @param  array|int                    $options
      * @param  string|array|\Elastica\Query $query
-     * @return \Elastica\Search
+     * @return $this
      */
     public function setOptionsAndQuery($options = null, $query = '')
     {
@@ -494,7 +494,7 @@ class Search
 
     /**
      * @param  Suggest $suggest
-     * @return Search
+     * @return $this
      */
     public function setSuggest(Suggest $suggest)
     {

--- a/lib/Elastica/Snapshot.php
+++ b/lib/Elastica/Snapshot.php
@@ -44,9 +44,11 @@ class Snapshot
 
     /**
      * Retrieve a repository record by name
-     * @param  string                      $name the name of the desired repository
+     *
      * @throws Exception\ResponseException
      * @throws Exception\NotFoundException
+     *
+     * @param  string $name the name of the desired repository
      * @return array
      */
     public function getRepository($name)
@@ -88,10 +90,12 @@ class Snapshot
 
     /**
      * Retrieve data regarding a specific snapshot
-     * @param  string                      $repository the name of the repository from which to retrieve the snapshot
-     * @param  string                      $name       the name of the desired snapshot
+     *
      * @throws Exception\ResponseException
      * @throws Exception\NotFoundException
+     *
+     * @param  string $repository the name of the repository from which to retrieve the snapshot
+     * @param  string $name       the name of the desired snapshot
      * @return array
      */
     public function getSnapshot($repository, $name)

--- a/lib/Elastica/Suggest.php
+++ b/lib/Elastica/Suggest.php
@@ -24,7 +24,7 @@ class Suggest extends Param
 
     /**
      * Set the global text for this suggester
-     * @param  string            $text
+     * @param  string $text
      * @return $this
      */
     public function setGlobalText($text)
@@ -34,7 +34,7 @@ class Suggest extends Param
 
     /**
      * Add a suggestion to this suggest clause
-     * @param  AbstractSuggest   $suggestion
+     * @param  AbstractSuggest $suggestion
      * @return $this
      */
     public function addSuggestion(AbstractSuggest $suggestion)
@@ -43,9 +43,10 @@ class Suggest extends Param
     }
 
     /**
-     * @param  Suggest|AbstractSuggest           $suggestion
-     * @return self
      * @throws Exception\NotImplementedException
+     *
+     * @param  Suggest|AbstractSuggest $suggestion
+     * @return self
      */
     public static function create($suggestion)
     {

--- a/lib/Elastica/Suggest.php
+++ b/lib/Elastica/Suggest.php
@@ -25,7 +25,7 @@ class Suggest extends Param
     /**
      * Set the global text for this suggester
      * @param  string            $text
-     * @return \Elastica\Suggest
+     * @return $this
      */
     public function setGlobalText($text)
     {
@@ -35,7 +35,7 @@ class Suggest extends Param
     /**
      * Add a suggestion to this suggest clause
      * @param  AbstractSuggest   $suggestion
-     * @return \Elastica\Suggest
+     * @return $this
      */
     public function addSuggestion(AbstractSuggest $suggestion)
     {
@@ -44,7 +44,7 @@ class Suggest extends Param
 
     /**
      * @param  Suggest|AbstractSuggest           $suggestion
-     * @return \Elastica\Suggest
+     * @return self
      * @throws Exception\NotImplementedException
      */
     public static function create($suggestion)

--- a/lib/Elastica/Suggest/AbstractSuggest.php
+++ b/lib/Elastica/Suggest/AbstractSuggest.php
@@ -32,7 +32,7 @@ abstract class AbstractSuggest extends Param
 
     /**
      * Suggest text must be set either globally or per suggestion
-     * @param  string                            $text
+     * @param  string $text
      * @return $this
      */
     public function setText($text)
@@ -43,7 +43,7 @@ abstract class AbstractSuggest extends Param
     }
 
     /**
-     * @param  string                            $field
+     * @param  string $field
      * @return $this
      */
     public function setField($field)
@@ -52,7 +52,7 @@ abstract class AbstractSuggest extends Param
     }
 
     /**
-     * @param  int                               $size
+     * @param  int   $size
      * @return $this
      */
     public function setSize($size)
@@ -61,7 +61,7 @@ abstract class AbstractSuggest extends Param
     }
 
     /**
-     * @param  int                               $size maximum number of suggestions to be retrieved from each shard
+     * @param  int   $size maximum number of suggestions to be retrieved from each shard
      * @return $this
      */
     public function setShardSize($size)

--- a/lib/Elastica/Suggest/AbstractSuggest.php
+++ b/lib/Elastica/Suggest/AbstractSuggest.php
@@ -33,7 +33,7 @@ abstract class AbstractSuggest extends Param
     /**
      * Suggest text must be set either globally or per suggestion
      * @param  string                            $text
-     * @return \Elastica\Suggest\AbstractSuggest
+     * @return $this
      */
     public function setText($text)
     {
@@ -44,7 +44,7 @@ abstract class AbstractSuggest extends Param
 
     /**
      * @param  string                            $field
-     * @return \Elastica\Suggest\AbstractSuggest
+     * @return $this
      */
     public function setField($field)
     {
@@ -53,7 +53,7 @@ abstract class AbstractSuggest extends Param
 
     /**
      * @param  int                               $size
-     * @return \Elastica\Suggest\AbstractSuggest
+     * @return $this
      */
     public function setSize($size)
     {
@@ -62,7 +62,7 @@ abstract class AbstractSuggest extends Param
 
     /**
      * @param  int                               $size maximum number of suggestions to be retrieved from each shard
-     * @return \Elastica\Suggest\AbstractSuggest
+     * @return $this
      */
     public function setShardSize($size)
     {

--- a/lib/Elastica/Suggest/CandidateGenerator/DirectGenerator.php
+++ b/lib/Elastica/Suggest/CandidateGenerator/DirectGenerator.php
@@ -24,7 +24,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     /**
      * Set the field name from which to fetch candidate suggestions
      * @param  string          $field
-     * @return DirectGenerator
+     * @return $this
      */
     public function setField($field)
     {
@@ -34,7 +34,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     /**
      * Set the maximum corrections to be returned per suggest text token
      * @param  int             $size
-     * @return DirectGenerator
+     * @return $this
      */
     public function setSize($size)
     {
@@ -43,7 +43,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * @param  string          $mode see SUGGEST_MODE_* constants for options
-     * @return DirectGenerator
+     * @return $this
      */
     public function setSuggestMode($mode)
     {
@@ -52,7 +52,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * @param  int             $max can only be a value between 1 and 2. Defaults to 2.
-     * @return DirectGenerator
+     * @return $this
      */
     public function setMaxEdits($max)
     {
@@ -61,7 +61,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * @param  int             $length defaults to 1
-     * @return DirectGenerator
+     * @return $this
      */
     public function setPrefixLength($length)
     {
@@ -70,7 +70,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * @param  int             $min defaults to 4
-     * @return DirectGenerator
+     * @return $this
      */
     public function setMinWordLength($min)
     {
@@ -79,7 +79,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * @param  int             $max
-     * @return DirectGenerator
+     * @return $this
      */
     public function setMaxInspections($max)
     {
@@ -88,7 +88,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * @param  float           $min
-     * @return DirectGenerator
+     * @return $this
      */
     public function setMinDocFrequency($min)
     {
@@ -97,7 +97,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * @param  float           $max
-     * @return DirectGenerator
+     * @return $this
      */
     public function setMaxTermFrequency($max)
     {
@@ -107,7 +107,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     /**
      * Set an analyzer to be applied to the original token prior to candidate generation
      * @param  string          $pre an analyzer
-     * @return DirectGenerator
+     * @return $this
      */
     public function setPreFilter($pre)
     {
@@ -117,7 +117,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     /**
      * Set an analyzer to be applied to generated tokens before they are passed to the phrase scorer
      * @param  string          $post
-     * @return DirectGenerator
+     * @return $this
      */
     public function setPostFilter($post)
     {

--- a/lib/Elastica/Suggest/CandidateGenerator/DirectGenerator.php
+++ b/lib/Elastica/Suggest/CandidateGenerator/DirectGenerator.php
@@ -23,7 +23,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * Set the field name from which to fetch candidate suggestions
-     * @param  string          $field
+     * @param  string $field
      * @return $this
      */
     public function setField($field)
@@ -33,7 +33,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * Set the maximum corrections to be returned per suggest text token
-     * @param  int             $size
+     * @param  int   $size
      * @return $this
      */
     public function setSize($size)
@@ -42,7 +42,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     }
 
     /**
-     * @param  string          $mode see SUGGEST_MODE_* constants for options
+     * @param  string $mode see SUGGEST_MODE_* constants for options
      * @return $this
      */
     public function setSuggestMode($mode)
@@ -51,7 +51,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     }
 
     /**
-     * @param  int             $max can only be a value between 1 and 2. Defaults to 2.
+     * @param  int   $max can only be a value between 1 and 2. Defaults to 2.
      * @return $this
      */
     public function setMaxEdits($max)
@@ -60,7 +60,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     }
 
     /**
-     * @param  int             $length defaults to 1
+     * @param  int   $length defaults to 1
      * @return $this
      */
     public function setPrefixLength($length)
@@ -69,7 +69,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     }
 
     /**
-     * @param  int             $min defaults to 4
+     * @param  int   $min defaults to 4
      * @return $this
      */
     public function setMinWordLength($min)
@@ -78,7 +78,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     }
 
     /**
-     * @param  int             $max
+     * @param  int   $max
      * @return $this
      */
     public function setMaxInspections($max)
@@ -87,7 +87,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     }
 
     /**
-     * @param  float           $min
+     * @param  float $min
      * @return $this
      */
     public function setMinDocFrequency($min)
@@ -96,7 +96,7 @@ class DirectGenerator extends AbstractCandidateGenerator
     }
 
     /**
-     * @param  float           $max
+     * @param  float $max
      * @return $this
      */
     public function setMaxTermFrequency($max)
@@ -106,7 +106,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * Set an analyzer to be applied to the original token prior to candidate generation
-     * @param  string          $pre an analyzer
+     * @param  string $pre an analyzer
      * @return $this
      */
     public function setPreFilter($pre)
@@ -116,7 +116,7 @@ class DirectGenerator extends AbstractCandidateGenerator
 
     /**
      * Set an analyzer to be applied to generated tokens before they are passed to the phrase scorer
-     * @param  string          $post
+     * @param  string $post
      * @return $this
      */
     public function setPostFilter($post)

--- a/lib/Elastica/Suggest/Phrase.php
+++ b/lib/Elastica/Suggest/Phrase.php
@@ -13,7 +13,7 @@ class Phrase extends AbstractSuggest
 {
     /**
      * @param  string                   $analyzer
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function setAnalyzer($analyzer)
     {
@@ -23,7 +23,7 @@ class Phrase extends AbstractSuggest
     /**
      * Set the max size of the n-grams (shingles) in the field
      * @param  int                      $size
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function setGramSize($size)
     {
@@ -33,7 +33,7 @@ class Phrase extends AbstractSuggest
     /**
      * Set the likelihood of a term being misspelled even if the term exists in the dictionary
      * @param  float                    $likelihood Defaults to 0.95, meaning 5% of the words are misspelled.
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function setRealWordErrorLikelihood($likelihood)
     {
@@ -44,7 +44,7 @@ class Phrase extends AbstractSuggest
      * Set the factor applied to the input phrases score to be used as a threshold for other suggestion candidates.
      * Only candidates which score higher than this threshold will be included in the result.
      * @param  float                    $confidence Defaults to 1.0.
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function setConfidence($confidence)
     {
@@ -54,7 +54,7 @@ class Phrase extends AbstractSuggest
     /**
      * Set the maximum percentage of the terms considered to be misspellings in order to form a correction
      * @param  float                    $max
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function setMaxErrors($max)
     {
@@ -63,7 +63,7 @@ class Phrase extends AbstractSuggest
 
     /**
      * @param  string          $separator
-     * @return \Elastica\Param
+     * @return $this
      */
     public function setSeparator($separator)
     {
@@ -74,7 +74,7 @@ class Phrase extends AbstractSuggest
      * Set suggestion highlighting
      * @param  string                   $preTag
      * @param  string                   $postTag
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function setHighlight($preTag, $postTag)
     {
@@ -86,7 +86,7 @@ class Phrase extends AbstractSuggest
 
     /**
      * @param  float                    $discount
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function setStupidBackoffSmoothing($discount = 0.4)
     {
@@ -97,7 +97,7 @@ class Phrase extends AbstractSuggest
 
     /**
      * @param  float                    $alpha
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function setLaplaceSmoothing($alpha = 0.5)
     {
@@ -110,7 +110,7 @@ class Phrase extends AbstractSuggest
      * @param  float                    $trigramLambda
      * @param  float                    $bigramLambda
      * @param  float                    $unigramLambda
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function setLinearInterpolationSmoothing($trigramLambda, $bigramLambda, $unigramLambda)
     {
@@ -124,7 +124,7 @@ class Phrase extends AbstractSuggest
     /**
      * @param  string                   $model  the name of the smoothing model
      * @param  array                    $params
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function setSmoothingModel($model, array $params)
     {
@@ -135,7 +135,7 @@ class Phrase extends AbstractSuggest
 
     /**
      * @param  AbstractCandidateGenerator $generator
-     * @return \Elastica\Suggest\Phrase
+     * @return $this
      */
     public function addCandidateGenerator(AbstractCandidateGenerator $generator)
     {

--- a/lib/Elastica/Suggest/Phrase.php
+++ b/lib/Elastica/Suggest/Phrase.php
@@ -12,7 +12,7 @@ use Elastica\Suggest\CandidateGenerator\AbstractCandidateGenerator;
 class Phrase extends AbstractSuggest
 {
     /**
-     * @param  string                   $analyzer
+     * @param  string $analyzer
      * @return $this
      */
     public function setAnalyzer($analyzer)
@@ -22,7 +22,7 @@ class Phrase extends AbstractSuggest
 
     /**
      * Set the max size of the n-grams (shingles) in the field
-     * @param  int                      $size
+     * @param  int   $size
      * @return $this
      */
     public function setGramSize($size)
@@ -32,7 +32,7 @@ class Phrase extends AbstractSuggest
 
     /**
      * Set the likelihood of a term being misspelled even if the term exists in the dictionary
-     * @param  float                    $likelihood Defaults to 0.95, meaning 5% of the words are misspelled.
+     * @param  float $likelihood Defaults to 0.95, meaning 5% of the words are misspelled.
      * @return $this
      */
     public function setRealWordErrorLikelihood($likelihood)
@@ -43,7 +43,7 @@ class Phrase extends AbstractSuggest
     /**
      * Set the factor applied to the input phrases score to be used as a threshold for other suggestion candidates.
      * Only candidates which score higher than this threshold will be included in the result.
-     * @param  float                    $confidence Defaults to 1.0.
+     * @param  float $confidence Defaults to 1.0.
      * @return $this
      */
     public function setConfidence($confidence)
@@ -53,7 +53,7 @@ class Phrase extends AbstractSuggest
 
     /**
      * Set the maximum percentage of the terms considered to be misspellings in order to form a correction
-     * @param  float                    $max
+     * @param  float $max
      * @return $this
      */
     public function setMaxErrors($max)
@@ -62,7 +62,7 @@ class Phrase extends AbstractSuggest
     }
 
     /**
-     * @param  string          $separator
+     * @param  string $separator
      * @return $this
      */
     public function setSeparator($separator)
@@ -72,8 +72,8 @@ class Phrase extends AbstractSuggest
 
     /**
      * Set suggestion highlighting
-     * @param  string                   $preTag
-     * @param  string                   $postTag
+     * @param  string $preTag
+     * @param  string $postTag
      * @return $this
      */
     public function setHighlight($preTag, $postTag)
@@ -85,7 +85,7 @@ class Phrase extends AbstractSuggest
     }
 
     /**
-     * @param  float                    $discount
+     * @param  float $discount
      * @return $this
      */
     public function setStupidBackoffSmoothing($discount = 0.4)
@@ -96,7 +96,7 @@ class Phrase extends AbstractSuggest
     }
 
     /**
-     * @param  float                    $alpha
+     * @param  float $alpha
      * @return $this
      */
     public function setLaplaceSmoothing($alpha = 0.5)
@@ -107,9 +107,9 @@ class Phrase extends AbstractSuggest
     }
 
     /**
-     * @param  float                    $trigramLambda
-     * @param  float                    $bigramLambda
-     * @param  float                    $unigramLambda
+     * @param  float $trigramLambda
+     * @param  float $bigramLambda
+     * @param  float $unigramLambda
      * @return $this
      */
     public function setLinearInterpolationSmoothing($trigramLambda, $bigramLambda, $unigramLambda)
@@ -122,8 +122,8 @@ class Phrase extends AbstractSuggest
     }
 
     /**
-     * @param  string                   $model  the name of the smoothing model
-     * @param  array                    $params
+     * @param  string $model  the name of the smoothing model
+     * @param  array  $params
      * @return $this
      */
     public function setSmoothingModel($model, array $params)

--- a/lib/Elastica/Suggest/Term.php
+++ b/lib/Elastica/Suggest/Term.php
@@ -17,7 +17,7 @@ class Term extends AbstractSuggest
     const SUGGEST_MODE_ALWAYS = 'always';
 
     /**
-     * @param  string                 $analyzer
+     * @param  string $analyzer
      * @return $this
      */
     public function setAnalyzer($analyzer)
@@ -26,7 +26,7 @@ class Term extends AbstractSuggest
     }
 
     /**
-     * @param  string                 $sort see SORT_* constants for options
+     * @param  string $sort see SORT_* constants for options
      * @return $this
      */
     public function setSort($sort)
@@ -35,7 +35,7 @@ class Term extends AbstractSuggest
     }
 
     /**
-     * @param  string                 $mode see SUGGEST_MODE_* constants for options
+     * @param  string $mode see SUGGEST_MODE_* constants for options
      * @return $this
      */
     public function setSuggestMode($mode)
@@ -45,7 +45,7 @@ class Term extends AbstractSuggest
 
     /**
      * If true, suggest terms will be lower cased after text analysis
-     * @param  bool                   $lowercase
+     * @param  bool  $lowercase
      * @return $this
      */
     public function setLowercaseTerms($lowercase = true)
@@ -55,7 +55,7 @@ class Term extends AbstractSuggest
 
     /**
      * Set the maximum edit distance candidate suggestions can have in order to be considered as a suggestion
-     * @param  int                    $max Either 1 or 2. Any other value will result in an error.
+     * @param  int   $max Either 1 or 2. Any other value will result in an error.
      * @return $this
      */
     public function setMaxEdits($max)
@@ -65,7 +65,7 @@ class Term extends AbstractSuggest
 
     /**
      * The number of minimum prefix characters that must match in order to be a suggestion candidate
-     * @param  int                    $length Defaults to 1.
+     * @param  int   $length Defaults to 1.
      * @return $this
      */
     public function setPrefixLength($length)
@@ -75,7 +75,7 @@ class Term extends AbstractSuggest
 
     /**
      * The minimum length a suggest text term must have in order to be included.
-     * @param  int                    $length Defaults to 4.
+     * @param  int   $length Defaults to 4.
      * @return $this
      */
     public function setMinWordLength($length)
@@ -84,7 +84,7 @@ class Term extends AbstractSuggest
     }
 
     /**
-     * @param  int                    $max Defaults to 5.
+     * @param  int   $max Defaults to 5.
      * @return $this
      */
     public function setMaxInspections($max)
@@ -94,7 +94,7 @@ class Term extends AbstractSuggest
 
     /**
      * Set the minimum number of documents in which a suggestion should appear
-     * @param  int|float              $min Defaults to 0. If the value is greater than 1, it must be a whole number.
+     * @param  int|float $min Defaults to 0. If the value is greater than 1, it must be a whole number.
      * @return $this
      */
     public function setMinDocFrequency($min)
@@ -104,7 +104,7 @@ class Term extends AbstractSuggest
 
     /**
      * Set the maximum number of documents in which a suggest text token can exist in order to be included
-     * @param  float                  $max
+     * @param  float $max
      * @return $this
      */
     public function setMaxTermFrequency($max)

--- a/lib/Elastica/Suggest/Term.php
+++ b/lib/Elastica/Suggest/Term.php
@@ -18,7 +18,7 @@ class Term extends AbstractSuggest
 
     /**
      * @param  string                 $analyzer
-     * @return \Elastica\Suggest\Term
+     * @return $this
      */
     public function setAnalyzer($analyzer)
     {
@@ -27,7 +27,7 @@ class Term extends AbstractSuggest
 
     /**
      * @param  string                 $sort see SORT_* constants for options
-     * @return \Elastica\Suggest\Term
+     * @return $this
      */
     public function setSort($sort)
     {
@@ -36,7 +36,7 @@ class Term extends AbstractSuggest
 
     /**
      * @param  string                 $mode see SUGGEST_MODE_* constants for options
-     * @return \Elastica\Suggest\Term
+     * @return $this
      */
     public function setSuggestMode($mode)
     {
@@ -46,7 +46,7 @@ class Term extends AbstractSuggest
     /**
      * If true, suggest terms will be lower cased after text analysis
      * @param  bool                   $lowercase
-     * @return \Elastica\Suggest\Term
+     * @return $this
      */
     public function setLowercaseTerms($lowercase = true)
     {
@@ -56,7 +56,7 @@ class Term extends AbstractSuggest
     /**
      * Set the maximum edit distance candidate suggestions can have in order to be considered as a suggestion
      * @param  int                    $max Either 1 or 2. Any other value will result in an error.
-     * @return \Elastica\Suggest\Term
+     * @return $this
      */
     public function setMaxEdits($max)
     {
@@ -66,7 +66,7 @@ class Term extends AbstractSuggest
     /**
      * The number of minimum prefix characters that must match in order to be a suggestion candidate
      * @param  int                    $length Defaults to 1.
-     * @return \Elastica\Suggest\Term
+     * @return $this
      */
     public function setPrefixLength($length)
     {
@@ -76,7 +76,7 @@ class Term extends AbstractSuggest
     /**
      * The minimum length a suggest text term must have in order to be included.
      * @param  int                    $length Defaults to 4.
-     * @return \Elastica\Suggest\Term
+     * @return $this
      */
     public function setMinWordLength($length)
     {
@@ -85,7 +85,7 @@ class Term extends AbstractSuggest
 
     /**
      * @param  int                    $max Defaults to 5.
-     * @return \Elastica\Suggest\Term
+     * @return $this
      */
     public function setMaxInspections($max)
     {
@@ -95,7 +95,7 @@ class Term extends AbstractSuggest
     /**
      * Set the minimum number of documents in which a suggestion should appear
      * @param  int|float              $min Defaults to 0. If the value is greater than 1, it must be a whole number.
-     * @return \Elastica\Suggest\Term
+     * @return $this
      */
     public function setMinDocFrequency($min)
     {
@@ -105,7 +105,7 @@ class Term extends AbstractSuggest
     /**
      * Set the maximum number of documents in which a suggest text token can exist in order to be included
      * @param  float                  $max
-     * @return \Elastica\Suggest\Term
+     * @return $this
      */
     public function setMaxTermFrequency($max)
     {

--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -42,7 +42,7 @@ abstract class AbstractTransport extends Param
     }
 
     /**
-     * @param \Elastica\Connection $connection Connection object
+     * @param  \Elastica\Connection $connection Connection object
      * @return $this
      */
     public function setConnection(Connection $connection)
@@ -71,10 +71,11 @@ abstract class AbstractTransport extends Param
      * * array: An array with a "type" key which must be set to one of the two options. All other
      *          keys in the array will be set as parameters in the transport instance
      *
-     * @param  mixed                                $transport  A transport definition
-     * @param  \Elastica\Connection                 $connection A connection instance
-     * @param  array                                $params     Parameters for the transport class
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  mixed                $transport  A transport definition
+     * @param  \Elastica\Connection $connection A connection instance
+     * @param  array                $params     Parameters for the transport class
      * @return AbstractTransport
      */
     public static function create($transport, Connection $connection, array $params = array())

--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -43,10 +43,13 @@ abstract class AbstractTransport extends Param
 
     /**
      * @param \Elastica\Connection $connection Connection object
+     * @return $this
      */
     public function setConnection(Connection $connection)
     {
         $this->_connection = $connection;
+
+        return $this;
     }
 
     /**

--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -41,12 +41,13 @@ class Guzzle extends AbstractTransport
      *
      * All calls that are made to the server are done through this function
      *
-     * @param  \Elastica\Request                            $request
-     * @param  array                                        $params  Host, Port, ...
      * @throws \Elastica\Exception\ConnectionException
      * @throws \Elastica\Exception\ResponseException
      * @throws \Elastica\Exception\Connection\HttpException
-     * @return \Elastica\Response                           Response object
+     *
+     * @param  \Elastica\Request  $request
+     * @param  array              $params  Host, Port, ...
+     * @return \Elastica\Response Response object
      */
     public function exec(Request $request, array $params)
     {

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -37,12 +37,13 @@ class Http extends AbstractTransport
      *
      * All calls that are made to the server are done through this function
      *
-     * @param  \Elastica\Request                            $request
-     * @param  array                                        $params  Host, Port, ...
      * @throws \Elastica\Exception\ConnectionException
      * @throws \Elastica\Exception\ResponseException
      * @throws \Elastica\Exception\Connection\HttpException
-     * @return \Elastica\Response                           Response object
+     *
+     * @param  \Elastica\Request  $request
+     * @param  array              $params  Host, Port, ...
+     * @return \Elastica\Response Response object
      */
     public function exec(Request $request, array $params)
     {

--- a/lib/Elastica/Transport/HttpAdapter.php
+++ b/lib/Elastica/Transport/HttpAdapter.php
@@ -40,12 +40,13 @@ class HttpAdapter extends AbstractTransport
      *
      * All calls that are made to the server are done through this function
      *
-     * @param  \Elastica\Request                            $elasticaRequest
-     * @param  array                                        $params          Host, Port, ...
      * @throws \Elastica\Exception\ConnectionException
      * @throws \Elastica\Exception\ResponseException
      * @throws \Elastica\Exception\Connection\HttpException
-     * @return \Elastica\Response                           Response object
+     *
+     * @param  \Elastica\Request  $elasticaRequest
+     * @param  array              $params          Host, Port, ...
+     * @return \Elastica\Response Response object
      */
     public function exec(ElasticaRequest $elasticaRequest, array $params)
     {

--- a/lib/Elastica/Transport/Memcache.php
+++ b/lib/Elastica/Transport/Memcache.php
@@ -24,11 +24,12 @@ class Memcache extends AbstractTransport
     /**
      * Makes calls to the elasticsearch server
      *
-     * @param  \Elastica\Request                     $request
-     * @param  array                                 $params  Host, Port, ...
      * @throws \Elastica\Exception\ResponseException
      * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Response                    Response object
+     *
+     * @param  \Elastica\Request  $request
+     * @param  array              $params  Host, Port, ...
+     * @return \Elastica\Response Response object
      */
     public function exec(Request $request, array $params)
     {
@@ -99,7 +100,8 @@ class Memcache extends AbstractTransport
      * Check if key that will be used dont exceed 250 symbols
      *
      * @throws Elastica\Exception\Connection\MemcacheException If key is too long
-     * @param  string                                          $key
+     *
+     * @param string $key
      */
     private function _checkKeyLength($key)
     {

--- a/lib/Elastica/Transport/Thrift.php
+++ b/lib/Elastica/Transport/Thrift.php
@@ -37,8 +37,9 @@ class Thrift extends AbstractTransport
     /**
      * Construct transport
      *
-     * @param  \Elastica\Connection                 $connection Connection object
      * @throws \Elastica\Exception\RuntimeException
+     *
+     * @param \Elastica\Connection $connection Connection object
      */
     public function __construct(Connection $connection = null)
     {
@@ -103,11 +104,12 @@ class Thrift extends AbstractTransport
     /**
      * Makes calls to the elasticsearch server
      *
-     * @param  \Elastica\Request                              $request
-     * @param  array                                          $params  Host, Port, ...
      * @throws \Elastica\Exception\Connection\ThriftException
      * @throws \Elastica\Exception\ResponseException
-     * @return \Elastica\Response                             Response object
+     *
+     * @param  \Elastica\Request  $request
+     * @param  array              $params  Host, Port, ...
+     * @return \Elastica\Response Response object
      */
     public function exec(Request $request, array $params)
     {

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -108,10 +108,11 @@ class Type implements SearchableInterface
     }
 
     /**
-     * @param $object
-     * @param  Document                   $doc
-     * @return Response
      * @throws Exception\RuntimeException
+     *
+     * @param $object
+     * @param  Document $doc
+     * @return Response
      */
     public function addObject($object, Document $doc = null)
     {
@@ -131,11 +132,12 @@ class Type implements SearchableInterface
     /**
      * Update document, using update script. Requires elasticsearch >= 0.19.0
      *
-     * @param  \Elastica\Document|\Elastica\Script  $data    Document with update data
-     * @param  array                                $options array of query params to use for query. For possible options check es api
-     * @throws \Elastica\Exception\InvalidException
-     * @return \Elastica\Response
      * @link http://www.elasticsearch.org/guide/reference/api/update.html
+     * @throws \Elastica\Exception\InvalidException
+     *
+     * @param  \Elastica\Document|\Elastica\Script $data    Document with update data
+     * @param  array                               $options array of query params to use for query. For possible options check es api
+     * @return \Elastica\Response
      */
     public function updateDocument($data, array $options = array())
     {
@@ -218,10 +220,11 @@ class Type implements SearchableInterface
     /**
      * Get the document from search index
      *
-     * @param  string                                $id      Document id
-     * @param  array                                 $options Options for the get request.
      * @throws \Elastica\Exception\NotFoundException
      * @throws \Elastica\Exception\ResponseException
+     *
+     * @param  string             $id      Document id
+     * @param  array              $options Options for the get request.
      * @return \Elastica\Document
      */
     public function getDocument($id, $options = array())
@@ -403,12 +406,13 @@ class Type implements SearchableInterface
     /**
      * Deletes an entry by its unique identifier
      *
-     * @param  int|string                            $id      Document id
-     * @param  array                                 $options
      * @throws \InvalidArgumentException
      * @throws \Elastica\Exception\NotFoundException
-     * @return \Elastica\Response                    Response object
      * @link http://www.elasticsearch.org/guide/reference/api/delete.html
+     *
+     * @param  int|string         $id      Document id
+     * @param  array              $options
+     * @return \Elastica\Response Response object
      */
     public function deleteById($id, array $options = array())
     {
@@ -516,7 +520,7 @@ class Type implements SearchableInterface
      * Sets the serializer callable used in addObject
      * @see \Elastica\Type::addObject
      *
-     * @param array|string $serializer @see \Elastica\Type::_serializer
+     * @param  array|string $serializer @see \Elastica\Type::_serializer
      * @return $this
      */
     public function setSerializer($serializer)

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -517,6 +517,7 @@ class Type implements SearchableInterface
      * @see \Elastica\Type::addObject
      *
      * @param array|string $serializer @see \Elastica\Type::_serializer
+     * @return $this
      */
     public function setSerializer($serializer)
     {

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -521,6 +521,8 @@ class Type implements SearchableInterface
     public function setSerializer($serializer)
     {
         $this->_serializer = $serializer;
+
+        return $this;
     }
 
     /**

--- a/lib/Elastica/Type/AbstractType.php
+++ b/lib/Elastica/Type/AbstractType.php
@@ -94,8 +94,9 @@ abstract class AbstractType implements SearchableInterface
      * Reads index and type name from protected vars _indexName and _typeName.
      * Has to be set in child class
      *
-     * @param  \Elastica\Client                     $client OPTIONAL Client object
      * @throws \Elastica\Exception\InvalidException
+     *
+     * @param \Elastica\Client $client OPTIONAL Client object
      */
     public function __construct(Client $client = null)
     {

--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -50,7 +50,7 @@ class Mapping
     /**
      * Sets the mapping type
      * Enter description here ...
-     * @param  \Elastica\Type         $type Type object
+     * @param  \Elastica\Type $type Type object
      * @return $this
      */
     public function setType(Type $type)
@@ -63,7 +63,7 @@ class Mapping
     /**
      * Sets the mapping properties
      *
-     * @param  array                  $properties Properties
+     * @param  array $properties Properties
      * @return $this
      */
     public function setProperties(array $properties)
@@ -83,7 +83,7 @@ class Mapping
 
     /**
      * Sets the mapping _meta
-     * @param  array                  $meta metadata
+     * @param  array $meta metadata
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/mapping/meta.html
      */
@@ -108,7 +108,7 @@ class Mapping
      * To disable source, argument is
      * array('enabled' => false)
      *
-     * @param  array                  $source Source array
+     * @param  array $source Source array
      * @return $this
      * @link http://www.elasticsearch.org/guide/reference/mapping/source-field.html
      */
@@ -122,7 +122,7 @@ class Mapping
      *
      * Param can be set to true to enable again
      *
-     * @param  bool                   $enabled OPTIONAL (default = false)
+     * @param  bool  $enabled OPTIONAL (default = false)
      * @return $this
      */
     public function disableSource($enabled = false)
@@ -147,8 +147,8 @@ class Mapping
      * _size
      * properties
      *
-     * @param  string                 $key   Key name
-     * @param  mixed                  $value Key value
+     * @param  string $key   Key name
+     * @param  mixed  $value Key value
      * @return $this
      */
     public function setParam($key, $value)
@@ -173,7 +173,7 @@ class Mapping
     /**
      * Sets params for the "_all" field
      *
-     * @param  array                  $params _all Params (enabled, store, term_vector, analyzer)
+     * @param  array $params _all Params (enabled, store, term_vector, analyzer)
      * @return $this
      */
     public function setAllField(array $params)
@@ -184,7 +184,7 @@ class Mapping
     /**
      * Enables the "_all" field
      *
-     * @param  bool                   $enabled OPTIONAL (default = true)
+     * @param  bool  $enabled OPTIONAL (default = true)
      * @return $this
      */
     public function enableAllField($enabled = true)
@@ -195,7 +195,7 @@ class Mapping
     /**
      * Set TTL
      *
-     * @param  array                  $params TTL Params (enabled, default, ...)
+     * @param  array $params TTL Params (enabled, default, ...)
      * @return $this
      */
     public function setTtl(array $params)
@@ -206,7 +206,7 @@ class Mapping
     /**
      * Enables TTL for all documents in this type
      *
-     * @param  bool                   $enabled OPTIONAL (default = true)
+     * @param  bool  $enabled OPTIONAL (default = true)
      * @return $this
      */
     public function enableTtl($enabled = true)
@@ -217,7 +217,7 @@ class Mapping
     /**
      * Set parent type
      *
-     * @param  string                 $type Parent type
+     * @param  string $type Parent type
      * @return $this
      */
     public function setParent($type)
@@ -229,7 +229,8 @@ class Mapping
      * Converts the mapping to an array
      *
      * @throws \Elastica\Exception\InvalidException
-     * @return array                                Mapping as array
+     *
+     * @return array Mapping as array
      */
     public function toArray()
     {
@@ -257,9 +258,10 @@ class Mapping
     /**
      * Creates a mapping object
      *
-     * @param  array|\Elastica\Type\Mapping         $mapping Mapping object or properties array
-     * @return self
      * @throws \Elastica\Exception\InvalidException If invalid type
+     *
+     * @param  array|\Elastica\Type\Mapping $mapping Mapping object or properties array
+     * @return self
      */
     public static function create($mapping)
     {

--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -51,7 +51,7 @@ class Mapping
      * Sets the mapping type
      * Enter description here ...
      * @param  \Elastica\Type         $type Type object
-     * @return \Elastica\Type\Mapping Current object
+     * @return $this
      */
     public function setType(Type $type)
     {
@@ -64,7 +64,7 @@ class Mapping
      * Sets the mapping properties
      *
      * @param  array                  $properties Properties
-     * @return \Elastica\Type\Mapping Mapping object
+     * @return $this
      */
     public function setProperties(array $properties)
     {
@@ -84,7 +84,7 @@ class Mapping
     /**
      * Sets the mapping _meta
      * @param  array                  $meta metadata
-     * @return \Elastica\Type\Mapping Mapping object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/mapping/meta.html
      */
     public function setMeta(array $meta)
@@ -109,7 +109,7 @@ class Mapping
      * array('enabled' => false)
      *
      * @param  array                  $source Source array
-     * @return \Elastica\Type\Mapping Current object
+     * @return $this
      * @link http://www.elasticsearch.org/guide/reference/mapping/source-field.html
      */
     public function setSource(array $source)
@@ -123,7 +123,7 @@ class Mapping
      * Param can be set to true to enable again
      *
      * @param  bool                   $enabled OPTIONAL (default = false)
-     * @return \Elastica\Type\Mapping Current object
+     * @return $this
      */
     public function disableSource($enabled = false)
     {
@@ -149,7 +149,7 @@ class Mapping
      *
      * @param  string                 $key   Key name
      * @param  mixed                  $value Key value
-     * @return \Elastica\Type\Mapping Current object
+     * @return $this
      */
     public function setParam($key, $value)
     {
@@ -174,7 +174,7 @@ class Mapping
      * Sets params for the "_all" field
      *
      * @param  array                  $params _all Params (enabled, store, term_vector, analyzer)
-     * @return \Elastica\Type\Mapping
+     * @return $this
      */
     public function setAllField(array $params)
     {
@@ -185,7 +185,7 @@ class Mapping
      * Enables the "_all" field
      *
      * @param  bool                   $enabled OPTIONAL (default = true)
-     * @return \Elastica\Type\Mapping
+     * @return $this
      */
     public function enableAllField($enabled = true)
     {
@@ -196,7 +196,7 @@ class Mapping
      * Set TTL
      *
      * @param  array                  $params TTL Params (enabled, default, ...)
-     * @return \Elastica\Type\Mapping
+     * @return $this
      */
     public function setTtl(array $params)
     {
@@ -207,7 +207,7 @@ class Mapping
      * Enables TTL for all documents in this type
      *
      * @param  bool                   $enabled OPTIONAL (default = true)
-     * @return \Elastica\Type\Mapping
+     * @return $this
      */
     public function enableTtl($enabled = true)
     {
@@ -218,7 +218,7 @@ class Mapping
      * Set parent type
      *
      * @param  string                 $type Parent type
-     * @return \Elastica\Type\Mapping
+     * @return $this
      */
     public function setParent($type)
     {
@@ -258,7 +258,7 @@ class Mapping
      * Creates a mapping object
      *
      * @param  array|\Elastica\Type\Mapping         $mapping Mapping object or properties array
-     * @return \Elastica\Type\Mapping               Mapping object
+     * @return self
      * @throws \Elastica\Exception\InvalidException If invalid type
      */
     public static function create($mapping)

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -18,10 +18,11 @@ class Util
      * and
      * escapes the following terms: + - && || ! ( ) { } [ ] ^ " ~ * ? : \
      *
-     * @param  string $term Query term to replace and escape
-     * @return string Replaced and escaped query term
      * @link http://lucene.apache.org/java/2_4_0/queryparsersyntax.html#Boolean%20operators
      * @link http://lucene.apache.org/java/2_4_0/queryparsersyntax.html#Escaping%20Special%20Characters
+     *
+     * @param  string $term Query term to replace and escape
+     * @return string Replaced and escaped query term
      */
     public static function replaceBooleanWordsAndEscapeTerm($term)
     {
@@ -36,9 +37,10 @@ class Util
      * Escapes the following terms (because part of the query language)
      * + - && || ! ( ) { } [ ] ^ " ~ * ? : \
      *
+     * @link http://lucene.apache.org/java/2_4_0/queryparsersyntax.html#Escaping%20Special%20Characters
+     *
      * @param  string $term Query term to escape
      * @return string Escaped query term
-     * @link http://lucene.apache.org/java/2_4_0/queryparsersyntax.html#Escaping%20Special%20Characters
      */
     public static function escapeTerm($term)
     {
@@ -57,9 +59,10 @@ class Util
      * Replace the following reserved words (because part of the query language)
      * AND OR NOT
      *
+     * @link http://lucene.apache.org/java/2_4_0/queryparsersyntax.html#Boolean%20operators
+     *
      * @param  string $term Query term to replace
      * @return string Replaced query term
-     * @link http://lucene.apache.org/java/2_4_0/queryparsersyntax.html#Boolean%20operators
      */
     public static function replaceBooleanWords($term)
     {

--- a/test/lib/Elastica/Test/Aggregation/FiltersTest.php
+++ b/test/lib/Elastica/Test/Aggregation/FiltersTest.php
@@ -6,7 +6,6 @@ use Elastica\Aggregation\Avg;
 use Elastica\Aggregation\Filter;
 use Elastica\Aggregation\Filters;
 use Elastica\Document;
-use Elastica\Filter\Range;
 use Elastica\Filter\Term;
 use Elastica\Query;
 
@@ -32,12 +31,12 @@ class FiltersTest extends BaseAggregationTest
             "filters" => array(
               "filters" => array(
                   "blue" => array(
-                      "term" => array("color" => "blue")
+                      "term" => array("color" => "blue"),
                   ),
                   "red" => array(
-                      "term" => array("color" => "red")
-                  )
-              )
+                      "term" => array("color" => "red"),
+                  ),
+              ),
             ),
             "aggs" => array(
                 "avg_price" => array("avg" => array("field" => "price")),
@@ -61,12 +60,12 @@ class FiltersTest extends BaseAggregationTest
             "filters" => array(
                 "filters" => array(
                     array(
-                        "term" => array("color" => "blue")
+                        "term" => array("color" => "blue"),
                     ),
                     array(
-                        "term" => array("color" => "red")
-                    )
-                )
+                        "term" => array("color" => "red"),
+                    ),
+                ),
             ),
             "aggs" => array(
                 "avg_price" => array("avg" => array("field" => "price")),

--- a/test/lib/Elastica/Test/BulkTest.php
+++ b/test/lib/Elastica/Test/BulkTest.php
@@ -646,6 +646,18 @@ class BulkTest extends BaseTest
         $this->assertEquals(5, $metadata[ '_retry_on_conflict' ]);
     }
 
+    public function testSetShardTimeout()
+    {
+        $bulk = new Bulk($this->_getClient());
+        $this->assertInstanceOf('Elastica\Bulk', $bulk->setShardTimeout(10));
+    }
+
+    public function testSetRequestParam()
+    {
+        $bulk = new Bulk($this->_getClient());
+        $this->assertInstanceOf('Elastica\Bulk', $bulk->setRequestParam('key', 'value'));
+    }
+
     public function udpDataProvider()
     {
         return array(

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -6,6 +6,7 @@ use Elastica\Client;
 use Elastica\Connection;
 use Elastica\Document;
 use Elastica\Exception\Connection\HttpException;
+use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Request;
 use Elastica\Script;
@@ -1001,5 +1002,63 @@ class ClientTest extends BaseTest
         $responseArray = $response->getData();
 
         $this->assertEquals(1, $responseArray['hits']['total']);
+    }
+
+    public function testAddHeader()
+    {
+        $client = new Client();
+
+        // add one header
+        $client->addHeader('foo', 'bar');
+        $this->assertEquals(array('foo' => 'bar'), $client->getConfigValue('headers'));
+
+        // check class
+        $this->assertInstanceOf('Elastica\Client', $client->addHeader('foo', 'bar'));
+
+        // check invalid parameters
+        try {
+            $client->addHeader(new \stdClass(), 'foo');
+            $this->fail('Header name is not a string but exception not thrown');
+        } catch (InvalidException $ex) {
+
+        }
+
+        try {
+            $client->addHeader('foo', new \stdClass());
+            $this->fail('Header value is not a string but exception not thrown');
+        } catch (InvalidException $ex) {
+
+        }
+    }
+
+    public function testRemoveHeader()
+    {
+        $client = new Client();
+
+        // set headers
+        $headers = array(
+            'first' => 'first value',
+            'second' => 'second value',
+        );
+        foreach ($headers as $key => $value) {
+            $client->addHeader($key, $value);
+        }
+        $this->assertEquals($headers, $client->getConfigValue('headers'));
+
+        // remove one
+        $client->removeHeader('first');
+        unset($headers['first']);
+        $this->assertEquals($headers, $client->getConfigValue('headers'));
+
+        // check class
+        $this->assertInstanceOf('Elastica\Client', $client->removeHeader('second'));
+
+        // check invalid parameter
+        try {
+            $client->removeHeader(new \stdClass());
+            $this->fail('Header name is not a string but exception not thrown');
+        } catch (InvalidException $ex) {
+
+        }
     }
 }

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -1020,14 +1020,12 @@ class ClientTest extends BaseTest
             $client->addHeader(new \stdClass(), 'foo');
             $this->fail('Header name is not a string but exception not thrown');
         } catch (InvalidException $ex) {
-
         }
 
         try {
             $client->addHeader('foo', new \stdClass());
             $this->fail('Header value is not a string but exception not thrown');
         } catch (InvalidException $ex) {
-
         }
     }
 
@@ -1058,7 +1056,6 @@ class ClientTest extends BaseTest
             $client->removeHeader(new \stdClass());
             $this->fail('Header name is not a string but exception not thrown');
         } catch (InvalidException $ex) {
-
         }
     }
 }

--- a/test/lib/Elastica/Test/Connection/ConnectionPollTest.php
+++ b/test/lib/Elastica/Test/Connection/ConnectionPollTest.php
@@ -30,6 +30,24 @@ class ConnectionPollTest extends BaseTest
         $pool->setConnections($connections);
 
         $this->assertEquals($connections, $pool->getConnections());
+
+        $this->assertInstanceOf('Elastica\Connection\ConnectionPool', $pool->setConnections($connections));
+    }
+
+    public function testAddConnection()
+    {
+        $pool = $this->createPool();
+        $pool->setConnections(array());
+
+        $connections = $this->getConnections(5);
+
+        foreach ($connections as $connection) {
+            $pool->addConnection($connection);
+        }
+
+        $this->assertEquals($connections, $pool->getConnections());
+
+        $this->assertInstanceOf('Elastica\Connection\ConnectionPool', $pool->addConnection($connections[0]));
     }
 
     public function testHasConnection()

--- a/test/lib/Elastica/Test/Filter/GeoShapePreIndexedTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoShapePreIndexedTest.php
@@ -87,4 +87,12 @@ class GeoShapePreIndexedTest extends BaseTest
 
         $index->delete();
     }
+
+    public function testSetRelation()
+    {
+        $gsp = new GeoShapePreIndexed('location', '1', 'type', 'indexName', 'location');
+        $gsp->setRelation(AbstractGeoShape::RELATION_INTERSECT);
+        $this->assertEquals(AbstractGeoShape::RELATION_INTERSECT, $gsp->getRelation());
+        $this->assertInstanceOf('Elastica\Filter\GeoShapePreIndexed', $gsp->setRelation(AbstractGeoShape::RELATION_INTERSECT));
+    }
 }

--- a/test/lib/Elastica/Test/Filter/GeoShapeProvidedTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoShapeProvidedTest.php
@@ -83,4 +83,12 @@ class GeoShapeProvidedTest extends BaseTest
 
         $this->assertEquals($expected, $gsp->toArray());
     }
+
+    public function testSetRelation()
+    {
+        $gsp = new GeoShapeProvided('location', array(array(25.0, 75.0), array(75.0, 25.0)));
+        $gsp->setRelation(AbstractGeoShape::RELATION_INTERSECT);
+        $this->assertEquals(AbstractGeoShape::RELATION_INTERSECT, $gsp->getRelation());
+        $this->assertInstanceOf('Elastica\Filter\GeoShapeProvided', $gsp->setRelation(AbstractGeoShape::RELATION_INTERSECT));
+    }
 }

--- a/test/lib/Elastica/Test/Filter/RangeTest.php
+++ b/test/lib/Elastica/Test/Filter/RangeTest.php
@@ -41,7 +41,8 @@ class RangeTest extends BaseTest
     /**
      * Tests that parent fields are not overwritten by the toArray method
      */
-    public function testSetCachedNotOverwritten() {
+    public function testSetCachedNotOverwritten()
+    {
         $filter = new Range('field_name', array());
         $filter->setCached(true);
         $array = $filter->toArray();

--- a/test/lib/Elastica/Test/Filter/RegexpTest.php
+++ b/test/lib/Elastica/Test/Filter/RegexpTest.php
@@ -24,26 +24,26 @@ class RegexpTest extends BaseTest
 
         $this->assertequals($expectedArray, $filter->toArray());
     }
-    
+
     public function testToArrayWithOptions()
     {
         $field = 'name';
         $regexp = 'ruf';
         $options = array(
-            'flags' => 'ALL'
+            'flags' => 'ALL',
         );
-        
+
         $filter = new Regexp($field, $regexp, $options);
-        
+
         $expectedArray = array(
             'regexp' => array(
                 $field => array(
                     'value' => $regexp,
-                    'flags' => 'ALL'
-                )
-            )
+                    'flags' => 'ALL',
+                ),
+            ),
         );
-        
+
         $this->assertequals($expectedArray, $filter->toArray());
     }
 

--- a/test/lib/Elastica/Test/Query/MatchTest.php
+++ b/test/lib/Elastica/Test/Query/MatchTest.php
@@ -223,7 +223,6 @@ class MatchTest extends BaseTest
         $this->assertEquals(2, $resultSet->count());
     }
 
-
     public function testMatchFuzzinessType()
     {
         $field = 'test';

--- a/test/lib/Elastica/Test/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryTest.php
@@ -81,6 +81,13 @@ class QueryTest extends BaseTest
         $this->assertEquals($query1->toArray(), $query2->toArray());
     }
 
+    public function testSetSuggestMustReturnQueryInstance()
+    {
+        $query = new Query();
+        $suggest = new Suggest();
+        $this->assertInstanceOf('Elastica\Query', $query->setSuggest($suggest));
+    }
+
     public function testArrayQuery()
     {
         $query = array(

--- a/test/lib/Elastica/Test/ScriptTest.php
+++ b/test/lib/Elastica/Test/ScriptTest.php
@@ -126,4 +126,26 @@ class ScriptTest extends BaseTest
             ),
         );
     }
+
+    public function testSetLang()
+    {
+        $script = new Script('foo', array(), Script::LANG_GROOVY);
+        $this->assertEquals(Script::LANG_GROOVY, $script->getLang());
+
+        $script->setLang(Script::LANG_PYTHON);
+        $this->assertEquals(Script::LANG_PYTHON, $script->getLang());
+
+        $this->assertInstanceOf('Elastica\Script', $script->setLang(Script::LANG_PYTHON));
+    }
+
+    public function testSetScript()
+    {
+        $script = new Script('foo');
+        $this->assertEquals('foo', $script->getScript());
+
+        $script->setScript('bar');
+        $this->assertEquals('bar', $script->getScript());
+
+        $this->assertInstanceOf('Elastica\Script', $script->setScript('foo'));
+    }
 }

--- a/test/lib/Elastica/Test/Type/MappingTest.php
+++ b/test/lib/Elastica/Test/Type/MappingTest.php
@@ -123,7 +123,7 @@ class MappingTest extends BaseTest
         );
 
         $response = $type->setMapping($mapping);
-		$this->assertFalse($response->hasError());
+        $this->assertFalse($response->hasError());
 
         $doc = new Document(1, array(
             'user' => array(
@@ -137,7 +137,7 @@ class MappingTest extends BaseTest
 
         $index->refresh();
         $resultSet = $type->search('ruflin');
-		$this->assertEquals($resultSet->count(), 1);
+        $this->assertEquals($resultSet->count(), 1);
 
         $index->delete();
     }

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -818,6 +818,14 @@ class TypeTest extends BaseTest
         $this->assertEquals('hans', $data['username']);
     }
 
+    public function testSetSerializer()
+    {
+        $index = $this->_createIndex();
+        $type = $index->getType('user');
+        $ret = $type->setSerializer(array(new SerializerMock(), 'serialize'));
+        $this->assertInstanceOf('Elastica\Type', $ret);
+    }
+
     public function testExists()
     {
         $index = $this->_createIndex();

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -799,7 +799,7 @@ class TypeTest extends BaseTest
         $index = $this->_createIndex();
 
         $type = new Type($index, 'user');
-        $type->setSerializer(array(new SerializerMock(), 'serialize'));
+        $type->setSerializer('get_object_vars');
 
         $userObject = new \stdClass();
         $userObject->username = 'hans';
@@ -822,7 +822,7 @@ class TypeTest extends BaseTest
     {
         $index = $this->_createIndex();
         $type = $index->getType('user');
-        $ret = $type->setSerializer(array(new SerializerMock(), 'serialize'));
+        $ret = $type->setSerializer('get_object_vars');
         $this->assertInstanceOf('Elastica\Type', $ret);
     }
 
@@ -886,13 +886,5 @@ class TypeTest extends BaseTest
             array('test-alias-type' => array('properties' => $expect)),
             $client->getIndex($aliasName)->getType($typeName)->getMapping()
         );
-    }
-}
-
-class SerializerMock
-{
-    public function serialize($object)
-    {
-        return get_object_vars($object);
     }
 }

--- a/test/shutdown/ShutdownTest.php
+++ b/test/shutdown/ShutdownTest.php
@@ -28,7 +28,7 @@ class ShutdownTest extends BaseTest
 
         // sayonara, wolverine, we'd never love you
         foreach ($nodes as $node) {
-            if ((int)$node->getInfo()->getPort() === 9201) {
+            if ((int) $node->getInfo()->getPort() === 9201) {
                 $node->shutdown('1s');
                 break;
             }


### PR DESCRIPTION
- All methods that supposed to be fluent now return instance from here they were called.
- Some tests were added.
- `@return` docblock updated across entire library. Finishes work started in #774.
- `@param` and `@return` realigned using php-cs-fixer.