### PR TITLE
Fix incorrect documentation URL in phpDoc

### DIFF
--- a/lib/Elastica/Document.php
+++ b/lib/Elastica/Document.php
@@ -207,7 +207,7 @@ class Document extends AbstractUpdateAction
      * @param  string $key       Field key
      * @param  float  $latitude  Latitude value
      * @param  float  $longitude Longitude value
-     * @link http://www.elasticsearch.org/guide/reference/mapping/geo-point-type.html
+     * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-geo-point-type.html
      * @return $this
      */
     public function addGeoPoint($key, $latitude, $longitude)


### PR DESCRIPTION
Old URL throws 404 error.
New correct URL is http://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-geo-point-type.html