### PR TITLE
Added option to set behaviour for scroll in regards to sorting results #827

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+2015-05-05
+- Added option to choose whether the ordering of results should be taken into account when Scrolling #827
+
 2015-04-23
 - Allow bool in Query::setSource function #818 http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
 - Fix empty bool query to act as match all query #817

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -512,10 +512,11 @@ class Search
      * @see Elastica\ScanAndScroll
      * @param  string        $expiryTime
      * @param  int           $sizePerShard
+     * @param  bool          $ignoreSorting
      * @return ScanAndScroll
      */
-    public function scanAndScroll($expiryTime = '1m', $sizePerShard = 1000)
+    public function scanAndScroll($expiryTime = '1m', $sizePerShard = 1000, $ignoreSorting = true)
     {
-        return new ScanAndScroll($this, $expiryTime, $sizePerShard);
+        return new ScanAndScroll($this, $expiryTime, $sizePerShard, $ignoreSorting);
     }
 }

--- a/test/lib/Elastica/Test/ScanAndScrollTest.php
+++ b/test/lib/Elastica/Test/ScanAndScrollTest.php
@@ -98,6 +98,59 @@ class ScanAndScrollTest extends BaseTest
         $this->assertEquals(2, $count);
     }
 
+    public function testScrollIgnoresSortingByDefault()
+    {
+        $search = $this->_prepareSearch(1, 2);
+        $scanAndScroll = new ScanAndScroll($search);
+        $scanAndScroll->rewind();
+
+        $option = $search->getOption(Search::OPTION_SEARCH_TYPE);
+        $this->assertNotSame(Search::OPTION_SEARCH_TYPE_SCAN, $option);
+    }
+
+    public function testSettingScrollToDoNotIgnoreSorting()
+    {
+        $search = $this->_prepareSearch(1, 2);
+        $scanAndScroll = new ScanAndScroll($search);
+        $scanAndScroll->ignoreSorting(false);
+        $scanAndScroll->rewind();
+
+        $option = $search->getOption(Search::OPTION_SEARCH_TYPE);
+        $this->assertSame(Search::OPTION_SEARCH_TYPE_SCROLL, $option);
+    }
+
+    public function testSettingScrollToDoNotIgnoreSortingConstructor()
+    {
+        $search = $this->_prepareSearch(1, 2);
+        $scanAndScroll = new ScanAndScroll($search, '1m', 1000, false);
+        $scanAndScroll->rewind();
+
+        $option = $search->getOption(Search::OPTION_SEARCH_TYPE);
+        $this->assertSame(Search::OPTION_SEARCH_TYPE_SCROLL, $option);
+    }
+
+    /**
+     * @param mixed $ignoreSorting
+     * @dataProvider invalidIgnoreSortingProvider
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidIgnoreSortingParameters($ignoreSorting)
+    {
+        $scanAndScroll = $this->_prepareScanAndScroll();
+        $scanAndScroll->ignoreSorting($ignoreSorting);
+    }
+
+    public function invalidIgnoreSortingProvider()
+    {
+        return array(
+            'string' => array('invalid'),
+            'array' => array(array()),
+            'stdClass' => array(new \StdClass),
+            'int' => array(10),
+            'float' => array(5.5),
+        );
+    }
+
     private function _prepareScanAndScroll()
     {
         return new ScanAndScroll(new Search($this->_getClient()));


### PR DESCRIPTION
This PR should allow the library user to choose whether they want to change the default's behaviour of Elastica when dealing with Scrolls in regards to sorting.

The changes should be backwards compatible, although I'd agree that it might look a bit odd since Elastica is defaulting to completely the opposite to what ES is defaulting to.

Any feedback appreciated.