### PR TITLE
Use Util function to check for debugging

### DIFF
--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -105,7 +105,7 @@ class Guzzle extends AbstractTransport
 
         $response = new Response((string) $res->getBody(), $res->getStatusCode());
 
-        if (defined('DEBUG') && DEBUG) {
+        if (\Elastica\Util::debugEnabled()) {
             $response->setQueryTime($end - $start);
         }
 

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -129,7 +129,7 @@ class Http extends AbstractTransport
 
         curl_setopt($conn, CURLOPT_CUSTOMREQUEST, $httpMethod);
 
-        if (defined('DEBUG') && DEBUG) {
+        if (\Elastica\Util::debugEnabled()) {
             // Track request headers when in debug mode
             curl_setopt($conn, CURLINFO_HEADER_OUT, true);
         }
@@ -148,7 +148,7 @@ class Http extends AbstractTransport
 
         $response = new Response($responseString, curl_getinfo($this->_getConnection(), CURLINFO_HTTP_CODE));
 
-        if (defined('DEBUG') && DEBUG) {
+        if (\Elastica\Util::debugEnabled()) {
             $response->setQueryTime($end - $start);
         }
 

--- a/lib/Elastica/Transport/HttpAdapter.php
+++ b/lib/Elastica/Transport/HttpAdapter.php
@@ -64,7 +64,7 @@ class HttpAdapter extends AbstractTransport
 
         $elasticaResponse = $this->_createElasticaResponse($httpAdapterResponse, $connection);
 
-        if (defined('DEBUG') && DEBUG) {
+        if (\Elastica\Util::debugEnabled()) {
             $elasticaResponse->setQueryTime($end - $start);
         }
 

--- a/lib/Elastica/Transport/Memcache.php
+++ b/lib/Elastica/Transport/Memcache.php
@@ -82,7 +82,7 @@ class Memcache extends AbstractTransport
 
         $response = new Response($responseString);
 
-        if (defined('DEBUG') && DEBUG) {
+        if (\Elastica\Util::debugEnabled()) {
             $response->setQueryTime($end - $start);
         }
 

--- a/lib/Elastica/Transport/Thrift.php
+++ b/lib/Elastica/Transport/Thrift.php
@@ -160,7 +160,7 @@ class Thrift extends AbstractTransport
             throw new ThriftException($e, $request, $response);
         }
 
-        if (defined('DEBUG') && DEBUG) {
+        if (\Elastica\Util::debugEnabled()) {
             $response->setQueryTime($end - $start);
         }
 

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -186,4 +186,12 @@ class Util
 
         return $message;
     }
+
+    /**
+     * @return bool Returns true if debugging is enabled, otherwise false
+     */
+    public static function debugEnabled()
+    {
+        return defined('DEBUG') && DEBUG;
+    }
 }

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -142,7 +142,7 @@ class Base extends \PHPUnit_Framework_TestCase
      */
     protected static function _checkDebug() {
 
-        if (defined('DEBUG') === false || DEBUG === false) {
+        if (! \Elastica\Util::debugEnabled()) {
             self::markTestSkipped('The DEBUG constant must be set to true for this test to run');
         }
     }


### PR DESCRIPTION
 Method in Utli instead of checking for constants in every class. This is related to #861 to have the debug variables only in one place which makes it easier to debug and change it.