### PR TITLE
Cardinality properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file based on the
 - Multiple rescore query [#820](https://github.com/ruflin/Elastica/issues/820/)
 - Support for a custom connection timeout through a connectTimeout parameter. [#841](https://github.com/ruflin/Elastica/issues/841/)
 - SignificantTerms Aggregation [#847](https://github.com/ruflin/Elastica/issues/847/)
+- Support for 'precision_threshold' and 'rehash' options for the Cardinality Aggregation [#851]
 
 
 ### Improvements

--- a/lib/Elastica/Aggregation/AbstractAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractAggregation.php
@@ -28,6 +28,7 @@ abstract class AbstractAggregation extends Param
     /**
      * Set the name of this aggregation
      * @param string $name
+     * @return $this
      */
     public function setName($name)
     {

--- a/lib/Elastica/Aggregation/Cardinality.php
+++ b/lib/Elastica/Aggregation/Cardinality.php
@@ -9,4 +9,17 @@ namespace Elastica\Aggregation;
  */
 class Cardinality extends AbstractSimpleAggregation
 {
+    /**
+     * @param int $precisionThreshold
+     *
+     * @return $this
+     */
+    public function setPrecisionThreshold($precisionThreshold)
+    {
+        if (!is_int($precisionThreshold)) {
+            throw new \InvalidArgumentException('precision_threshold only supports integer values');
+        }
+
+        return $this->setParam("precision_threshold", $precisionThreshold);
+    }
 }

--- a/lib/Elastica/Aggregation/Cardinality.php
+++ b/lib/Elastica/Aggregation/Cardinality.php
@@ -22,4 +22,18 @@ class Cardinality extends AbstractSimpleAggregation
 
         return $this->setParam("precision_threshold", $precisionThreshold);
     }
+
+    /**
+     * @param bool $rehash
+     *
+     * @return $this
+     */
+    public function setRehash($rehash)
+    {
+        if (!is_bool($rehash)) {
+            throw new \InvalidArgumentException('rehash only supports boolean values');
+        }
+
+        return $this->setParam("rehash", $rehash);
+    }
 }

--- a/test/lib/Elastica/Test/Aggregation/CardinalityTest.php
+++ b/test/lib/Elastica/Test/Aggregation/CardinalityTest.php
@@ -78,4 +78,47 @@ class CardinalityTest extends BaseAggregationTest
             'more-than-max' => array(40001),
         );
     }
+
+    /**
+     * @dataProvider validRehashProvider
+     * @param bool $rehash
+     */
+    public function testRehash($rehash)
+    {
+        $agg = new Cardinality('rehash');
+        $agg->setRehash($rehash);
+
+        $this->assertNotNull($agg->getParam('rehash'));
+        $this->assertInternalType('boolean', $agg->getParam('rehash'));
+    }
+
+    /**
+     * @dataProvider invalidRehashProvider
+     * @expectedException \InvalidArgumentException
+     * @param mixed $rehash
+     */
+    public function testInvalidRehash($rehash)
+    {
+        $agg = new Cardinality('rehash');
+        $agg->setRehash($rehash);
+    }
+
+    public function invalidRehashProvider()
+    {
+        return array(
+            'string' => array('100'),
+            'int' => array(100),
+            'float' => array(7.8),
+            'array' => array(array()),
+            'object' => array(new \StdClass),
+        );
+    }
+
+    public function validRehashProvider()
+    {
+        return array(
+            'true' => array(true),
+            'false' => array(false),
+        );
+    }
 }

--- a/test/lib/Elastica/Test/Aggregation/CardinalityTest.php
+++ b/test/lib/Elastica/Test/Aggregation/CardinalityTest.php
@@ -33,4 +33,49 @@ class CardinalityTest extends BaseAggregationTest
 
         $this->assertEquals(3, $results['value']);
     }
+
+    /**
+     * @dataProvider invalidPrecisionThresholdProvider
+     * @expectedException \InvalidArgumentException
+     * @param $threshold
+     */
+    public function testInvalidPrecisionThreshold($threshold)
+    {
+        $agg = new Cardinality('threshold');
+        $agg->setPrecisionThreshold($threshold);
+    }
+
+    /**
+     * @dataProvider validPrecisionThresholdProvider
+     * @param $threshold
+     */
+    public function testPrecisionThreshold($threshold)
+    {
+        $agg = new Cardinality('threshold');
+        $agg->setPrecisionThreshold($threshold);
+
+        $this->assertNotNull($agg->getParam('precision_threshold'));
+        $this->assertInternalType('int', $agg->getParam('precision_threshold'));
+    }
+
+    public function invalidPrecisionThresholdProvider()
+    {
+        return array(
+            'string' => array('100'),
+            'float' => array(7.8),
+            'boolean' => array(true),
+            'array' => array(array()),
+            'object' => array(new \StdClass),
+        );
+    }
+
+    public function validPrecisionThresholdProvider()
+    {
+        return array(
+            'negative-int' => array(-140),
+            'zero' => array(0),
+            'positive-int' => array(150),
+            'more-than-max' => array(40001),
+        );
+    }
 }


### PR DESCRIPTION
This PR introduces the ability to set a couple of properties to the "Cardinality" aggregation as per ES documentation:

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html

The 2 options are:
* precision_threshold (integer)
* rehash (boolean)

Both setters control that the parameter given is of the right type.