### PR TITLE
Tests host refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 - Introduction of Changelog standard based on http://keepachangelog.com/. changes.txt moved to CHANGELOG.md [#844](https://github.com/ruflin/Elastica/issues/844/)
+- Make host for all tests dynamic to prepare it for a more dynamic test environment #846
+
+
+
+
 
 
 ## [2.0.0](https://github.com/ruflin/Elastica/releases/tag/2.0.0) - 2015-05-11

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -7,12 +7,28 @@ use Elastica\Index;
 
 class Base extends \PHPUnit_Framework_TestCase
 {
-    protected function _getClient()
+    /**
+     * @param array $params Additional configuration params. Host and Port are already set
+     * @param callback $callback
+     * @return Client
+     */
+    protected function _getClient(array $params = array(), $callback = null)
     {
-        return new Client(array(
-            'host' => getenv('ES_HOST') ?: 'localhost',
+        $config = array(
+            'host' => $this->_getHost(),
             'port' => getenv('ES_PORT') ?: 9200,
-        ));
+        );
+
+        $config = array_merge($config, $params);
+        return new Client($config, $callback);
+    }
+
+    /**
+     * @return string Returns es host for tests
+     */
+    protected function _getHost()
+    {
+        return getenv('ES_HOST') ?: 'localhost';
     }
 
     /**

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -33,6 +33,14 @@ class Base extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return string Proxy url string
+     */
+    protected function _getProxyUrl()
+    {
+        return "http://127.0.0.1:12345";
+    }
+
+    /**
      * @param  string          $name   Index name
      * @param  bool            $delete Delete index if it exists
      * @param  int             $shards Number of shards to create

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -20,6 +20,7 @@ class Base extends \PHPUnit_Framework_TestCase
         );
 
         $config = array_merge($config, $params);
+
         return new Client($config, $callback);
     }
 
@@ -65,6 +66,7 @@ class Base extends \PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
+        parent::tearDown();
         $this->_getClient()->getIndex('_all')->delete();
         $this->_getClient()->getIndex('_all')->clearCache();
     }

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -54,7 +54,7 @@ class Base extends \PHPUnit_Framework_TestCase
      */
     protected function _getProxyUrl403()
     {
-        return "http://127.0.0.1:12345";
+        return "http://127.0.0.1:12346";
     }
 
     /**

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test;
 
 use Elastica\Client;
+use Elastica\Connection;
 use Elastica\Index;
 
 class Base extends \PHPUnit_Framework_TestCase
@@ -16,7 +17,7 @@ class Base extends \PHPUnit_Framework_TestCase
     {
         $config = array(
             'host' => $this->_getHost(),
-            'port' => getenv('ES_PORT') ?: 9200,
+            'port' => $this->_getPort(),
         );
 
         $config = array_merge($config, $params);
@@ -25,11 +26,19 @@ class Base extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return string Returns es host for tests
+     * @return string Host to es for elastica tests
      */
     protected function _getHost()
     {
-        return getenv('ES_HOST') ?: 'localhost';
+        return getenv('ES_HOST') ?: Connection::DEFAULT_HOST;
+    }
+
+    /**
+     * @return int Port to es for elastica tests
+     */
+    protected function _getPort()
+    {
+        return getenv('ES_PORT') ?: Connection::DEFAULT_PORT;
     }
 
     /**

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -46,7 +46,15 @@ class Base extends \PHPUnit_Framework_TestCase
      */
     protected function _getProxyUrl()
     {
-        return "http://127.0.0.1:12346";
+        return "http://127.0.0.1:12345";
+    }
+
+    /**
+     * @return string Proxy url string to proxy which returns 403
+     */
+    protected function _getProxyUrl403()
+    {
+        return "http://127.0.0.1:12345";
     }
 
     /**

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -46,7 +46,7 @@ class Base extends \PHPUnit_Framework_TestCase
      */
     protected function _getProxyUrl()
     {
-        return "http://127.0.0.1:12345";
+        return "http://127.0.0.1:12346";
     }
 
     /**

--- a/test/lib/Elastica/Test/Bulk/ActionTest.php
+++ b/test/lib/Elastica/Test/Bulk/ActionTest.php
@@ -37,7 +37,7 @@ class ActionTest extends BaseTest
         $expected = '{"index":{"_index":"index","_type":"type","_id":1,"_routing":1}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
-        $client = new Client();
+        $client = $this->_getClient();
         $index = new Index($client, 'index2');
         $type = new Type($index, 'type2');
 

--- a/test/lib/Elastica/Test/BulkTest.php
+++ b/test/lib/Elastica/Test/BulkTest.php
@@ -668,7 +668,7 @@ class BulkTest extends BaseTest
             ),
             array(
                 array(),
-                'localhost',
+                $this->_getHost(),
                 null,
             ),
             array(
@@ -678,13 +678,13 @@ class BulkTest extends BaseTest
             ),
             array(
                 array(),
-                'localhost',
+                $this->_getHost(),
                 9700,
             ),
             array(
                 array(
                     'udp' => array(
-                        'host' => 'localhost',
+                        'host' => $this->_getHost(),
                         'port' => 9700,
                     ),
                 ),
@@ -694,17 +694,17 @@ class BulkTest extends BaseTest
             array(
                 array(
                     'udp' => array(
-                        'host' => 'localhost',
+                        'host' => $this->_getHost(),
                         'port' => 9800,
                     ),
                 ),
-                'localhost',
+                $this->_getHost(),
                 9700,
             ),
             array(
                 array(
                     'udp' => array(
-                        'host' => 'localhost',
+                        'host' => $this->_getHost(),
                         'port' => 9800,
                     ),
                 ),
@@ -714,7 +714,7 @@ class BulkTest extends BaseTest
             ),
             array(
                 array(),
-                'localhost',
+                $this->_getHost(),
                 9800,
                 true,
             ),

--- a/test/lib/Elastica/Test/BulkTest.php
+++ b/test/lib/Elastica/Test/BulkTest.php
@@ -162,7 +162,7 @@ class BulkTest extends BaseTest
 
     public function testSetIndexType()
     {
-        $client = new Client();
+        $client = $this->_getClient();
         $index = $client->getIndex('index');
         $type = $index->getType('type');
 
@@ -200,7 +200,7 @@ class BulkTest extends BaseTest
 
     public function testAddActions()
     {
-        $client = new Client();
+        $client = $this->_getClient();
         $bulk = new Bulk($client);
 
         $action1 = new Action(Action::OP_TYPE_DELETE);
@@ -427,7 +427,7 @@ class BulkTest extends BaseTest
         if (!function_exists('socket_create')) {
             $this->markTestSkipped('Function socket_create() does not exist.');
         }
-        $client = new Client($clientConfig);
+        $client = $this->_getClient($clientConfig);
         $index = $client->getIndex('elastica_test');
         $index->create(array('index' => array('number_of_shards' => 1, 'number_of_replicas' => 0)), true);
         $type = $index->getType('udp_test');

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -25,7 +25,7 @@ class ClientTest extends BaseTest
     public function testConnectionsArray()
     {
         // Creates a new index 'xodoa' and a type 'user' inside this index
-        $client = new Client(array('connections' => array(array('host' => 'localhost', 'port' => 9200))));
+        $client = $this->_getClient(array('connections' => array(array('host' => 'localhost', 'port' => 9200))));
         $index = $client->getIndex('elastica_test1');
         $index->create(array(), true);
 
@@ -56,7 +56,7 @@ class ClientTest extends BaseTest
     public function testTwoServersSame()
     {
         // Creates a new index 'xodoa' and a type 'user' inside this index
-        $client = new Client(array('connections' => array(
+        $client = $this->_getClient(array('connections' => array(
             array('host' => 'localhost', 'port' => 9200),
             array('host' => 'localhost', 'port' => 9200),
         )));
@@ -67,17 +67,17 @@ class ClientTest extends BaseTest
 
         // Adds 1 document to the index
         $doc1 = new Document(1,
-        array('username' => 'hans', 'test' => array('2', '3', '5'))
+            array('username' => 'hans', 'test' => array('2', '3', '5'))
         );
         $type->addDocument($doc1);
 
         // Adds a list of documents with _bulk upload to the index
         $docs = array();
         $docs[] = new Document(2,
-        array('username' => 'john', 'test' => array('1', '3', '6'))
+            array('username' => 'john', 'test' => array('1', '3', '6'))
         );
         $docs[] = new Document(3,
-        array('username' => 'rolf', 'test' => array('2', '3', '7'))
+            array('username' => 'rolf', 'test' => array('2', '3', '7'))
         );
         $type->addDocuments($docs);
 
@@ -89,7 +89,7 @@ class ClientTest extends BaseTest
 
     public function testConnectionParamsArePreparedForConnectionsOption()
     {
-        $client = new Client(array('connections' => array(array('url' => 'https://localhost:9200'))));
+        $client = $this->_getClient(array('connections' => array(array('url' => 'https://localhost:9200'))));
         $connection = $client->getConnection();
 
         $this->assertEquals('https://localhost:9200', $connection->getConfig('url'));
@@ -97,7 +97,7 @@ class ClientTest extends BaseTest
 
     public function testConnectionParamsArePreparedForServersOption()
     {
-        $client = new Client(array('servers' => array(array('url' => 'https://localhost:9200'))));
+        $client = $this->_getClient(array('servers' => array(array('url' => 'https://localhost:9200'))));
         $connection = $client->getConnection();
 
         $this->assertEquals('https://localhost:9200', $connection->getConfig('url'));
@@ -105,7 +105,7 @@ class ClientTest extends BaseTest
 
     public function testConnectionParamsArePreparedForDefaultOptions()
     {
-        $client = new Client(array('url' => 'https://localhost:9200'));
+        $client = $this->_getClient(array('url' => 'https://localhost:9200'));
         $connection = $client->getConnection();
 
         $this->assertEquals('https://localhost:9200', $connection->getConfig('url'));
@@ -565,7 +565,7 @@ class ClientTest extends BaseTest
             $count++;
         };
 
-        $client = new Client(array(), $callback);
+        $client = $this->_getClient(array(), $callback);
 
         // First connection work, second should not work
         $connection1 = new Connection(array('port' => '9101', 'timeout' => 2));
@@ -591,7 +591,7 @@ class ClientTest extends BaseTest
         $url = 'http://localhost:9200/';
 
         // Url should overwrite invalid host
-        $client = new Client(array('url' => $url, 'port' => '9101', 'timeout' => 2));
+        $client = $this->_getClient(array('url' => $url, 'port' => '9101', 'timeout' => 2));
 
         $response = $client->request('_status');
         $this->assertInstanceOf('Elastica\Response', $response);
@@ -835,7 +835,7 @@ class ClientTest extends BaseTest
 
     public function testLastRequestResponse()
     {
-        $client = new Client();
+        $client = $this->_getClient();
         $response = $client->request('_status');
 
         $this->assertInstanceOf('Elastica\Response', $response);
@@ -943,7 +943,7 @@ class ClientTest extends BaseTest
             ),
             'level11' => 'value11',
         );
-        $client = new Client($config);
+        $client = $this->_getClient($config);
 
         $this->assertNull($client->getConfigValue('level12'));
         $this->assertFalse($client->getConfigValue('level12', false));
@@ -960,7 +960,7 @@ class ClientTest extends BaseTest
 
     public function testArrayQuery()
     {
-        $client = new Client();
+        $client = $this->_getClient();
 
         $index = $client->getIndex('test');
         $index->create(array(), true);
@@ -986,7 +986,7 @@ class ClientTest extends BaseTest
 
     public function testJSONQuery()
     {
-        $client = new Client();
+        $client = $this->_getClient();
 
         $index = $client->getIndex('test');
         $index->create(array(), true);
@@ -1006,7 +1006,7 @@ class ClientTest extends BaseTest
 
     public function testAddHeader()
     {
-        $client = new Client();
+        $client = $this->_getClient();
 
         // add one header
         $client->addHeader('foo', 'bar');
@@ -1031,7 +1031,7 @@ class ClientTest extends BaseTest
 
     public function testRemoveHeader()
     {
-        $client = new Client();
+        $client = $this->_getClient();
 
         // set headers
         $headers = array(

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -25,7 +25,7 @@ class ClientTest extends BaseTest
     public function testConnectionsArray()
     {
         // Creates a new index 'xodoa' and a type 'user' inside this index
-        $client = $this->_getClient(array('connections' => array(array('host' => 'localhost', 'port' => 9200))));
+        $client = $this->_getClient(array('connections' => array(array('host' => $this->_getHost(), 'port' => 9200))));
         $index = $client->getIndex('elastica_test1');
         $index->create(array(), true);
 
@@ -57,8 +57,8 @@ class ClientTest extends BaseTest
     {
         // Creates a new index 'xodoa' and a type 'user' inside this index
         $client = $this->_getClient(array('connections' => array(
-            array('host' => 'localhost', 'port' => 9200),
-            array('host' => 'localhost', 'port' => 9200),
+            array('host' => $this->_getHost(), 'port' => 9200),
+            array('host' => $this->_getHost(), 'port' => 9200),
         )));
         $index = $client->getIndex('elastica_test1');
         $index->create(array(), true);
@@ -89,26 +89,29 @@ class ClientTest extends BaseTest
 
     public function testConnectionParamsArePreparedForConnectionsOption()
     {
-        $client = $this->_getClient(array('connections' => array(array('url' => 'https://localhost:9200'))));
+        $url = 'https://' . $this->_getHost() . ':9200';
+        $client = $this->_getClient(array('connections' => array(array('url' => $url))));
         $connection = $client->getConnection();
 
-        $this->assertEquals('https://localhost:9200', $connection->getConfig('url'));
+        $this->assertEquals($url, $connection->getConfig('url'));
     }
 
     public function testConnectionParamsArePreparedForServersOption()
     {
-        $client = $this->_getClient(array('servers' => array(array('url' => 'https://localhost:9200'))));
+        $url = 'https://' . $this->_getHost() . ':9200';
+        $client = $this->_getClient(array('servers' => array(array('url' => $url))));
         $connection = $client->getConnection();
 
-        $this->assertEquals('https://localhost:9200', $connection->getConfig('url'));
+        $this->assertEquals($url, $connection->getConfig('url'));
     }
 
     public function testConnectionParamsArePreparedForDefaultOptions()
     {
-        $client = $this->_getClient(array('url' => 'https://localhost:9200'));
+        $url = 'https://' . $this->_getHost() . ':9200';
+        $client = $this->_getClient(array('url' => $url));
         $connection = $client->getConnection();
 
-        $this->assertEquals('https://localhost:9200', $connection->getConfig('url'));
+        $this->assertEquals($url, $connection->getConfig('url'));
     }
 
     public function testBulk()
@@ -588,7 +591,7 @@ class ClientTest extends BaseTest
 
     public function testUrlConstructor()
     {
-        $url = 'http://localhost:9200/';
+        $url = 'http://' . $this->_getHost() . ':9200/';
 
         // Url should overwrite invalid host
         $client = $this->_getClient(array('url' => $url, 'port' => '9101', 'timeout' => 2));

--- a/test/lib/Elastica/Test/Connection/Strategy/CallbackStrategyTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/CallbackStrategyTest.php
@@ -55,7 +55,7 @@ class CallbackStrategyTest extends Base
             return current($connections);
        });
 
-        $client = new Client($config);
+        $client = $this->_getClient($config);
         $response = $client->request('/_aliases');
 
         $this->assertEquals(1, $count);

--- a/test/lib/Elastica/Test/Connection/Strategy/RoundRobinTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/RoundRobinTest.php
@@ -20,7 +20,7 @@ class RoundRobinTest extends Base
     public function testConnection()
     {
         $config = array('connectionStrategy' => 'RoundRobin');
-        $client = new Client($config);
+        $client = $this->_getClient($config);
         $response = $client->request('/_aliases');
         /* @var $response Response */
 
@@ -32,7 +32,7 @@ class RoundRobinTest extends Base
     public function testOldStrategySetted()
     {
         $config = array('roundRobin' => true);
-        $client = new Client($config);
+        $client = $this->_getClient($config);
 
         $this->_checkStrategy($client);
     }
@@ -43,7 +43,7 @@ class RoundRobinTest extends Base
     public function testFailConnection()
     {
         $config = array('connectionStrategy' => 'RoundRobin', 'host' => '255.255.255.0');
-        $client = new Client($config);
+        $client = $this->_getClient($config);
 
         $this->_checkStrategy($client);
 
@@ -62,7 +62,7 @@ class RoundRobinTest extends Base
             ++$count;
         };
 
-        $client = new Client(array('connectionStrategy' => 'RoundRobin'), $callback);
+        $client = $this->_getClient(array('connectionStrategy' => 'RoundRobin'), $callback);
         $client->setConnections($connections);
 
         $response = $client->request('/_aliases');
@@ -84,7 +84,7 @@ class RoundRobinTest extends Base
         );
 
         $count = 0;
-        $client = new Client(array('roundRobin' => true), function () use (&$count) {
+        $client = $this->_getClient(array('roundRobin' => true), function () use (&$count) {
             ++$count;
         });
 

--- a/test/lib/Elastica/Test/Connection/Strategy/RoundRobinTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/RoundRobinTest.php
@@ -54,7 +54,7 @@ class RoundRobinTest extends Base
     {
         $connections = array(
             new Connection(array('host' => '255.255.255.0')),
-            new Connection(array('host' => 'localhost')),
+            new Connection(array('host' => $this->_getHost())),
         );
 
         $count = 0;

--- a/test/lib/Elastica/Test/Connection/Strategy/SimpleTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/SimpleTest.php
@@ -17,7 +17,7 @@ class SimpleTest extends Base
 {
     public function testConnection()
     {
-        $client = new Client();
+        $client = $this->_getClient();
         $response = $client->request('/_aliases');
         /* @var $response \Elastica\Response */
 
@@ -32,7 +32,7 @@ class SimpleTest extends Base
     public function testFailConnection()
     {
         $config = array('host' => '255.255.255.0');
-        $client = new Client($config);
+        $client = $this->_getClient($config);
 
         $this->_checkStrategy($client);
 
@@ -51,7 +51,7 @@ class SimpleTest extends Base
             ++$count;
         };
 
-        $client = new Client(array(), $callback);
+        $client = $this->_getClient(array(), $callback);
         $client->setConnections($connections);
 
         $response = $client->request('/_aliases');
@@ -73,7 +73,7 @@ class SimpleTest extends Base
         );
 
         $count = 0;
-        $client = new Client(array(), function () use (&$count) {
+        $client = $this->_getClient(array(), function () use (&$count) {
             ++$count;
         });
 

--- a/test/lib/Elastica/Test/Connection/Strategy/SimpleTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/SimpleTest.php
@@ -43,7 +43,7 @@ class SimpleTest extends Base
     {
         $connections = array(
             new Connection(array('host' => '255.255.255.0')),
-            new Connection(array('host' => 'localhost')),
+            new Connection(array('host' => $this->_getHost())),
         );
 
         $count = 0;

--- a/test/lib/Elastica/Test/ExampleTest.php
+++ b/test/lib/Elastica/Test/ExampleTest.php
@@ -13,7 +13,7 @@ class ExampleTest extends BaseTest
 {
     public function testBasicGettingStarted()
     {
-        $client = new Client();
+        $client = $this->_getClient();
         $index = $client->getIndex('ruflin');
         $type = $index->getType('users');
 

--- a/test/lib/Elastica/Test/LogTest.php
+++ b/test/lib/Elastica/Test/LogTest.php
@@ -28,19 +28,19 @@ class LogTest extends BaseTest
     public function testSetLogConfigPath()
     {
         $logPath = '/tmp/php.log';
-        $client = new Client(array('log' => $logPath));
+        $client = $this->_getClient(array('log' => $logPath));
         $this->assertEquals($logPath, $client->getConfig('log'));
     }
 
     public function testSetLogConfigEnable()
     {
-        $client = new Client(array('log' => true));
+        $client = $this->_getClient(array('log' => true));
         $this->assertTrue($client->getConfig('log'));
     }
 
     public function testSetLogConfigEnable1()
     {
-        $client = new Client();
+        $client = $this->_getClient();
         $client->setLogger(new Log());
         $this->assertFalse($client->getConfig('log'));
     }
@@ -65,7 +65,7 @@ class LogTest extends BaseTest
 
     public function testGetLastMessage2()
     {
-        $client = new Client(array('log' => true));
+        $client = $this->_getClient(array('log' => true));
         $log = new Log($client);
 
         // Set log path temp path as otherwise test fails with output

--- a/test/lib/Elastica/Test/RequestTest.php
+++ b/test/lib/Elastica/Test/RequestTest.php
@@ -36,7 +36,7 @@ class RequestTest extends BaseTest
     public function testSend()
     {
         $connection = new Connection();
-        $connection->setHost('localhost');
+        $connection->setHost($this->_getHost());
         $connection->setPort('9200');
 
         $request = new Request('_status', Request::GET, array(), array(), $connection);
@@ -54,7 +54,7 @@ class RequestTest extends BaseTest
         $data = array('key' => 'value');
 
         $connection = new Connection();
-        $connection->setHost('localhost');
+        $connection->setHost($this->_getHost());
         $connection->setPort('9200');
 
         $request = new Request($path, $method, $data, $query, $connection);

--- a/test/lib/Elastica/Test/Transport/GuzzleTest.php
+++ b/test/lib/Elastica/Test/Transport/GuzzleTest.php
@@ -82,7 +82,7 @@ class GuzzleTest extends BaseTest
 
     public function testWithEnvironmentalProxy()
     {
-        putenv('http_proxy=' . $this->_getProxyUrl());
+        putenv('http_proxy=' . $this->_getProxyUrl() . '/');
 
         $client = new \Elastica\Client(array('transport' => 'Guzzle', 'persistent' => false));
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
@@ -97,7 +97,7 @@ class GuzzleTest extends BaseTest
 
     public function testWithEnabledEnvironmentalProxy()
     {
-        putenv('http_proxy=' . $this->_getProxyUrl());
+        putenv('http_proxy=' . $this->_getProxyUrl() . '/');
 
         $client = new \Elastica\Client(array('transport' => 'Guzzle', 'persistent' => false));
         $transferInfo = $client->request('/_nodes')->getTransferInfo();

--- a/test/lib/Elastica/Test/Transport/GuzzleTest.php
+++ b/test/lib/Elastica/Test/Transport/GuzzleTest.php
@@ -97,7 +97,7 @@ class GuzzleTest extends BaseTest
 
     public function testWithEnabledEnvironmentalProxy()
     {
-        putenv('http_proxy=' . $this->_getProxyUrl() . '/');
+        putenv('http_proxy=' . $this->_getProxyUrl403() . '/');
 
         $client = $this->_getClient(array('transport' => 'Guzzle', 'persistent' => false));
         $transferInfo = $client->request('/_nodes')->getTransferInfo();

--- a/test/lib/Elastica/Test/Transport/GuzzleTest.php
+++ b/test/lib/Elastica/Test/Transport/GuzzleTest.php
@@ -56,7 +56,7 @@ class GuzzleTest extends BaseTest
      */
     public function testDynamicHttpMethodBasedOnConfigParameter(array $config, $httpMethod)
     {
-        $client = new Client($config);
+        $client = $this->_getClient($config);
 
         $index = $client->getIndex('dynamic_http_method_test');
         $index->create(array(), true);
@@ -73,7 +73,7 @@ class GuzzleTest extends BaseTest
      */
     public function testDynamicHttpMethodOnlyAffectsRequestsWithBody(array $config, $httpMethod)
     {
-        $client = new Client($config);
+        $client = $this->_getClient($config);
 
         $status = $client->getStatus();
         $info = $status->getResponse()->getTransferInfo();
@@ -131,7 +131,7 @@ class GuzzleTest extends BaseTest
 
     public function testBodyReuse()
     {
-        $client = new Client(array('transport' => 'Guzzle', 'persistent' => false));
+        $client = $this->_getClient(array('transport' => 'Guzzle', 'persistent' => false));
 
         $index = $client->getIndex('elastica_body_reuse_test');
         $index->create(array(), true);
@@ -163,7 +163,7 @@ class GuzzleTest extends BaseTest
      */
     public function testInvalidConnection()
     {
-        $client = new Client(array('transport' => 'Guzzle', 'port' => 4500, 'persistent' => false));
+        $client = $this->_getClient(array('transport' => 'Guzzle', 'port' => 4500, 'persistent' => false));
         $response = $client->request('_status', 'GET');
     }
 }

--- a/test/lib/Elastica/Test/Transport/GuzzleTest.php
+++ b/test/lib/Elastica/Test/Transport/GuzzleTest.php
@@ -84,7 +84,7 @@ class GuzzleTest extends BaseTest
     {
         putenv('http_proxy=' . $this->_getProxyUrl() . '/');
 
-        $client = new \Elastica\Client(array('transport' => 'Guzzle', 'persistent' => false));
+        $client = $this->_getClient(array('transport' => 'Guzzle', 'persistent' => false));
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);
 
@@ -99,11 +99,11 @@ class GuzzleTest extends BaseTest
     {
         putenv('http_proxy=' . $this->_getProxyUrl() . '/');
 
-        $client = new \Elastica\Client(array('transport' => 'Guzzle', 'persistent' => false));
+        $client = $this->_getClient(array('transport' => 'Guzzle', 'persistent' => false));
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(403, $transferInfo['http_code']);
 
-        $client = new \Elastica\Client(array('transport' => 'Guzzle', 'persistent' => false));
+        $client = $this->_getClient(array('transport' => 'Guzzle', 'persistent' => false));
         $client->getConnection()->setProxy('');
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);
@@ -113,7 +113,7 @@ class GuzzleTest extends BaseTest
 
     public function testWithProxy()
     {
-        $client = new \Elastica\Client(array('transport' => 'Guzzle', 'persistent' => false));
+        $client = $this->_getClient(array('transport' => 'Guzzle', 'persistent' => false));
         $client->getConnection()->setProxy($this->_getProxyUrl());
 
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
@@ -122,7 +122,7 @@ class GuzzleTest extends BaseTest
 
     public function testWithoutProxy()
     {
-        $client = new \Elastica\Client(array('transport' => 'Guzzle', 'persistent' => false));
+        $client = $this->_getClient(array('transport' => 'Guzzle', 'persistent' => false));
         $client->getConnection()->setProxy('');
 
         $transferInfo = $client->request('/_nodes')->getTransferInfo();

--- a/test/lib/Elastica/Test/Transport/GuzzleTest.php
+++ b/test/lib/Elastica/Test/Transport/GuzzleTest.php
@@ -166,4 +166,11 @@ class GuzzleTest extends BaseTest
         $client = $this->_getClient(array('transport' => 'Guzzle', 'port' => 4500, 'persistent' => false));
         $response = $client->request('_status', 'GET');
     }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        putenv('http_proxy=');
+    }
+
 }

--- a/test/lib/Elastica/Test/Transport/GuzzleTest.php
+++ b/test/lib/Elastica/Test/Transport/GuzzleTest.php
@@ -82,7 +82,7 @@ class GuzzleTest extends BaseTest
 
     public function testWithEnvironmentalProxy()
     {
-        putenv('http_proxy=http://127.0.0.1:12345/');
+        putenv('http_proxy=' . $this->_getProxyUrl());
 
         $client = new \Elastica\Client(array('transport' => 'Guzzle', 'persistent' => false));
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
@@ -97,7 +97,7 @@ class GuzzleTest extends BaseTest
 
     public function testWithEnabledEnvironmentalProxy()
     {
-        putenv('http_proxy=http://127.0.0.1:12346/');
+        putenv('http_proxy=' . $this->_getProxyUrl());
 
         $client = new \Elastica\Client(array('transport' => 'Guzzle', 'persistent' => false));
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
@@ -114,7 +114,7 @@ class GuzzleTest extends BaseTest
     public function testWithProxy()
     {
         $client = new \Elastica\Client(array('transport' => 'Guzzle', 'persistent' => false));
-        $client->getConnection()->setProxy('http://127.0.0.1:12345');
+        $client->getConnection()->setProxy($this->_getProxyUrl());
 
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -49,7 +49,7 @@ class HttpTest extends BaseTest
      */
     public function testDynamicHttpMethodBasedOnConfigParameter(array $config, $httpMethod)
     {
-        $client = new Client($config);
+        $client = $this->_getClient($config);
 
         $index = $client->getIndex('dynamic_http_method_test');
         $index->create(array(), true);
@@ -71,7 +71,7 @@ class HttpTest extends BaseTest
      */
     public function testDynamicHttpMethodOnlyAffectsRequestsWithBody(array $config, $httpMethod)
     {
-        $client = new Client($config);
+        $client = $this->_getClient($config);
 
         $status = $client->getStatus();
         $info = $status->getResponse()->getTransferInfo();
@@ -188,7 +188,7 @@ class HttpTest extends BaseTest
 
     public function testBodyReuse()
     {
-        $client = new Client();
+        $client = $this->_getClient();
 
         $index = $client->getIndex('elastica_body_reuse_test');
         $index->create(array(), true);
@@ -217,7 +217,7 @@ class HttpTest extends BaseTest
 
     public function testPostWith0Body()
     {
-        $client = new Client();
+        $client = $this->_getClient();
 
         $index = $client->getIndex('elastica_0_body');
         $index->create(array(), true);

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -153,7 +153,7 @@ class HttpTest extends BaseTest
 
     public function testWithEnabledEnvironmentalProxy()
     {
-        putenv('http_proxy=http://127.0.0.1:12346/');
+        putenv('http_proxy=http://' . $this->_getProxyUrl() . '/');
 
         $client = new \Elastica\Client();
 
@@ -227,5 +227,11 @@ class HttpTest extends BaseTest
         $tokens = $index->analyze('0');
 
         $this->assertNotEmpty($tokens);
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        putenv('http_proxy=');
     }
 }

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -154,10 +154,10 @@ class HttpTest extends BaseTest
     public function testWithEnabledEnvironmentalProxy()
     {
         putenv('http_proxy=http://127.0.0.1:12346/');
-        $client = new \Elastica\Client();
+        $client = $this->_getClient();
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(403, $transferInfo['http_code']);
-        $client = new \Elastica\Client();
+        $client = $this->_getClient();
         $client->getConnection()->setProxy('');
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -153,7 +153,7 @@ class HttpTest extends BaseTest
 
     public function testWithEnabledEnvironmentalProxy()
     {
-        putenv('http_proxy=http://127.0.0.1:12346/');
+        putenv('http_proxy=' . $this->_getProxyUrl403() . '/');
         $client = $this->_getClient();
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(403, $transferInfo['http_code']);

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -153,19 +153,14 @@ class HttpTest extends BaseTest
 
     public function testWithEnabledEnvironmentalProxy()
     {
-        putenv('http_proxy=http://' . $this->_getProxyUrl403() . '/');
-
-        $client = $this->_getClient();
-
+        putenv('http_proxy=http://127.0.0.1:12346/');
+        $client = new \Elastica\Client();
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(403, $transferInfo['http_code']);
-
-        $client = $this->_getClient();
-
+        $client = new \Elastica\Client();
         $client->getConnection()->setProxy('');
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);
-
         putenv('http_proxy=');
     }
 

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -80,7 +80,7 @@ class HttpTest extends BaseTest
 
     public function testCurlNobodyOptionIsResetAfterHeadRequest()
     {
-        $client = new \Elastica\Client();
+        $client = $this->_getClient();
         $index = $client->getIndex('curl_test');
         $index->create(array(), true);
         $this->_waitForAllocation($index);
@@ -106,7 +106,7 @@ class HttpTest extends BaseTest
 
     public function testUnicodeData()
     {
-        $client = new \Elastica\Client();
+        $client = $this->_getClient();
         $index = $client->getIndex('curl_test');
         $index->create(array(), true);
         $this->_waitForAllocation($index);
@@ -138,9 +138,9 @@ class HttpTest extends BaseTest
 
     public function testWithEnvironmentalProxy()
     {
-        putenv('http_proxy=http://127.0.0.1:12345/');
+        putenv('http_proxy=' . $this->_getProxyUrl());
 
-        $client = new \Elastica\Client();
+        $client = $this->_getClient();
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);
 
@@ -153,14 +153,14 @@ class HttpTest extends BaseTest
 
     public function testWithEnabledEnvironmentalProxy()
     {
-        putenv('http_proxy=http://127.0.0.1:12346/');
+        putenv('http_proxy=' . $this->_getProxyUrl());
 
-        $client = new \Elastica\Client();
+        $client = $this->_getClient();
 
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(403, $transferInfo['http_code']);
 
-        $client = new \Elastica\Client();
+        $client = $this->_getClient();
         $client->getConnection()->setProxy('');
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);
@@ -170,8 +170,8 @@ class HttpTest extends BaseTest
 
     public function testWithProxy()
     {
-        $client = new \Elastica\Client();
-        $client->getConnection()->setProxy('http://127.0.0.1:12345');
+        $client = $this->_getClient();
+        $client->getConnection()->setProxy($this->_getProxyUrl());
 
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);
@@ -179,7 +179,7 @@ class HttpTest extends BaseTest
 
     public function testWithoutProxy()
     {
-        $client = new \Elastica\Client();
+        $client = $this->_getClient();
         $client->getConnection()->setProxy('');
 
         $transferInfo = $client->request('/_nodes')->getTransferInfo();

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -155,12 +155,12 @@ class HttpTest extends BaseTest
     {
         putenv('http_proxy=' . $this->_getProxyUrl() . '/');
 
-        $client = $this->_getClient();
+        $client = new \Elastica\Client();
 
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(403, $transferInfo['http_code']);
 
-        $client = $this->_getClient();
+        $client =  new \Elastica\Client();
         $client->getConnection()->setProxy('');
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -153,14 +153,14 @@ class HttpTest extends BaseTest
 
     public function testWithEnabledEnvironmentalProxy()
     {
-        putenv('http_proxy=' . $this->_getProxyUrl() . '/');
+        putenv('http_proxy=http://127.0.0.1:12346/');
 
         $client = new \Elastica\Client();
 
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(403, $transferInfo['http_code']);
 
-        $client =  new \Elastica\Client();
+        $client = new \Elastica\Client();
         $client->getConnection()->setProxy('');
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -153,7 +153,7 @@ class HttpTest extends BaseTest
 
     public function testWithEnabledEnvironmentalProxy()
     {
-        putenv('http_proxy=http://' . $this->_getProxyUrl() . '/');
+        putenv('http_proxy=http://' . $this->_getProxyUrl403() . '/');
 
         $client = new \Elastica\Client();
 

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -155,12 +155,13 @@ class HttpTest extends BaseTest
     {
         putenv('http_proxy=http://' . $this->_getProxyUrl403() . '/');
 
-        $client = new \Elastica\Client();
+        $client = $this->_getClient();
 
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(403, $transferInfo['http_code']);
 
-        $client = new \Elastica\Client();
+        $client = $this->_getClient();
+
         $client->getConnection()->setProxy('');
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
         $this->assertEquals(200, $transferInfo['http_code']);

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -138,7 +138,7 @@ class HttpTest extends BaseTest
 
     public function testWithEnvironmentalProxy()
     {
-        putenv('http_proxy=' . $this->_getProxyUrl());
+        putenv('http_proxy=' . $this->_getProxyUrl() . '/');
 
         $client = $this->_getClient();
         $transferInfo = $client->request('/_nodes')->getTransferInfo();
@@ -153,7 +153,7 @@ class HttpTest extends BaseTest
 
     public function testWithEnabledEnvironmentalProxy()
     {
-        putenv('http_proxy=' . $this->_getProxyUrl());
+        putenv('http_proxy=' . $this->_getProxyUrl() . '/');
 
         $client = $this->_getClient();
 

--- a/test/lib/Elastica/Test/Transport/MemcacheTest.php
+++ b/test/lib/Elastica/Test/Transport/MemcacheTest.php
@@ -149,7 +149,8 @@ class MemcacheTest extends BaseTest
      */
     public function testRequestWithLongPath()
     {
-        $index = $this->_createIndex();
+        $client = $this->_getMemcacheClient();
+        $index = $client->getIndex('memcache-test');
         $this->_waitForAllocation($index);
 
         $queryString = new QueryString(str_repeat('z', 300));

--- a/test/lib/Elastica/Test/Transport/MemcacheTest.php
+++ b/test/lib/Elastica/Test/Transport/MemcacheTest.php
@@ -151,6 +151,8 @@ class MemcacheTest extends BaseTest
     {
         $client = $this->_getMemcacheClient();
         $index = $client->getIndex('memcache-test');
+        $index->create();
+
         $this->_waitForAllocation($index);
 
         $queryString = new QueryString(str_repeat('z', 300));

--- a/test/lib/Elastica/Test/Transport/MemcacheTest.php
+++ b/test/lib/Elastica/Test/Transport/MemcacheTest.php
@@ -20,7 +20,7 @@ class MemcacheTest extends BaseTest
 
     protected function _getClient()
     {
-        return new Client(array(
+        return $this->_getClient(array(
             'host' => 'localhost',
             'port' => 11211,
             'transport' => 'Memcache',

--- a/test/lib/Elastica/Test/Transport/MemcacheTest.php
+++ b/test/lib/Elastica/Test/Transport/MemcacheTest.php
@@ -20,8 +20,8 @@ class MemcacheTest extends BaseTest
 
     protected function _getClient()
     {
-        return $this->_getClient(array(
-            'host' => 'localhost',
+        return parent::_getClient(array(
+            'host' => $this->_getHost(),
             'port' => 11211,
             'transport' => 'Memcache',
         ));
@@ -30,7 +30,7 @@ class MemcacheTest extends BaseTest
     public function testConstruct()
     {
         $client = $this->_getClient();
-        $this->assertEquals('localhost', $client->getConnection()->getHost());
+        $this->assertEquals($this->_getHost(), $client->getConnection()->getHost());
         $this->assertEquals(11211, $client->getConnection()->getPort());
     }
 

--- a/test/lib/Elastica/Test/Transport/MemcacheTest.php
+++ b/test/lib/Elastica/Test/Transport/MemcacheTest.php
@@ -149,7 +149,7 @@ class MemcacheTest extends BaseTest
      */
     public function testRequestWithLongPath()
     {
-        $index = $this->_createIndex();
+        $index = $this->_getMemcacheClient();
         $this->_waitForAllocation($index);
 
         $queryString = new QueryString(str_repeat('z', 300));

--- a/test/lib/Elastica/Test/Transport/MemcacheTest.php
+++ b/test/lib/Elastica/Test/Transport/MemcacheTest.php
@@ -149,7 +149,7 @@ class MemcacheTest extends BaseTest
      */
     public function testRequestWithLongPath()
     {
-        $index = $this->_getMemcacheClient();
+        $index = $this->_createIndex();
         $this->_waitForAllocation($index);
 
         $queryString = new QueryString(str_repeat('z', 300));

--- a/test/lib/Elastica/Test/Transport/MemcacheTest.php
+++ b/test/lib/Elastica/Test/Transport/MemcacheTest.php
@@ -18,9 +18,9 @@ class MemcacheTest extends BaseTest
         }
     }
 
-    protected function _getClient()
+    protected function _getMemcacheClient()
     {
-        return parent::_getClient(array(
+        return $this->_getClient(array(
             'host' => $this->_getHost(),
             'port' => 11211,
             'transport' => 'Memcache',
@@ -29,7 +29,7 @@ class MemcacheTest extends BaseTest
 
     public function testConstruct()
     {
-        $client = $this->_getClient();
+        $client = $this->_getMemcacheClient();
         $this->assertEquals($this->_getHost(), $client->getConnection()->getHost());
         $this->assertEquals(11211, $client->getConnection()->getPort());
     }
@@ -129,7 +129,7 @@ class MemcacheTest extends BaseTest
      */
     public function testHeadRequest()
     {
-        $client = $this->_getClient();
+        $client = $this->_getMemcacheClient();
         $client->request('foo', Request::HEAD);
     }
 
@@ -139,7 +139,7 @@ class MemcacheTest extends BaseTest
      */
     public function testInvalidRequest()
     {
-        $client = $this->_getClient();
+        $client = $this->_getMemcacheClient();
         $client->request('foo', 'its_fail');
     }
 

--- a/test/lib/Elastica/Test/Transport/ThriftTest.php
+++ b/test/lib/Elastica/Test/Transport/ThriftTest.php
@@ -19,7 +19,7 @@ class ThriftTest extends BaseTest
 
     public function testConstruct()
     {
-        $host = 'localhost';
+        $host = $this->_getHost();
         $port = 9500;
         $client = $this->_getClient(array('host' => $host, 'port' => $port, 'transport' => 'Thrift'));
 
@@ -85,7 +85,7 @@ class ThriftTest extends BaseTest
         $this->_checkPlugin();
 
         $connection = new Connection();
-        $connection->setHost('localhost');
+        $connection->setHost($this->_getHost());
         $connection->setPort(9500);
         $connection->setTransport('Thrift');
 
@@ -101,14 +101,14 @@ class ThriftTest extends BaseTest
         return array(
             array(
                 array(
-                    'host' => 'localhost',
+                    'host' => $this->_getHost(),
                     'port' => 9500,
                     'transport' => 'Thrift',
                 ),
             ),
             array(
                 array(
-                    'host' => 'localhost',
+                    'host' => $this->_getHost(),
                     'port' => 9500,
                     'transport' => 'Thrift',
                     'config' => array(

--- a/test/lib/Elastica/Test/Transport/ThriftTest.php
+++ b/test/lib/Elastica/Test/Transport/ThriftTest.php
@@ -21,7 +21,7 @@ class ThriftTest extends BaseTest
     {
         $host = 'localhost';
         $port = 9500;
-        $client = new Client(array('host' => $host, 'port' => $port, 'transport' => 'Thrift'));
+        $client = $this->_getClient(array('host' => $host, 'port' => $port, 'transport' => 'Thrift'));
 
         $this->assertEquals($host, $client->getConnection()->getHost());
         $this->assertEquals($port, $client->getConnection()->getPort());
@@ -35,7 +35,7 @@ class ThriftTest extends BaseTest
         $this->_checkPlugin();
 
         // Creates a new index 'xodoa' and a type 'user' inside this index
-        $client = new Client($config);
+        $client = $this->_getClient($config);
 
         $index = $client->getIndex('elastica_test1');
         $index->create(array(), true);
@@ -73,7 +73,7 @@ class ThriftTest extends BaseTest
     {
         $this->_checkPlugin();
 
-        $client = new Client(array('host' => 'unknown', 'port' => 9555, 'transport' => 'Thrift'));
+        $client = $this->_getClient(array('host' => 'unknown', 'port' => 9555, 'transport' => 'Thrift'));
         $client->getStatus();
     }
 
@@ -89,7 +89,7 @@ class ThriftTest extends BaseTest
         $connection->setPort(9500);
         $connection->setTransport('Thrift');
 
-        $client = new Client();
+        $client = $this->_getClient();
         $client->addConnection($connection);
 
         $index = new Index($client, 'missing_index');

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -333,7 +333,7 @@ class TypeTest extends BaseTest
      */
     public function testGetDocumentNotExistingIndex()
     {
-        $client = new Client();
+        $client = $this->_getClient();
         $index = new Index($client, 'index');
         $type = new Type($index, 'type');
 
@@ -512,7 +512,7 @@ class TypeTest extends BaseTest
 
     public function testMoreLikeThisApi()
     {
-        $client = new Client(array('persistent' => false));
+        $client = $this->_getClient(array('persistent' => false));
         $index = $client->getIndex('elastica_test');
         $index->create(array('index' => array('number_of_shards' => 1, 'number_of_replicas' => 0)), true);
 

--- a/test/lib/Elastica/Test/UtilTest.php
+++ b/test/lib/Elastica/Test/UtilTest.php
@@ -84,14 +84,14 @@ class UtilTest extends BaseTest
         $data = array('key' => 'value');
 
         $connection = new Connection();
-        $connection->setHost('localhost');
+        $connection->setHost($this->_getHost());
         $connection->setPort('9200');
 
         $request = new Request($path, $method, $data, $query, $connection);
 
         $curlCommand = Util::convertRequestToCurlCommand($request);
 
-        $expected = 'curl -XPOST \'http://localhost:9200/test?no=params\' -d \'{"key":"value"}\'';
+        $expected = 'curl -XPOST \'http://' . $this->_getHost() . ':9200/test?no=params\' -d \'{"key":"value"}\'';
         $this->assertEquals($expected, $curlCommand);
     }
 


### PR DESCRIPTION
Make the hostname in the tests dynamic to not require elasticsearch to run on localhost. This is in preparation for also test separations (unit, integration, ...) to make the tests run faster.

@im-denisenko FYI