### PR TITLE
deleteByQuery() implemented in Elastica\Index

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2015-04-15
+- deleteByQuery() implemented in Elastica\Index
+
 2015-03-29
 - Added Elastica\Suggest\Completion
 

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -149,6 +149,27 @@ class Index implements SearchableInterface
     }
 
     /**
+     * Deletes entries in the db based on a query
+     *
+     * @param  \Elastica\Query|string $query   Query object
+     * @param  array                  $options Optional params
+     * @return \Elastica\Response
+     * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+     */
+    public function deleteByQuery($query, array $options = array())
+    {
+        if (is_string($query)) {
+            // query_string queries are not supported for delete by query operations
+            $options['q'] = $query;
+
+            return $this->request('_query', Request::DELETE, array(), $options);
+        }
+        $query = Query::create($query);
+
+        return $this->request('_query', Request::DELETE, array('query' => $query->getQuery()), $options);
+    }
+
+    /**
      * Deletes the index
      *
      * @return \Elastica\Response Response object


### PR DESCRIPTION
I've noticed that `deleteByQuery()` is only available at `Elastica\Type`, for convenience I've implemented `Elastica\Index::deleteByQuery()` and I've added the same tests that `Elastica\Type` has but with a few modifications to validate that documents from all types of the index are successfully deleted.