### PR TITLE
SignificantTerms aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 - Multiple rescore query [#820](https://github.com/ruflin/Elastica/issues/820/)
 - Support for a custom connection timeout through a connectTimeout parameter. CURLOPT_CONNECTTIMEOUT added to the HTTP transport curl options if a connectTimeout is >0 #841
+- SignificantTerms Aggregation [#847](https://github.com/ruflin/Elastica/issues/847/)
+
 
 ### Improvements
 - Introduction of Changelog standard based on http://keepachangelog.com/. changes.txt moved to CHANGELOG.md [#844](https://github.com/ruflin/Elastica/issues/844/)

--- a/lib/Elastica/Aggregation/AbstractTermsAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractTermsAggregation.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Elastica\Aggregation;
+
+/**
+ * Class AbstractTermsAggergation
+ * @package Elastica\Aggregation
+ */
+class AbstractTermsAggregation extends AbstractSimpleAggregation
+{
+
+    /**
+     * Set the minimum number of documents in which a term must appear in order to be returned in a bucket
+     * @param  int   $count
+     * @return $this
+     */
+    public function setMinimumDocumentCount($count)
+    {
+        return $this->setParam("min_doc_count", $count);
+    }
+
+    /**
+     * Filter documents to include based on a regular expression
+     * @param  string $pattern a regular expression
+     * @param  string $flags   Java Pattern flags
+     * @return $this
+     */
+    public function setInclude($pattern, $flags = null)
+    {
+        if (is_null($flags)) {
+            return $this->setParam("include", $pattern);
+        }
+
+        return $this->setParam("include", array(
+            "pattern" => $pattern,
+            "flags" => $flags,
+        ));
+    }
+
+    /**
+     * Filter documents to exclude based on a regular expression
+     * @param  string $pattern a regular expression
+     * @param  string $flags   Java Pattern flags
+     * @return $this
+     */
+    public function setExclude($pattern, $flags = null)
+    {
+        if (is_null($flags)) {
+            return $this->setParam("exclude", $pattern);
+        }
+
+        return $this->setParam("exclude", array(
+            "pattern" => $pattern,
+            "flags" => $flags,
+        ));
+    }
+
+    /**
+     * Sets the amount of terms to be returned.
+     * @param  int   $size The amount of terms to be returned.
+     * @return $this
+     */
+    public function setSize($size)
+    {
+        return $this->setParam('size', $size);
+    }
+
+    /**
+     * Sets how many terms the coordinating node will request from each shard.
+     * @param  int   $shard_size The amount of terms to be returned.
+     * @return $this
+     */
+    public function setShardSize($shard_size)
+    {
+        return $this->setParam('shard_size', $shard_size);
+    }
+
+    /**
+     * Instruct Elasticsearch to use direct field data or ordinals of the field values to execute this aggregation.
+     * The execution hint will be ignored if it is not applicable.
+     * @param  string $hint map or ordinals
+     * @return $this
+     */
+    public function setExecutionHint($hint)
+    {
+        return $this->setParam("execution_hint", $hint);
+    }
+}

--- a/lib/Elastica/Aggregation/SignificantTerms.php
+++ b/lib/Elastica/Aggregation/SignificantTerms.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Elastica\Aggregation;
+use Elastica\Filter\AbstractFilter;
+
+/**
+ * Class SignificantTerms
+ * @package Elastica\Aggregation
+ * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html
+ */
+class SignificantTerms extends AbstractTermsAggregation
+{
+
+    /**
+     * The default source of statistical information for background term frequencies is the entire index and this scope can
+     * be narrowed through the use of a background_filter to focus in on significant terms within a narrower context
+     * @param AbstractFilter $filter
+     * @return $this
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html#_custom_background_context
+     *
+     */
+    public function setBackgroundFilter(AbstractFilter $filter) {
+        return $this->setParam("background_filter", $filter->toArray());
+    }
+
+}

--- a/lib/Elastica/Aggregation/Terms.php
+++ b/lib/Elastica/Aggregation/Terms.php
@@ -7,7 +7,7 @@ namespace Elastica\Aggregation;
  * @package Elastica\Aggregation
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html
  */
-class Terms extends AbstractSimpleAggregation
+class Terms extends AbstractTermsAggregation
 {
     /**
      * Set the bucket sort order
@@ -20,80 +20,4 @@ class Terms extends AbstractSimpleAggregation
         return $this->setParam("order", array($order => $direction));
     }
 
-    /**
-     * Set the minimum number of documents in which a term must appear in order to be returned in a bucket
-     * @param  int   $count
-     * @return $this
-     */
-    public function setMinimumDocumentCount($count)
-    {
-        return $this->setParam("min_doc_count", $count);
-    }
-
-    /**
-     * Filter documents to include based on a regular expression
-     * @param  string $pattern a regular expression
-     * @param  string $flags   Java Pattern flags
-     * @return $this
-     */
-    public function setInclude($pattern, $flags = null)
-    {
-        if (is_null($flags)) {
-            return $this->setParam("include", $pattern);
-        }
-
-        return $this->setParam("include", array(
-            "pattern" => $pattern,
-            "flags" => $flags,
-        ));
-    }
-
-    /**
-     * Filter documents to exclude based on a regular expression
-     * @param  string $pattern a regular expression
-     * @param  string $flags   Java Pattern flags
-     * @return $this
-     */
-    public function setExclude($pattern, $flags = null)
-    {
-        if (is_null($flags)) {
-            return $this->setParam("exclude", $pattern);
-        }
-
-        return $this->setParam("exclude", array(
-            "pattern" => $pattern,
-            "flags" => $flags,
-        ));
-    }
-
-    /**
-     * Sets the amount of terms to be returned.
-     * @param  int   $size The amount of terms to be returned.
-     * @return $this
-     */
-    public function setSize($size)
-    {
-        return $this->setParam('size', $size);
-    }
-
-    /**
-     * Sets how many terms the coordinating node will request from each shard.
-     * @param  int   $shard_size The amount of terms to be returned.
-     * @return $this
-     */
-    public function setShardSize($shard_size)
-    {
-        return $this->setParam('shard_size', $shard_size);
-    }
-
-    /**
-     * Instruct Elasticsearch to use direct field data or ordinals of the field values to execute this aggregation.
-     * The execution hint will be ignored if it is not applicable.
-     * @param  string $hint map or ordinals
-     * @return $this
-     */
-    public function setExecutionHint($hint)
-    {
-        return $this->setParam("execution_hint", $hint);
-    }
 }

--- a/lib/Elastica/QueryBuilder/DSL/Aggregation.php
+++ b/lib/Elastica/QueryBuilder/DSL/Aggregation.php
@@ -25,6 +25,7 @@ use Elastica\Aggregation\ScriptedMetric;
 use Elastica\Aggregation\Stats;
 use Elastica\Aggregation\Sum;
 use Elastica\Aggregation\Terms;
+use Elastica\Aggregation\SignificantTerms;
 use Elastica\Aggregation\TopHits;
 use Elastica\Aggregation\ValueCount;
 use Elastica\Exception\NotImplementedException;
@@ -318,10 +319,11 @@ class Aggregation implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html
      * @param string $name
+     * @return SignificantTerms
      */
     public function significant_terms($name)
     {
-        throw new NotImplementedException();
+        return new SignificantTerms($name);
     }
 
     /**

--- a/test/lib/Elastica/Test/Aggregation/SignificantTermsTest.php
+++ b/test/lib/Elastica/Test/Aggregation/SignificantTermsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Elastica\Test\Aggregation;
+
+use Elastica\Aggregation\SignificantTerms;
+use Elastica\Document;
+use Elastica\Query;
+use Elastica\Query\Terms;
+use Elastica\Filter\Terms as TermsFilter;
+
+class SignificantSignificantTermsTest extends BaseAggregationTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->_index = $this->_createIndex();
+        $colors = array("blue", "blue", "red", "red", "green", "yellow", "white", "cyan", "magenta");
+        $temperatures = array(1500, 1500, 1500, 1500, 2500, 3500, 4500, 5500, 6500, 7500, 7500, 8500, 9500);
+        $docs = array();
+        for($i=0;$i<250;$i++) {
+            $docs[] = new Document($i, array("color" => $colors[$i%count($colors)], "temperature" => $temperatures[$i%count($temperatures)]));
+        }
+        $this->_index->getType("test")->addDocuments($docs);
+        $this->_index->refresh();
+    }
+
+    public function testSignificantTermsAggregation()
+    {
+        $agg = new SignificantTerms("significantTerms");
+        $agg->setField("temperature");
+        $agg->setSize(1);
+
+        $termsQuery = new Terms();
+        $termsQuery->setTerms("color",array("blue", "red", "green", "yellow", "white"));
+
+        $query = new Query($termsQuery);
+        $query->addAggregation($agg);
+        $results = $this->_index->search($query)->getAggregation("significantTerms");
+
+        $this->assertEquals(1, count($results['buckets']));
+        $this->assertEquals(63, $results['buckets'][0]['doc_count']);
+        $this->assertEquals(79, $results['buckets'][0]['bg_count']);
+        $this->assertEquals("1500", $results['buckets'][0]['key_as_string']);
+    }
+
+    public function testSignificantTermsAggregationWithBackgroundFilter()
+    {
+        $agg = new SignificantTerms("significantTerms");
+        $agg->setField("temperature");
+        $agg->setSize(1);
+        $termsFilter = new TermsFilter();
+        $termsFilter->setTerms("color",array("blue", "red", "green", "yellow"));
+        $agg->setBackgroundFilter($termsFilter);
+
+        $termsQuery = new Terms();
+        $termsQuery->setTerms("color",array("blue", "red", "green", "yellow", "white"));
+
+        $query = new Query($termsQuery);
+        $query->addAggregation($agg);
+        $results = $this->_index->search($query)->getAggregation("significantTerms");
+
+        $this->assertEquals(15, $results['buckets'][0]['doc_count']);
+        $this->assertEquals(12, $results['buckets'][0]['bg_count']);
+        $this->assertEquals("4500", $results['buckets'][0]['key_as_string']);
+    }
+}


### PR DESCRIPTION
SignificantTerms aggregation is almost identical to Terms Aggregation. Extended it and added a convenience method for setting a background filter. Simple tests added, although they may not be very good examples: SignificantTerms doesn't shine on automatically generated datasets.