### PR TITLE
prevent mix keys in filters (#936)

### DIFF
--- a/lib/Elastica/Aggregation/Filters.php
+++ b/lib/Elastica/Aggregation/Filters.php
@@ -17,7 +17,7 @@ class Filters extends AbstractAggregation
     /**
      * @var int Type of bucket keys - named, or anonymous
      */
-    private $type = null;
+    private $_type = null;
 
     /**
      * Add a filter.
@@ -48,12 +48,12 @@ class Filters extends AbstractAggregation
 
         if ($this->hasParam('filters')
             && count($this->getParam('filters'))
-            && $this->type !== $type
+            && $this->_type !== $type
         ) {
             throw new InvalidException('Mix named and anonymous keys are not allowed');
         }
 
-        $this->type = $type;
+        $this->_type = $type;
 
         return $this->addParam('filters', $filterArray);
     }
@@ -67,7 +67,7 @@ class Filters extends AbstractAggregation
         $filters = $this->getParam('filters');
 
         foreach ($filters as $filter) {
-            if (self::NAMED_TYPE === $this->type) {
+            if (self::NAMED_TYPE === $this->_type) {
                 $key = key($filter);
                 $array['filters']['filters'][$key] = current($filter)->toArray();
             } else {

--- a/lib/Elastica/Aggregation/Filters.php
+++ b/lib/Elastica/Aggregation/Filters.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Aggregation;
 
+use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
 
 /**
@@ -10,6 +11,14 @@ use Elastica\Filter\AbstractFilter;
  */
 class Filters extends AbstractAggregation
 {
+    const NAMED_TYPE = 1;
+    const ANONYMOUS_TYPE = 2;
+
+    /**
+     * @var int Type of bucket keys - named, or anonymous
+     */
+    private $type = null;
+
     /**
      * Add a filter.
      *
@@ -22,13 +31,29 @@ class Filters extends AbstractAggregation
      */
     public function addFilter(AbstractFilter $filter, $name = null)
     {
+        if (null !== $name && !is_string($name)) {
+            throw new InvalidException('Name must be a string');
+        }
+
         $filterArray = array();
 
-        if (is_string($name)) {
-            $filterArray[$name] = $filter;
-        } else {
+        $type = self::NAMED_TYPE;
+
+        if (null === $name) {
             $filterArray[] = $filter;
+            $type = self::ANONYMOUS_TYPE;
+        } else {
+            $filterArray[$name] = $filter;
         }
+
+        if ($this->hasParam('filters')
+            && count($this->getParam('filters'))
+            && $this->type !== $type
+        ) {
+            throw new InvalidException('Mix named and anonymous keys are not allowed');
+        }
+
+        $this->type = $type;
 
         return $this->addParam('filters', $filterArray);
     }
@@ -42,10 +67,8 @@ class Filters extends AbstractAggregation
         $filters = $this->getParam('filters');
 
         foreach ($filters as $filter) {
-            // Detect between anonymous filters and named ones
-            $key = key($filter);
-
-            if (is_string($key)) {
+            if (self::NAMED_TYPE === $this->type) {
+                $key = key($filter);
                 $array['filters']['filters'][$key] = current($filter)->toArray();
             } else {
                 $array['filters']['filters'][] = current($filter)->toArray();

--- a/test/lib/Elastica/Test/Aggregation/FiltersTest.php
+++ b/test/lib/Elastica/Test/Aggregation/FiltersTest.php
@@ -69,6 +69,17 @@ class FiltersTest extends BaseAggregationTest
     /**
      * @group unit
      * @expectedException Elastica\Exception\InvalidException
+     * @expectedExceptionMessage Name must be a string
+     */
+    public function testWrongName()
+    {
+        $agg = new Filters('by_color');
+        $agg->addFilter(new Term(array('color' => '0')), 0);
+    }
+
+    /**
+     * @group unit
+     * @expectedException Elastica\Exception\InvalidException
      * @expectedExceptionMessage Mix named and anonymous keys are not allowed
      */
     public function testMixNamedAndAnonymousFilters()

--- a/test/lib/Elastica/Test/Aggregation/FiltersTest.php
+++ b/test/lib/Elastica/Test/Aggregation/FiltersTest.php
@@ -68,6 +68,30 @@ class FiltersTest extends BaseAggregationTest
 
     /**
      * @group unit
+     * @expectedException Elastica\Exception\InvalidException
+     * @expectedExceptionMessage Mix named and anonymous keys are not allowed
+     */
+    public function testMixNamedAndAnonymousFilters()
+    {
+        $agg = new Filters('by_color');
+        $agg->addFilter(new Term(array('color' => '0')), '0');
+        $agg->addFilter(new Term(array('color' => '0')));
+    }
+
+    /**
+     * @group unit
+     * @expectedException Elastica\Exception\InvalidException
+     * @expectedExceptionMessage Mix named and anonymous keys are not allowed
+     */
+    public function testMixAnonymousAndNamedFilters()
+    {
+        $agg = new Filters('by_color');
+        $agg->addFilter(new Term(array('color' => '0')));
+        $agg->addFilter(new Term(array('color' => '0')), '0');
+    }
+
+    /**
+     * @group unit
      */
     public function testToArrayUsingAnonymousFilters()
     {


### PR DESCRIPTION
According to discussion in #936 - this PR does not allow to mix Filters keys