### PR TITLE
ES2.0 Fix MoreLikeThis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/2.3.1...HEAD)
 
 ### Backward Compatibility Breaks
+- MoreLikeThis::setLikeText deprecated from ES 2.0, use setLike instead, but there is a difference - setLike haven't trim magic inside for strings
+- Type::moreLikeThis API was removed from ES 2.0, use MoreLikeThis query instead
 - Remove Thrift transport and everything related to it
 - Remove Memcache transport and everything related to it
 - Remove BulkUdp and everything related to it
@@ -23,12 +25,15 @@ All notable changes to this project will be documented in this file based on the
 
 ### Added
 - Elastica\Reponse::getErrorMessage was added as getError is now an object
+- Elastica\Query\MoreLikeThis::setLike
 
 ### Improvements
 - Travis builds were moved to docker-compose setup. Ansible scripts and Vagrant files were removed
 
 
 ### Deprecated
+- Elastica\Query\MoreLikeThis::setLikeText is deprecated
+- Elastica\Query\MoreLikeThis::setIds is deprecated
 
 
 ## [2.3.1](https://github.com/ruflin/Elastica/releases/tag/2.3.1) - 2015-10-17

--- a/lib/Elastica/Filter/Bool.php
+++ b/lib/Elastica/Filter/Bool.php
@@ -8,6 +8,8 @@ namespace Elastica\Filter;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
+ * @deprecated Use BoolFilter instead. From PHP7 bool is reserved word.
+ *
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-filter.html
  */
 class Bool extends BoolFilter

--- a/lib/Elastica/Query/Bool.php
+++ b/lib/Elastica/Query/Bool.php
@@ -8,6 +8,8 @@ namespace Elastica\Query;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
+ * @deprecated Use BoolQuery instead. From PHP7 bool is reserved word.
+ *
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
  */
 class Bool extends BoolQuery

--- a/lib/Elastica/Query/MoreLikeThis.php
+++ b/lib/Elastica/Query/MoreLikeThis.php
@@ -1,5 +1,6 @@
 <?php
 namespace Elastica\Query;
+use Elastica\Document;
 
 /**
  * More Like This query.
@@ -27,6 +28,8 @@ class MoreLikeThis extends AbstractQuery
      *
      * @param array $ids Document ids
      *
+     * @deprecated Option "ids" deprecated as of ES 2.0.0-beta1 Use "like" instead.
+
      * @return \Elastica\Query\MoreLikeThis Current object
      */
     public function setIds(array $ids)
@@ -35,10 +38,24 @@ class MoreLikeThis extends AbstractQuery
     }
 
     /**
+     * Set the "like" value.
+     *
+     * @param string|Document $like
+     *
+     * @return $this
+     */
+    public function setLike($like)
+    {
+        return $this->setParam('like', $like);
+    }
+
+    /**
      * Set the "like_text" value.
      *
      * @param string $likeText
      *
+     * @deprecated Option "like_text" deprecated as of ES 2.0.0-beta1 Use "like" instead.
+
      * @return $this
      */
     public function setLikeText($likeText)
@@ -194,5 +211,18 @@ class MoreLikeThis extends AbstractQuery
     public function setMinimumShouldMatch($minimumShouldMatch)
     {
         return $this->setParam('minimum_should_match', $minimumShouldMatch);
+    }
+
+    public function toArray()
+    {
+        $array = parent::toArray();
+
+        if (isset($array['more_like_this']['like']['_id'])) {
+            $doc = $array['more_like_this']['like'];
+            $doc = array_intersect_key($doc, array('_index' => 1, '_type' => 1, '_id' => 1));
+            $array['more_like_this']['like'] = $doc;
+        }
+
+        return $array;
     }
 }

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -501,30 +501,6 @@ class Type implements SearchableInterface
     }
 
     /**
-     * More like this query based on the given object.
-     *
-     * The id in the given object has to be set
-     *
-     * @param \Elastica\Document           $doc    Document to query for similar objects
-     * @param array                        $params OPTIONAL Additional arguments for the query
-     * @param string|array|\Elastica\Query $query  OPTIONAL Query to filter the moreLikeThis results
-     *
-     * @return \Elastica\ResultSet ResultSet with all results inside
-     *
-     * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/search-more-like-this.html
-     */
-    public function moreLikeThis(Document $doc, $params = array(), $query = array())
-    {
-        $path = $doc->getId().'/_mlt';
-
-        $query = Query::create($query);
-
-        $response = $this->request($path, Request::GET, $query->toArray(), $params);
-
-        return ResultSet::create($response, $query);
-    }
-
-    /**
      * Makes calls to the elasticsearch server based on this type.
      *
      * @param string $path   Path to call

--- a/test/lib/Elastica/Test/Query/MoreLikeThisTest.php
+++ b/test/lib/Elastica/Test/Query/MoreLikeThisTest.php
@@ -2,7 +2,7 @@
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
-use Elastica\Filter\Bool;
+use Elastica\Filter\BoolFilter;
 use Elastica\Filter\Term;
 use Elastica\Index;
 use Elastica\Query;
@@ -104,7 +104,7 @@ class MoreLikeThisTest extends BaseTest
 
         $query = new Query\Filtered($mltQuery);
         // Return just the visible similar
-        $filter = new Bool();
+        $filter = new BoolFilter();
         $filterTerm = new Term();
         $filterTerm->setTerm('visible', true);
         $filter->addMust($filterTerm);

--- a/test/lib/Elastica/Test/Query/MoreLikeThisTest.php
+++ b/test/lib/Elastica/Test/Query/MoreLikeThisTest.php
@@ -2,6 +2,8 @@
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
+use Elastica\Filter\Bool;
+use Elastica\Filter\Term;
 use Elastica\Index;
 use Elastica\Query;
 use Elastica\Query\MoreLikeThis;
@@ -41,19 +43,74 @@ class MoreLikeThisTest extends BaseTest
         $index->refresh();
 
         $mltQuery = new MoreLikeThis();
-        $mltQuery->setLikeText('fake gmail sample');
+        $mltQuery->setLike('fake gmail sample');
         $mltQuery->setFields(array('email', 'content'));
-        $mltQuery->setMaxQueryTerms(1);
+        $mltQuery->setMaxQueryTerms(3);
         $mltQuery->setMinDocFrequency(1);
         $mltQuery->setMinTermFrequency(1);
 
         $query = new Query();
-        $query->setFields(array('email', 'content'));
         $query->setQuery($mltQuery);
 
-        $this->es20('this returns now 1 instaed of 2. what did change in the more like this?');
         $resultSet = $type->search($query);
         $resultSet->getResponse()->getData();
+        $this->assertEquals(2, $resultSet->count());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testSearchByDocument()
+    {
+        $client = $this->_getClient(array('persistent' => false));
+        $index = $client->getIndex('elastica_test');
+        $index->create(array('index' => array('number_of_shards' => 1, 'number_of_replicas' => 0)), true);
+
+        $type = new Type($index, 'mlt_test');
+
+        $type->addDocuments(array(
+            new Document(1, array('visible' => true, 'name' => 'bruce wayne batman')),
+            new Document(2, array('visible' => true, 'name' => 'bruce wayne')),
+            new Document(3, array('visible' => false, 'name' => 'bruce wayne')),
+            new Document(4, array('visible' => true, 'name' => 'batman')),
+            new Document(5, array('visible' => false, 'name' => 'batman')),
+            new Document(6, array('visible' => true, 'name' => 'superman')),
+            new Document(7, array('visible' => true, 'name' => 'spiderman')),
+        ));
+
+        $index->refresh();
+
+        $doc = $type->getDocument(1);
+
+        // Return all similar
+        $mltQuery = new MoreLikeThis();
+
+        $mltQuery->setMinTermFrequency(1);
+        $mltQuery->setMinDocFrequency(1);
+
+        $mltQuery->setLike($doc);
+
+        $query = new Query($mltQuery);
+
+        $resultSet = $type->search($query);
+        $this->assertEquals(4, $resultSet->count());
+
+        $mltQuery = new MoreLikeThis();
+
+        $mltQuery->setMinTermFrequency(1);
+        $mltQuery->setMinDocFrequency(1);
+
+        $mltQuery->setLike($doc);
+
+        $query = new Query\Filtered($mltQuery);
+        // Return just the visible similar
+        $filter = new Bool();
+        $filterTerm = new Term();
+        $filterTerm->setTerm('visible', true);
+        $filter->addMust($filterTerm);
+        $query->setFilter($filter);
+
+        $resultSet = $type->search($query);
         $this->assertEquals(2, $resultSet->count());
     }
 
@@ -82,6 +139,18 @@ class MoreLikeThisTest extends BaseTest
 
         $data = $query->toArray();
         $this->assertEquals($ids, $data['more_like_this']['ids']);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetLike()
+    {
+        $query = new MoreLikeThis();
+        $query->setLike(' hello world');
+
+        $data = $query->toArray();
+        $this->assertEquals(' hello world', $data['more_like_this']['like']);
     }
 
     /**
@@ -237,5 +306,29 @@ class MoreLikeThisTest extends BaseTest
         $query->setStopWords($stopWords);
 
         $this->assertEquals($stopWords, $query->getParam('stop_words'));
+    }
+
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $query = new MoreLikeThis();
+        $query->setLike(new Document(1, array(), 'type', 'index'));
+
+        $data = $query->toArray();
+
+        $this->assertEquals(
+            array('more_like_this' =>
+                array(
+                    'like' => array(
+                        '_id' => 1,
+                        '_type' => 'type',
+                        '_index' => 'index'
+                    )
+                )
+            ),
+            $data
+        );
     }
 }

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -562,44 +562,6 @@ class TypeTest extends BaseTest
     /**
      * @group functional
      */
-    public function testMoreLikeThisApi()
-    {
-        $client = $this->_getClient(array('persistent' => false));
-        $index = $client->getIndex('elastica_test');
-        $index->create(array('index' => array('number_of_shards' => 1, 'number_of_replicas' => 0)), true);
-
-        $type = new Type($index, 'mlt_test');
-        $type->addDocuments(array(
-            new Document(1, array('visible' => true, 'name' => 'bruce wayne batman')),
-            new Document(2, array('visible' => true, 'name' => 'bruce wayne')),
-            new Document(3, array('visible' => false, 'name' => 'bruce wayne')),
-            new Document(4, array('visible' => true, 'name' => 'batman')),
-            new Document(5, array('visible' => false, 'name' => 'batman')),
-            new Document(6, array('visible' => true, 'name' => 'superman')),
-            new Document(7, array('visible' => true, 'name' => 'spiderman')),
-        ));
-        $index->refresh();
-
-        $document = $type->getDocument(1);
-
-        $this->es20('More like this does not match the results as expected (0 vs 4 results)');
-        // Return all similar
-        $resultSet = $type->moreLikeThis($document, array('min_term_freq' => '1', 'min_doc_freq' => '1'));
-        $this->assertEquals(4, $resultSet->count());
-
-        // Return just the visible similar
-        $query = new Query();
-        $filterTerm = new Term();
-        $filterTerm->setTerm('visible', true);
-        $query->setPostFilter($filterTerm);
-
-        $resultSet = $type->moreLikeThis($document, array('min_term_freq' => '1', 'min_doc_freq' => '1'), $query);
-        $this->assertEquals(2, $resultSet->count());
-    }
-
-    /**
-     * @group functional
-     */
     public function testUpdateDocument()
     {
         $this->_checkScriptInlineSetting();


### PR DESCRIPTION
Some notes:

1. MoreLikeThis::setLikeText is deprecated. I create setLike, but remove trim magic there. Any information why it is needed in setLikeText? In ES documentation there is no any notices about must be "like" trimmed, or not. So, at least if it is really needed, I prefer to move it at toArray to follow "what we get is what we set"

2. MoreLikeThis API was removed from ES 2.0 at all.

3. I increase setMaxQueryTerms in one test case. I don't see any another reason why this test case fail.
