### PR TITLE
Latest version class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 - Update Elasticsearch dependency to 1.7.0 and update plugin dependencies
+- Elastica\QueryBuilder now uses Elastica\QueryBuilder\Version\Latest as default version to avoid empty version classes. [#897](https://github.com/ruflin/Elastica/pull/897)
 
 ### Deprecated
+- Elastica\QueryBuilder\Version\Version150 deprecated in favor of Elastica\QueryBuilder\Version\Latest
 
 
 ## [2.2.0](https://github.com/ruflin/Elastica/releases/tag/2.2.0) - 2015-07-08

--- a/lib/Elastica/QueryBuilder.php
+++ b/lib/Elastica/QueryBuilder.php
@@ -5,7 +5,6 @@ use Elastica\Exception\QueryBuilderException;
 use Elastica\QueryBuilder\DSL;
 use Elastica\QueryBuilder\Facade;
 use Elastica\QueryBuilder\Version;
-use Elastica\QueryBuilder\Version\Version150;
 
 /**
  * Query Builder.
@@ -31,7 +30,7 @@ class QueryBuilder
      */
     public function __construct(Version $version = null)
     {
-        $this->_version = $version ?: new Version150();
+        $this->_version = $version ?: new Version\Latest();
 
         $this->addDSL(new DSL\Query());
         $this->addDSL(new DSL\Filter());

--- a/lib/Elastica/QueryBuilder/Version/Latest.php
+++ b/lib/Elastica/QueryBuilder/Version/Latest.php
@@ -1,0 +1,14 @@
+<?php
+namespace Elastica\QueryBuilder\Version;
+
+/**
+ * Latest elasticsearch DSL.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+ *
+ * @author Manuel Andreo Garcia <andreo.garcia@gmail.com>
+ */
+class Latest extends Version140
+{
+    // this class always points to the latest valid DSL version
+}

--- a/lib/Elastica/QueryBuilder/Version/Latest.php
+++ b/lib/Elastica/QueryBuilder/Version/Latest.php
@@ -4,6 +4,8 @@ namespace Elastica\QueryBuilder\Version;
 /**
  * Latest elasticsearch DSL.
  *
+ * Latest refers to the version mentioned in README.md.
+ *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
  *
  * @author Manuel Andreo Garcia <andreo.garcia@gmail.com>

--- a/lib/Elastica/QueryBuilder/Version/Version150.php
+++ b/lib/Elastica/QueryBuilder/Version/Version150.php
@@ -7,6 +7,8 @@ namespace Elastica\QueryBuilder\Version;
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/1.5/index.html
  *
  * @author Igor Denisenko <im.denisenko@yahoo.com>
+ *
+ * @deprecated deprecated in favor of Elastica\QueryBuilder\Version\Latest
  */
 class Version150 extends Version140
 {

--- a/test/lib/Elastica/Test/QueryBuilder/VersionTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/VersionTest.php
@@ -27,6 +27,7 @@ class VersionTest extends BaseTest
             new Version\Version130(),
             new Version\Version140(),
             new Version\Version150(),
+            new Version\Latest(),
         );
 
         foreach ($versions as $version) {


### PR DESCRIPTION
description of this PR: https://github.com/ruflin/Elastica/pull/893

another option would be to just use `Version140` as default `QueryBuilder` version without `Latest` class but it could be misunderstood as "Elastica is outdated".

I will add changelog entry after discussion.