### PR TITLE
Remove gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-/ansible export-ignore
-/test export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
-.travis.yml export-ignore
-.coveralls.yml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 
 before_script:
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "7" ]; then echo "extension=memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
-  - if $(phpenv version-name | grep -q '5.3'); then sudo composer update --no-dev; fi
+  - if $(phpenv version-name | grep -q '5.3'); then sudo composer update --no-dev; sudo composer dump-autoload; fi
 
 script:
   - make phpunit

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Elastica\\": "lib/Elastica/",
+            "Elastica\\": "lib/Elastica/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Elastica\\Test\\": "test/lib/Elastica/Test/"
         }
     },


### PR DESCRIPTION
As far as I see, existence of `export-ignore` feature in context of php packages distribution it's just a reason for lots of debates.

It was discussed in #869 and #745, and also in many places across internet, but for now it's not widely used, hence developers most likely will not know answer for "why part of the library is missing in my installation".

Also, most of packages I've seen while thinking about this issue follows the same scenario: "add export-ignore" -> "issues arrived" -> "remove export-ignore". 

I suggest to remove this file completely.