### PR TITLE
fix HttpAdapter after egeloen/http-adapter changes

### DIFF
--- a/lib/Elastica/Transport/HttpAdapter.php
+++ b/lib/Elastica/Transport/HttpAdapter.php
@@ -11,7 +11,6 @@ use Elastica\Response as ElasticaResponse;
 use Ivory\HttpAdapter\HttpAdapterInterface;
 use Ivory\HttpAdapter\Message\Request as HttpAdapterRequest;
 use Ivory\HttpAdapter\Message\Response as HttpAdapterResponse;
-use Ivory\HttpAdapter\Message\Stream\StringStream;
 
 class HttpAdapter extends AbstractTransport
 {
@@ -126,9 +125,9 @@ class HttpAdapter extends AbstractTransport
         }
 
         $url = $this->_getUri($elasticaRequest, $connection);
-        $streamBody = new StringStream($body);
 
-        return new HttpAdapterRequest($url, $method, HttpAdapterRequest::PROTOCOL_VERSION_1_1, $headers, $streamBody);
+        $factory = new \Ivory\HttpAdapter\Message\MessageFactory();
+        return $factory->createRequest($url, $method, HttpAdapterRequest::PROTOCOL_VERSION_1_1, $headers, $body);
     }
 
     /**


### PR DESCRIPTION
Streams have changed on PSR7 and egeloen/http-adapter.
This change allows to work with this last version of egeloen/http-adapter.

On a Symfony project it works on the production environnment but there is an error on the debugger of the playbloom/guzzle-bundle bundle. Maybe some changes are required on the bundle or Guzzle but i'd like to validate that before this PR is merged.
