### PR TITLE
Change check to OR instead of AND

### DIFF
--- a/lib/Elastica/Filter/BoolFilter.php
+++ b/lib/Elastica/Filter/BoolFilter.php
@@ -81,7 +81,7 @@ class BoolFilter extends AbstractFilter
      */
     protected function _addFilter($type, $args)
     {
-        if (!is_array($args) && !($args instanceof AbstractFilter)) {
+        if (!is_array($args) || !($args instanceof AbstractFilter)) {
             throw new InvalidException('Invalid parameter. Has to be array or instance of Elastica\Filter');
         }
 


### PR DESCRIPTION
Fixes the check for when `$args` is an array. So that the check doesn't fail, preventing the use of array arguments.

```php
$args = [];
        var_dump((!is_array($args) || !($args instanceof AbstractFilter))); // true
        var_dump((!is_array($args) && !($args instanceof AbstractFilter))); // false
```