### PR TITLE
Deprecation of facets and querybuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Deprecated
 - Facets are deprecated. You are encouraged to migrate to aggregations instead.
+- Elastica\Query\Builder is deprecated. Use new Elastica\QueryBuilder instead.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ All notable changes to this project will be documented in this file based on the
 - Node information is retrieved based on id instead of name as multiple nodes can have the same name.
 
 ### Deprecated
-- Facets are deprecated. You are encouraged to migrate to aggregations instead.
-- Elastica\Query\Builder is deprecated. Use new Elastica\QueryBuilder instead.
+- Facets are deprecated. You are encouraged to migrate to aggregations instead. [#855](https://github.com/ruflin/Elastica/pull/855/)
+- Elastica\Query\Builder is deprecated. Use new Elastica\QueryBuilder instead. [#855](https://github.com/ruflin/Elastica/pull/855/)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to this project will be documented in this file based on the
 - Make host for all tests dynamic to prepare it for a more dynamic test environment #846
 - Node information is retrieved based on id instead of name as multiple nodes can have the same name.
 
-
+### Deprecated
+- Facets are deprecated. You are encouraged to migrate to aggregations instead.
 
 
 

--- a/lib/Elastica/Facet/AbstractFacet.php
+++ b/lib/Elastica/Facet/AbstractFacet.php
@@ -13,6 +13,8 @@ use Elastica\Param;
  * @package Elastica
  * @author Nicolas Ruflin <spam@ruflin.com>
  * @author Jasper van Wanrooy <jasper@vanwanrooy.net>
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 abstract class AbstractFacet extends Param
 {

--- a/lib/Elastica/Facet/DateHistogram.php
+++ b/lib/Elastica/Facet/DateHistogram.php
@@ -10,6 +10,8 @@ namespace Elastica\Facet;
  * @author Raul Martinez Jr  <juneym@gmail.com>
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets-date-histogram-facet.html
  * @link https://github.com/elasticsearch/elasticsearch/issues/591
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 class DateHistogram extends Histogram
 {

--- a/lib/Elastica/Facet/Filter.php
+++ b/lib/Elastica/Facet/Filter.php
@@ -11,6 +11,8 @@ use Elastica\Filter\AbstractFilter;
  * @package Elastica
  * @author Nicolas Ruflin <spam@ruflin.com>
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets-filter-facet.html
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 class Filter extends AbstractFacet
 {

--- a/lib/Elastica/Facet/GeoCluster.php
+++ b/lib/Elastica/Facet/GeoCluster.php
@@ -9,6 +9,8 @@ namespace Elastica\Facet;
  * @package Elastica
  * @author Konstantin Nikiforov <konstantin.nikiforov@gmail.com>
  * @link https://github.com/zenobase/geocluster-facet
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 class GeoCluster extends AbstractFacet
 {

--- a/lib/Elastica/Facet/GeoDistance.php
+++ b/lib/Elastica/Facet/GeoDistance.php
@@ -9,6 +9,8 @@ namespace Elastica\Facet;
  * @package Elastica
  * @author Gerard A. Matthew  <gerard.matthew@gmail.com>
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets-geo-distance-facet.html
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 class GeoDistance extends AbstractFacet
 {

--- a/lib/Elastica/Facet/Histogram.php
+++ b/lib/Elastica/Facet/Histogram.php
@@ -9,6 +9,8 @@ namespace Elastica\Facet;
  * @package Elastica
  * @author Raul Martinez Jr  <juneym@gmail.com>
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets-histogram-facet.html
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 class Histogram extends AbstractFacet
 {

--- a/lib/Elastica/Facet/Query.php
+++ b/lib/Elastica/Facet/Query.php
@@ -11,6 +11,8 @@ use Elastica\Query\AbstractQuery;
  * @package Elastica
  * @author Nicolas Ruflin <spam@ruflin.com>
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets-query-facet.html
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 class Query extends AbstractFacet
 {

--- a/lib/Elastica/Facet/Range.php
+++ b/lib/Elastica/Facet/Range.php
@@ -11,6 +11,8 @@ use Elastica\Exception\InvalidException;
  * @package Elastica
  * @author Jasper van Wanrooy <jasper@vanwanrooy.net>
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets-range-facet.html
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 class Range extends AbstractFacet
 {

--- a/lib/Elastica/Facet/Statistical.php
+++ b/lib/Elastica/Facet/Statistical.php
@@ -9,6 +9,8 @@ namespace Elastica\Facet;
  * @package Elastica
  * @author Robert Katzki <robert@katzki.de>
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets-statistical-facet.html
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 class Statistical extends AbstractFacet
 {

--- a/lib/Elastica/Facet/Terms.php
+++ b/lib/Elastica/Facet/Terms.php
@@ -13,6 +13,8 @@ use Elastica\Script;
  * @author Nicolas Ruflin <spam@ruflin.com>
  * @author Jasper van Wanrooy <jasper@vanwanrooy.net>
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets-terms-facet.html
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 class Terms extends AbstractFacet
 {

--- a/lib/Elastica/Facet/TermsStats.php
+++ b/lib/Elastica/Facet/TermsStats.php
@@ -11,6 +11,8 @@ use Elastica\Exception\InvalidException;
  * @package Elastica
  * @author Tom Michaelis <tom.michaelis@gmail.com>
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets-terms-stats-facet.html
+ *
+ * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
 class TermsStats extends AbstractFacet
 {

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -301,6 +301,8 @@ class Query extends Param
      * @param  array $facets List of facet objects
      * @return $this
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-facets.html
+     *
+     * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
      */
     public function setFacets(array $facets)
     {
@@ -317,6 +319,8 @@ class Query extends Param
      *
      * @param  \Elastica\Facet\AbstractFacet $facet Facet object
      * @return $this
+     *
+     * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
      */
     public function addFacet(AbstractFacet $facet)
     {

--- a/lib/Elastica/Query/Builder.php
+++ b/lib/Elastica/Query/Builder.php
@@ -13,6 +13,8 @@ use Elastica\JSON;
  * @package Elastica
  * @author Chris Gedrim <chris@gedr.im>
  * @link http://www.elastic.co/
+ *
+ * @deprecated This builder is deprecated and will be removed. Use new Elastica\QueryBuilder instead.
  **/
 class Builder extends AbstractQuery
 {

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -166,6 +166,8 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      * Returns whether facets exist
      *
      * @return boolean Facet existence
+     *
+     * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
      */
     public function hasFacets()
     {
@@ -220,6 +222,8 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      * Returns all facets results
      *
      * @return array Facet results
+     *
+     * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
      */
     public function getFacets()
     {

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -448,7 +448,7 @@ class Search
     /**
      *
      * @param  mixed         $query
-     * @param $fullResult (default = false) By default only the total hit count is returned. If set to true, the full ResultSet including facets is returned.
+     * @param $fullResult (default = false) By default only the total hit count is returned. If set to true, the full ResultSet including aggregations is returned.
      * @return int|ResultSet
      */
     public function count($query = '', $fullResult = false)


### PR DESCRIPTION
This changeset just adds `@deprecated` to old classes and functions, so we can remove them in the future.

Facets issues to be closed: #630, #409, #648.
Builder issues to be closed: #638, #433, #426.
Branch to be removed: [query-builder](https://github.com/ruflin/Elastica/tree/query-builder)

I'm not sure should `E_USER_DEPRECATED` be triggered or docblock+release note is enough?