### PR TITLE
Update elasticseach-image to work with ES 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Dependencies
 |[Elasticsearch thrift transport plugin](https://github.com/elasticsearch/elasticsearch-transport-thrift/tree/v2.7.0)|2.7.0|no|
 |[Elasticsearch memcached transport plugin](https://github.com/elastic/elasticsearch-transport-memcached/tree/v2.7.0)|2.7.0|no|
 |[Elasticsearch geocluster facet plugin](https://github.com/zenobase/geocluster-facet/tree/0.0.12)|0.0.12|no|
-|[Elasticsearch image plugin](https://github.com/SibaTokyo/elasticsearch-image/tree/1.4.0)|1.4.0|no|
+|[Elasticsearch image plugin](https://github.com/Jmoati/elasticsearch-image/releases/tag/1.7.1)|1.7.1|no|

--- a/ansible/es-playbook.yml
+++ b/ansible/es-playbook.yml
@@ -11,7 +11,7 @@
     - ES_TRANSPORT_MEMCACHED_VER: "2.7.0"
     - ES_TRANSPORT_THRIFT_VER: "2.7.0"
     - ES_GEOCLUSTER_FACET_VER: "0.0.12"
-    - ES_IMAGE_PLUGIN_VER: "1.4.0"
+    - ES_IMAGE_PLUGIN_VER: "1.7.1"
     - ES_PROJECT_ROOT: "{{ lookup('env', 'ES_PROJECT_ROOT') }}"
   roles:
     - base

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -48,7 +48,7 @@
 - name: install image plugin
   command: >
     creates=/usr/share/elasticsearch/plugins/image
-    /usr/share/elasticsearch/bin/plugin --url https://github.com/SibaTokyo/elasticsearch-image/releases/download/{{ ES_IMAGE_PLUGIN_VER }}/elasticsearch-image-{{ ES_IMAGE_PLUGIN_VER }}.zip -install image
+    /usr/share/elasticsearch/bin/plugin --url https://github.com/Jmoati/elasticsearch-image/releases/download/{{ ES_IMAGE_PLUGIN_VER }}/elasticsearch-image-{{ ES_IMAGE_PLUGIN_VER }}.zip -install image
 
 - name: install mapper-attachments plugin
   command: >

--- a/lib/Elastica/Query/Image.php
+++ b/lib/Elastica/Query/Image.php
@@ -11,10 +11,10 @@ namespace Elastica\Query;
  * To use this feature you have to call the following command in the
  * elasticsearch directory:
  * <code>
- * ./bin/plugin --url https://github.com/SibaTokyo/elasticsearch-image/releases/download/1.4.0/elasticsearch-image-1.4.0.zip --install image
+ * ./bin/plugin --url https://github.com/Jmoati/elasticsearch-image/releases/download/1.7.1/elasticsearch-image-1.7.1.zip --install image
  * </code>
  * This installs the image plugin. More infos
- * can be found here: {@link https://github.com/SibaTokyo/elasticsearch-image}
+ * can be found here: {@link https://github.com/Jmoati/elasticsearch-image}
  */
 class Image extends AbstractQuery
 {

--- a/test/lib/Elastica/Test/Query/ImageTest.php
+++ b/test/lib/Elastica/Test/Query/ImageTest.php
@@ -65,7 +65,6 @@ class ImageTest extends BaseTest
      */
     public function testFromReference()
     {
-        $this->markTestSkipped('Tests skipped as plugin not working properly with ES 1.6.0. See https://github.com/ruflin/Elastica/pull/881');
         $field = 'image';
 
         $client = $this->_getClient();
@@ -113,8 +112,6 @@ class ImageTest extends BaseTest
      */
     public function testFromImage()
     {
-        $this->markTestSkipped('Tests skipped as plugin not working properly with ES 1.6.0. See https://github.com/ruflin/Elastica/pull/881');
-
         $field = 'image';
 
         $client = $this->_getClient();


### PR DESCRIPTION
Remove skip test.

I will now compile elasticsearch-image to always work with new version of elasticsearch.