### PR TITLE
Implemented index template support

### DIFF
--- a/lib/Elastica/IndexTemplate.php
+++ b/lib/Elastica/IndexTemplate.php
@@ -1,0 +1,118 @@
+<?php
+namespace Elastica;
+
+use Elastica\Exception\InvalidException;
+
+/**
+ * Elastica index template object.
+ *
+ * @author Dmitry Balabka <dmitry.balabka@gmail.com>
+ */
+class IndexTemplate
+{
+    /**
+     * Index template name.
+     *
+     * @var string Index pattern
+     */
+    protected $name = '';
+
+    /**
+     * Client object.
+     *
+     * @var \Elastica\Client Client object
+     */
+    protected $client = null;
+
+    /**
+     * Creates a new index template object.
+     *
+     * @param \Elastica\Client $client Client object
+     * @param string           $name   Index template name
+     *
+     * @throws \Elastica\Exception\InvalidException
+     */
+    public function __construct(Client $client, $name)
+    {
+        $this->client = $client;
+
+        if (!is_scalar($name)) {
+            throw new InvalidException('Index template should be a scalar type');
+        }
+        $this->name = (string) $name;
+    }
+
+    /**
+     * Deletes the index template.
+     *
+     * @return \Elastica\Response Response object
+     */
+    public function delete()
+    {
+        $response = $this->request(Request::DELETE);
+
+        return $response;
+    }
+
+    /**
+     * Creates a new index template with the given arguments.
+     *
+     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
+     *
+     * @param array      $args    OPTIONAL Arguments to use
+     *
+     * @return \Elastica\Response
+     */
+    public function create(array $args = array())
+    {
+        return $this->request(Request::PUT, $args);
+    }
+
+    /**
+     * Checks if the given index template is already created.
+     *
+     * @return bool True if index exists
+     */
+    public function exists()
+    {
+        $response = $this->request(Request::HEAD);
+        $info = $response->getTransferInfo();
+
+        return (bool) ($info['http_code'] == 200);
+    }
+
+    /**
+     * Returns the index template name.
+     *
+     * @return string Index name
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Returns index template client.
+     *
+     * @return \Elastica\Client Index client object
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    /**
+     * Makes calls to the elasticsearch server based on this index template name.
+     *
+     * @param string $method Rest method to use (GET, POST, DELETE, PUT)
+     * @param array  $data   OPTIONAL Arguments as array
+     *
+     * @return \Elastica\Response Response object
+     */
+    public function request($method, $data = array())
+    {
+        $path = '/_template/' . $this->getName();
+
+        return $this->getClient()->request($path, $method, $data);
+    }
+}

--- a/test/lib/Elastica/Test/IndexTemplateTest.php
+++ b/test/lib/Elastica/Test/IndexTemplateTest.php
@@ -1,0 +1,113 @@
+<?php
+namespace Elastica\Test;
+
+use Elastica\Client;
+use Elastica\Index;
+use Elastica\IndexTemplate;
+use Elastica\Request;
+use Elastica\Response;
+use Elastica\Test\Base as BaseTest;
+use Elastica\Type;
+
+/**
+ * IndexTemplate class tests
+ *
+ * @author Dmitry Balabka <dmitry.balabka@intexsys.lv>
+ */
+class IndexTemplateTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testInstantiate()
+    {
+        $name = 'index_template1';
+        $client = $this->_getClient();
+        $indexTemplate = new IndexTemplate($client, $name);
+        $indexTemplate->getName();
+        $this->assertSame($client, $indexTemplate->getClient());
+        $this->assertEquals($name, $indexTemplate->getName());
+    }
+
+    /**
+     * @expectedException \Elastica\Exception\InvalidException
+     * @group unit
+     */
+    public function testIncorrectInstantiate()
+    {
+        $client = $this->_getClient();
+        new IndexTemplate($client, null);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testDelete()
+    {
+        $name = 'index_template1';
+        $response = new Response('');
+        /** @var \PHPUnit_Framework_MockObject_MockObject|Client $clientMock */
+        $clientMock = $this->getMock('\Elastica\Client', array('request'));
+        $clientMock->expects($this->once())
+            ->method('request')
+            ->with('/_template/' . $name, Request::DELETE, array(), array())
+            ->willReturn($response);
+        $indexTemplate = new IndexTemplate($clientMock, $name);
+        $this->assertSame($response, $indexTemplate->delete());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testCreate()
+    {
+        $args = array(1);
+        $response = new Response('');
+        $name = 'index_template1';
+        /** @var \PHPUnit_Framework_MockObject_MockObject|Client $clientMock */
+        $clientMock = $this->getMock('\Elastica\Client', array('request'));
+        $clientMock->expects($this->once())
+            ->method('request')
+            ->with('/_template/' . $name, Request::PUT, $args, array())
+            ->willReturn($response);
+        $indexTemplate = new IndexTemplate($clientMock, $name);
+        $this->assertSame($response, $indexTemplate->create($args));
+    }
+
+    /**
+     * @group unit
+     */
+    public function testExists()
+    {
+        $name = 'index_template1';
+        $response = new Response('');
+        $response->setTransferInfo(array('http_code' => 200));
+        /** @var \PHPUnit_Framework_MockObject_MockObject|Client $clientMock */
+        $clientMock = $this->getMock('\Elastica\Client', array('request'));
+        $clientMock->expects($this->once())
+            ->method('request')
+            ->with('/_template/' . $name, Request::HEAD, array(), array())
+            ->willReturn($response);
+        $indexTemplate = new IndexTemplate($clientMock, $name);
+        $this->assertTrue($indexTemplate->exists());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testCreateTemplate()
+    {
+        $template = array(
+            'template' => 'te*',
+            'settings' => array(
+                'number_of_shards' => 1
+            ),
+        );
+        $name = 'index_template1';
+        $indexTemplate = new IndexTemplate($this->_getClient(), $name);
+        $indexTemplate->create($template);
+        $this->assertTrue($indexTemplate->exists());
+        $indexTemplate->delete();
+        $this->assertFalse($indexTemplate->exists());
+    }
+}


### PR DESCRIPTION
Initial implemtation of elastica index templates support:
https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html

Required for FriendsOfSymfony/FOSElasticaBundle#916