### PR TITLE
php-cs-fixer PreIncrementFixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 - Update Elasticsearch dependency to 1.7.0 and update plugin dependencies
+- Update php-cs-fixer to 1.10 [#898](https://github.com/ruflin/Elastica/pull/898)
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN composer global require "mayflower/php-codebrowser=~1.1"
 RUN composer global require "sebastian/phpcpd=~2.0"
 RUN composer global require "squizlabs/php_codesniffer=~2.3"
 RUN composer global require "phploc/phploc=~2.1"
-RUN composer global require "fabpot/php-cs-fixer=1.8.1"
+RUN composer global require "fabpot/php-cs-fixer=1.10.*"
 
 
 # Documentor dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 elastica:
   #build: . # In case the image must be built locally
-  image: ruflin/elastica
+  image: ruflin/elastica # comment out to build locally
   ports:
     - "9200:9200"
   volumes:

--- a/lib/Elastica/Aggregation/ReverseNested.php
+++ b/lib/Elastica/Aggregation/ReverseNested.php
@@ -34,7 +34,7 @@ class ReverseNested extends AbstractAggregation
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function toArray()
     {

--- a/lib/Elastica/Bulk/ResponseSet.php
+++ b/lib/Elastica/Bulk/ResponseSet.php
@@ -104,7 +104,7 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
      */
     public function next()
     {
-        $this->_position++;
+        ++$this->_position;
     }
 
     /**

--- a/lib/Elastica/Facet/Range.php
+++ b/lib/Elastica/Facet/Range.php
@@ -118,13 +118,13 @@ class Range extends AbstractFacet
          */
         $fieldTypesSet = 0;
         if (isset($this->_params['field'])) {
-            $fieldTypesSet++;
+            ++$fieldTypesSet;
         }
         if (isset($this->_params['key_field'])) {
-            $fieldTypesSet++;
+            ++$fieldTypesSet;
         }
         if (isset($this->_params['key_script'])) {
-            $fieldTypesSet++;
+            ++$fieldTypesSet;
         }
 
         if ($fieldTypesSet === 0) {

--- a/lib/Elastica/Multi/ResultSet.php
+++ b/lib/Elastica/Multi/ResultSet.php
@@ -128,7 +128,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
      */
     public function next()
     {
-        $this->_position++;
+        ++$this->_position;
     }
 
     /**

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -329,7 +329,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      */
     public function next()
     {
-        $this->_position++;
+        ++$this->_position;
 
         return $this->current();
     }

--- a/test/lib/Elastica/Test/Aggregation/SignificantTermsTest.php
+++ b/test/lib/Elastica/Test/Aggregation/SignificantTermsTest.php
@@ -15,7 +15,7 @@ class SignificantTermsTest extends BaseAggregationTest
         $colors = array('blue', 'blue', 'red', 'red', 'green', 'yellow', 'white', 'cyan', 'magenta');
         $temperatures = array(1500, 1500, 1500, 1500, 2500, 3500, 4500, 5500, 6500, 7500, 7500, 8500, 9500);
         $docs = array();
-        for ($i = 0;$i < 250;$i++) {
+        for ($i = 0;$i < 250;++$i) {
             $docs[] = new Document($i, array('color' => $colors[$i % count($colors)], 'temperature' => $temperatures[$i % count($temperatures)]));
         }
         $index->getType('test')->addDocuments($docs);

--- a/test/lib/Elastica/Test/BulkTest.php
+++ b/test/lib/Elastica/Test/BulkTest.php
@@ -709,10 +709,10 @@ class BulkTest extends BaseTest
 
         $startMemory = memory_get_usage();
 
-        for ($n = 1; $n < 10; $n++) {
+        for ($n = 1; $n < 10; ++$n) {
             $docs = array();
 
-            for ($i = 1; $i <= 3000; $i++) {
+            for ($i = 1; $i <= 3000; ++$i) {
                 $docs[] = new Document(uniqid(), $data);
             }
 

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -610,7 +610,7 @@ class ClientTest extends BaseTest
             $object->assertInstanceOf('Elastica\Exception\ConnectionException', $exception);
             $object->assertInstanceOf('Elastica\Client', $client);
             $object->assertFalse($connection->isEnabled());
-            $count++;
+            ++$count;
         };
 
         $client = $this->_getClient(array(), $callback);
@@ -993,7 +993,7 @@ class ClientTest extends BaseTest
     public function testAddDocumentsWithoutIds()
     {
         $docs = array();
-        for ($i = 0; $i < 10; $i++) {
+        for ($i = 0; $i < 10; ++$i) {
             $docs[] = new Document(null, array('pos' => $i));
         }
 

--- a/test/lib/Elastica/Test/Connection/ConnectionPoolTest.php
+++ b/test/lib/Elastica/Test/Connection/ConnectionPoolTest.php
@@ -93,7 +93,7 @@ class ConnectionPoolTest extends BaseTest
         $params = array();
         $connections = array();
 
-        for ($i = 0; $i < $quantity; $i++) {
+        for ($i = 0; $i < $quantity; ++$i) {
             $connections[] = new Connection($params);
         }
 

--- a/test/lib/Elastica/Test/Connection/Strategy/CallbackStrategyTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/CallbackStrategyTest.php
@@ -19,7 +19,7 @@ class CallbackStrategyTest extends Base
         $count = 0;
 
         $callback = function ($connections) use (&$count) {
-            $count++;
+            ++$count;
         };
 
         $strategy = new CallbackStrategy($callback);

--- a/test/lib/Elastica/Test/Filter/IdsTest.php
+++ b/test/lib/Elastica/Test/Filter/IdsTest.php
@@ -15,14 +15,14 @@ class IdsTest extends BaseTest
 
         // Add documents to first type
         $docs = array();
-        for ($i = 1; $i < 100; $i++) {
+        for ($i = 1; $i < 100; ++$i) {
             $docs[] = new Document($i, array('name' => 'ruflin'));
         }
         $index->getType('helloworld1')->addDocuments($docs);
 
         // Add documents to second type
         $docs = array();
-        for ($i = 1; $i < 100; $i++) {
+        for ($i = 1; $i < 100; ++$i) {
             $docs[] = new Document($i, array('name' => 'ruflin'));
         }
         // This is a special id that will only be in the second type

--- a/test/lib/Elastica/Test/Query/BoolQueryTest.php
+++ b/test/lib/Elastica/Test/Query/BoolQueryTest.php
@@ -128,7 +128,7 @@ class BoolQueryTest extends BaseTest
         $type = new Type($index, 'test');
 
         $docNumber = 3;
-        for ($i = 0; $i < $docNumber; $i++) {
+        for ($i = 0; $i < $docNumber; ++$i) {
             $doc = new Document($i, array('email' => 'test@test.com'));
             $type->addDocument($doc);
         }
@@ -155,7 +155,7 @@ class BoolQueryTest extends BaseTest
         $type = new Type($index, 'test');
 
         $docNumber = 3;
-        for ($i = 0; $i < $docNumber; $i++) {
+        for ($i = 0; $i < $docNumber; ++$i) {
             $doc = new Document($i, array('email' => 'test@test.com'));
             $type->addDocument($doc);
         }

--- a/test/lib/Elastica/Test/Query/CommonTest.php
+++ b/test/lib/Elastica/Test/Query/CommonTest.php
@@ -42,7 +42,7 @@ class CommonTest extends BaseTest
             new Document(3, array('body' => 'foo bar baz bat')),
         );
         //add documents to create common terms
-        for ($i = 4; $i < 24; $i++) {
+        for ($i = 4; $i < 24; ++$i) {
             $docs[] = new Document($i, array('body' => 'foo bar'));
         }
         $type->addDocuments($docs);

--- a/test/lib/Elastica/Test/Query/QueryStringTest.php
+++ b/test/lib/Elastica/Test/Query/QueryStringTest.php
@@ -23,7 +23,7 @@ class QueryStringTest extends BaseTest
 
         $fields = array();
         $max = rand() % 10 + 1;
-        for ($i = 0; $i <  $max; $i++) {
+        for ($i = 0; $i <  $max; ++$i) {
             $fields[] = md5(rand());
         }
 

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/AbstractDSLTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/AbstractDSLTest.php
@@ -55,7 +55,7 @@ abstract class AbstractDSLTest extends BaseTest
     {
         $this->assertEquals(count($left), count($right), 'Parameters count mismatch');
 
-        for ($i = 0; $i < count($left); $i++) {
+        for ($i = 0; $i < count($left); ++$i) {
             $this->assertEquals($left[$i]->getName(), $right[$i]->getName(), 'Parameters names mismatch');
             $this->assertEquals($left[$i]->isOptional(), $right[$i]->isOptional(), 'Parameters optionality mismatch');
             $this->assertEquals($this->_getHintName($left[$i]), $this->_getHintName($right[$i]), 'Parameters typehints mismatch');

--- a/test/lib/Elastica/Test/ScanAndScrollTest.php
+++ b/test/lib/Elastica/Test/ScanAndScrollTest.php
@@ -62,7 +62,7 @@ class ScanAndScrollTest extends BaseTest
         $index->refresh();
 
         $docs = array();
-        for ($x = 1; $x <= 12; $x++) {
+        for ($x = 1; $x <= 12; ++$x) {
             $docs[] = new Document($x, array('id' => $x, 'key' => 'value'));
         }
 

--- a/test/lib/Elastica/Test/ScrollTest.php
+++ b/test/lib/Elastica/Test/ScrollTest.php
@@ -49,7 +49,7 @@ class ScrollTest extends Base
                     $this->fail('too many iterations');
             }
 
-            $count++;
+            ++$count;
         }
     }
 
@@ -88,7 +88,7 @@ class ScrollTest extends Base
         $index->refresh();
 
         $docs = array();
-        for ($x = 1; $x <= 11; $x++) {
+        for ($x = 1; $x <= 11; ++$x) {
             $docs[] = new Document($x, array('id' => $x, 'key' => 'value'));
         }
 

--- a/test/lib/Elastica/Test/SearchTest.php
+++ b/test/lib/Elastica/Test/SearchTest.php
@@ -251,7 +251,7 @@ class SearchTest extends BaseTest
         $type = $index->getType('scrolltest');
 
         $docs = array();
-        for ($x = 1; $x <= 10; $x++) {
+        for ($x = 1; $x <= 10; ++$x) {
             $docs[] = new Document($x, array('id' => $x, 'testscroll' => 'jbafford'));
         }
 
@@ -355,7 +355,7 @@ class SearchTest extends BaseTest
         $index->create(array('index' => array('number_of_shards' => 1, 'number_of_replicas' => 0)), true);
 
         $docs = array();
-        for ($i = 0; $i < 11; $i++) {
+        for ($i = 0; $i < 11; ++$i) {
             $docs[] = new Document($i, array('id' => 1, 'email' => 'test@test.com', 'username' => 'test'));
         }
 

--- a/test/lib/Elastica/Test/Tool/CrossIndexTest.php
+++ b/test/lib/Elastica/Test/Tool/CrossIndexTest.php
@@ -123,7 +123,7 @@ class CrossIndexTest extends Base
     private function _addDocs(Type $type, $docs)
     {
         $insert = array();
-        for ($i = 1; $i <= $docs; $i++) {
+        for ($i = 1; $i <= $docs; ++$i) {
             $insert[] = new Document($i, array('_id' => $i, 'key' => 'value'));
         }
 

--- a/test/lib/Elastica/Test/Transport/TransportBenchmarkTest.php
+++ b/test/lib/Elastica/Test/Transport/TransportBenchmarkTest.php
@@ -46,7 +46,7 @@ class TransportBenchmarkTest extends BaseTest
         $index->create(array(), true);
 
         $times = array();
-        for ($i = 0; $i < $this->_max; $i++) {
+        for ($i = 0; $i < $this->_max; ++$i) {
             $data = $this->getData($i);
             $doc = new Document($i, $data);
             $result = $type->addDocument($doc);
@@ -73,7 +73,7 @@ class TransportBenchmarkTest extends BaseTest
         $type->search('test');
 
         $times = array();
-        for ($i = 0; $i < $this->_max; $i++) {
+        for ($i = 0; $i < $this->_max; ++$i) {
             $test = rand(1, $this->_max);
             $query = new Query();
             $query->setQuery(new \Elastica\Query\MatchAll());
@@ -95,9 +95,9 @@ class TransportBenchmarkTest extends BaseTest
         $type = $this->getType($config);
 
         $times = array();
-        for ($i = 0; $i < $this->_max; $i++) {
+        for ($i = 0; $i < $this->_max; ++$i) {
             $docs = array();
-            for ($j = 0; $j < 10; $j++) {
+            for ($j = 0; $j < 10; ++$j) {
                 $data = $this->getData($i.$j);
                 $docs[] = new Document($i, $data);
             }
@@ -142,7 +142,7 @@ class TransportBenchmarkTest extends BaseTest
         $index->refresh();
 
         $times = array();
-        for ($i = 0; $i < $this->_max; $i++) {
+        for ($i = 0; $i < $this->_max; ++$i) {
             $response = $type->request('_mapping', \Elastica\Request::GET);
             $times[] = $response->getQueryTime();
         }
@@ -195,7 +195,7 @@ class TransportBenchmarkTest extends BaseTest
             'test' => $test,
             'name' => array(),
         );
-        for ($i = 0; $i < $this->_maxData; $i++) {
+        for ($i = 0; $i < $this->_maxData; ++$i) {
             $data['name'][] = uniqid();
         }
 


### PR DESCRIPTION
some housekeeping:

php-cs-fixer recently added PreIncrementFixer in [1.9](https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v1.9) to `symfony` level. See also the [discussion](https://github.com/symfony/symfony/pull/14121).