### PR TITLE
fix delete by query tests

### DIFF
--- a/test/lib/Elastica/Test/IndexTest.php
+++ b/test/lib/Elastica/Test/IndexTest.php
@@ -422,22 +422,34 @@ class IndexTest extends BaseTest
     public function testDeleteByQueryWithQueryAndOptions()
     {
         $index = $this->_createIndex(null, true, 2);
-        $type1 = new Type($index, 'test1');
-        $type1->addDocument(new Document(1, array('name' => 'ruflin nicolas')));
-        $type1->addDocument(new Document(2, array('name' => 'ruflin')));
-        $type2 = new Type($index, 'test2');
-        $type2->addDocument(new Document(1, array('name' => 'ruflin nicolas')));
-        $type2->addDocument(new Document(2, array('name' => 'ruflin')));
+
+        $routing1 = 'first_routing';
+        $routing2 = 'second_routing';
+
+        for ($i=1; $i<=2; $i++) {
+            $type = new Type($index, 'test'.$i);
+            $doc = new Document(1, array('name' => 'ruflin nicolas'));
+            $doc->setRouting($routing1);
+            $type->addDocument($doc);
+
+            $doc = new Document(2, array('name' => 'ruflin'));
+            $doc->setRouting($routing1);
+            $type->addDocument($doc);
+        }
+
         $index->refresh();
 
         $response = $index->search('ruflin*');
         $this->assertEquals(4, $response->count());
 
+        $response = $index->search('ruflin*', array('routing' => $routing2));
+        $this->assertEquals(0, $response->count());
+
         $response = $index->search('nicolas');
         $this->assertEquals(2, $response->count());
 
         // Route to the wrong document id; should not delete
-        $response = $index->deleteByQuery(new SimpleQueryString('nicolas'), array('routing' => '2'));
+        $response = $index->deleteByQuery(new SimpleQueryString('nicolas'), array('routing' => $routing2));
         $this->assertTrue($response->isOk());
 
         $index->refresh();
@@ -449,7 +461,7 @@ class IndexTest extends BaseTest
         $this->assertEquals(2, $response->count());
 
         // Delete first document
-        $response = $index->deleteByQuery(new SimpleQueryString('nicolas'), array('routing' => '1'));
+        $response = $index->deleteByQuery(new SimpleQueryString('nicolas'), array('routing' => $routing1));
         $this->assertTrue($response->isOk());
 
         $index->refresh();


### PR DESCRIPTION
Fix for deleteByQuery tests.

In Elasticsearch shard defined like:
shard = hash(routing) % number_of_primary_shards

In 2.0 version hash function is changed, probably this is why test broken. I add assert that we really insert document to desired shards and after that there is deleteByQuery asserts performed.
