### PR TITLE
Add testing on PHP 7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7
   - hhvm
 
 matrix:
     allow_failures:
         - php: 5.3
+        - php: 7
         - php: hhvm
     fast_finish: true
 
@@ -23,7 +25,7 @@ install:
 
 before_script:
   - mkdir -p build/logs
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension=memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
+  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7" ]; then echo "extension=memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
   - if [ $ES_COMPOSER_NODEV == "no" ] && ! $(phpenv version-name | grep -q '5.3'); then sudo composer require "guzzlehttp/guzzle" "4.2.*" --dev --no-ansi --no-progress --no-interaction; fi
 
 script:


### PR DESCRIPTION
This is the first step for #825: running tests on PHP 7 (with failures allowed as the library is not compatible yet).
memcache.so is not available for PHP 7 on Travis currently, so enabling it is skipped (as done for HHVM currently).

I als removed a few useless sudo usages for Composer calls