### PR TITLE
Curl connect timeout

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,9 @@
 CHANGES
 
+2015-05-14
+- CURLOPT_CONNECTTIMEOUT added to the HTTP transport curl options
+- Support for a custom connection timeout through a connectTimeout parameter
+
 2015-05-11
 - Release 2.0.0
 - Update elasticsearch dependency to elasticsearch 1.5.2 https://www.elastic.co/downloads/past-releases/elasticsearch-1-5-2 #834

--- a/changes.txt
+++ b/changes.txt
@@ -1,8 +1,7 @@
 CHANGES
 
 2015-05-14
-- CURLOPT_CONNECTTIMEOUT added to the HTTP transport curl options
-- Support for a custom connection timeout through a connectTimeout parameter
+- Support for a custom connection timeout through a connectTimeout parameter. CURLOPT_CONNECTTIMEOUT added to the HTTP transport curl options if a connectTimeout is >0 #841
 
 2015-05-11
 - Release 2.0.0

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -38,6 +38,12 @@ class Connection extends Param
     const TIMEOUT = 300;
 
     /**
+     * Number of seconds after a connection timeout occurs for every request
+     * Use a small value if you need a fast response in case of dead servers.
+     */
+    const CONNECT_TIMEOUT = 5;
+
+    /**
      * Creates a new connection object. A connection is enabled by default
      *
      * @param array $params OPTIONAL Connection params: host, port, transport, timeout. All are optional
@@ -157,6 +163,23 @@ class Connection extends Param
     public function getTimeout()
     {
         return (int) $this->hasParam('timeout') ? $this->getParam('timeout') : self::TIMEOUT;
+    }
+
+    /**
+     * @param  int   $timeout Connect timeout in seconds
+     * @return $this
+     */
+    public function setConnectTimeout($timeout)
+    {
+        return $this->setParam('connectTimeout', $timeout);
+    }
+
+    /**
+     * @return int Connection timeout in seconds
+     */
+    public function getConnectTimeout()
+    {
+        return (int) $this->hasParam('connectTimeout') ? $this->getParam('connectTimeout') : self::CONNECT_TIMEOUT;
     }
 
     /**

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -38,10 +38,10 @@ class Connection extends Param
     const TIMEOUT = 300;
 
     /**
-     * Number of seconds after a connection timeout occurs for every request
-     * Use a small value if you need a fast response in case of dead servers.
+     * Number of seconds after a connection timeout occurs for every request during the connection phase.
+     * @see Connection::setConnectTimeout();
      */
-    const CONNECT_TIMEOUT = 5;
+    const CONNECT_TIMEOUT = 0;
 
     /**
      * Creates a new connection object. A connection is enabled by default
@@ -166,6 +166,12 @@ class Connection extends Param
     }
 
     /**
+     * Number of seconds after a connection timeout occurs for every request during the connection phase.
+     * Use a small value if you need a fast fail in case of dead, unresponsive or unreachable servers (~5 sec).
+     *
+     * Set to zero to switch to the default built-in connection timeout (300 seconds in curl).
+     * @see http://curl.haxx.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html
+     *
      * @param  int   $timeout Connect timeout in seconds
      * @return $this
      */

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -70,8 +70,13 @@ class Http extends AbstractTransport
 
         curl_setopt($conn, CURLOPT_URL, $baseUri);
         curl_setopt($conn, CURLOPT_TIMEOUT, $connection->getTimeout());
-        curl_setopt($conn, CURLOPT_CONNECTTIMEOUT, $connection->getConnectTimeout());
         curl_setopt($conn, CURLOPT_FORBID_REUSE, 0);
+
+        /* @see Connection::setConnectTimeout() */
+        $connectTimeout = $connection->getConnectTimeout();
+        if ($connectTimeout>0) {
+            curl_setopt($conn, CURLOPT_CONNECTTIMEOUT, $connectTimeout);
+        }
 
         $proxy = $connection->getProxy();
 

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -70,6 +70,7 @@ class Http extends AbstractTransport
 
         curl_setopt($conn, CURLOPT_URL, $baseUri);
         curl_setopt($conn, CURLOPT_TIMEOUT, $connection->getTimeout());
+        curl_setopt($conn, CURLOPT_CONNECTTIMEOUT, $connection->getConnectTimeout());
         curl_setopt($conn, CURLOPT_FORBID_REUSE, 0);
 
         $proxy = $connection->getProxy();

--- a/test/lib/Elastica/Test/ConnectionTest.php
+++ b/test/lib/Elastica/Test/ConnectionTest.php
@@ -17,6 +17,7 @@ class ConnectionTest extends BaseTest
         $this->assertEquals(Connection::DEFAULT_TRANSPORT, $connection->getTransport());
         $this->assertInstanceOf('Elastica\Transport\AbstractTransport', $connection->getTransportObject());
         $this->assertEquals(Connection::TIMEOUT, $connection->getTimeout());
+        $this->assertEquals(Connection::CONNECT_TIMEOUT, $connection->getConnectTimeout());
         $this->assertEquals(array(), $connection->getConfig());
         $this->assertTrue($connection->isEnabled());
     }


### PR DESCRIPTION
CURLOPT_CONNECTTIMEOUT added to the HTTP transport curl options to allow connections to unresponsive nodes to fail as soon as possible. The timeout can be customized with the connectTimeout parameter (default of 5 seconds).

