### PR TITLE
lazy toArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/2.2.1...HEAD)
+- Lazy toArray [#916](https://github.com/ruflin/Elastica/pull/916)
 
 ### Backward Compatibility Breaks
+- Objects do not casts to arrays in setters and saved in params as objects. There is many side effects if you work with params on "low-level" or change your objects after you call setter with object as argument. [#916](https://github.com/ruflin/Elastica/pull/916)
 
 ### Bugfixes
 

--- a/lib/Elastica/Aggregation/AbstractAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractAggregation.php
@@ -2,10 +2,10 @@
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
-use Elastica\Nameable;
+use Elastica\NameableInterface;
 use Elastica\Param;
 
-abstract class AbstractAggregation extends Param implements Nameable
+abstract class AbstractAggregation extends Param implements NameableInterface
 {
     /**
      * @var string The name of this aggregation

--- a/lib/Elastica/Aggregation/AbstractAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractAggregation.php
@@ -2,9 +2,10 @@
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
+use Elastica\Nameable;
 use Elastica\Param;
 
-abstract class AbstractAggregation extends Param
+abstract class AbstractAggregation extends Param implements Nameable
 {
     /**
      * @var string The name of this aggregation
@@ -73,7 +74,7 @@ abstract class AbstractAggregation extends Param
             throw new InvalidException('Global aggregators can only be placed as top level aggregators');
         }
 
-        $this->_aggs[$aggregation->getName()] = $aggregation->toArray();
+        $this->_aggs[] = $aggregation;
 
         return $this;
     }
@@ -84,12 +85,13 @@ abstract class AbstractAggregation extends Param
     public function toArray()
     {
         $array = parent::toArray();
+
         if (array_key_exists('global_aggregation', $array)) {
             // compensate for class name GlobalAggregation
             $array = array('global' => new \stdClass());
         }
         if (sizeof($this->_aggs)) {
-            $array['aggs'] = $this->_aggs;
+            $array['aggs'] = $this->_convertArrayable($this->_aggs);
         }
 
         return $array;

--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -36,12 +36,14 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
     {
         $array = parent::toArray();
 
-        if (isset($array[$this->_getBaseName()]['script']) && is_array($array[$this->_getBaseName()]['script'])) {
-            $script = $array[$this->_getBaseName()]['script'];
+        $baseName = $this->_getBaseName();
 
-            unset($array[$this->_getBaseName()]['script']);
+        if (isset($array[$baseName]['script']) && is_array($array[$baseName]['script'])) {
+            $script = $array[$baseName]['script'];
 
-            $array[$this->_getBaseName()] = array_merge($array[$this->_getBaseName()], $script);
+            unset($array[$baseName]['script']);
+
+            $array[$baseName] = array_merge($array[$baseName], $script);
         }
 
         return $array;

--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -30,7 +30,7 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function toArray()
     {

--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -26,12 +26,24 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
      */
     public function setScript($script)
     {
-        if ($script instanceof Script) {
-            $params = array_merge($this->getParams(), $script->toArray());
+        return $this->setParam('script', $script);
+    }
 
-            return $this->setParams($params);
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        $array = parent::toArray();
+
+        if (isset($array[$this->_getBaseName()]['script']) && is_array($array[$this->_getBaseName()]['script'])) {
+            $script = $array[$this->_getBaseName()]['script'];
+
+            unset($array[$this->_getBaseName()]['script']);
+
+            $array[$this->_getBaseName()] = array_merge($array[$this->_getBaseName()], $script);
         }
 
-        return $this->setParam('script', $script);
+        return $array;
     }
 }

--- a/lib/Elastica/Aggregation/Filter.php
+++ b/lib/Elastica/Aggregation/Filter.php
@@ -32,7 +32,7 @@ class Filter extends AbstractAggregation
      */
     public function setFilter(AbstractFilter $filter)
     {
-        return $this->setParam('filter', $filter->toArray());
+        return $this->setParam('filter', $filter);
     }
 
     /**
@@ -41,11 +41,11 @@ class Filter extends AbstractAggregation
     public function toArray()
     {
         $array = array(
-            'filter' => $this->getParam('filter'),
+            'filter' => $this->getParam('filter')->toArray(),
         );
 
         if ($this->_aggs) {
-            $array['aggs'] = $this->_aggs;
+            $array['aggs'] = $this->_convertArrayable($this->_aggs);
         }
 
         return $array;

--- a/lib/Elastica/Aggregation/Filter.php
+++ b/lib/Elastica/Aggregation/Filter.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Aggregation;
 
+use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
 
 /**
@@ -36,10 +37,16 @@ class Filter extends AbstractAggregation
     }
 
     /**
+     * @throws \Elastica\Exception\InvalidException If filter is not set
+     *
      * @return array
      */
     public function toArray()
     {
+        if (!$this->hasParam('filter')) {
+            throw new InvalidException('Filter is required');
+        }
+
         $array = array(
             'filter' => $this->getParam('filter')->toArray(),
         );

--- a/lib/Elastica/Aggregation/Filters.php
+++ b/lib/Elastica/Aggregation/Filters.php
@@ -23,9 +23,9 @@ class Filters extends AbstractAggregation
     public function addFilter(AbstractFilter $filter, $name = '')
     {
         if (empty($name)) {
-            $filterArray[] = $filter->toArray();
+            $filterArray[] = $filter;
         } else {
-            $filterArray[$name] = $filter->toArray();
+            $filterArray[$name] = $filter;
         }
 
         return $this->addParam('filters', $filterArray);
@@ -44,14 +44,14 @@ class Filters extends AbstractAggregation
             $key = key($filter);
 
             if (is_string($key)) {
-                $array['filters']['filters'][$key] = current($filter);
+                $array['filters']['filters'][$key] = current($filter)->toArray();
             } else {
-                $array['filters']['filters'][] = current($filter);
+                $array['filters']['filters'][] = current($filter)->toArray();
             }
         }
 
         if ($this->_aggs) {
-            $array['aggs'] = $this->_aggs;
+            $array['aggs'] = $this->_convertArrayable($this->_aggs);
         }
 
         return $array;

--- a/lib/Elastica/Aggregation/Filters.php
+++ b/lib/Elastica/Aggregation/Filters.php
@@ -22,10 +22,12 @@ class Filters extends AbstractAggregation
      */
     public function addFilter(AbstractFilter $filter, $name = '')
     {
-        if (empty($name)) {
-            $filterArray[] = $filter;
-        } else {
+        $filterArray = array();
+
+        if (is_string($name)) {
             $filterArray[$name] = $filter;
+        } else {
+            $filterArray[] = $filter;
         }
 
         return $this->addParam('filters', $filterArray);

--- a/lib/Elastica/Aggregation/SignificantTerms.php
+++ b/lib/Elastica/Aggregation/SignificantTerms.php
@@ -22,6 +22,6 @@ class SignificantTerms extends AbstractTermsAggregation
      */
     public function setBackgroundFilter(AbstractFilter $filter)
     {
-        return $this->setParam('background_filter', $filter->toArray());
+        return $this->setParam('background_filter', $filter);
     }
 }

--- a/lib/Elastica/Aggregation/TopHits.php
+++ b/lib/Elastica/Aggregation/TopHits.php
@@ -112,7 +112,7 @@ class TopHits extends AbstractAggregation
             $scriptFields = new ScriptFields($scriptFields);
         }
 
-        return $this->setParam('script_fields', $scriptFields->toArray());
+        return $this->setParam('script_fields', $scriptFields);
     }
 
     /**
@@ -125,7 +125,11 @@ class TopHits extends AbstractAggregation
      */
     public function addScriptField($name, Script $script)
     {
-        $this->_params['script_fields'][$name] = $script->toArray();
+        if (!isset($this->_params['script_fields'])) {
+            $this->_params['script_fields'] = new ScriptFields();
+        }
+
+        $this->_params['script_fields']->addScript($name, $script);
 
         return $this;
     }

--- a/lib/Elastica/Arrayable.php
+++ b/lib/Elastica/Arrayable.php
@@ -1,0 +1,18 @@
+<?php
+namespace Elastica;
+
+/**
+ * Interface for params.
+ *
+ *
+ * @author Evgeniy Sokolov <ewgraf@gmail.com>
+ */
+interface Arrayable
+{
+    /**
+     * Converts the object to an array.
+     *
+     * @return array Object as array
+     */
+    public function toArray();
+}

--- a/lib/Elastica/ArrayableInterface.php
+++ b/lib/Elastica/ArrayableInterface.php
@@ -7,7 +7,7 @@ namespace Elastica;
  *
  * @author Evgeniy Sokolov <ewgraf@gmail.com>
  */
-interface Arrayable
+interface ArrayableInterface
 {
     /**
      * Converts the object to an array.

--- a/lib/Elastica/Bulk/Action/UpdateDocument.php
+++ b/lib/Elastica/Bulk/Action/UpdateDocument.php
@@ -48,6 +48,7 @@ class UpdateDocument extends IndexDocument
     {
         parent::setScript($script);
 
+        // FIXME: can we throw away toArray cast?
         $source = $script->toArray();
 
         if ($script->hasUpsert()) {

--- a/lib/Elastica/Facet/AbstractFacet.php
+++ b/lib/Elastica/Facet/AbstractFacet.php
@@ -3,7 +3,7 @@ namespace Elastica\Facet;
 
 use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
-use Elastica\Nameable;
+use Elastica\NameableInterface;
 use Elastica\Param;
 
 /**
@@ -14,7 +14,7 @@ use Elastica\Param;
  *
  * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
-abstract class AbstractFacet extends Param implements Nameable
+abstract class AbstractFacet extends Param implements NameableInterface
 {
     /**
      * @var string Holds the name of the facet.

--- a/lib/Elastica/Facet/AbstractFacet.php
+++ b/lib/Elastica/Facet/AbstractFacet.php
@@ -3,6 +3,7 @@ namespace Elastica\Facet;
 
 use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
+use Elastica\Nameable;
 use Elastica\Param;
 
 /**
@@ -13,7 +14,7 @@ use Elastica\Param;
  *
  * @deprecated Facets are deprecated and will be removed in a future release. You are encouraged to migrate to aggregations instead.
  */
-abstract class AbstractFacet extends Param
+abstract class AbstractFacet extends Param implements Nameable
 {
     /**
      * @var string Holds the name of the facet.
@@ -74,7 +75,7 @@ abstract class AbstractFacet extends Param
      */
     public function setFilter(AbstractFilter $filter)
     {
-        return $this->_setFacetParam('facet_filter', $filter->toArray());
+        return $this->_setFacetParam('facet_filter', $filter);
     }
 
     /**
@@ -124,7 +125,7 @@ abstract class AbstractFacet extends Param
      */
     public function toArray()
     {
-        return $this->_facet;
+        return $this->_convertArrayable($this->_facet);
     }
 
     /**

--- a/lib/Elastica/Facet/DateHistogram.php
+++ b/lib/Elastica/Facet/DateHistogram.php
@@ -53,6 +53,6 @@ class DateHistogram extends Histogram
          */
         $this->_setFacetParam('date_histogram', $this->_params);
 
-        return $this->_facet;
+        return $this->_convertArrayable($this->_facet);
     }
 }

--- a/lib/Elastica/Facet/Filter.php
+++ b/lib/Elastica/Facet/Filter.php
@@ -22,6 +22,6 @@ class Filter extends AbstractFacet
      */
     public function setFilter(AbstractFilter $filter)
     {
-        return $this->_setFacetParam('filter', $filter->toArray());
+        return $this->_setFacetParam('filter', $filter);
     }
 }

--- a/lib/Elastica/Facet/Query.php
+++ b/lib/Elastica/Facet/Query.php
@@ -22,6 +22,6 @@ class Query extends AbstractFacet
      */
     public function setQuery(AbstractQuery $query)
     {
-        return $this->_setFacetParam('query', $query->toArray());
+        return $this->_setFacetParam('query', $query);
     }
 }

--- a/lib/Elastica/Facet/Terms.php
+++ b/lib/Elastica/Facet/Terms.php
@@ -44,11 +44,7 @@ class Terms extends AbstractFacet
      */
     public function setScript($script)
     {
-        $script = Script::create($script);
-        foreach ($script->toArray() as $param => $value) {
-            $this->setParam($param, $value);
-        }
-
+        $this->setParam('script', Script::create($script));
         return $this;
     }
 
@@ -132,6 +128,12 @@ class Terms extends AbstractFacet
     {
         $this->_setFacetParam('terms', $this->_params);
 
-        return parent::toArray();
+        $array = parent::toArray();
+
+        if (isset($array[$this->_getBaseName()]['script'])) {
+            $array[$this->_getBaseName()]['script'] = $array[$this->_getBaseName()]['script']['script'];
+        }
+
+        return $array;
     }
 }

--- a/lib/Elastica/Facet/Terms.php
+++ b/lib/Elastica/Facet/Terms.php
@@ -130,8 +130,10 @@ class Terms extends AbstractFacet
 
         $array = parent::toArray();
 
-        if (isset($array[$this->_getBaseName()]['script'])) {
-            $array[$this->_getBaseName()]['script'] = $array[$this->_getBaseName()]['script']['script'];
+        $baseName = $this->_getBaseName();
+
+        if (isset($array[$baseName]['script'])) {
+            $array[$baseName]['script'] = $array[$baseName]['script']['script'];
         }
 
         return $array;

--- a/lib/Elastica/Facet/Terms.php
+++ b/lib/Elastica/Facet/Terms.php
@@ -45,6 +45,7 @@ class Terms extends AbstractFacet
     public function setScript($script)
     {
         $this->setParam('script', Script::create($script));
+
         return $this;
     }
 

--- a/lib/Elastica/Filter/AbstractMulti.php
+++ b/lib/Elastica/Filter/AbstractMulti.php
@@ -34,7 +34,7 @@ abstract class AbstractMulti extends AbstractFilter
      */
     public function addFilter(AbstractFilter $filter)
     {
-        $this->_filters[] = $filter->toArray();
+        $this->_filters[] = $filter;
 
         return $this;
     }
@@ -84,6 +84,6 @@ abstract class AbstractMulti extends AbstractFilter
 
         $data[$name] = $filterData;
 
-        return $data;
+        return $this->_convertArrayable($data);
     }
 }

--- a/lib/Elastica/Filter/BoolFilter.php
+++ b/lib/Elastica/Filter/BoolFilter.php
@@ -81,17 +81,19 @@ class BoolFilter extends AbstractFilter
      */
     protected function _addFilter($type, $args)
     {
-        if ($args instanceof AbstractFilter) {
-            $args = $args->toArray();
-        } elseif (!is_array($args)) {
+        if (!is_array($args) && !($args instanceof AbstractFilter)) {
             throw new InvalidException('Invalid parameter. Has to be array or instance of Elastica\Filter');
-        } else {
+        }
+
+        if (is_array($args)) {
             $parsedArgs = array();
+
             foreach ($args as $filter) {
                 if ($filter instanceof AbstractFilter) {
-                    $parsedArgs[] = $filter->toArray();
+                    $parsedArgs[] = $filter;
                 }
             }
+
             $args = $parsedArgs;
         }
 
@@ -128,6 +130,6 @@ class BoolFilter extends AbstractFilter
             $args['bool'] = array_merge($args['bool'], $this->getParams());
         }
 
-        return $args;
+        return $this->_convertArrayable($args);
     }
 }

--- a/lib/Elastica/Filter/BoolNot.php
+++ b/lib/Elastica/Filter/BoolNot.php
@@ -29,7 +29,7 @@ class BoolNot extends AbstractFilter
      */
     public function setFilter(AbstractFilter $filter)
     {
-        return $this->setParam('filter', $filter->toArray());
+        return $this->setParam('filter', $filter);
     }
 
     /**

--- a/lib/Elastica/Filter/HasChild.php
+++ b/lib/Elastica/Filter/HasChild.php
@@ -35,10 +35,7 @@ class HasChild extends AbstractFilter
      */
     public function setQuery($query)
     {
-        $query = \Elastica\Query::create($query);
-        $data = $query->toArray();
-
-        return $this->setParam('query', $data['query']);
+        return $this->setParam('query', \Elastica\Query::create($query));
     }
 
     /**
@@ -50,7 +47,7 @@ class HasChild extends AbstractFilter
      */
     public function setFilter($filter)
     {
-        return $this->setParam('filter', $filter->toArray());
+        return $this->setParam('filter', $filter);
     }
 
     /**
@@ -91,5 +88,16 @@ class HasChild extends AbstractFilter
     public function setMaximumChildrenCount($count)
     {
         return $this->setParam('max_children', (int) $count);
+    }
+
+    public function toArray()
+    {
+        $array = parent::toArray();
+
+        if (isset($array[$this->_getBaseName()]['query'])) {
+            $array[$this->_getBaseName()]['query'] = $array[$this->_getBaseName()]['query']['query'];
+        }
+
+        return $array;
     }
 }

--- a/lib/Elastica/Filter/HasChild.php
+++ b/lib/Elastica/Filter/HasChild.php
@@ -97,8 +97,10 @@ class HasChild extends AbstractFilter
     {
         $array = parent::toArray();
 
-        if (isset($array[$this->_getBaseName()]['query'])) {
-            $array[$this->_getBaseName()]['query'] = $array[$this->_getBaseName()]['query']['query'];
+        $baseName = $this->_getBaseName();
+
+        if (isset($array[$baseName]['query'])) {
+            $array[$baseName]['query'] = $array[$baseName]['query']['query'];
         }
 
         return $array;

--- a/lib/Elastica/Filter/HasChild.php
+++ b/lib/Elastica/Filter/HasChild.php
@@ -90,6 +90,9 @@ class HasChild extends AbstractFilter
         return $this->setParam('max_children', (int) $count);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function toArray()
     {
         $array = parent::toArray();

--- a/lib/Elastica/Filter/HasParent.php
+++ b/lib/Elastica/Filter/HasParent.php
@@ -71,8 +71,10 @@ class HasParent extends AbstractFilter
     {
         $array = parent::toArray();
 
-        if (isset($array[$this->_getBaseName()]['query'])) {
-            $array[$this->_getBaseName()]['query'] = $array[$this->_getBaseName()]['query']['query'];
+        $baseName = $this->_getBaseName();
+
+        if (isset($array[$baseName]['query'])) {
+            $array[$baseName]['query'] = $array[$baseName]['query']['query'];
         }
 
         return $array;

--- a/lib/Elastica/Filter/HasParent.php
+++ b/lib/Elastica/Filter/HasParent.php
@@ -33,10 +33,7 @@ class HasParent extends AbstractFilter
      */
     public function setQuery($query)
     {
-        $query = \Elastica\Query::create($query);
-        $data = $query->toArray();
-
-        return $this->setParam('query', $data['query']);
+        return $this->setParam('query', \Elastica\Query::create($query));
     }
 
     /**
@@ -48,7 +45,7 @@ class HasParent extends AbstractFilter
      */
     public function setFilter($filter)
     {
-        return $this->setParam('filter', $filter->toArray());
+        return $this->setParam('filter', $filter);
     }
 
     /**
@@ -65,5 +62,16 @@ class HasParent extends AbstractFilter
         }
 
         return $this->setParam('type', (string) $type);
+    }
+
+    public function toArray()
+    {
+        $array = parent::toArray();
+
+        if (isset($array[$this->_getBaseName()]['query'])) {
+            $array[$this->_getBaseName()]['query'] = $array[$this->_getBaseName()]['query']['query'];
+        }
+
+        return $array;
     }
 }

--- a/lib/Elastica/Filter/HasParent.php
+++ b/lib/Elastica/Filter/HasParent.php
@@ -64,6 +64,9 @@ class HasParent extends AbstractFilter
         return $this->setParam('type', (string) $type);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function toArray()
     {
         $array = parent::toArray();

--- a/lib/Elastica/Filter/Indices.php
+++ b/lib/Elastica/Filter/Indices.php
@@ -61,7 +61,7 @@ class Indices extends AbstractFilter
      */
     public function setFilter(AbstractFilter $filter)
     {
-        return $this->setParam('filter', $filter->toArray());
+        return $this->setParam('filter', $filter);
     }
 
     /**
@@ -73,6 +73,6 @@ class Indices extends AbstractFilter
      */
     public function setNoMatchFilter(AbstractFilter $filter)
     {
-        return $this->setParam('no_match_filter', $filter->toArray());
+        return $this->setParam('no_match_filter', $filter);
     }
 }

--- a/lib/Elastica/Filter/Nested.php
+++ b/lib/Elastica/Filter/Nested.php
@@ -33,7 +33,7 @@ class Nested extends AbstractFilter
      */
     public function setQuery(AbstractQuery $query)
     {
-        return $this->setParam('query', $query->toArray());
+        return $this->setParam('query', $query);
     }
 
     /**
@@ -45,7 +45,7 @@ class Nested extends AbstractFilter
      */
     public function setFilter(AbstractFilter $filter)
     {
-        return $this->setParam('filter', $filter->toArray());
+        return $this->setParam('filter', $filter);
     }
 
     /**

--- a/lib/Elastica/Filter/Query.php
+++ b/lib/Elastica/Filter/Query.php
@@ -47,10 +47,6 @@ class Query extends AbstractFilter
             throw new InvalidException('expected an array or instance of Elastica\Query\AbstractQuery');
         }
 
-        if ($query instanceof AbstractQuery) {
-            $query = $query->toArray();
-        }
-
         $this->_query = $query;
 
         return $this;
@@ -86,6 +82,6 @@ class Query extends AbstractFilter
 
         $data[$name] = $filterData;
 
-        return $data;
+        return $this->_convertArrayable($data);
     }
 }

--- a/lib/Elastica/Filter/Script.php
+++ b/lib/Elastica/Filter/Script.php
@@ -40,8 +40,17 @@ class Script extends AbstractFilter
      */
     public function setScript($script)
     {
-        $script = Elastica\Script::create($script);
+        return $this->setParam('script', Elastica\Script::create($script));
+    }
 
-        return $this->setParams($script->toArray());
+    public function toArray()
+    {
+        $array = parent::toArray();
+
+        if (isset($array['script'])) {
+            $array['script'] = $array['script']['script'];
+        }
+
+        return $array;
     }
 }

--- a/lib/Elastica/Filter/Script.php
+++ b/lib/Elastica/Filter/Script.php
@@ -43,6 +43,9 @@ class Script extends AbstractFilter
         return $this->setParam('script', Elastica\Script::create($script));
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function toArray()
     {
         $array = parent::toArray();

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -170,7 +170,7 @@ class Index implements SearchableInterface
         }
         $query = Query::create($query);
 
-        return $this->request('_query', Request::DELETE, array('query' => $query->getQuery()), $options);
+        return $this->request('_query', Request::DELETE, array('query' => $query->getQuery()->toArray()), $options);
     }
 
     /**

--- a/lib/Elastica/Nameable.php
+++ b/lib/Elastica/Nameable.php
@@ -1,0 +1,13 @@
+<?php
+namespace Elastica;
+
+/**
+ * Interface for params.
+ *
+ *
+ * @author Evgeniy Sokolov <ewgraf@gmail.com>
+ */
+interface Nameable
+{
+    public function getName();
+}

--- a/lib/Elastica/NameableInterface.php
+++ b/lib/Elastica/NameableInterface.php
@@ -2,12 +2,14 @@
 namespace Elastica;
 
 /**
- * Interface for params.
+ * Interface for named objects.
  *
  *
  * @author Evgeniy Sokolov <ewgraf@gmail.com>
  */
-interface Nameable
+interface NameableInterface
 {
     public function getName();
+
+    public function setName($name);
 }

--- a/lib/Elastica/NameableInterface.php
+++ b/lib/Elastica/NameableInterface.php
@@ -9,7 +9,19 @@ namespace Elastica;
  */
 interface NameableInterface
 {
+    /**
+     * Retrieve the name of this object.
+     *
+     * @return string
+     */
     public function getName();
 
+    /**
+     * Set the name of this object.
+     *
+     * @param string $name
+     *
+     * @return $this
+     */
     public function setName($name);
 }

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -10,7 +10,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  */
-class Param implements Arrayable
+class Param implements ArrayableInterface
 {
     /**
      * Params.
@@ -49,8 +49,8 @@ class Param implements Arrayable
         $arr = array();
 
         foreach ($array as $key => $value) {
-            if ($value instanceof Arrayable) {
-                $arr[$value instanceof Nameable ? $value->getName() : $key] = $value->toArray();
+            if ($value instanceof ArrayableInterface) {
+                $arr[$value instanceof NameableInterface ? $value->getName() : $key] = $value->toArray();
             } elseif (is_array($value)) {
                 $arr[$key] = $this->_convertArrayable($value);
             } else {

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -10,7 +10,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  */
-class Param
+class Param implements Arrayable
 {
     /**
      * Params.
@@ -41,7 +41,24 @@ class Param
             $data = array_merge($data, $this->_rawParams);
         }
 
-        return $data;
+        return $this->_convertArrayable($data);
+    }
+
+    protected function _convertArrayable(array $array)
+    {
+        $arr = array();
+
+        foreach ($array as $key => $value) {
+            if ($value instanceof Arrayable) {
+                $arr[$value instanceof Nameable ? $value->getName() : $key] = $value->toArray();
+            } elseif (is_array($value)) {
+                $arr[$key] = $this->_convertArrayable($value);
+            } else {
+                $arr[$key] = $value;
+            }
+        }
+
+        return $arr;
     }
 
     /**

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -45,9 +45,10 @@ class Param implements ArrayableInterface
     }
 
     /**
-     * Cast objects to arrays
+     * Cast objects to arrays.
      *
      * @param array $array
+     *
      * @return array
      */
     protected function _convertArrayable(array $array)

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -44,6 +44,12 @@ class Param implements ArrayableInterface
         return $this->_convertArrayable($data);
     }
 
+    /**
+     * Cast objects to arrays
+     *
+     * @param array $array
+     * @return array
+     */
     protected function _convertArrayable(array $array)
     {
         $arr = array();

--- a/lib/Elastica/Percolator.php
+++ b/lib/Elastica/Percolator.php
@@ -169,7 +169,7 @@ class Percolator
         // Add query to filter the percolator queries which are executed.
         if ($query) {
             $query = Query::create($query);
-            $data['query'] = $query->getQuery();
+            $data['query'] = $query->getQuery()->toArray();
         }
 
         $response = $this->getIndex()->getClient()->request($path, Request::GET, $data, $params);

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -116,7 +116,7 @@ class Query extends Param
      */
     public function setQuery(AbstractQuery $query)
     {
-        return $this->setParam('query', $query->toArray());
+        return $this->setParam('query', $query);
     }
 
     /**
@@ -300,7 +300,7 @@ class Query extends Param
             $scriptFields = new ScriptFields($scriptFields);
         }
 
-        return $this->setParam('script_fields', $scriptFields->toArray());
+        return $this->setParam('script_fields', $scriptFields);
     }
 
     /**
@@ -313,7 +313,7 @@ class Query extends Param
      */
     public function addScriptField($name, AbstractScript $script)
     {
-        $this->_params['script_fields'][$name] = $script->toArray();
+        $this->_params['script_fields'][$name] = $script;
 
         return $this;
     }
@@ -349,7 +349,7 @@ class Query extends Param
      */
     public function addFacet(AbstractFacet $facet)
     {
-        $this->_params['facets'][$facet->getName()] = $facet->toArray();
+        $this->_params['facets'][] = $facet;
 
         return $this;
     }
@@ -366,7 +366,8 @@ class Query extends Param
         if (!array_key_exists('aggs', $this->_params)) {
             $this->_params['aggs'] = array();
         }
-        $this->_params['aggs'][$agg->getName()] = $agg->toArray();
+
+        $this->_params['aggs'][] = $agg;
 
         return $this;
     }
@@ -390,7 +391,13 @@ class Query extends Param
             unset($this->_params['post_filter']);
         }
 
-        return $this->_params;
+        $array = $this->_convertArrayable($this->_params);
+
+        if (isset($array['suggest'])) {
+            $array['suggest'] = $array['suggest']['suggest'];
+        }
+
+        return $array;
     }
 
     /**
@@ -420,10 +427,7 @@ class Query extends Param
      */
     public function setSuggest(Suggest $suggest)
     {
-        $this->setParams(array_merge(
-            $this->getParams(),
-            $suggest->toArray()
-        ));
+        $this->setParam('suggest', $suggest);
 
         $this->_suggest = 1;
 
@@ -443,10 +447,10 @@ class Query extends Param
             $buffer = array();
 
             foreach ($rescore as $rescoreQuery) {
-                $buffer [] = $rescoreQuery->toArray();
+                $buffer [] = $rescoreQuery;
             }
         } else {
-            $buffer = $rescore->toArray();
+            $buffer = $rescore;
         }
 
         return $this->setParam('rescore', $buffer);
@@ -477,9 +481,7 @@ class Query extends Param
      */
     public function setPostFilter($filter)
     {
-        if ($filter instanceof AbstractFilter) {
-            $filter = $filter->toArray();
-        } else {
+        if (!($filter instanceof AbstractFilter)) {
             trigger_error('Deprecated: Elastica\Query::setPostFilter() passing filter as array is deprecated. Pass instance of AbstractFilter instead.', E_USER_DEPRECATED);
         }
 

--- a/lib/Elastica/Query/BoolQuery.php
+++ b/lib/Elastica/Query/BoolQuery.php
@@ -60,11 +60,7 @@ class BoolQuery extends AbstractQuery
      */
     protected function _addQuery($type, $args)
     {
-        if ($args instanceof AbstractQuery) {
-            $args = $args->toArray();
-        }
-
-        if (!is_array($args)) {
+        if (!is_array($args) && !($args instanceof AbstractQuery)) {
             throw new InvalidException('Invalid parameter. Has to be array or instance of Elastica\Query\AbstractQuery');
         }
 

--- a/lib/Elastica/Query/Boosting.php
+++ b/lib/Elastica/Query/Boosting.php
@@ -21,7 +21,7 @@ class Boosting extends AbstractQuery
      */
     public function setPositiveQuery(AbstractQuery $query)
     {
-        return $this->setParam('positive', $query->toArray());
+        return $this->setParam('positive', $query);
     }
 
     /**
@@ -33,7 +33,7 @@ class Boosting extends AbstractQuery
      */
     public function setNegativeQuery(AbstractQuery $query)
     {
-        return $this->setParam('negative', $query->toArray());
+        return $this->setParam('negative', $query);
     }
 
     /**

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -42,6 +42,8 @@ class ConstantScore extends AbstractQuery
      *
      * @param array|\Elastica\Query\AbstractQuery $query
      *
+     * @throws InvalidException If query is not an array or instance of AbstractQuery
+     *
      * @return $this
      */
     public function setQuery($query)

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -2,7 +2,6 @@
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
-use Elastica\Filter\AbstractFilter;
 
 /**
  * Constant score query.

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Query;
 
+use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
 
 /**
@@ -33,10 +34,6 @@ class ConstantScore extends AbstractQuery
      */
     public function setFilter($filter)
     {
-        if ($filter instanceof AbstractFilter) {
-            $filter = $filter->toArray();
-        }
-
         return $this->setParam('filter', $filter);
     }
 
@@ -49,8 +46,8 @@ class ConstantScore extends AbstractQuery
      */
     public function setQuery($query)
     {
-        if ($query instanceof AbstractQuery) {
-            $query = $query->toArray();
+        if (!is_array($query) && !($query instanceof AbstractQuery)) {
+            throw new InvalidException('Invalid parameter. Has to be array or instance of Elastica\Query\AbstractQuery');
         }
 
         return $this->setParam('query', $query);

--- a/lib/Elastica/Query/DisMax.php
+++ b/lib/Elastica/Query/DisMax.php
@@ -23,11 +23,7 @@ class DisMax extends AbstractQuery
      */
     public function addQuery($args)
     {
-        if ($args instanceof AbstractQuery) {
-            $args = $args->toArray();
-        }
-
-        if (!is_array($args)) {
+        if (!is_array($args) && !($args instanceof AbstractQuery)) {
             throw new InvalidException('Invalid parameter. Has to be array or instance of Elastica\Query\AbstractQuery');
         }
 

--- a/lib/Elastica/Query/FunctionScore.php
+++ b/lib/Elastica/Query/FunctionScore.php
@@ -40,7 +40,7 @@ class FunctionScore extends AbstractQuery
      */
     public function setQuery(AbstractQuery $query)
     {
-        return $this->setParam('query', $query->toArray());
+        return $this->setParam('query', $query);
     }
 
     /**
@@ -50,7 +50,7 @@ class FunctionScore extends AbstractQuery
      */
     public function setFilter(AbstractFilter $filter)
     {
-        return $this->setParam('filter', $filter->toArray());
+        return $this->setParam('filter', $filter);
     }
 
     /**
@@ -69,7 +69,7 @@ class FunctionScore extends AbstractQuery
             $functionType => $functionParams,
         );
         if (!is_null($filter)) {
-            $function['filter'] = $filter->toArray();
+            $function['filter'] = $filter;
         }
         if ($weight !== null) {
             $function['weight'] = $weight;
@@ -91,7 +91,7 @@ class FunctionScore extends AbstractQuery
      */
     public function addScriptScoreFunction(Script $script, AbstractFilter $filter = null, $weight = null)
     {
-        return $this->addFunction('script_score', $script->toArray(), $filter, $weight);
+        return $this->addFunction('script_score', $script, $filter, $weight);
     }
 
     /**

--- a/lib/Elastica/Query/HasChild.php
+++ b/lib/Elastica/Query/HasChild.php
@@ -67,8 +67,10 @@ class HasChild extends AbstractQuery
     {
         $array = parent::toArray();
 
-        if (isset($array[$this->_getBaseName()]['query'])) {
-            $array[$this->_getBaseName()]['query'] = $array[$this->_getBaseName()]['query']['query'];
+        $baseName = $this->_getBaseName();
+
+        if (isset($array[$baseName]['query'])) {
+            $array[$baseName]['query'] = $array[$baseName]['query']['query'];
         }
 
         return $array;

--- a/lib/Elastica/Query/HasChild.php
+++ b/lib/Elastica/Query/HasChild.php
@@ -60,6 +60,9 @@ class HasChild extends AbstractQuery
         return $this->setParam('_scope', $scope);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function toArray()
     {
         $array = parent::toArray();

--- a/lib/Elastica/Query/HasChild.php
+++ b/lib/Elastica/Query/HasChild.php
@@ -33,10 +33,7 @@ class HasChild extends AbstractQuery
      */
     public function setQuery($query)
     {
-        $query = BaseQuery::create($query);
-        $data = $query->toArray();
-
-        return $this->setParam('query', $data['query']);
+        return $this->setParam('query', BaseQuery::create($query));
     }
 
     /**
@@ -61,5 +58,16 @@ class HasChild extends AbstractQuery
     public function setScope($scope)
     {
         return $this->setParam('_scope', $scope);
+    }
+
+    public function toArray()
+    {
+        $array = parent::toArray();
+
+        if (isset($array[$this->_getBaseName()]['query'])) {
+            $array[$this->_getBaseName()]['query'] = $array[$this->_getBaseName()]['query']['query'];
+        }
+
+        return $array;
     }
 }

--- a/lib/Elastica/Query/HasParent.php
+++ b/lib/Elastica/Query/HasParent.php
@@ -31,10 +31,7 @@ class HasParent extends AbstractQuery
      */
     public function setQuery($query)
     {
-        $query = BaseQuery::create($query);
-        $data = $query->toArray();
-
-        return $this->setParam('query', $data['query']);
+        return $this->setParam('query', BaseQuery::create($query));
     }
 
     /**
@@ -60,4 +57,16 @@ class HasParent extends AbstractQuery
     {
         return $this->setParam('_scope', $scope);
     }
+
+    public function toArray()
+    {
+        $array = parent::toArray();
+
+        if (isset($array[$this->_getBaseName()]['query'])) {
+            $array[$this->_getBaseName()]['query'] = $array[$this->_getBaseName()]['query']['query'];
+        }
+
+        return $array;
+    }
 }
+

--- a/lib/Elastica/Query/HasParent.php
+++ b/lib/Elastica/Query/HasParent.php
@@ -65,8 +65,10 @@ class HasParent extends AbstractQuery
     {
         $array = parent::toArray();
 
-        if (isset($array[$this->_getBaseName()]['query'])) {
-            $array[$this->_getBaseName()]['query'] = $array[$this->_getBaseName()]['query']['query'];
+        $baseName = $this->_getBaseName();
+
+        if (isset($array[$baseName]['query'])) {
+            $array[$baseName]['query'] = $array[$baseName]['query']['query'];
         }
 
         return $array;

--- a/lib/Elastica/Query/HasParent.php
+++ b/lib/Elastica/Query/HasParent.php
@@ -58,6 +58,9 @@ class HasParent extends AbstractQuery
         return $this->setParam('_scope', $scope);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function toArray()
     {
         $array = parent::toArray();

--- a/lib/Elastica/Query/HasParent.php
+++ b/lib/Elastica/Query/HasParent.php
@@ -74,4 +74,3 @@ class HasParent extends AbstractQuery
         return $array;
     }
 }
-

--- a/lib/Elastica/Query/Nested.php
+++ b/lib/Elastica/Query/Nested.php
@@ -31,7 +31,7 @@ class Nested extends AbstractQuery
      */
     public function setQuery(AbstractQuery $query)
     {
-        return $this->setParam('query', $query->toArray());
+        return $this->setParam('query', $query);
     }
 
     /**

--- a/lib/Elastica/Query/TopChildren.php
+++ b/lib/Elastica/Query/TopChildren.php
@@ -33,10 +33,7 @@ class TopChildren extends AbstractQuery
      */
     public function setQuery($query)
     {
-        $query = BaseQuery::create($query);
-        $data = $query->toArray();
-
-        return $this->setParam('query', $data['query']);
+        return $this->setParam('query', BaseQuery::create($query));
     }
 
     /**

--- a/lib/Elastica/Rescore/Query.php
+++ b/lib/Elastica/Rescore/Query.php
@@ -38,7 +38,13 @@ class Query extends AbstractRescore
             $data = array_merge($data, $this->_rawParams);
         }
 
-        return $data;
+        $array = $this->_convertArrayable($data);
+
+        if (isset($array['query']['rescore_query']['query'])) {
+            $array['query']['rescore_query'] = $array['query']['rescore_query']['query'];
+        }
+
+        return $array;
     }
 
     /**
@@ -50,11 +56,10 @@ class Query extends AbstractRescore
      */
     public function setRescoreQuery($rescoreQuery)
     {
-        $query = BaseQuery::create($rescoreQuery);
-        $data = $query->toArray();
+        $rescoreQuery = BaseQuery::create($rescoreQuery);
 
         $query = $this->getParam('query');
-        $query['rescore_query'] = $data['query'];
+        $query['rescore_query'] = $rescoreQuery;
 
         return $this->setParam('query', $query);
     }

--- a/lib/Elastica/Script.php
+++ b/lib/Elastica/Script.php
@@ -136,7 +136,7 @@ class Script extends AbstractScript
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function toArray()
     {

--- a/lib/Elastica/Script.php
+++ b/lib/Elastica/Script.php
@@ -145,7 +145,7 @@ class Script extends AbstractScript
         );
 
         if (!empty($this->_params)) {
-            $array['params'] = $this->_params;
+            $array['params'] = $this->_convertArrayable($this->_params);
         }
 
         if ($this->_lang) {

--- a/lib/Elastica/ScriptFields.php
+++ b/lib/Elastica/ScriptFields.php
@@ -35,7 +35,7 @@ class ScriptFields extends Param
         if (!is_string($name) || !strlen($name)) {
             throw new InvalidException('The name of a Script is required and must be a string');
         }
-        $this->setParam($name, $script->toArray());
+        $this->setParam($name, $script);
 
         return $this;
     }
@@ -60,6 +60,6 @@ class ScriptFields extends Param
      */
     public function toArray()
     {
-        return $this->_params;
+        return $this->_convertArrayable($this->_params);
     }
 }

--- a/lib/Elastica/Suggest.php
+++ b/lib/Elastica/Suggest.php
@@ -42,7 +42,7 @@ class Suggest extends Param
      */
     public function addSuggestion(AbstractSuggest $suggestion)
     {
-        return $this->setParam($suggestion->getName(), $suggestion->toArray());
+        return $this->addParam('suggestion', $suggestion);
     }
 
     /**
@@ -61,5 +61,24 @@ class Suggest extends Param
                 return new self($suggestion);
         }
         throw new NotImplementedException();
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        $array = parent::toArray();
+
+        if (isset($array[$this->_getBaseName()]['suggestion'])) {
+            $suggestion = $array[$this->_getBaseName()]['suggestion'];
+            unset($array[$this->_getBaseName()]['suggestion']);
+
+            foreach ($suggestion as $key => $value) {
+                $array[$this->_getBaseName()][$key] = $value;
+            }
+        }
+
+        return $array;
     }
 }

--- a/lib/Elastica/Suggest.php
+++ b/lib/Elastica/Suggest.php
@@ -64,7 +64,7 @@ class Suggest extends Param
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function toArray()
     {

--- a/lib/Elastica/Suggest.php
+++ b/lib/Elastica/Suggest.php
@@ -70,12 +70,14 @@ class Suggest extends Param
     {
         $array = parent::toArray();
 
-        if (isset($array[$this->_getBaseName()]['suggestion'])) {
-            $suggestion = $array[$this->_getBaseName()]['suggestion'];
-            unset($array[$this->_getBaseName()]['suggestion']);
+        $baseName = $this->_getBaseName();
+
+        if (isset($array[$baseName]['suggestion'])) {
+            $suggestion = $array[$baseName]['suggestion'];
+            unset($array[$baseName]['suggestion']);
 
             foreach ($suggestion as $key => $value) {
-                $array[$this->_getBaseName()][$key] = $value;
+                $array[$baseName][$key] = $value;
             }
         }
 

--- a/lib/Elastica/Suggest/AbstractSuggest.php
+++ b/lib/Elastica/Suggest/AbstractSuggest.php
@@ -1,13 +1,14 @@
 <?php
 namespace Elastica\Suggest;
 
-use Elastica\Nameable;
+use Elastica\Exception\InvalidException;
+use Elastica\NameableInterface;
 use Elastica\Param;
 
 /**
  * Class AbstractSuggestion.
  */
-abstract class AbstractSuggest extends Param implements Nameable
+abstract class AbstractSuggest extends Param implements NameableInterface
 {
     /**
      * @var string the name of this suggestion
@@ -25,7 +26,7 @@ abstract class AbstractSuggest extends Param implements Nameable
      */
     public function __construct($name, $field)
     {
-        $this->_name = $name;
+        $this->setName($name);
         $this->setField($field);
     }
 
@@ -71,6 +72,26 @@ abstract class AbstractSuggest extends Param implements Nameable
     public function setShardSize($size)
     {
         return $this->setParam('shard_size', $size);
+    }
+
+    /**
+     * Sets the name of the suggest. It is automatically set by
+     * the constructor.
+     *
+     * @param string $name The name of the facet.
+     *
+     * @throws \Elastica\Exception\InvalidException If name is empty
+     *
+     * @return $this
+     */
+    public function setName($name)
+    {
+        if (empty($name)) {
+            throw new InvalidException('Suggest name has to be set');
+        }
+        $this->_name = $name;
+
+        return $this;
     }
 
     /**

--- a/lib/Elastica/Suggest/AbstractSuggest.php
+++ b/lib/Elastica/Suggest/AbstractSuggest.php
@@ -1,12 +1,13 @@
 <?php
 namespace Elastica\Suggest;
 
+use Elastica\Nameable;
 use Elastica\Param;
 
 /**
  * Class AbstractSuggestion.
  */
-abstract class AbstractSuggest extends Param
+abstract class AbstractSuggest extends Param implements Nameable
 {
     /**
      * @var string the name of this suggestion

--- a/lib/Elastica/Suggest/Phrase.php
+++ b/lib/Elastica/Suggest/Phrase.php
@@ -155,10 +155,30 @@ class Phrase extends AbstractSuggest
      */
     public function addCandidateGenerator(AbstractCandidateGenerator $generator)
     {
-        $generator = $generator->toArray();
-        $keys = array_keys($generator);
-        $values = array_values($generator);
+        return $this->setParam('candidate_generator', $generator);
+    }
 
-        return $this->addParam($keys[0], $values[0]);
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        $array = parent::toArray();
+
+        if (isset($array[$this->_getBaseName()]['candidate_generator'])) {
+            $generator = $array[$this->_getBaseName()]['candidate_generator'];
+            unset($array[$this->_getBaseName()]['candidate_generator']);
+
+            $keys = array_keys($generator);
+            $values = array_values($generator);
+
+            if (!isset($array[$this->_getBaseName()][$keys[0]])) {
+                $array[$this->_getBaseName()][$keys[0]] = array();
+            }
+
+            $array[$this->_getBaseName()][$keys[0]][] = $values[0];
+        }
+
+        return $array;
     }
 }

--- a/lib/Elastica/Suggest/Phrase.php
+++ b/lib/Elastica/Suggest/Phrase.php
@@ -165,18 +165,20 @@ class Phrase extends AbstractSuggest
     {
         $array = parent::toArray();
 
-        if (isset($array[$this->_getBaseName()]['candidate_generator'])) {
-            $generator = $array[$this->_getBaseName()]['candidate_generator'];
-            unset($array[$this->_getBaseName()]['candidate_generator']);
+        $baseName = $this->_getBaseName();
+
+        if (isset($array[$baseName]['candidate_generator'])) {
+            $generator = $array[$baseName]['candidate_generator'];
+            unset($array[$baseName]['candidate_generator']);
 
             $keys = array_keys($generator);
             $values = array_values($generator);
 
-            if (!isset($array[$this->_getBaseName()][$keys[0]])) {
-                $array[$this->_getBaseName()][$keys[0]] = array();
+            if (!isset($array[$baseName][$keys[0]])) {
+                $array[$baseName][$keys[0]] = array();
             }
 
-            $array[$this->_getBaseName()][$keys[0]][] = $values[0];
+            $array[$baseName][$keys[0]][] = $values[0];
         }
 
         return $array;

--- a/lib/Elastica/Suggest/Phrase.php
+++ b/lib/Elastica/Suggest/Phrase.php
@@ -159,7 +159,7 @@ class Phrase extends AbstractSuggest
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function toArray()
     {

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -485,7 +485,7 @@ class Type implements SearchableInterface
         }
         $query = Query::create($query);
 
-        return $this->request('_query', Request::DELETE, array('query' => $query->getQuery()), $options);
+        return $this->request('_query', Request::DELETE, array('query' => $query->getQuery()->toArray()), $options);
     }
 
     /**

--- a/test/lib/Elastica/Test/Aggregation/TopHitsTest.php
+++ b/test/lib/Elastica/Test/Aggregation/TopHitsTest.php
@@ -161,7 +161,7 @@ class TopHitsTest extends BaseAggregationTest
 
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setScriptFields($scriptFields);
-        $this->assertEquals($scriptFields->toArray(), $agg->getParam('script_fields'));
+        $this->assertEquals($scriptFields->toArray(), $agg->getParam('script_fields')->toArray());
         $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
     }
 
@@ -173,7 +173,7 @@ class TopHitsTest extends BaseAggregationTest
         $script = new Script('2+3');
         $agg = new TopHits('agg_name');
         $returnValue = $agg->addScriptField('five', $script);
-        $this->assertEquals(array('five' => $script->toArray()), $agg->getParam('script_fields'));
+        $this->assertEquals(array('five' => $script->toArray()), $agg->getParam('script_fields')->toArray());
         $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
     }
 

--- a/test/lib/Elastica/Test/Filter/MultiTest.php
+++ b/test/lib/Elastica/Test/Filter/MultiTest.php
@@ -28,10 +28,10 @@ class AbstractMultiTest extends BaseTest
         $stub->addFilter($filter);
 
         $expected = array(
-            $filter->toArray(),
+            $filter,
         );
 
-        $this->assertEquals($expected, $stub->getFilters());
+        $this->assertSame($expected, $stub->getFilters());
     }
 
     /**
@@ -45,10 +45,10 @@ class AbstractMultiTest extends BaseTest
         $stub->setFilters(array($filter));
 
         $expected = array(
-            $filter->toArray(),
+            $filter
         );
 
-        $this->assertEquals($expected, $stub->getFilters());
+        $this->assertSame($expected, $stub->getFilters());
     }
 
     /**

--- a/test/lib/Elastica/Test/Filter/MultiTest.php
+++ b/test/lib/Elastica/Test/Filter/MultiTest.php
@@ -45,7 +45,7 @@ class AbstractMultiTest extends BaseTest
         $stub->setFilters(array($filter));
 
         $expected = array(
-            $filter
+            $filter,
         );
 
         $this->assertSame($expected, $stub->getFilters());

--- a/test/lib/Elastica/Test/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryTest.php
@@ -228,7 +228,7 @@ class QueryTest extends BaseTest
         $termQuery->setTerm('text', 'value');
         $query->setQuery($termQuery);
 
-        $this->assertEquals($termQuery->toArray(), $query->getQuery());
+        $this->assertSame($termQuery, $query->getQuery());
     }
 
     /**
@@ -266,7 +266,7 @@ class QueryTest extends BaseTest
         $anotherQuery = new Query();
         $anotherQuery->setQuery($termQuery);
 
-        $this->assertNotEquals($query->toArray(), $anotherQuery->toArray());
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
     }
 
     /**
@@ -282,9 +282,9 @@ class QueryTest extends BaseTest
         $queryArray = $query->toArray();
 
         $termQuery = $query->getQuery();
-        $termQuery['term']['text']['value'] = 'another value';
+        $termQuery->setTerm('text', 'another value');
 
-        $this->assertEquals($queryArray, $query->toArray());
+        $this->assertNotEquals($queryArray, $query->toArray());
     }
 
     /**
@@ -303,7 +303,7 @@ class QueryTest extends BaseTest
         $anotherQuery = new Query();
         $anotherQuery->setScriptFields($scriptFields);
 
-        $this->assertNotEquals($query->toArray(), $anotherQuery->toArray());
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
     }
 
     /**
@@ -321,7 +321,7 @@ class QueryTest extends BaseTest
         $anotherQuery = new Query();
         $anotherQuery->addScriptField('script', $scriptField);
 
-        $this->assertNotEquals($query->toArray(), $anotherQuery->toArray());
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
     }
 
     /**
@@ -339,7 +339,7 @@ class QueryTest extends BaseTest
         $anotherQuery = new Query();
         $anotherQuery->addFacet($facet);
 
-        $this->assertNotEquals($query->toArray(), $anotherQuery->toArray());
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
     }
 
     /**
@@ -357,7 +357,7 @@ class QueryTest extends BaseTest
         $anotherQuery = new Query();
         $anotherQuery->addAggregation($aggregation);
 
-        $this->assertNotEquals($query->toArray(), $anotherQuery->toArray());
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
     }
 
     /**
@@ -376,7 +376,7 @@ class QueryTest extends BaseTest
         $anotherQuery = new Query();
         $anotherQuery->setSuggest($suggest);
 
-        $this->assertNotEquals($query->toArray(), $anotherQuery->toArray());
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
     }
 
     /**
@@ -395,7 +395,7 @@ class QueryTest extends BaseTest
         $anotherQuery = new Query();
         $anotherQuery->setRescore($rescore);
 
-        $this->assertNotEquals($query->toArray(), $anotherQuery->toArray());
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
     }
 
     /**
@@ -413,7 +413,7 @@ class QueryTest extends BaseTest
         $anotherQuery = new Query();
         $anotherQuery->setPostFilter($postFilter);
 
-        $this->assertNotEquals($query->toArray(), $anotherQuery->toArray());
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
     }
 
     /**

--- a/test/lib/Elastica/Test/ScriptFieldsTest.php
+++ b/test/lib/Elastica/Test/ScriptFieldsTest.php
@@ -19,20 +19,20 @@ class ScriptFieldsTest extends BaseTest
         // addScript
         $scriptFields = new ScriptFields();
         $scriptFields->addScript('test', $script);
-        $this->assertEquals($scriptFields->getParam('test'), $script->toArray());
+        $this->assertSame($scriptFields->getParam('test'), $script);
 
         // setScripts
         $scriptFields = new ScriptFields();
         $scriptFields->setScripts(array(
             'test' => $script,
         ));
-        $this->assertEquals($scriptFields->getParam('test'), $script->toArray());
+        $this->assertSame($scriptFields->getParam('test'), $script);
 
         // Constructor
         $scriptFields = new ScriptFields(array(
             'test' => $script,
         ));
-        $this->assertEquals($scriptFields->getParam('test'), $script->toArray());
+        $this->assertSame($scriptFields->getParam('test'), $script);
     }
 
     /**
@@ -47,12 +47,12 @@ class ScriptFieldsTest extends BaseTest
             'test' => $script,
         ));
         $query->setScriptFields($scriptFields);
-        $this->assertEquals($query->getParam('script_fields'), $scriptFields->toArray());
+        $this->assertSame($query->getParam('script_fields'), $scriptFields);
 
         $query->setScriptFields(array(
             'test' => $script,
         ));
-        $this->assertEquals($query->getParam('script_fields'), $scriptFields->toArray());
+        $this->assertSame($query->getParam('script_fields')->getParam('test'), $script);
     }
 
     /**


### PR DESCRIPTION
This is PR for #783, convert object toArray when it is really needed. Comments, tests, review - welcome.

BC: 
1. Now toArray is lazy. This mean that if you set object to Query, Aggregation and so on, and later will change it - changes will be affected at toArray also.
For example such test:
```php
        $query = new Query();
        $aggregation = new \Elastica\Aggregation\Terms('text');

        $query->addAggregation($aggregation);

        $aggregation->setName('another text');

        $anotherQuery = new Query();
        $anotherQuery->addAggregation($aggregation);

        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
```
with previous code will be not passed. With this PR - it is passed.


2. if your code work with params somehow (direct access to _params, getParams() methods and so on) - it can be broken.
For example, before:
```php
$script = Elastica\Script::create($script);
return $this->setParams($script->toArray());
```
Now:
```php
return $this->setParam('script', Elastica\Script::create($script));
```
Same as some named object:
before:
```php
$this->_aggs[$aggregation->getName()] = $aggregation->toArray();
```
after:
```php
$this->_aggs[] = $aggregation;
```

As you can see, aggregation name in toArray also become lazy.