### PR TITLE
Make sure lowercase transport names don't break on linux

### DIFF
--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -89,6 +89,17 @@ abstract class AbstractTransport extends Param
         }
 
         if (is_string($transport)) {
+            $specialTransports = array(
+              	'httpadapter' => 'HttpAdapter',
+              	'nulltransport' => 'NullTransport',
+          	);
+          	
+          	if (isset($specialTransports[strtolower($transport)])) {
+          	    $transport = $specialTransports[strtolower($transport)];
+          	} else {
+          	    $transport = ucfirst($transport);
+          	}
+          	
             $className = 'Elastica\\Transport\\'.$transport;
 
             if (!class_exists($className)) {

--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -90,16 +90,16 @@ abstract class AbstractTransport extends Param
 
         if (is_string($transport)) {
             $specialTransports = array(
-              	'httpadapter' => 'HttpAdapter',
-              	'nulltransport' => 'NullTransport',
-          	);
-          	
-          	if (isset($specialTransports[strtolower($transport)])) {
-          	    $transport = $specialTransports[strtolower($transport)];
-          	} else {
-          	    $transport = ucfirst($transport);
-          	}
-          	
+                'httpadapter' => 'HttpAdapter',
+                'nulltransport' => 'NullTransport',
+            );
+
+            if (isset($specialTransports[strtolower($transport)])) {
+                $transport = $specialTransports[strtolower($transport)];
+            } else {
+                $transport = ucfirst($transport);
+            }
+
             $className = 'Elastica\\Transport\\'.$transport;
 
             if (!class_exists($className)) {


### PR DESCRIPTION
Fixes stuff like https://github.com/symfony/monolog-bundle/pull/149