### PR TITLE
added Scroll Iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to this project will be documented in this file based on the
 - Make host for all tests dynamic to prepare it for a more dynamic test environment #846
 
 
-
+### Backward Compatibility Breaks
+- `Elastica\ScanAndScroll::$_lastScrollId` removed: `key()` now always returns the next scroll id [#842](https://github.com/ruflin/Elastica/issues/842/)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file based on the
 - Multiple rescore query [#820](https://github.com/ruflin/Elastica/issues/820/)
 - Support for a custom connection timeout through a connectTimeout parameter. [#841](https://github.com/ruflin/Elastica/issues/841/)
 - SignificantTerms Aggregation [#847](https://github.com/ruflin/Elastica/issues/847/)
+- Scroll Iterator [#842](https://github.com/ruflin/Elastica/issues/842/)
 
 
 ### Improvements

--- a/lib/Elastica/ScanAndScroll.php
+++ b/lib/Elastica/ScanAndScroll.php
@@ -3,49 +3,21 @@
 namespace Elastica;
 
 /**
- * scan and scroll object
+ * Scan and Scroll Iterator
  *
- * @category Xodoa
- * @package Elastica
  * @author Manuel Andreo Garcia <andreo.garcia@gmail.com>
+ *
  * @link http://www.elastic.co/guide/en/elasticsearch/guide/current/scan-scroll.html
  */
-class ScanAndScroll implements \Iterator
+class ScanAndScroll extends Scroll
 {
-    /**
-     * time value parameter
-     *
-     * @var string
-     */
-    public $expiryTime;
-
     /**
      * @var int
      */
     public $sizePerShard;
 
     /**
-     * @var Search
-     */
-    protected $_search;
-
-    /**
-     * @var null|string
-     */
-    protected $_nextScrollId = null;
-
-    /**
-     * @var null|string
-     */
-    protected $_lastScrollId = null;
-
-    /**
-     * @var null|ResultSet
-     */
-    protected $_currentResultSet = null;
-
-    /**
-     * Constructs scroll iterator object
+     * Constructor
      *
      * @param Search $search
      * @param string $expiryTime
@@ -53,104 +25,57 @@ class ScanAndScroll implements \Iterator
      */
     public function __construct(Search $search, $expiryTime = '1m', $sizePerShard = 1000)
     {
-        $this->_search = $search;
-        $this->expiryTime = $expiryTime;
         $this->sizePerShard = $sizePerShard;
+
+        parent::__construct($search, $expiryTime);
     }
 
     /**
-     * Return the current result set
+     * Initial scan search
      *
-     * @link http://php.net/manual/en/iterator.current.php
-     * @return ResultSet
-     */
-    public function current()
-    {
-        return $this->_currentResultSet;
-    }
-
-    /**
-     * Perform next scroll search
-     *
-     * @link http://php.net/manual/en/iterator.next.php
-     * @return void
-     */
-    public function next()
-    {
-        $this->_scroll();
-    }
-
-    /**
-     * Return the scroll id of current scroll request
-     *
-     * @link http://php.net/manual/en/iterator.key.php
-     * @return string
-     */
-    public function key()
-    {
-        return $this->_lastScrollId;
-    }
-
-    /**
-     * Returns true if current result set contains one hit
-     *
-     * @link http://php.net/manual/en/iterator.valid.php
-     * @return boolean
-     */
-    public function valid()
-    {
-        return
-            $this->_nextScrollId !== null
-            && $this->_currentResultSet !== null
-            && $this->_currentResultSet->count() > 0;
-    }
-
-    /**
-     * Start the initial scan search
      * @link http://php.net/manual/en/iterator.rewind.php
-     * @throws \Elastica\Exception\InvalidException
-     *
-     * @return void
      */
     public function rewind()
     {
-        $this->_search->getQuery()->setSize($this->sizePerShard);
+        // reset state
+        $this->_nextScrollId = null;
+        $this->_options = array(null, null, null, null);
 
-        $this->_search->setOption(Search::OPTION_SEARCH_TYPE, Search::OPTION_SEARCH_TYPE_SCAN);
-        $this->_search->setOption(Search::OPTION_SCROLL, $this->expiryTime);
+        $this->_saveOptions();
 
         // initial scan request
+        $this->_search->getQuery()->setSize($this->sizePerShard);
+        $this->_search->setOption(Search::OPTION_SCROLL, $this->expiryTime);
+        $this->_search->setOption(Search::OPTION_SCROLL_ID, null);
+        $this->_search->setOption(Search::OPTION_SEARCH_TYPE, Search::OPTION_SEARCH_TYPE_SCAN);
         $this->_setScrollId($this->_search->search());
 
-        // trigger first scroll request
-        $this->_scroll();
+        $this->_revertOptions();
+
+        // first scroll request
+        $this->next();
     }
 
     /**
-     * Perform next scroll search
-     * @throws \Elastica\Exception\InvalidException
+     * Save all search options manipulated by Scroll
      */
-    protected function _scroll()
+    protected function _saveOptions()
     {
-        $this->_search->setOption(Search::OPTION_SEARCH_TYPE, Search::OPTION_SEARCH_TYPE_SCROLL);
-        $this->_search->setOption(Search::OPTION_SCROLL_ID, $this->_nextScrollId);
-
-        $resultSet = $this->_search->search();
-        $this->_currentResultSet = $resultSet;
-        $this->_setScrollId($resultSet);
-    }
-
-    /**
-     * Save last scroll id and extract the new one if possible
-     * @param ResultSet $resultSet
-     */
-    protected function _setScrollId(ResultSet $resultSet)
-    {
-        $this->_lastScrollId = $this->_nextScrollId;
-
-        $this->_nextScrollId = null;
-        if ($resultSet->getResponse()->isOk()) {
-            $this->_nextScrollId = $resultSet->getResponse()->getScrollId();
+        $query = $this->_search->getQuery();
+        if ($query->hasParam('size')) {
+            $this->_options[3] = $query->getParam('size');
         }
+
+        parent::_saveOptions();
+    }
+
+    /**
+     * Revert search options to previously saved state
+     */
+    protected function _revertOptions()
+    {
+        $this->_search->getQuery()->setSize($this->_options[3]);
+
+        parent::_revertOptions();
     }
 }

--- a/lib/Elastica/Scroll.php
+++ b/lib/Elastica/Scroll.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Elastica;
+
+/**
+ * Scroll Iterator
+ *
+ * @author Manuel Andreo Garcia <andreo.garcia@gmail.com>
+ *
+ * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
+ */
+class Scroll implements \Iterator
+{
+    /**
+     * @var string
+     */
+    public $expiryTime;
+
+    /**
+     * @var Search
+     */
+    protected $_search;
+
+    /**
+     * @var null|string
+     */
+    protected $_nextScrollId = null;
+
+    /**
+     * @var null|ResultSet
+     */
+    protected $_currentResultSet = null;
+
+    /**
+     * 0: scroll<br>
+     * 1: scroll id<br>
+     * 2: search type.
+     *
+     * @var array
+     */
+    protected $_options = array(null, null, null);
+
+    /**
+     * Constructor
+     *
+     * @param Search $search
+     * @param string $expiryTime
+     */
+    public function __construct(Search $search, $expiryTime = '1m')
+    {
+        $this->_search = $search;
+        $this->expiryTime = $expiryTime;
+    }
+
+    /**
+     * Returns current result set
+     *
+     * @link http://php.net/manual/en/iterator.current.php
+     *
+     * @return ResultSet
+     */
+    public function current()
+    {
+        return $this->_currentResultSet;
+    }
+
+    /**
+     * Next scroll search
+     *
+     * @link http://php.net/manual/en/iterator.next.php
+     */
+    public function next()
+    {
+        $this->_saveOptions();
+
+        $this->_search->setOption(Search::OPTION_SCROLL, $this->expiryTime);
+        $this->_search->setOption(Search::OPTION_SCROLL_ID, $this->_nextScrollId);
+        $this->_search->setOption(Search::OPTION_SEARCH_TYPE, Search::OPTION_SEARCH_TYPE_SCROLL);
+        $this->_setScrollId($this->_search->search());
+
+        $this->_revertOptions();
+    }
+
+    /**
+     * Returns scroll id
+     *
+     * @link http://php.net/manual/en/iterator.key.php
+     *
+     * @return string
+     */
+    public function key()
+    {
+        return $this->_nextScrollId;
+    }
+
+    /**
+     * Returns true if current result set contains at least one hit
+     *
+     * @link http://php.net/manual/en/iterator.valid.php
+     *
+     * @return bool
+     */
+    public function valid()
+    {
+        return
+            $this->_nextScrollId !== null
+            && $this->_currentResultSet !== null
+            && $this->_currentResultSet->count() > 0;
+    }
+
+    /**
+     * Initial scroll search
+     *
+     * @link http://php.net/manual/en/iterator.rewind.php
+     */
+    public function rewind()
+    {
+        // reset state
+        $this->_nextScrollId = null;
+        $this->_options = array(null, null, null);
+
+        // initial search
+        $this->_saveOptions();
+
+        $this->_search->setOption(Search::OPTION_SCROLL, $this->expiryTime);
+        $this->_search->setOption(Search::OPTION_SCROLL_ID, null);
+        $this->_search->setOption(Search::OPTION_SEARCH_TYPE, null);
+        $this->_setScrollId($this->_search->search());
+
+        $this->_revertOptions();
+    }
+
+    /**
+     * Prepares Scroll for next request
+     *
+     * @param ResultSet $resultSet
+     */
+    protected function _setScrollId(ResultSet $resultSet)
+    {
+        $this->_currentResultSet = $resultSet;
+
+        $this->_nextScrollId = null;
+        if ($resultSet->getResponse()->isOk()) {
+            $this->_nextScrollId = $resultSet->getResponse()->getScrollId();
+        }
+    }
+
+    /**
+     * Save all search options manipulated by Scroll
+     */
+    protected function _saveOptions()
+    {
+        if ($this->_search->hasOption(Search::OPTION_SCROLL)) {
+            $this->_options[0] = $this->_search->getOption(Search::OPTION_SCROLL);
+        }
+
+        if ($this->_search->hasOption(Search::OPTION_SCROLL_ID)) {
+            $this->_options[1] = $this->_search->getOption(Search::OPTION_SCROLL_ID);
+        }
+
+        if ($this->_search->hasOption(Search::OPTION_SEARCH_TYPE)) {
+            $this->_options[2] = $this->_search->getOption(Search::OPTION_SEARCH_TYPE);
+        }
+    }
+
+    /**
+     * Revert search options to previously saved state
+     */
+    protected function _revertOptions()
+    {
+        $this->_search->setOption(Search::OPTION_SCROLL, $this->_options[0]);
+        $this->_search->setOption(Search::OPTION_SCROLL_ID, $this->_options[1]);
+        $this->_search->setOption(Search::OPTION_SEARCH_TYPE, $this->_options[2]);
+    }
+}

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -507,6 +507,18 @@ class Search
     }
 
     /**
+     * Returns the Scroll Iterator
+     *
+     * @see Elastica\Scroll
+     * @param  string        $expiryTime
+     * @return Scroll
+     */
+    public function scroll($expiryTime = '1m')
+    {
+        return new Scroll($this, $expiryTime);
+    }
+
+    /**
      * Returns the ScanAndScroll Iterator
      *
      * @see Elastica\ScanAndScroll

--- a/test/lib/Elastica/Test/ScanAndScrollTest.php
+++ b/test/lib/Elastica/Test/ScanAndScrollTest.php
@@ -11,109 +11,60 @@ use Elastica\Test\Base as BaseTest;
 
 class ScanAndScrollTest extends BaseTest
 {
-
-    public function testConstruct()
-    {
-        $scanAndScroll = $this->_prepareScanAndScroll();
-
-        $this->assertInstanceOf('Elastica\ScanAndScroll', $scanAndScroll);
-    }
-
-    public function testDefaultProperties()
-    {
-        $scanAndScroll = $this->_prepareScanAndScroll();
-
-        $this->assertEquals('1m', $scanAndScroll->expiryTime);
-        $this->assertEquals(1000, $scanAndScroll->sizePerShard);
-    }
-
-    public function testQuerySizeOverride()
-    {
-        $query = new Query();
-        $query->setSize(100);
-
-        $index = $this->_createIndex();
-        $index->refresh();  // Waits for the index to be fully created.
-        $type = $index->getType('scanAndScrollTest');
-
-        $search = new Search($this->_getClient());
-        $search->addIndex($index)->addType($type);
-        $search->setQuery($query);
-
-        $scanAndScroll = new ScanAndScroll($search);
-        $scanAndScroll->sizePerShard = 10;
-        $scanAndScroll->rewind();
-
-        $this->assertEquals(10, $query->getParam('size'));
-    }
-
-    public function testSizePerShard()
-    {
-        $search = $this->_prepareSearch(2, 20);
-
-        $scanAndScroll = new ScanAndScroll($search);
-        $scanAndScroll->sizePerShard = 5;
-        $scanAndScroll->rewind();
-
-        $this->assertEquals(10, $scanAndScroll->current()->count());
-    }
-
-    public function testScrollId()
-    {
-        $search = $this->_prepareSearch(1, 2);
-
-        $scanAndScroll = new ScanAndScroll($search);
-        $scanAndScroll->sizePerShard = 1;
-
-        $scanAndScroll->rewind();
-        $this->assertEquals(
-            $scanAndScroll->current()->getResponse()->getScrollId(),
-            $scanAndScroll->key()
-        );
-    }
-
+    /**
+     * Full foreach test
+     */
     public function testForeach()
     {
-        $search = $this->_prepareSearch(2, 11);
+        $scanAndScroll = new ScanAndScroll($this->_prepareSearch(), '1m', 2);
+        $docCount = 0;
+
+        /** @var ResultSet $resultSet */
+        foreach ($scanAndScroll as $scrollId => $resultSet) {
+            $docCount += $resultSet->count();
+        }
+
+        /*
+         * number of loops and documents per iteration may fluctuate
+         * => only test end results
+         */
+        $this->assertEquals(12, $docCount);
+    }
+
+    /**
+     * query size revert options
+     */
+    public function testQuerySizeRevert()
+    {
+        $search = $this->_prepareSearch();
+        $search->getQuery()->setSize(9);
 
         $scanAndScroll = new ScanAndScroll($search);
-        $scanAndScroll->sizePerShard = 5;
 
-        // We expect 2 scrolls:
-        // 1. with 10 hits,
-        // 2. with 1 hit
-        // Note: there is a 3. scroll with 0 hits
+        $scanAndScroll->rewind();
+        $this->assertEquals(9, $search->getQuery()->getParam('size'));
 
-        $count = 0;
-        foreach ($scanAndScroll as $resultSet) {
-            /** @var ResultSet $resultSet */
-            $count++;
+        $scanAndScroll->next();
+        $this->assertEquals(9, $search->getQuery()->getParam('size'));
+    }
 
-            switch (true) {
-                case $count == 1: $this->assertEquals(10, $resultSet->count()); break;
-                case $count == 2: $this->assertEquals(1, $resultSet->count()); break;
-            }
+    /**
+     * index: 12 docs, 2 shards
+     *
+     * @return Search
+     */
+    private function _prepareSearch()
+    {
+        $index = $this->_createIndex('', true, 2);
+        $index->refresh();
+
+        $docs = array();
+        for ($x = 1; $x <= 12; $x++) {
+            $docs[] = new Document($x, array('id' => $x, 'key' => 'value'));
         }
 
-        $this->assertEquals(2, $count);
-    }
-
-    private function _prepareScanAndScroll()
-    {
-        return new ScanAndScroll(new Search($this->_getClient()));
-    }
-
-    private function _prepareSearch($indexShards, $docs)
-    {
-        $index = $this->_createIndex(null, true, $indexShards);
         $type = $index->getType('scanAndScrollTest');
-
-        $insert = array();
-        for ($x = 1; $x <= $docs; $x++) {
-            $insert[] = new Document($x, array('id' => $x, 'key' => 'value'));
-        }
-
-        $type->addDocuments($insert);
+        $type->addDocuments($docs);
         $index->refresh();
 
         $search = new Search($this->_getClient());

--- a/test/lib/Elastica/Test/ScrollTest.php
+++ b/test/lib/Elastica/Test/ScrollTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Elastica\Test;
+
+use Elastica\Document;
+use Elastica\Query;
+use Elastica\ResultSet;
+use Elastica\Scroll;
+use Elastica\Search;
+
+class ScrollTest extends Base
+{
+    /**
+     * Full foreach test
+     */
+    public function testForeach()
+    {
+        $scroll = new Scroll($this->_prepareSearch());
+        $count = 1;
+
+        /** @var ResultSet $resultSet */
+        foreach ($scroll as $scrollId => $resultSet) {
+            $this->assertNotEmpty($scrollId);
+
+            $results = $resultSet->getResults();
+            switch (true) {
+                case $count === 1:
+                    // hits: 1 - 5
+                    $this->assertEquals(5, $resultSet->count());
+                    $this->assertEquals('1', $results[0]->getId());
+                    $this->assertEquals('5', $results[4]->getId());
+                    break;
+                case $count === 2:
+                    // hits: 6 - 10
+                    $this->assertEquals(5, $resultSet->count());
+                    $this->assertEquals('6', $results[0]->getId());
+                    $this->assertEquals('10', $results[4]->getId());
+                    break;
+                case $count === 3:
+                    // hit: 11
+                    $this->assertEquals(1, $resultSet->count());
+                    $this->assertEquals('11', $results[0]->getId());
+                    break;
+                case $count === 4:
+                    $this->assertEquals(0, $resultSet->count());
+                    break;
+                default:
+                    $this->fail('too many iterations');
+            }
+
+            $count++;
+        }
+    }
+
+    /**
+     * Scroll must not overwrite options
+     */
+    public function testSearchRevert()
+    {
+        $search = $this->_prepareSearch();
+
+        $search->setOption(Search::OPTION_SCROLL, 'must');
+        $search->setOption(Search::OPTION_SCROLL_ID, 'not');
+        $search->setOption(Search::OPTION_SEARCH_TYPE, 'change');
+        $old = $search->getOptions();
+
+        $scroll = new Scroll($search);
+
+        $scroll->rewind();
+        $this->assertEquals($old, $search->getOptions());
+
+        $scroll->next();
+        $this->assertEquals($old, $search->getOptions());
+    }
+
+    /**
+     * index: 11 docs
+     * query size: 5
+     *
+     * @return Search
+     */
+    private function _prepareSearch()
+    {
+        $index = $this->_createIndex();
+        $index->refresh();
+
+        $docs = array();
+        for ($x = 1; $x <= 11; $x++) {
+            $docs[] = new Document($x, array('id' => $x, 'key' => 'value'));
+        }
+
+        $type = $index->getType('scrollTest');
+        $type->addDocuments($docs);
+        $index->refresh();
+
+        $search = new Search($this->_getClient());
+        $search->addIndex($index)->addType($type);
+        $search->getQuery()->setSize(5);
+
+        return $search;
+    }
+}


### PR DESCRIPTION
Implementation of `Scroll` Iterator requested by @hasumedic in https://github.com/ruflin/Elastica/issues/827

The `Scroll` Iterator executes every request fully isolated. That means search options manipulated during iterations are changed and reverted automatically.

```php
$search->setOption(Search::OPTION_SEARCH_TYPE, Search::OPTION_SEARCH_TYPE_COUNT);

$path = $search->getPath();
foreach ($search->scroll() as $scrollId => $resultSet) {
    $search->getPath() === $path; // returns true
}
$search->getPath() === $path; // returns true
```

In addition I changed the `ScanAndScroll` Iterator to a child class of `Scroll` in order to profit from that isolation.

Finally I added a `Search::scroll()` function just like `Search::scanAndScroll()`