### PR TITLE
Enable the support of "http.compression: true" in elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file based on the
 - Add Script File feature #902 #914
 
 ### Improvements
+- Support the http.compression in the Http transport adapter #515
 
 ### Deprecated
 

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -35,6 +35,7 @@ class Client
         'roundRobin' => false,
         'log' => false,
         'retryOnConflict' => 0,
+        'compression' => false,
     );
 
     /**

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -118,7 +118,15 @@ class Http extends AbstractTransport
             // Escaping of / not necessary. Causes problems in base64 encoding of files
             $content = str_replace('\/', '/', $content);
 
-            curl_setopt($conn, CURLOPT_POSTFIELDS, $content);
+            // An "Accept-Encoding" header containing all supported encoding types is sent
+            // Curl will decode the response automatically
+            curl_setopt($conn, CURLOPT_ENCODING, '');
+
+            // Let's precise that the request is also compressed
+            curl_setopt($conn, CURLOPT_HTTPHEADER, ['Content-Encoding: gzip']);
+
+            // Let's compress the request body
+            curl_setopt($conn, CURLOPT_POSTFIELDS, gzencode($content));
         } else {
             curl_setopt($conn, CURLOPT_POSTFIELDS, '');
         }

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -118,15 +118,19 @@ class Http extends AbstractTransport
             // Escaping of / not necessary. Causes problems in base64 encoding of files
             $content = str_replace('\/', '/', $content);
 
-            // An "Accept-Encoding" header containing all supported encoding types is sent
-            // Curl will decode the response automatically
-            curl_setopt($conn, CURLOPT_ENCODING, '');
+            if (true === $connection->getParam('compression')) {
+                // An "Accept-Encoding" header containing all supported encoding types is sent
+                // Curl will decode the response automatically
+                curl_setopt($conn, CURLOPT_ENCODING, '');
 
-            // Let's precise that the request is also compressed
-            curl_setopt($conn, CURLOPT_HTTPHEADER, ['Content-Encoding: gzip']);
+                // Let's precise that the request is also compressed
+                curl_setopt($conn, CURLOPT_HTTPHEADER, ['Content-Encoding: gzip']);
 
-            // Let's compress the request body
-            curl_setopt($conn, CURLOPT_POSTFIELDS, gzencode($content));
+                // Let's compress the request body,
+                curl_setopt($conn, CURLOPT_POSTFIELDS, gzencode($content));
+            } else {
+                curl_setopt($conn, CURLOPT_POSTFIELDS, $content);
+            }
         } else {
             curl_setopt($conn, CURLOPT_POSTFIELDS, '');
         }


### PR DESCRIPTION
Hi !

After some tests and the reading of https://github.com/ruflin/Elastica/issues/515
I figured out that compress the request and the response can be a big performance improvement !
I don't know exactly where you want to put the configuration to enable this compression but here are the lines that works.

Hope it will help you !