### PR TITLE
Add Field Data Fields property and possibility to get 'script_fields' in same time that '_source' fields in result

### DIFF
--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -286,6 +286,20 @@ class Query extends Param
     }
 
     /**
+     * Sets the fields not stored to be returned by the search
+     *
+     * @param array $fieldDataFields Fields not stored to be returned
+     *
+     * @return $this
+     *
+     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fielddata-fields.html
+     */
+    public function setFieldDataFields(array $fieldDataFields)
+    {
+        return $this->setParam('fielddata_fields', $fieldDataFields);
+    }
+
+    /**
      * Set script fields.
      *
      * @param array|\Elastica\ScriptFields $scriptFields Script fields

--- a/lib/Elastica/Result.php
+++ b/lib/Elastica/Result.php
@@ -142,7 +142,7 @@ class Result
     /**
      * Returns result data.
      *
-     * Checks for partial result data with getFields, falls back to getSource
+     * Checks for partial result data with getFields, falls back to getSource or both
      *
      * @return array Result data array
      */
@@ -150,6 +150,8 @@ class Result
     {
         if (isset($this->_hit['fields']) && !isset($this->_hit['_source'])) {
             return $this->getFields();
+        } else if (isset($this->_hit['fields']) && isset($this->_hit['_source'])) {
+            return array_merge($this->getFields(), $this->getSource());
         }
 
         return $this->getSource();


### PR DESCRIPTION
Add Field Data Fields property for search because actually don't exist and add too possibility to get 'script_fields' in same time that '_source' fields.

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fielddata-fields.html#search-request-fielddata-fields