### PR TITLE
Pass term arguments to Query\Term constructor

### DIFF
--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -499,9 +499,9 @@ class Query implements DSL
      *
      * @return Term
      */
-    public function term()
+    public function term(array $term = array())
     {
-        return new Term();
+        return new Term($term);
     }
 
     /**

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -497,6 +497,8 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html
      *
+     * @param array $term
+     * 
      * @return Term
      */
     public function term(array $term = array())


### PR DESCRIPTION
The arguments where missing from the QueryBuilder