### PR TITLE
QueryBuilder methods should have same signatures as corresponding constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 - `CallbackStrategy` now will accept any `callable` as callback, not only instance of `Closure`. [#871](https://github.com/ruflin/Elastica/pull/871)
 - `StrategyFactory` now will try to find predefined strategy before looking to global namespace. [#877](https://github.com/ruflin/Elastica/pull/877)
-
+- Methods of classes in `QueryBuilder\DSL` namespace now have exact same signatures as corresponding constructors. [#878](https://github.com/ruflin/Elastica/pull/878)
+- Constructor of `Aggregation\Filter` now accepts filter as second parameter [#878](https://github.com/ruflin/Elastica/pull/878)
+- Constructor of `Filter\AbstractMulti` (`BoolAnd`, `BooldOr`) now accepts array of filters as parameter [#878](https://github.com/ruflin/Elastica/pull/878)
 
 ## [2.1.0](https://github.com/ruflin/Elastica/releases/tag/2.1.0) - 2015-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file based on the
 - Methods of classes in `QueryBuilder\DSL` namespace now have exact same signatures as corresponding constructors. [#878](https://github.com/ruflin/Elastica/pull/878)
 - Constructor of `Aggregation\Filter` now accepts filter as second parameter [#878](https://github.com/ruflin/Elastica/pull/878)
 - Constructor of `Filter\AbstractMulti` (`BoolAnd`, `BooldOr`) now accepts array of filters as parameter [#878](https://github.com/ruflin/Elastica/pull/878)
+- Constructor of `Query\Match` now accepts arguments [#878](https://github.com/ruflin/Elastica/pull/878)
 
 ## [2.1.0](https://github.com/ruflin/Elastica/releases/tag/2.1.0) - 2015-06-01
 

--- a/lib/Elastica/Aggregation/Filter.php
+++ b/lib/Elastica/Aggregation/Filter.php
@@ -11,6 +11,19 @@ use Elastica\Filter\AbstractFilter;
 class Filter extends AbstractAggregation
 {
     /**
+     * @param string         $name
+     * @param AbstractFilter $filter
+     */
+    public function __construct($name, AbstractFilter $filter = null)
+    {
+        parent::__construct($name);
+
+        if ($filter !== null) {
+            $this->setFilter($filter);
+        }
+    }
+
+    /**
      * Set the filter for this aggregation.
      *
      * @param AbstractFilter $filter

--- a/lib/Elastica/Filter/AbstractMulti.php
+++ b/lib/Elastica/Filter/AbstractMulti.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 /**
@@ -21,7 +20,9 @@ abstract class AbstractMulti extends AbstractFilter
      */
     public function __construct(array $filters = array())
     {
-        $this->setFilters($filters);
+        if (!empty($filters)) {
+            $this->setFilters($filters);
+        }
     }
 
     /**

--- a/lib/Elastica/Filter/AbstractMulti.php
+++ b/lib/Elastica/Filter/AbstractMulti.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Filter;
 
 /**
@@ -14,6 +15,14 @@ abstract class AbstractMulti extends AbstractFilter
      * @var array
      */
     protected $_filters = array();
+
+    /**
+     * @param \Elastica\Filter\AbstractFilter $filters
+     */
+    public function __construct(array $filters = array())
+    {
+        $this->setFilters($filters);
+    }
 
     /**
      * Add filter.

--- a/lib/Elastica/Filter/Type.php
+++ b/lib/Elastica/Filter/Type.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 /**

--- a/lib/Elastica/Filter/Type.php
+++ b/lib/Elastica/Filter/Type.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Filter;
 
 /**
@@ -20,12 +21,12 @@ class Type extends AbstractFilter
     /**
      * Construct Type Filter.
      *
-     * @param string $typeName Type name
+     * @param string $type Type name
      */
-    public function __construct($typeName = null)
+    public function __construct($type = null)
     {
-        if ($typeName) {
-            $this->setType($typeName);
+        if ($type) {
+            $this->setType($type);
         }
     }
 

--- a/lib/Elastica/Query/Match.php
+++ b/lib/Elastica/Query/Match.php
@@ -15,6 +15,17 @@ class Match extends AbstractQuery
     const ZERO_TERM_ALL = 'all';
 
     /**
+     * @param string $field
+     * @param mixed  $values
+     */
+    public function __construct($field = null, $values = null)
+    {
+        if ($field !== null && $values !== null) {
+            $this->setParam($field, $values);
+        }
+    }
+
+    /**
      * Sets a param for the message array.
      *
      * @param string $field

--- a/lib/Elastica/QueryBuilder/DSL/Aggregation.php
+++ b/lib/Elastica/QueryBuilder/DSL/Aggregation.php
@@ -258,12 +258,9 @@ class Aggregation implements DSL
      *
      * @return FilterAggregation
      */
-    public function filter($name, AbstractFilter $filter)
+    public function filter($name, AbstractFilter $filter = null)
     {
-        $filterAgg = new FilterAggregation($name);
-        $filterAgg->setFilter($filter);
-
-        return $filterAgg;
+        return new FilterAggregation($name, $filter);
     }
 
     /**
@@ -315,11 +312,12 @@ class Aggregation implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-reverse-nested-aggregation.html
      *
-     * @param string $name
+     * @param string $name The name of this aggregation
+     * @param string $path Optional path to the nested object for this aggregation. Defaults to the root of the main document.
      *
      * @return ReverseNested
      */
-    public function reverse_nested($name)
+    public function reverse_nested($name, $path = null)
     {
         return new ReverseNested($name);
     }

--- a/lib/Elastica/QueryBuilder/DSL/Filter.php
+++ b/lib/Elastica/QueryBuilder/DSL/Filter.php
@@ -62,12 +62,9 @@ class Filter implements DSL
      *
      * @return BoolAnd
      */
-    public function bool_and(array $filters)
+    public function bool_and(array $filters = array())
     {
-        $and = new BoolAnd();
-        $and->setFilters($filters);
-
-        return $and;
+        return new BoolAnd($filters);
     }
 
     /**
@@ -101,14 +98,14 @@ class Filter implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-filter.html
      *
-     * @param string $field
+     * @param string $key
      * @param array  $coordinates
      *
      * @return GeoBoundingBox
      */
-    public function geo_bounding_box($field, array $coordinates)
+    public function geo_bounding_box($key, array $coordinates)
     {
-        return new GeoBoundingBox($field, $coordinates);
+        return new GeoBoundingBox($key, $coordinates);
     }
 
     /**
@@ -197,16 +194,16 @@ class Filter implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geohash-cell-filter.html
      *
-     * @param string       $field     The field on which to filter
+     * @param string       $key       The field on which to filter
      * @param array|string $location  Location as coordinates array or geohash string ['lat' => 40.3, 'lon' => 45.2]
      * @param int|string   $precision length of geohash prefix or distance (3, or "50m")
      * @param bool         $neighbors If true, filters cells next to the given cell.
      *
      * @return GeohashCell
      */
-    public function geohash_cell($field, $location, $precision = -1, $neighbors = false)
+    public function geohash_cell($key, $location, $precision = -1, $neighbors = false)
     {
-        return new GeohashCell($field, $location, $precision, $neighbors);
+        return new GeohashCell($key, $location, $precision, $neighbors);
     }
 
     /**
@@ -219,7 +216,7 @@ class Filter implements DSL
      *
      * @return HasChild
      */
-    public function has_child($query, $type)
+    public function has_child($query, $type = null)
     {
         return new HasChild($query, $type);
     }
@@ -249,7 +246,7 @@ class Filter implements DSL
      *
      * @return Ids
      */
-    public function ids($type, array $ids)
+    public function ids($type = null, array $ids = array())
     {
         return new Ids($type, $ids);
     }
@@ -304,7 +301,7 @@ class Filter implements DSL
      *
      * @return Missing
      */
-    public function missing($field)
+    public function missing($field = '')
     {
         return new Missing($field);
     }
@@ -340,11 +337,14 @@ class Filter implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/0.90/query-dsl-numeric-range-filter.html
      *
+     * @param string $fieldName Field name
+     * @param array  $args      Field arguments
+     *
      * @return NumericRange
      */
-    public function numeric_range()
+    public function numeric_range($fieldName = '', array $args = array())
     {
-        return new NumericRange();
+        return new NumericRange($fieldName, $args);
     }
 
     /**
@@ -356,12 +356,9 @@ class Filter implements DSL
      *
      * @return BoolOr
      */
-    public function bool_or($filters)
+    public function bool_or(array $filters = array())
     {
-        $or = new BoolOr();
-        $or->setFilters($filters);
-
-        return $or;
+        return new BoolOr($filters);
     }
 
     /**
@@ -374,7 +371,7 @@ class Filter implements DSL
      *
      * @return Prefix
      */
-    public function prefix($field, $prefix)
+    public function prefix($field = '', $prefix = '')
     {
         return new Prefix($field, $prefix);
     }
@@ -384,11 +381,11 @@ class Filter implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-filter.html
      *
-     * @param AbstractQuery $query
+     * @param array|AbstractQuery $query
      *
      * @return QueryFilter
      */
-    public function query(AbstractQuery $query)
+    public function query($query = null)
     {
         return new QueryFilter($query);
     }
@@ -403,7 +400,7 @@ class Filter implements DSL
      *
      * @return Range
      */
-    public function range($fieldName, array $args)
+    public function range($fieldName = '', array $args = array())
     {
         return new Range($fieldName, $args);
     }
@@ -413,14 +410,15 @@ class Filter implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-filter.html
      *
-     * @param string $field
-     * @param string $regexp
+     * @param string $field   Field name
+     * @param string $regexp  Regular expression
+     * @param array  $options Regular expression options
      *
      * @return Regexp
      */
-    public function regexp($field, $regexp)
+    public function regexp($field = '', $regexp = '', $options = array())
     {
-        return new Regexp($field, $regexp);
+        return new Regexp($field, $regexp, $options);
     }
 
     /**
@@ -432,7 +430,7 @@ class Filter implements DSL
      *
      * @return Script
      */
-    public function script($script)
+    public function script($script = null)
     {
         return new Script($script);
     }
@@ -456,14 +454,14 @@ class Filter implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-filter.html
      *
-     * @param string $field
+     * @param string $key
      * @param array  $terms
      *
      * @return Terms
      */
-    public function terms($field, array $terms)
+    public function terms($key = '', array $terms = array())
     {
-        return new Terms($field, $terms);
+        return new Terms($key, $terms);
     }
 
     /**
@@ -475,7 +473,7 @@ class Filter implements DSL
      *
      * @return Type
      */
-    public function type($type)
+    public function type($type = null)
     {
         return new Type($type);
     }

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -160,11 +160,13 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-constant-score-query.html
      *
+     * @param null|\Elastica\Filter\AbstractFilter|array $filter
+     *
      * @return ConstantScore
      */
-    public function constant_score()
+    public function constant_score($filter = null)
     {
-        return new ConstantScore();
+        return new ConstantScore($filter);
     }
 
     /**
@@ -199,7 +201,7 @@ class Query implements DSL
      *
      * @return Filtered
      */
-    public function filtered(AbstractQuery $query, AbstractFilter $filter)
+    public function filtered(AbstractQuery $query = null, AbstractFilter $filter = null)
     {
         return new Filtered($query, $filter);
     }
@@ -243,11 +245,14 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html
      *
+     * @param string $fieldName Field name
+     * @param string $value     String to search for
+     *
      * @return Fuzzy
      */
-    public function fuzzy()
+    public function fuzzy($fieldName = null, $value = null)
     {
-        return new Fuzzy();
+        return new Fuzzy($fieldName, $value);
     }
 
     /**
@@ -265,12 +270,12 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
      *
-     * @param AbstractQuery $query
-     * @param null|string   $type
+     * @param string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
+     * @param string                                               $type  Parent document type
      *
      * @return HasChild
      */
-    public function has_child(AbstractQuery $query, $type = null)
+    public function has_child($query, $type = null)
     {
         return new HasChild($query, $type);
     }
@@ -280,12 +285,12 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
      *
-     * @param AbstractQuery $query
-     * @param string        $type
+     * @param string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
+     * @param string                                               $type  Parent document type
      *
      * @return HasParent
      */
-    public function has_parent(AbstractQuery $query, $type)
+    public function has_parent($query, $type)
     {
         return new HasParent($query, $type);
     }
@@ -300,7 +305,7 @@ class Query implements DSL
      *
      * @return Ids
      */
-    public function ids($type, array $ids)
+    public function ids($type = null, array $ids = array())
     {
         return new Ids($type, $ids);
     }
@@ -367,11 +372,13 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
      *
+     * @param array $prefix Prefix array
+     *
      * @return Prefix
      */
-    public function prefix()
+    public function prefix(array $prefix = array())
     {
-        return new Prefix();
+        return new Prefix($prefix);
     }
 
     /**
@@ -379,11 +386,13 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
      *
+     * @param string $queryString OPTIONAL Query string for object
+     *
      * @return QueryString
      */
-    public function query_string()
+    public function query_string($queryString = '')
     {
-        return new QueryString();
+        return new QueryString($queryString);
     }
 
     /**
@@ -411,7 +420,7 @@ class Query implements DSL
      *
      * @return Range
      */
-    public function range($fieldName, array $args)
+    public function range($fieldName = null, array $args = array())
     {
         return new Range($fieldName, $args);
     }
@@ -419,7 +428,7 @@ class Query implements DSL
     /**
      * regexp query.
      *
-     * @param string $fieldName
+     * @param string $key
      * @param string $value
      * @param float  $boost
      *
@@ -427,9 +436,9 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html
      */
-    public function regexp($fieldName, $value, $boost)
+    public function regexp($key = '', $value = null, $boost = 1.0)
     {
-        return new Regexp($fieldName, $value, $boost);
+        return new Regexp($key, $value, $boost);
     }
 
     /**
@@ -511,14 +520,14 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
      *
-     * @param string $field
+     * @param string $key
      * @param array  $terms
      *
      * @return Terms
      */
-    public function terms($field, array $terms)
+    public function terms($key = '', array $terms = array())
     {
-        return new Terms($field, $terms);
+        return new Terms($key, $terms);
     }
 
     /**
@@ -526,12 +535,12 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-top-children-query.html
      *
-     * @param AbstractQuery $query
-     * @param string        $type
+     * @param string|AbstractQuery|\Elastica\Query $query
+     * @param string                               $type
      *
      * @return TopChildren
      */
-    public function top_children(AbstractQuery $query, $type)
+    public function top_children($query, $type = null)
     {
         return new TopChildren($query, $type);
     }
@@ -541,11 +550,15 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
      *
+     * @param string $key   OPTIONAL Wildcard key
+     * @param string $value OPTIONAL Wildcard value
+     * @param float  $boost OPTIONAL Boost value (default = 1)
+     *
      * @return Wildcard
      */
-    public function wildcard()
+    public function wildcard($key = '', $value = null, $boost = 1.0)
     {
-        return new Wildcard();
+        return new Wildcard($key, $value, $boost);
     }
 
     /**

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -56,21 +56,14 @@ class Query implements DSL
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
      *
-     * @param null|string $field
-     * @param null|string $value
+     * @param string $field
+     * @param mixed  $values
      *
      * @return Match
      */
-    public function match($field = null, $value = null)
+    public function match($field = null, $values = null)
     {
-        if ($field !== null && $value !== null) {
-            $match = new Match();
-            $match->setParam($field, $value);
-
-            return $match;
-        }
-
-        return new Match();
+        return new Match($field, $values);
     }
 
     /**

--- a/test/lib/Elastica/Test/Aggregation/FilterTest.php
+++ b/test/lib/Elastica/Test/Aggregation/FilterTest.php
@@ -83,4 +83,31 @@ class FilterTest extends BaseAggregationTest
 
         $this->assertEquals((5 + 8 + 1 + 3) / 4.0, $results);
     }
+
+    /**
+     * @group unit
+     */
+    public function testConstruct()
+    {
+        $agg = new Filter('foo', new Term(array('color' => 'blue')));
+
+        $expected = array(
+            'filter' => array(
+                'term' => array(
+                    'color' => 'blue',
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $agg->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testConstructWithoutFilter()
+    {
+        $agg = new Filter('foo');
+        $this->assertEquals('foo', $agg->getName());
+    }
 }

--- a/test/lib/Elastica/Test/Filter/BoolAndTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolAndTest.php
@@ -66,4 +66,21 @@ class BoolAndTest extends BaseTest
 
         $this->assertEquals(1, $resultSet->count());
     }
+
+    /**
+     * @group unit
+     */
+    public function testConstruct()
+    {
+        $ids1 = new Ids('foo', array(1, 2));
+        $ids2 = new Ids('bar', array(3, 4));
+
+        $and1 = new BoolAnd(array($ids1, $ids2));
+
+        $and2 = new BoolAnd();
+        $and2->addFilter($ids1);
+        $and2->addFilter($ids2);
+
+        $this->assertEquals($and1->toArray(), $and2->toArray());
+    }
 }

--- a/test/lib/Elastica/Test/Filter/BoolOrTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolOrTest.php
@@ -43,4 +43,21 @@ class BoolOrTest extends BaseTest
 
         $this->assertEquals($expectedArray, $orFilter->toArray());
     }
+
+    /**
+     * @group unit
+     */
+    public function testConstruct()
+    {
+        $ids1 = new Ids('foo', array(1, 2));
+        $ids2 = new Ids('bar', array(3, 4));
+
+        $and1 = new BoolOr(array($ids1, $ids2));
+
+        $and2 = new BoolOr();
+        $and2->addFilter($ids1);
+        $and2->addFilter($ids2);
+
+        $this->assertEquals($and1->toArray(), $and2->toArray());
+    }
 }

--- a/test/lib/Elastica/Test/Query/MatchTest.php
+++ b/test/lib/Elastica/Test/Query/MatchTest.php
@@ -319,4 +319,21 @@ class MatchTest extends BaseTest
         $parameters = $query->getParam($field);
         $this->assertEquals($fuzziness, $parameters['fuzziness']);
     }
+
+    /**
+     * @group unit
+     */
+    public function testConstruct()
+    {
+        $match = new Match(null, 'values');
+        $this->assertEquals(array('match' => array()), $match->toArray());
+
+        $match = new Match('field', null);
+        $this->assertEquals(array('match' => array()), $match->toArray());
+
+        $match1 = new Match('field', 'values');
+        $match2 = new Match();
+        $match2->setField('field', 'values');
+        $this->assertEquals($match1->toArray(), $match2->toArray());
+    }
 }

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/AbstractDSLTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/AbstractDSLTest.php
@@ -1,0 +1,97 @@
+<?php
+namespace Elastica\Test\QueryBuilder\DSL;
+
+use Elastica\Exception\NotImplementedException;
+use Elastica\QueryBuilder\DSL;
+use Elastica\Test\Base as BaseTest;
+
+abstract class AbstractDSLTest extends BaseTest
+{
+    /**
+     * @param DSL    $dsl
+     * @param string $methodName
+     * @param string $className
+     * @param array  $arguments
+     */
+    protected function _assertImplemented(DSL $dsl, $methodName, $className, $arguments)
+    {
+        // Check method existence
+        $this->assertTrue(method_exists($dsl, $methodName));
+
+        // Check returned value
+        $return = call_user_func_array(array($dsl, $methodName), $arguments);
+        $this->assertTrue(class_exists($className), 'Class not exists but NotImplementedException is not thrown');
+        $this->assertInstanceOf($className, $return);
+
+        // Check method signature
+        $class = new \ReflectionClass($className);
+        $method = new \ReflectionMethod(get_class($dsl), $methodName);
+        if (!$class->hasMethod('__construct')) {
+            $this->assertEmpty($method->getParameters(), 'Constructor is not defined, but method has some parameters');
+        } else {
+            $this->_assertParametersEquals($class->getMethod('__construct')->getParameters(), $method->getParameters());
+        }
+    }
+
+    /**
+     * @param DSL    $dsl
+     * @param string $name
+     */
+    protected function _assertNotImplemented(DSL $dsl, $methodName, $arguments)
+    {
+        try {
+            call_user_func(array($dsl, $methodName), $arguments);
+            $this->fail('NotImplementedException is not thrown');
+        } catch (NotImplementedException $ex) {
+            // expected
+        }
+    }
+
+    /**
+     * @param \ReflectionParameter[] $left
+     * @param \ReflectionParameter[] $right
+     */
+    protected function _assertParametersEquals($left, $right)
+    {
+        $this->assertEquals(count($left), count($right), 'Parameters count mismatch');
+
+        for ($i = 0; $i < count($left); $i++) {
+            $this->assertEquals($left[$i]->getName(), $right[$i]->getName(), 'Parameters names mismatch');
+            $this->assertEquals($left[$i]->isOptional(), $right[$i]->isOptional(), 'Parameters optionality mismatch');
+            $this->assertEquals($this->_getHintName($left[$i]), $this->_getHintName($right[$i]), 'Parameters typehints mismatch');
+            $this->assertEquals($this->_getDefaultValue($left[$i]), $this->_getDefaultValue($right[$i]), 'Default values mismatch');
+        }
+    }
+
+    /**
+     * @param \ReflectionParameter $param
+     *
+     * @return string|null
+     */
+    protected function _getDefaultValue(\ReflectionParameter $param)
+    {
+        if ($param->isOptional()) {
+            return $param->getDefaultValue();
+        }
+    }
+
+    /**
+     * @param \ReflectionParameter $param
+     *
+     * @return string|null
+     */
+    protected function _getHintName(\ReflectionParameter $param)
+    {
+        if ($param->isCallable()) {
+            return 'callable';
+        }
+
+        if ($param->isArray()) {
+            return 'array';
+        }
+
+        if ($class = $param->getClass()) {
+            return $class->getName();
+        }
+    }
+}

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/AbstractDSLTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/AbstractDSLTest.php
@@ -82,7 +82,7 @@ abstract class AbstractDSLTest extends BaseTest
      */
     protected function _getHintName(\ReflectionParameter $param)
     {
-        if ($param->isCallable()) {
+        if (version_compare(phpversion(), '5.4', '>=') && $param->isCallable()) {
             return 'callable';
         }
 

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/AggregationTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/AggregationTest.php
@@ -3,9 +3,8 @@ namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\Filter\Exists;
 use Elastica\QueryBuilder\DSL;
-use Elastica\Test\Base as BaseTest;
 
-class AggregationTest extends BaseTest
+class AggregationTest extends AbstractDSLTest
 {
     /**
      * @group unit
@@ -21,64 +20,39 @@ class AggregationTest extends BaseTest
     /**
      * @group unit
      */
-    public function testAggregations()
+    public function testInterface()
     {
         $aggregationDSL = new DSL\Aggregation();
 
-        foreach ($this->_getAggregations() as $methodName => $arguments) {
-            $this->assertTrue(
-                method_exists($aggregationDSL, $methodName),
-                'method for aggregation "'.$methodName.'" not found'
-            );
+        $this->_assertImplemented($aggregationDSL, 'avg', 'Elastica\Aggregation\Avg', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'cardinality', 'Elastica\Aggregation\Cardinality', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'date_histogram', 'Elastica\Aggregation\DateHistogram', array('name', 'field', 1));
+        $this->_assertImplemented($aggregationDSL, 'date_range', 'Elastica\Aggregation\DateRange', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'extended_stats', 'Elastica\Aggregation\ExtendedStats', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'filter', 'Elastica\Aggregation\Filter', array('name', new Exists('field')));
+        $this->_assertImplemented($aggregationDSL, 'filters', 'Elastica\Aggregation\Filters', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'geo_distance', 'Elastica\Aggregation\GeoDistance', array('name', 'field', 'origin'));
+        $this->_assertImplemented($aggregationDSL, 'geohash_grid', 'Elastica\Aggregation\GeohashGrid', array('name', 'field'));
+        $this->_assertImplemented($aggregationDSL, 'global_agg', 'Elastica\Aggregation\GlobalAggregation', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'histogram', 'Elastica\Aggregation\Histogram', array('name', 'field', 1));
+        $this->_assertImplemented($aggregationDSL, 'ipv4_range', 'Elastica\Aggregation\IpRange', array('name', 'field'));
+        $this->_assertImplemented($aggregationDSL, 'max', 'Elastica\Aggregation\Max', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'min', 'Elastica\Aggregation\Min', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'missing', 'Elastica\Aggregation\Missing', array('name', 'field'));
+        $this->_assertImplemented($aggregationDSL, 'nested', 'Elastica\Aggregation\Nested', array('name', 'path'));
+        $this->_assertImplemented($aggregationDSL, 'percentiles', 'Elastica\Aggregation\Percentiles', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'range', 'Elastica\Aggregation\Range', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'reverse_nested', 'Elastica\Aggregation\ReverseNested', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'scripted_metric', 'Elastica\Aggregation\ScriptedMetric', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'significant_terms', 'Elastica\Aggregation\SignificantTerms', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'stats', 'Elastica\Aggregation\Stats', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'sum', 'Elastica\Aggregation\Sum', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'terms', 'Elastica\Aggregation\Terms', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'top_hits', 'Elastica\Aggregation\TopHits', array('name'));
+        $this->_assertImplemented($aggregationDSL, 'value_count', 'Elastica\Aggregation\ValueCount', array('name', 'field'));
 
-            try {
-                $return = call_user_func_array(array($aggregationDSL, $methodName), $arguments);
-                $this->assertInstanceOf('Elastica\Aggregation\AbstractAggregation', $return);
-            } catch (\Exception $exception) {
-                $this->assertInstanceOf(
-                    'Elastica\Exception\NotImplementedException',
-                    $exception,
-                    'breaking change in aggregation "'.$methodName.'" found: '.$exception->getMessage()
-                );
-            }
-        }
-    }
-
-    /**
-     * @return array
-     */
-    protected function _getAggregations()
-    {
-        return array(
-            'min' => array('name'),
-            'max' => array('name'),
-            'sum' => array('name'),
-            'avg' => array('name'),
-            'stats' => array('name'),
-            'extended_stats' => array('name'),
-            'value_count' => array('name', 'field'),
-            'percentiles' => array('name'),
-            'percentile_ranks' => array('name'),
-            'cardinality' => array('name'),
-            'geo_bounds' => array('name'),
-            'top_hits' => array('name'),
-            'scripted_metric' => array('name'),
-            'global_agg' => array('name'),
-            'filters' => array('name'),
-            'missing' => array('name', 'field'),
-            'nested' => array('name', 'path'),
-            'reverse_nested' => array('name'),
-            'children' => array('name'),
-            'terms' => array('name'),
-            'significant_terms' => array('name'),
-            'range' => array('name'),
-            'date_range' => array('name'),
-            'ipv4_range' => array('name', 'field'),
-            'histogram' => array('name', 'field', 1),
-            'date_histogram' => array('name', 'field', 1),
-            'geo_distance' => array('name', 'field', 'origin'),
-            'geohash_grid' => array('name', 'field'),
-            'filter' => array('name', new Exists('field')),
-        );
+        $this->_assertNotImplemented($aggregationDSL, 'children', array('name'));
+        $this->_assertNotImplemented($aggregationDSL, 'geo_bounds', array('name'));
+        $this->_assertNotImplemented($aggregationDSL, 'percentile_ranks', array('name'));
     }
 }

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/FilterTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/FilterTest.php
@@ -4,9 +4,8 @@ namespace Elastica\Test\QueryBuilder\DSL;
 use Elastica\Filter\Exists;
 use Elastica\Query\Match;
 use Elastica\QueryBuilder\DSL;
-use Elastica\Test\Base as BaseTest;
 
-class FilterTest extends BaseTest
+class FilterTest extends AbstractDSLTest
 {
     /**
      * @group unit
@@ -22,64 +21,38 @@ class FilterTest extends BaseTest
     /**
      * @group unit
      */
-    public function testFilters()
+    public function testInterface()
     {
         $filterDSL = new DSL\Filter();
 
-        foreach ($this->_getFilters() as $methodName => $arguments) {
-            $this->assertTrue(
-                method_exists($filterDSL, $methodName),
-                'method for filter "'.$methodName.'" not found'
-            );
-
-            try {
-                $return = call_user_func_array(array($filterDSL, $methodName), $arguments);
-                $this->assertInstanceOf('Elastica\Filter\AbstractFilter', $return);
-            } catch (\Exception $exception) {
-                $this->assertInstanceOf(
-                    'Elastica\Exception\NotImplementedException',
-                    $exception,
-                    'breaking change in filter "'.$methodName.'" found: '.$exception->getMessage()
-                );
-            }
-        }
-    }
-
-    /**
-     * @return array
-     */
-    protected function _getFilters()
-    {
-        return array(
-            'bool' => array(),
-            'exists' => array('field'),
-            'geo_bounding_box' => array('field', array(1, 2)),
-            'geo_distance' => array('key', 'location', 'distance'),
-            'geo_distance_range' => array('key', 'location'),
-            'geo_polygon' => array('key', array()),
-            'geo_shape_provided' => array('path', array()),
-            'geo_shape_pre_indexed' => array('path', 'indexedId', 'indexedType', 'indexedIndex', 'indexedPath'),
-            'geohash_cell' => array('field', 'location'),
-            'ids' => array('type', array()),
-            'limit' => array(1),
-            'match_all' => array(),
-            'missing' => array('field'),
-            'nested' => array(),
-            'numeric_range' => array(),
-            'prefix' => array('field', 'prefix'),
-            'range' => array('field', array()),
-            'regexp' => array('field', 'regex'),
-            'script' => array('script'),
-            'term' => array(),
-            'terms' => array('field', array()),
-            'type' => array('type'),
-            'bool_and' => array(array(new Exists('field'))),
-            'bool_or' => array(array(new Exists('field'))),
-            'bool_not' => array(new Exists('field')),
-            'has_child' => array(new Match(), 'type'),
-            'has_parent' => array(new Match(), 'type'),
-            'indices' => array(new Exists('field'), array()),
-            'query' => array(new Match()),
-        );
+        $this->_assertImplemented($filterDSL, 'bool', 'Elastica\Filter\BoolFilter', array());
+        $this->_assertImplemented($filterDSL, 'bool_and', 'Elastica\Filter\BoolAnd', array(array(new Exists('field'))));
+        $this->_assertImplemented($filterDSL, 'bool_not', 'Elastica\Filter\BoolNot', array(new Exists('field')));
+        $this->_assertImplemented($filterDSL, 'bool_or', 'Elastica\Filter\BoolOr', array(array(new Exists('field'))));
+        $this->_assertImplemented($filterDSL, 'exists', 'Elastica\Filter\Exists', array('field'));
+        $this->_assertImplemented($filterDSL, 'geo_bounding_box', 'Elastica\Filter\GeoBoundingBox', array('field', array(1, 2)));
+        $this->_assertImplemented($filterDSL, 'geo_distance', 'Elastica\Filter\GeoDistance', array('key', 'location', 'distance'));
+        $this->_assertImplemented($filterDSL, 'geo_distance_range', 'Elastica\Filter\GeoDistanceRange', array('key', 'location'));
+        $this->_assertImplemented($filterDSL, 'geo_polygon', 'Elastica\Filter\GeoPolygon', array('key', array()));
+        $this->_assertImplemented($filterDSL, 'geo_shape_pre_indexed', 'Elastica\Filter\GeoShapePreIndexed', array('path', 'indexedId', 'indexedType', 'indexedIndex', 'indexedPath'));
+        $this->_assertImplemented($filterDSL, 'geo_shape_provided', 'Elastica\Filter\GeoShapeProvided', array('path', array()));
+        $this->_assertImplemented($filterDSL, 'geohash_cell', 'Elastica\Filter\GeohashCell', array('field', 'location'));
+        $this->_assertImplemented($filterDSL, 'has_child', 'Elastica\Filter\HasChild', array(new Match(), 'type'));
+        $this->_assertImplemented($filterDSL, 'has_parent', 'Elastica\Filter\HasParent', array(new Match(), 'type'));
+        $this->_assertImplemented($filterDSL, 'ids', 'Elastica\Filter\Ids', array('type', array()));
+        $this->_assertImplemented($filterDSL, 'indices', 'Elastica\Filter\Indices', array(new Exists('field'), array()));
+        $this->_assertImplemented($filterDSL, 'limit', 'Elastica\Filter\Limit', array(1));
+        $this->_assertImplemented($filterDSL, 'match_all', 'Elastica\Filter\MatchAll', array());
+        $this->_assertImplemented($filterDSL, 'missing', 'Elastica\Filter\Missing', array('field'));
+        $this->_assertImplemented($filterDSL, 'nested', 'Elastica\Filter\Nested', array());
+        $this->_assertImplemented($filterDSL, 'numeric_range', 'Elastica\Filter\NumericRange', array());
+        $this->_assertImplemented($filterDSL, 'prefix', 'Elastica\Filter\Prefix', array('field', 'prefix'));
+        $this->_assertImplemented($filterDSL, 'query', 'Elastica\Filter\Query', array(new Match()));
+        $this->_assertImplemented($filterDSL, 'range', 'Elastica\Filter\Range', array('field', array()));
+        $this->_assertImplemented($filterDSL, 'regexp', 'Elastica\Filter\Regexp', array('field', 'regex'));
+        $this->_assertImplemented($filterDSL, 'script', 'Elastica\Filter\Script', array('script'));
+        $this->_assertImplemented($filterDSL, 'term', 'Elastica\Filter\Term', array());
+        $this->_assertImplemented($filterDSL, 'terms', 'Elastica\Filter\Terms', array('field', array()));
+        $this->_assertImplemented($filterDSL, 'type', 'Elastica\Filter\Type', array('type'));
     }
 }

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/QueryTest.php
@@ -4,9 +4,8 @@ namespace Elastica\Test\QueryBuilder\DSL;
 use Elastica\Filter\Exists;
 use Elastica\Query\Match;
 use Elastica\QueryBuilder\DSL;
-use Elastica\Test\Base as BaseTest;
 
-class QueryTest extends BaseTest
+class QueryTest extends AbstractDSLTest
 {
     /**
      * @group unit
@@ -22,87 +21,64 @@ class QueryTest extends BaseTest
     /**
      * @group unit
      */
-    public function testQueries()
+    public function testMatch()
     {
         $queryDSL = new DSL\Query();
 
-        foreach ($this->_getQueries() as $methodName => $arguments) {
-            $this->assertTrue(
-                method_exists($queryDSL, $methodName),
-                'method for query "'.$methodName.'" not found'
-            );
-
-            try {
-                $return = call_user_func_array(array($queryDSL, $methodName), $arguments);
-                $this->assertInstanceOf('Elastica\Query\AbstractQuery', $return);
-            } catch (\Exception $exception) {
-                $this->assertInstanceOf(
-                    'Elastica\Exception\NotImplementedException',
-                    $exception,
-                    'breaking change in query "'.$methodName.'" found: '.$exception->getMessage()
-                );
-            }
-        }
+        $match = $queryDSL->match('field', 'match');
+        $this->assertEquals('match', $match->getParam('field'));
+        $this->assertInstanceOf('Elastica\Query\Match', $match);
     }
 
     /**
      * @group unit
      */
-    public function testMatch()
+    public function testInterface()
     {
         $queryDSL = new DSL\Query();
 
-        $shortMatch = $queryDSL->match('field', 'match');
-        $this->assertEquals('match', $shortMatch->getParam('field'));
+        $this->_assertImplemented($queryDSL, 'bool', 'Elastica\Query\BoolQuery', array());
+        $this->_assertImplemented($queryDSL, 'boosting', 'Elastica\Query\Boosting', array());
+        $this->_assertImplemented($queryDSL, 'common_terms', 'Elastica\Query\Common', array('field', 'query', 0.001));
+        $this->_assertImplemented($queryDSL, 'constant_score', 'Elastica\Query\ConstantScore', array(new Match()));
+        $this->_assertImplemented($queryDSL, 'dis_max', 'Elastica\Query\DisMax', array());
+        $this->_assertImplemented($queryDSL, 'filtered', 'Elastica\Query\Filtered', array(new Match(), new Exists('field')));
+        $this->_assertImplemented($queryDSL, 'function_score', 'Elastica\Query\FunctionScore', array());
+        $this->_assertImplemented($queryDSL, 'fuzzy', 'Elastica\Query\Fuzzy', array('field', 'type'));
+        $this->_assertImplemented($queryDSL, 'fuzzy_like_this', 'Elastica\Query\FuzzyLikeThis', array());
+        $this->_assertImplemented($queryDSL, 'has_child', 'Elastica\Query\HasChild', array(new Match()));
+        $this->_assertImplemented($queryDSL, 'has_parent', 'Elastica\Query\HasParent', array(new Match(), 'type'));
+        $this->_assertImplemented($queryDSL, 'ids', 'Elastica\Query\Ids', array('type', array()));
+        $this->_assertImplemented($queryDSL, 'match_all', 'Elastica\Query\MatchAll', array());
+        $this->_assertImplemented($queryDSL, 'more_like_this', 'Elastica\Query\MoreLikeThis', array());
+        $this->_assertImplemented($queryDSL, 'multi_match', 'Elastica\Query\MultiMatch', array());
+        $this->_assertImplemented($queryDSL, 'nested', 'Elastica\Query\Nested', array());
+        $this->_assertImplemented($queryDSL, 'prefix', 'Elastica\Query\Prefix', array());
+        $this->_assertImplemented($queryDSL, 'query_string', 'Elastica\Query\QueryString', array());
+        $this->_assertImplemented($queryDSL, 'range', 'Elastica\Query\Range', array('field', array()));
+        $this->_assertImplemented($queryDSL, 'regexp', 'Elastica\Query\Regexp', array('field', 'value', 1.0));
+        $this->_assertImplemented($queryDSL, 'simple_query_string', 'Elastica\Query\SimpleQueryString', array('query'));
+        $this->_assertImplemented($queryDSL, 'term', 'Elastica\Query\Term', array());
+        $this->_assertImplemented($queryDSL, 'terms', 'Elastica\Query\Terms', array('field', array()));
+        $this->_assertImplemented($queryDSL, 'top_children', 'Elastica\Query\TopChildren', array(new Match(), 'type'));
+        $this->_assertImplemented($queryDSL, 'wildcard', 'Elastica\Query\Wildcard', array());
 
-        $this->assertInstanceOf('Elastica\Query\Match', $queryDSL->match());
-    }
-
-    protected function _getQueries()
-    {
-        return array(
-            'multi_match' => array(),
-            'bool' => array(),
-            'boosting' => array(),
-            'common_terms' => array('field', 'query', .001),
-            'custom_filters_score' => array(),
-            'custom_score' => array(),
-            'custom_boost_factor' => array(),
-            'constant_score' => array(),
-            'dis_max' => array(),
-            'field' => array(),
-            'fuzzy_like_this' => array(),
-            'fuzzy_like_this_field' => array(),
-            'function_score' => array(),
-            'fuzzy' => array(),
-            'geo_shape' => array(),
-            'ids' => array('type', array()),
-            'indices' => array(),
-            'match_all' => array(),
-            'more_like_this' => array(),
-            'more_like_this_field' => array(),
-            'nested' => array(),
-            'prefix' => array(),
-            'query_string' => array(),
-            'simple_query_string' => array('query'),
-            'range' => array('field', array()),
-            'regexp' => array('field', 'value', 1.0),
-            'span_first' => array(),
-            'span_multi_term' => array(),
-            'span_near' => array(),
-            'span_not' => array(),
-            'span_or' => array(),
-            'span_term' => array(),
-            'term' => array(),
-            'terms' => array('field', array()),
-            'wildcard' => array(),
-            'text' => array(),
-            'minimum_should_match' => array(),
-            'template' => array(),
-            'filtered' => array(new Match(), new Exists('field')),
-            'has_child' => array(new Match()),
-            'has_parent' => array(new Match(), 'type'),
-            'top_children' => array(new Match(), 'type'),
-        );
+        $this->_assertNotImplemented($queryDSL, 'custom_boost_factor', array());
+        $this->_assertNotImplemented($queryDSL, 'custom_filters_score', array());
+        $this->_assertNotImplemented($queryDSL, 'custom_score', array());
+        $this->_assertNotImplemented($queryDSL, 'field', array());
+        $this->_assertNotImplemented($queryDSL, 'fuzzy_like_this_field', array());
+        $this->_assertNotImplemented($queryDSL, 'geo_shape', array());
+        $this->_assertNotImplemented($queryDSL, 'indices', array());
+        $this->_assertNotImplemented($queryDSL, 'minimum_should_match', array());
+        $this->_assertNotImplemented($queryDSL, 'more_like_this_field', array());
+        $this->_assertNotImplemented($queryDSL, 'span_first', array());
+        $this->_assertNotImplemented($queryDSL, 'span_multi_term', array());
+        $this->_assertNotImplemented($queryDSL, 'span_near', array());
+        $this->_assertNotImplemented($queryDSL, 'span_not', array());
+        $this->_assertNotImplemented($queryDSL, 'span_or', array());
+        $this->_assertNotImplemented($queryDSL, 'span_term', array());
+        $this->_assertNotImplemented($queryDSL, 'template', array());
+        $this->_assertNotImplemented($queryDSL, 'text', array());
     }
 }

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/QueryTest.php
@@ -49,6 +49,7 @@ class QueryTest extends AbstractDSLTest
         $this->_assertImplemented($queryDSL, 'has_child', 'Elastica\Query\HasChild', array(new Match()));
         $this->_assertImplemented($queryDSL, 'has_parent', 'Elastica\Query\HasParent', array(new Match(), 'type'));
         $this->_assertImplemented($queryDSL, 'ids', 'Elastica\Query\Ids', array('type', array()));
+        $this->_assertImplemented($queryDSL, 'match', 'Elastica\Query\Match', array('field', 'values'));
         $this->_assertImplemented($queryDSL, 'match_all', 'Elastica\Query\MatchAll', array());
         $this->_assertImplemented($queryDSL, 'more_like_this', 'Elastica\Query\MoreLikeThis', array());
         $this->_assertImplemented($queryDSL, 'multi_match', 'Elastica\Query\MultiMatch', array());

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/SuggestTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/SuggestTest.php
@@ -2,9 +2,8 @@
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\QueryBuilder\DSL;
-use Elastica\Test\Base as BaseTest;
 
-class SuggestTest extends BaseTest
+class SuggestTest extends AbstractDSLTest
 {
     /**
      * @group unit
@@ -20,39 +19,14 @@ class SuggestTest extends BaseTest
     /**
      * @group unit
      */
-    public function testFilters()
+    public function testInterface()
     {
         $suggestDSL = new DSL\Suggest();
 
-        foreach ($this->_getSuggesters() as $methodName => $arguments) {
-            $this->assertTrue(
-                method_exists($suggestDSL, $methodName),
-                'method for suggest "'.$methodName.'" not found'
-            );
+        $this->_assertImplemented($suggestDSL, 'completion', 'Elastica\Suggest\Completion', array('name', 'field'));
+        $this->_assertImplemented($suggestDSL, 'phrase', 'Elastica\Suggest\Phrase', array('name', 'field'));
+        $this->_assertImplemented($suggestDSL, 'term', 'Elastica\Suggest\Term', array('name', 'field'));
 
-            try {
-                $return = call_user_func_array(array($suggestDSL, $methodName), $arguments);
-                $this->assertInstanceOf('Elastica\Suggest\AbstractSuggest', $return);
-            } catch (\Exception $exception) {
-                $this->assertInstanceOf(
-                    'Elastica\Exception\NotImplementedException',
-                    $exception,
-                    'breaking change in suggest "'.$methodName.'" found: '.$exception->getMessage()
-                );
-            }
-        }
-    }
-
-    /**
-     * @return array
-     */
-    protected function _getSuggesters()
-    {
-        return array(
-            'term' => array('name', 'field'),
-            'phrase' => array('name', 'field'),
-            'completion' => array('name', 'field'),
-            'context' => array(),
-        );
+        $this->_assertNotImplemented($suggestDSL, 'context', array());
     }
 }


### PR DESCRIPTION
I would like to force all methods of QueryBuilder DSL classes have exact same signatures as constructors of classes they create. It'll prevent from something like #872, #796, #798 in future.

It could be done in two different ways:
* Reflection magic in QueryBuilder tests (check [here](https://github.com/im-denisenko/Elastica/blob/querybuilder-cleanup/test/lib/Elastica/Test/QueryBuilder/DSL/AbstractDSLTest.php#L55))
* Replace current methods implementation with combination of call_user_func + func_get_args.

@webdevsHub Is there some reason why querybuilder was not implemented by second way?