### PR TITLE
fix empty string is not anonymous filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/2.3.0...HEAD)
+- Filters aggregation: empty name is named bucket #935
 
 ### Backward Compatibility Breaks
 
 ### Bugfixes
+- Filters aggregation: empty name is named bucket #935
 
 ### Added
 

--- a/lib/Elastica/Aggregation/Filters.php
+++ b/lib/Elastica/Aggregation/Filters.php
@@ -20,7 +20,7 @@ class Filters extends AbstractAggregation
      *
      * @return $this
      */
-    public function addFilter(AbstractFilter $filter, $name = '')
+    public function addFilter(AbstractFilter $filter, $name = null)
     {
         $filterArray = array();
 
@@ -45,7 +45,7 @@ class Filters extends AbstractAggregation
             // Detect between anonymous filters and named ones
             $key = key($filter);
 
-            if (is_string($key) && !empty($key)) {
+            if (is_string($key)) {
                 $array['filters']['filters'][$key] = current($filter)->toArray();
             } else {
                 $array['filters']['filters'][] = current($filter)->toArray();

--- a/test/lib/Elastica/Test/Aggregation/FiltersTest.php
+++ b/test/lib/Elastica/Test/Aggregation/FiltersTest.php
@@ -34,6 +34,12 @@ class FiltersTest extends BaseAggregationTest
         $expected = array(
             'filters' => array(
                 'filters' => array(
+                    '' => array(
+                        'term' => array('color' => ''),
+                    ),
+                    '0' => array(
+                        'term' => array('color' => '0'),
+                    ),
                     'blue' => array(
                         'term' => array('color' => 'blue'),
                     ),
@@ -48,6 +54,8 @@ class FiltersTest extends BaseAggregationTest
         );
 
         $agg = new Filters('by_color');
+        $agg->addFilter(new Term(array('color' => '')), '');
+        $agg->addFilter(new Term(array('color' => '0')), '0');
         $agg->addFilter(new Term(array('color' => 'blue')), 'blue');
         $agg->addFilter(new Term(array('color' => 'red')), 'red');
 


### PR DESCRIPTION
Add tests for Filters keys and fix for this test.

'' - is not anonymous key. Proof - 
![empty-key](https://cloud.githubusercontent.com/assets/735804/9915747/0c8da410-5cb9-11e5-8341-27bb74c09c73.png)


From discussion here https://github.com/ruflin/Elastica/pull/916#discussion-diff-37099377 and here https://github.com/ruflin/Elastica/pull/916#discussion_r39566782