### PR TITLE
Allow PHP 7.0 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,12 @@ php:
   - 5.5
   - 5.4
   - 5.3
-  - 7
+  - 7.0
   - hhvm
 
 matrix:
   allow_failures:
     - php: 5.3
-    - php: 7
     - php: hhvm
   fast_finish: true
 


### PR DESCRIPTION
* We should aim at 100% PHP 7 compatibility
* PHP 5.3 works anyway