### PR TITLE
#819 Implement multiple rescore query

### DIFF
--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -401,7 +401,7 @@ class Query extends Param
     /**
      * Add a Rescore
      *
-     * @param  \Elastica\Rescore\AbstractRescore $rescore suggestion object
+     * @param  mixed $rescore suggestion object
      * @return $this
      */
     public function setRescore($rescore)

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -406,7 +406,18 @@ class Query extends Param
      */
     public function setRescore($rescore)
     {
-        return $this->setParam('rescore', $rescore->toArray());
+        if (is_array($rescore)) {
+            $buffer = [];
+
+            foreach($rescore as $rescoreQuery) {
+                $buffer []= $rescoreQuery->toArray();
+            }
+        }
+        else {
+            $buffer = $rescore->toArray();
+        }
+
+        return $this->setParam('rescore', $buffer);
     }
 
     /**

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -407,7 +407,7 @@ class Query extends Param
     public function setRescore($rescore)
     {
         if (is_array($rescore)) {
-            $buffer = [];
+            $buffer = array();
 
             foreach($rescore as $rescoreQuery) {
                 $buffer []= $rescoreQuery->toArray();

--- a/test/lib/Elastica/Test/Query/RescoreTest.php
+++ b/test/lib/Elastica/Test/Query/RescoreTest.php
@@ -146,13 +146,19 @@ class RescoreTest extends BaseTest
         $query = new Query();
         $mainQuery = new Match();
         $mainQuery = $mainQuery->setFieldQuery('test1', 'foo');
+
         $secQuery1 = new Term();
         $secQuery1 = $secQuery1->setTerm('test2', 'bar', 1);
+        $rescoreQuery1 = new QueryRescore();
+        $rescoreQuery1->setRescoreQuery($secQuery1);
+
         $secQuery2 = new Term();
         $secQuery2 = $secQuery2->setTerm('test2', 'tom', 2);
-        $queryRescore = new QueryRescore(array($secQuery1, $secQuery2));
+        $rescoreQuery2 = new QueryRescore();
+        $rescoreQuery2->setRescoreQuery($secQuery2);
+
         $query->setQuery($mainQuery);
-        $query->setRescore($queryRescore);
+        $query->setRescore(array($rescoreQuery1, $rescoreQuery2));
         $data = $query->toArray();
 
         $expected = array(

--- a/test/lib/Elastica/Test/Query/RescoreTest.php
+++ b/test/lib/Elastica/Test/Query/RescoreTest.php
@@ -198,6 +198,12 @@ class RescoreTest extends BaseTest
         );
 
         $this->assertEquals($expected, $data);
+
+        $results = $this->_index->search($query);
+        $response = $results->getResponse();
+
+        $this->assertEquals(true, $response->isOk());
+        $this->assertEquals(0, $results->getTotalHits());
     }
 
     public function testQuery()

--- a/test/lib/Elastica/Test/Query/RescoreTest.php
+++ b/test/lib/Elastica/Test/Query/RescoreTest.php
@@ -141,6 +141,59 @@ class RescoreTest extends BaseTest
         $this->assertEquals($expected, $data);
     }
 
+    public function testMultipleQueries()
+    {
+        $query = new Query();
+        $mainQuery = new Match();
+        $mainQuery = $mainQuery->setFieldQuery('test1', 'foo');
+        $secQuery1 = new Term();
+        $secQuery1 = $secQuery1->setTerm('test2', 'bar', 1);
+        $secQuery2 = new Term();
+        $secQuery2 = $secQuery2->setTerm('test2', 'tom', 2);
+        $queryRescore = new QueryRescore(array($secQuery1, $secQuery2));
+        $query->setQuery($mainQuery);
+        $query->setRescore($queryRescore);
+        $data = $query->toArray();
+
+        $expected = array(
+            'query' => array(
+                'match' => array(
+                    'test1' => array(
+                        'query' => 'foo',
+                    ),
+                ),
+            ),
+            'rescore' => array(
+                array(
+                    'query' => array(
+                        'rescore_query' => array(
+                            'term' => array(
+                                'test2' => array(
+                                    'value' => 'bar',
+                                    'boost' => 1,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                array(
+                    'query' => array(
+                        'rescore_query' => array(
+                            'term' => array(
+                                'test2' => array(
+                                    'value' => 'tom',
+                                    'boost' => 2,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $data);
+    }
+
     public function testQuery()
     {
         $query = new Query();


### PR DESCRIPTION
According Elastic documentation:

http://www.elastic.co/guide/en/elasticsearch/reference/1.4/search-request-rescore.html

Rescore query can be a query or an array of queries.

I am sending a PR right now that should fix this case.