### PR TITLE
typo in getErrorMessage

### DIFF
--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -95,13 +95,11 @@ class Response
     {
         $error = $this->getError();
 
-        $message = '';
-
         if (!is_string($error)) {
-            $message = json_encode($message);
+            $error = json_encode($error);
         }
 
-        return $message;
+        return $error;
     }
 
     /**

--- a/test/lib/Elastica/Test/ResponseTest.php
+++ b/test/lib/Elastica/Test/ResponseTest.php
@@ -131,6 +131,30 @@ class ResponseTest extends BaseTest
     /**
      * @group unit
      */
+    public function testArrayErrorMessage()
+    {
+        $response = new Response(json_encode(array(
+            'error' => array('a', 'b')
+        )));
+
+        $this->assertEquals(json_encode(array('a', 'b')), $response->getErrorMessage());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testStringErrorMessage()
+    {
+        $response = new Response(json_encode(array(
+            'error' => 'a'
+        )));
+
+        $this->assertEquals('a', $response->getErrorMessage());
+    }
+
+    /**
+     * @group unit
+     */
     public function testIsNotOkBulkItemsWithOkField()
     {
         $response = new Response(json_encode(array(


### PR DESCRIPTION
In original version there is kind of typo, always return empty. This PR fix it and also add some tests.