### PR TITLE
test that clone doesn't clone inner objects

### DIFF
--- a/test/lib/Elastica/Test/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryTest.php
@@ -272,6 +272,23 @@ class QueryTest extends BaseTest
     /**
      * @group unit
      */
+    public function testNotCloneInnerObjects()
+    {
+        $query = new Query();
+        $termQuery = new Term();
+        $termQuery->setTerm('text', 'value');
+        $query->setQuery($termQuery);
+
+        $anotherQuery = clone $query;
+
+        $termQuery->setTerm('text', 'another value');
+
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
+    }
+
+    /**
+     * @group unit
+     */
     public function testSetQueryToArrayChangeQuery()
     {
         $query = new Query();


### PR DESCRIPTION
Test, that cover current work when object cloned.

From this comment: https://github.com/ruflin/Elastica/pull/916#issuecomment-140550935