### PR TITLE
Removed the deprecated warning for Type::deleteByQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 - Fixed segmentation fault in PHP7 [#868](https://github.com/ruflin/Elastica/pull/868)
+- Removed deprecation for Elastica\Type::deleteByQuery [875] https://github.com/ruflin/Elastica/pull/875
 
 ### Improvements
 - `CallbackStrategy` now will accept any `callable` as callback, not only instance of `Closure`. [#871](https://github.com/ruflin/Elastica/pull/871)

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -474,7 +474,6 @@ class Type implements SearchableInterface
      * @return \Elastica\Response
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
-     * @deprecated Delete by Query api is deprecated as of ES 1.5, and will be removed in ES 2.0
      */
     public function deleteByQuery($query, array $options = array())
     {


### PR DESCRIPTION
I can't find any documentation on https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html mentioning that the deleteByQuery for type is deprecated.

Note there is a deprecated message for The ability to specify async replication is deprecated and will be removed in version 2.0.0.
