### PR TITLE
Fix errors in hhvm build

### DIFF
--- a/ansible/provision.sh
+++ b/ansible/provision.sh
@@ -1,85 +1,68 @@
 #!/bin/bash
 
-# ----------------------------------------------------------------------------
-# Install ansible
+set -o xtrace
 
-sudo apt-get update -q
-sudo apt-get install python python-pip python-dev -yq
-sudo pip install ansible==1.8.2 -q
-sudo mkdir -p /etc/ansible/
-echo 'localhost' | sudo tee /etc/ansible/hosts
+install_ansible() {
+    sudo apt-get update
+    sudo apt-get install python python-pip python-dev -y
+    sudo pip install ansible==1.8.2
+    sudo mkdir -p /etc/ansible/
+    echo "localhost" | sudo tee /etc/ansible/hosts
+}
 
-# ----------------------------------------------------------------------------
-# Configure playbook
+run_playbook() {
+    # Write to stdout directly
+    export PYTHONUNBUFFERED=1
 
-# Write to stdout directly
-export PYTHONUNBUFFERED=1
+    # No cows >_<
+    export ANSIBLE_NOCOWS=1
 
-# No cows >_<
-export ANSIBLE_NOCOWS=1
+    # Root of git repo
+    if [ -z "$ES_PROJECT_ROOT" ]; then
+        export ES_PROJECT_ROOT="$(dirname $(dirname $(readlink -f $0)))"
+    fi
 
-# Root of git repo
-if [ -z "$ES_PROJECT_ROOT" ]; then
-    export ES_PROJECT_ROOT="$(dirname $(dirname $(readlink -f $0)))"
-fi
+    # Install or not require-dev packages
+    if [ -z "$ES_COMPOSER_NODEV" ]; then
+        export ES_COMPOSER_NODEV="no"
+    fi
 
-# Install or not require-dev packages
-if [ -z "$ES_COMPOSER_NODEV" ]; then
-    export ES_COMPOSER_NODEV="no"
-fi
+    if [ ! -x $(which ansible-playbook) ]; then
+        echo "Ansible is not installed"
+        return 1
+    fi
 
-# ----------------------------------------------------------------------------
-# Run playbook
+    ansible-playbook $ES_PROJECT_ROOT/ansible/es-playbook.yml -v | tee /tmp/ansible-playbook-progress
 
-ansible-playbook $ES_PROJECT_ROOT/ansible/es-playbook.yml -v | tee /tmp/ansible-playbook-progress
+    if grep -q "FATAL\|ERROR" /tmp/ansible-playbook-progress; then
+        return 1
+    fi
+}
 
-if grep -q 'FATAL\|ERROR' /tmp/ansible-playbook-progress; then
-    exit 1
-fi
-
-# ----------------------------------------------------------------------------
-
-all_nodes_available() {
+check_cluster() {
     curl -m 5 -s -o /dev/null "http://localhost:9200" &&
     curl -m 5 -s -o /dev/null "http://localhost:9201"
     return $?
 }
 
-check_cluster() {
-    restarts_left=$1
-    seconds_left=$2
+travis_retry() {
+    # We don't use builtin Travis CI function, because this script is also used for vagrant provision.
+    # But main idea of restarts is so simple, so lets override it without name change.
 
-    if [ $seconds_left -eq 0 ]; then
-        if [ $restarts_left -eq 0 ]; then
-            echo "Cluster was restarted 10 times, but still not ready for phpunit. Build failed!"
-            return 1
-        else
-            echo "Restart cluster. Restarts left: $restarts_left"
-            sudo service elasticsearch restart
-            check_cluster $(( $restarts_left - 1 )) 30
-            return $?
-        fi
-    else
-        if all_nodes_available; then
-            echo "All nodes available. Sleep 30 seconds and try to check them again..."
-            if sleep 10s && all_nodes_available; then
-                echo "All nodes still available - cluster ready."
-                return 0
-            else
-                echo "Some nodes were stopped during sleep. Trying cluster restart..."
-                check_cluster $restarts_left 0
-                return $?
-            fi
-        else
-            echo "Some nodes still unavailable. Sleep 1 second and try to check them again. Seconds to start left: $seconds_left"
-            sleep 1s && check_cluster $restarts_left $(( $seconds_left - 1 ))
-            return $?
-        fi
-    fi
+    $@ && return 0
+
+    echo "The command $@ failed. Retrying, 2 of 3"
+    sleep 60s && $@ && return 0
+
+    echo "The command $@ failed. Retrying, 3 of 3"
+    sleep 60s && $@ && return 0
+
+    echo "The command $@ failed."
+    return 1
 }
 
-echo "Wait cluster start..."
-if ! check_cluster 10 30; then
-    cat /var/log/elasticsearch/*.log
-    exit 1
-fi
+travis_retry install_ansible || exit 1
+
+travis_retry run_playbook || exit 1
+
+travis_retry check_cluster || exit 1

--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -63,6 +63,12 @@ class Guzzle extends AbstractTransport
         }
 
         $proxy = $connection->getProxy();
+
+        // See: https://github.com/facebook/hhvm/issues/4875
+        if (is_null($proxy) && defined('HHVM_VERSION')) {
+            $proxy = getenv('http_proxy') ?: null;
+        }
+
         if (!is_null($proxy)) {
             $options['proxy'] = $proxy;
         }

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -73,6 +73,12 @@ class Http extends AbstractTransport
         curl_setopt($conn, CURLOPT_FORBID_REUSE, 0);
 
         $proxy = $connection->getProxy();
+
+        // See: https://github.com/facebook/hhvm/issues/4875
+        if (is_null($proxy) && defined('HHVM_VERSION')) {
+            $proxy = getenv('http_proxy') ?: null;
+        }
+
         if (!is_null($proxy)) {
             curl_setopt($conn, CURLOPT_PROXY, $proxy);
         }

--- a/test/lib/Elastica/Test/Connection/ConnectionPoolTest.php
+++ b/test/lib/Elastica/Test/Connection/ConnectionPoolTest.php
@@ -8,11 +8,9 @@ use Elastica\Connection\Strategy\StrategyFactory;
 use Elastica\Test\Base as BaseTest;
 
 /**
- * Description of ConnectionPollTest
- *
  * @author chabior
  */
-class ConnectionPollTest extends BaseTest
+class ConnectionPoolTest extends BaseTest
 {
     public function testConstruct()
     {

--- a/test/lib/Elastica/Test/Exception/AbstractExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/AbstractExceptionTest.php
@@ -5,7 +5,7 @@ use Elastica\Test\Base as BaseTest;
 
 abstract class AbstractExceptionTest extends BaseTest
 {
-    protected function getExceptionClass()
+    protected function _getExceptionClass()
     {
         $reflection = new \ReflectionObject($this);
 
@@ -20,7 +20,7 @@ abstract class AbstractExceptionTest extends BaseTest
 
     public function testInheritance()
     {
-        $className = $this->getExceptionClass();
+        $className = $this->_getExceptionClass();
         $reflection = new \ReflectionClass($className);
         $this->assertTrue($reflection->isSubclassOf('Exception'));
         $this->assertTrue($reflection->implementsInterface('Elastica\Exception\ExceptionInterface'));

--- a/test/lib/Elastica/Test/Exception/AbstractExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/AbstractExceptionTest.php
@@ -7,7 +7,7 @@ abstract class AbstractExceptionTest extends BaseTest
 {
     protected function getExceptionClass()
     {
-        $reflection = new ReflectionObject($this);
+        $reflection = new \ReflectionObject($this);
 
         // Elastica\Test\Exception\RuntimeExceptionTest => Elastica\Exception\RuntimeExceptionTest
         $name = preg_replace('/^Elastica\\\\Test/', 'Elastica', $reflection->getName());

--- a/test/lib/Elastica/Test/Exception/AbstractExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/AbstractExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace Elastica\Test\Exception;
+
+use Elastica\Test\Base as BaseTest;
+
+abstract class AbstractExceptionTest extends BaseTest
+{
+    protected function getExceptionClass()
+    {
+        $reflection = new ReflectionObject($this);
+
+        // Elastica\Test\Exception\RuntimeExceptionTest => Elastica\Exception\RuntimeExceptionTest
+        $name = preg_replace('/^Elastica\\\\Test/', 'Elastica', $reflection->getName());
+
+        // Elastica\Exception\RuntimeExceptionTest => Elastica\Exception\RuntimeException
+        $name = preg_replace('/Test$/', '', $name);
+
+        return $name;
+    }
+
+    public function testInheritance()
+    {
+        $className = $this->getExceptionClass();
+        $reflection = new \ReflectionClass($className);
+        $this->assertTrue($reflection->isSubclassOf('Exception'));
+        $this->assertTrue($reflection->implementsInterface('Elastica\Exception\ExceptionInterface'));
+    }
+}

--- a/test/lib/Elastica/Test/Exception/Bulk/Response/ActionExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Bulk/Response/ActionExceptionTest.php
@@ -1,16 +1,8 @@
 <?php
 namespace Elastica\Test\Exception\Bulk\Response;
 
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\Exception\AbstractExceptionTest;
 
-class ActionExceptionTest extends BaseTest
+class ActionExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = $this->getMockBuilder('Elastica\Exception\Bulk\Response\ActionException')
-                          ->disableOriginalConstructor()
-                          ->getMock();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/Bulk/ResponseExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Bulk/ResponseExceptionTest.php
@@ -1,16 +1,8 @@
 <?php
 namespace Elastica\Test\Exception\Bulk;
 
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\Exception\AbstractExceptionTest;
 
-class ResponseExceptionTest extends BaseTest
+class ResponseExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = $this->getMockBuilder('Elastica\Exception\Bulk\ResponseException')
-                          ->disableOriginalConstructor()
-                          ->getMock();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/Bulk/UdpExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Bulk/UdpExceptionTest.php
@@ -1,15 +1,8 @@
 <?php
 namespace Elastica\Test\Exception\Bulk;
 
-use Elastica\Exception\Bulk\UdpException;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\Exception\AbstractExceptionTest;
 
-class UdpExceptionTest extends BaseTest
+class UdpExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = new UdpException();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/BulkExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/BulkExceptionTest.php
@@ -1,15 +1,6 @@
 <?php
 namespace Elastica\Test\Exception;
 
-use Elastica\Exception\BulkException;
-use Elastica\Test\Base as BaseTest;
-
-class BulkExceptionTest extends BaseTest
+class BulkExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = new BulkException();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/ClientExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ClientExceptionTest.php
@@ -1,15 +1,6 @@
 <?php
 namespace Elastica\Test\Exception;
 
-use Elastica\Exception\ClientException;
-use Elastica\Test\Base as BaseTest;
-
-class ClientExceptionTest extends BaseTest
+class ClientExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = new ClientException();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/Connection/GuzzleExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/GuzzleExceptionTest.php
@@ -1,23 +1,14 @@
 <?php
 namespace Elastica\Test\Exception\Connection;
 
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\Exception\AbstractExceptionTest;
 
-class GuzzleExceptionTest extends BaseTest
+class GuzzleExceptionTest extends AbstractExceptionTest
 {
     public static function setUpBeforeClass()
     {
         if (!class_exists('GuzzleHttp\\Client')) {
             self::markTestSkipped('guzzlehttp/guzzle package should be installed to run guzzle transport tests');
         }
-    }
-
-    public function testInheritance()
-    {
-        $exception = $this->getMockBuilder('Elastica\Exception\Connection\GuzzleException')
-                          ->disableOriginalConstructor()
-                          ->getMock();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
     }
 }

--- a/test/lib/Elastica/Test/Exception/Connection/HttpExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/HttpExceptionTest.php
@@ -1,16 +1,8 @@
 <?php
 namespace Elastica\Test\Exception\Connection;
 
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\Exception\AbstractExceptionTest;
 
-class HttpExceptionTest extends BaseTest
+class HttpExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = $this->getMockBuilder('Elastica\Exception\Connection\HttpException')
-                          ->disableOriginalConstructor()
-                          ->getMock();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/Connection/MemcacheExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/MemcacheExceptionTest.php
@@ -1,16 +1,8 @@
 <?php
 namespace Elastica\Test\Exception\Connection;
 
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\Exception\AbstractExceptionTest;
 
-class MemcacheExceptionTest extends BaseTest
+class MemcacheExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = $this->getMockBuilder('Elastica\Exception\Connection\MemcacheException')
-                          ->disableOriginalConstructor()
-                          ->getMock();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/Connection/ThriftExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/ThriftExceptionTest.php
@@ -1,23 +1,14 @@
 <?php
 namespace Elastica\Test\Exception\Connection;
 
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\Exception\AbstractExceptionTest;
 
-class ThriftExceptionTest extends BaseTest
+class ThriftExceptionTest extends AbstractExceptionTest
 {
     public static function setUpBeforeClass()
     {
         if (!class_exists('Elasticsearch\\RestClient')) {
             self::markTestSkipped('munkie/elasticsearch-thrift-php package should be installed to run thrift exception tests');
         }
-    }
-
-    public function testInheritance()
-    {
-        $exception = $this->getMockBuilder('Elastica\Exception\Connection\ThriftException')
-                          ->disableOriginalConstructor()
-                          ->getMock();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
     }
 }

--- a/test/lib/Elastica/Test/Exception/ConnectionExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ConnectionExceptionTest.php
@@ -1,16 +1,6 @@
 <?php
 namespace Elastica\Test\Exception;
 
-use Elastica\Test\Base as BaseTest;
-
-class ConnectionExceptionTest extends BaseTest
+class ConnectionExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = $this->getMockBuilder('Elastica\Exception\ConnectionException')
-                          ->disableOriginalConstructor()
-                          ->getMock();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/ElasticsearchExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ElasticsearchExceptionTest.php
@@ -1,16 +1,6 @@
 <?php
 namespace Elastica\Test\Exception;
 
-use Elastica\Test\Base as BaseTest;
-
-class ElasticsearchExceptionTest extends BaseTest
+class ElasticsearchExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = $this->getMockBuilder('Elastica\Exception\ElasticsearchException')
-                          ->disableOriginalConstructor()
-                          ->getMock();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/InvalidExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/InvalidExceptionTest.php
@@ -1,15 +1,6 @@
 <?php
 namespace Elastica\Test\Exception;
 
-use Elastica\Exception\InvalidException;
-use Elastica\Test\Base as BaseTest;
-
-class InvalidExceptionTest extends BaseTest
+class InvalidExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = new InvalidException();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/JSONParseExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/JSONParseExceptionTest.php
@@ -1,15 +1,6 @@
 <?php
 namespace Elastica\Test\Exception;
 
-use Elastica\Exception\JSONParseException;
-use Elastica\Test\Base as BaseTest;
-
-class JSONParseExceptionTest extends BaseTest
+class JSONParseExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = new JSONParseException();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/NotFoundExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/NotFoundExceptionTest.php
@@ -1,15 +1,6 @@
 <?php
 namespace Elastica\Test\Exception;
 
-use Elastica\Exception\NotFoundException;
-use Elastica\Test\Base as BaseTest;
-
-class NotFoundExceptionTest extends BaseTest
+class NotFoundExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = new NotFoundException();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/NotImplementedExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/NotImplementedExceptionTest.php
@@ -2,17 +2,9 @@
 namespace Elastica\Test\Exception;
 
 use Elastica\Exception\NotImplementedException;
-use Elastica\Test\Base as BaseTest;
 
-class NotImplementedExceptionTest extends BaseTest
+class NotImplementedExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = new NotImplementedException();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
-
     public function testInstance()
     {
         $code = 4;

--- a/test/lib/Elastica/Test/Exception/PartialShardFailureExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/PartialShardFailureExceptionTest.php
@@ -5,19 +5,9 @@ use Elastica\Document;
 use Elastica\Exception\PartialShardFailureException;
 use Elastica\Query;
 use Elastica\ResultSet;
-use Elastica\Test\Base as BaseTest;
 
-class PartialShardFailureExceptionTest extends BaseTest
+class PartialShardFailureExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = $this->getMockBuilder('Elastica\Exception\PartialShardFailureException')
-                          ->disableOriginalConstructor()
-                          ->getMock();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
-
     public function testPartialFailure()
     {
         $client = $this->_getClient();

--- a/test/lib/Elastica/Test/Exception/QueryBuilderExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/QueryBuilderExceptionTest.php
@@ -1,15 +1,6 @@
 <?php
 namespace Elastica\Test\Exception;
 
-use Elastica\Exception\QueryBuilderException;
-use Elastica\Test\Base as BaseTest;
-
-class QueryBuilderExceptionTest extends BaseTest
+class QueryBuilderExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = new QueryBuilderException();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }

--- a/test/lib/Elastica/Test/Exception/ResponseExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ResponseExceptionTest.php
@@ -3,19 +3,9 @@ namespace Elastica\Test\Exception;
 
 use Elastica\Document;
 use Elastica\Exception\ResponseException;
-use Elastica\Test\Base as BaseTest;
 
-class ResponseExceptionTest extends BaseTest
+class ResponseExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = $this->getMockBuilder('Elastica\Exception\ResponseException')
-                          ->disableOriginalConstructor()
-                          ->getMock();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
-
     public function testCreateExistingIndex()
     {
         $this->_createIndex('woo', true);

--- a/test/lib/Elastica/Test/Exception/RuntimeExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/RuntimeExceptionTest.php
@@ -2,14 +2,7 @@
 namespace Elastica\Test\Exception;
 
 use Elastica\Exception\RuntimeException;
-use Elastica\Test\Base as BaseTest;
 
-class RuntimeExceptionTest extends BaseTest
+class RuntimeExceptionTest extends AbstractExceptionTest
 {
-    public function testInheritance()
-    {
-        $exception = new RuntimeException();
-        $this->assertInstanceOf('Exception', $exception);
-        $this->assertInstanceOf('Elastica\Exception\ExceptionInterface', $exception);
-    }
 }


### PR DESCRIPTION
- Exception tests was rewritten to avoid mocking. https://github.com/sebastianbergmann/phpunit-mock-objects/issues/207
- Monkeyfix for environment proxy added. https://github.com/facebook/hhvm/issues/4875

Also, build now has a chance to retry failed step, e.g. `pip install` by using `travis_retry` function. It should make builds more stable.