### PR TITLE
Introduce DeprecatedException and trigger_error in deprecated places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file based on the
 
 ### Backward Compatibility Breaks
 - MoreLikeThis::setLikeText deprecated from ES 2.0, use setLike instead, but there is a difference - setLike haven't trim magic inside for strings
+- Elastica\Document, methods: setScript, getScript, hasScript now throw DeprecatedException.
+- MoreLikeThis, methods: setLikeText, setIds, setPercentTermsToMatch now throw DeprecatedException.
+- Elastica\Aggregation\DateHistogram, methods: setPreZone, setPostZone, setPreZoneAdjustLargeInterval, setPreOffset, setPostOffset now throw DeprecatedException.
+- Elastica\Query\Builder trigger E_USER_DEPRECATED error when you try use it.
+- Elastica\Filter\Bool and Elastica\Query\Bool trigger E_USER_DEPRECATED error when you try use them.
+- Elastica\Query\Fuzzy:addField method trigger E_USER_DEPRECATED error
+- Elastica\Query\FunctionScore:addBoostFactorFunction method trigger E_USER_DEPRECATED error
+- Elastica\Query:setLimit method trigger E_USER_DEPRECATED error
+- Elastica\Document:add method trigger E_USER_DEPRECATED error
 - Type::moreLikeThis API was removed from ES 2.0, use MoreLikeThis query instead
 - Remove Thrift transport and everything related to it
 - Remove Memcache transport and everything related to it
@@ -26,15 +35,18 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 - Elastica\Reponse::getErrorMessage was added as getError is now an object
 - Elastica\Query\MoreLikeThis::setLike
+- \Elastica\Exception\DeprecatedException
 
 ### Improvements
 - Travis builds were moved to docker-compose setup. Ansible scripts and Vagrant files were removed
-
+- trigger_error with E_USER_DEPRECATE added to deprecated places
+- DeprecatedException will be thrown, if there is a call of method that not support BC
 
 ### Deprecated
+- Elastica\Filter\Bool is deprecated
+- Elastica\Query\Bool is deprecated
 - Elastica\Query\MoreLikeThis::setLikeText is deprecated
 - Elastica\Query\MoreLikeThis::setIds is deprecated
-
 
 ## [2.3.1](https://github.com/ruflin/Elastica/releases/tag/2.3.1) - 2015-10-17
 

--- a/lib/Elastica/Aggregation/DateHistogram.php
+++ b/lib/Elastica/Aggregation/DateHistogram.php
@@ -1,5 +1,6 @@
 <?php
 namespace Elastica\Aggregation;
+use Elastica\Exception\DeprecatedException;
 
 /**
  * Class DateHistogram.
@@ -11,7 +12,7 @@ class DateHistogram extends Histogram
     /**
      * Set pre-rounding based on interval.
      *
-     * @deprecated Option "pre_zone" is deprecated as of ES 1.5. Use "time_zone" instead
+     * @deprecated Option "pre_zone" is deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "time_zone" instead
      *
      * @param string $preZone
      *
@@ -19,13 +20,13 @@ class DateHistogram extends Histogram
      */
     public function setPreZone($preZone)
     {
-        return $this->setParam('pre_zone', $preZone);
+        throw new DeprecatedException('Option "pre_zone" is deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "time_zone" instead.');
     }
 
     /**
      * Set post-rounding based on interval.
      *
-     * @deprecated Option "post_zone" is deprecated as of ES 1.5. Use "time_zone" instead
+     * @deprecated Option "post_zone" is deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "time_zone" instead.
      *
      * @param string $postZone
      *
@@ -33,7 +34,7 @@ class DateHistogram extends Histogram
      */
     public function setPostZone($postZone)
     {
-        return $this->setParam('post_zone', $postZone);
+        throw new DeprecatedException('Option "post_zone" is deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "time_zone" instead.');
     }
 
     /**
@@ -51,7 +52,7 @@ class DateHistogram extends Histogram
     /**
      * Set pre-zone adjustment for larger time intervals (day and above).
      *
-     * @deprecated Option "pre_zone_adjust_large_interval" is deprecated as of ES 1.5
+     * @deprecated Option "pre_zone_adjust_large_interval" is deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "time_zone" instead.
      *
      * @param string $adjust
      *
@@ -59,7 +60,7 @@ class DateHistogram extends Histogram
      */
     public function setPreZoneAdjustLargeInterval($adjust)
     {
-        return $this->setParam('pre_zone_adjust_large_interval', $adjust);
+        throw new DeprecatedException('Option "pre_zone_adjust_large_interval" is deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "time_zone" instead.');
     }
 
     /**
@@ -77,7 +78,7 @@ class DateHistogram extends Histogram
     /**
      * Set the offset for pre-rounding.
      *
-     * @deprecated Option "pre_offset" is deprecated as of ES 1.5. Use "offset" instead
+     * @deprecated Option "pre_offset" is deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "offset" instead.
      *
      * @param string $offset "1d", for example
      *
@@ -85,13 +86,13 @@ class DateHistogram extends Histogram
      */
     public function setPreOffset($offset)
     {
-        return $this->setParam('pre_offset', $offset);
+        throw new DeprecatedException('Option "pre_offset" is deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "offset" instead.');
     }
 
     /**
      * Set the offset for post-rounding.
      *
-     * @deprecated Option "post_offset" is deprecated as of ES 1.5. Use "offset" instead
+     * @deprecated Option "post_offset" is deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "offset" instead.
      *
      * @param string $offset "1d", for example
      *
@@ -99,7 +100,7 @@ class DateHistogram extends Histogram
      */
     public function setPostOffset($offset)
     {
-        return $this->setParam('post_offset', $offset);
+        throw new DeprecatedException('Option "post_offset" is deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "offset" instead.');
     }
 
     /**

--- a/lib/Elastica/Document.php
+++ b/lib/Elastica/Document.php
@@ -2,6 +2,7 @@
 namespace Elastica;
 
 use Elastica\Bulk\Action;
+use Elastica\Exception\DeprecatedException;
 use Elastica\Exception\InvalidException;
 use Elastica\Exception\NotImplementedException;
 
@@ -150,7 +151,7 @@ class Document extends AbstractUpdateAction
     /**
      * Adds the given key/value pair to the document.
      *
-     * @deprecated
+     * @deprecated Will be removed in Elastica 4.0. Use Elastica\Document::set instead
      *
      * @param string $key   Document entry key
      * @param mixed  $value Document entry value
@@ -159,6 +160,8 @@ class Document extends AbstractUpdateAction
      */
     public function add($key, $value)
     {
+        trigger_error('Deprecated: Elastica\Document::add is deprecated and will be removed in Elastica 4.0. Use Elastica\Document::set instead.', E_USER_DEPRECATED);
+
         return $this->set($key, $value);
     }
 
@@ -252,7 +255,8 @@ class Document extends AbstractUpdateAction
     }
 
     /**
-     * @deprecated
+     * @deprecated setScript() is no longer available as of 0.90.2. See http://elastica.io/migration/0.90.2/upsert.html to migrate. This method will be removed in Elastica 4.0
+
      *
      * @param \Elastica\Script $data
      *
@@ -260,27 +264,27 @@ class Document extends AbstractUpdateAction
      */
     public function setScript($data)
     {
-        throw new NotImplementedException('setScript() is no longer available as of 0.90.2. See http://elastica.io/migration/0.90.2/upsert.html to migrate');
+        throw new DeprecatedException('setScript() is no longer available as of 0.90.2. See http://elastica.io/migration/0.90.2/upsert.html to migrate');
     }
 
     /**
      * @throws NotImplementedException
      *
-     * @deprecated
+     * @deprecated getScript() is no longer available as of 0.90.2. See http://elastica.io/migration/0.90.2/upsert.html to migrate. This method will be removed in Elastica 4.0
      */
     public function getScript()
     {
-        throw new NotImplementedException('getScript() is no longer available as of 0.90.2. See http://elastica.io/migration/0.90.2/upsert.html to migrate');
+        throw new DeprecatedException('getScript() is no longer available as of 0.90.2. See http://elastica.io/migration/0.90.2/upsert.html to migrate');
     }
 
     /**
      * @throws NotImplementedException
      *
-     * @deprecated
+     * @deprecated hasScript() is no longer available as of 0.90.2. See http://elastica.io/migration/0.90.2/upsert.html to migrate. This method will be removed in Elastica 4.0
      */
     public function hasScript()
     {
-        throw new NotImplementedException('hasScript() is no longer available as of 0.90.2. See http://elastica.io/migration/0.90.2/upsert.html to migrate');
+        throw new DeprecatedException('hasScript() is no longer available as of 0.90.2. See http://elastica.io/migration/0.90.2/upsert.html to migrate');
     }
 
     /**

--- a/lib/Elastica/Exception/DeprecatedException.php
+++ b/lib/Elastica/Exception/DeprecatedException.php
@@ -1,0 +1,13 @@
+<?php
+namespace Elastica\Exception;
+
+/**
+ * Deprecated exception.
+ *
+ * Is thrown if a function or feature is deprecated and its usage can't be supported by BC layer
+ *
+ * @author Evgeniy Sokolov <ewgraf@gmail.com>
+ */
+class DeprecatedException extends NotImplementedException
+{
+}

--- a/lib/Elastica/Filter/Bool.php
+++ b/lib/Elastica/Filter/Bool.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Use BoolFilter instead. From PHP7 bool is reserved word and this class will be removed in Elastica 4.0', E_USER_DEPRECATED);
+
 /**
  * Bool Filter.
  *
@@ -8,7 +10,7 @@ namespace Elastica\Filter;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @deprecated Use BoolFilter instead. From PHP7 bool is reserved word.
+ * @deprecated Use BoolFilter instead. From PHP7 bool is reserved word and this class will be removed in Elastica 4.0
  *
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-filter.html
  */

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -136,11 +136,11 @@ class Query extends Param
      * @return $this
      *
      * @link    https://github.com/elasticsearch/elasticsearch/issues/7422
-     * @deprecated
+     * @deprecated Use Elastica\Query::setPostFilter() instead, this method will be removed in Elastica 4.0
      */
     public function setFilter(AbstractFilter $filter)
     {
-        trigger_error('Deprecated: Elastica\Query::setFilter() is deprecated. Use Elastica\Query::setPostFilter() instead.', E_USER_DEPRECATED);
+        trigger_error('Deprecated: Elastica\Query::setFilter() is deprecated and will be removed in Elastica 4.0. Use Elastica\Query::setPostFilter() instead.', E_USER_DEPRECATED);
 
         return $this->setPostFilter($filter);
     }
@@ -229,7 +229,7 @@ class Query extends Param
     /**
      * Alias for setSize.
      *
-     * @deprecated Use the setSize() method, this method will be removed in future releases
+     * @deprecated Use the setSize() method, this method will be removed in Elastica 4.0
      *
      * @param int $limit OPTIONAL Maximal number of results for query (default = 10)
      *
@@ -237,6 +237,7 @@ class Query extends Param
      */
     public function setLimit($limit = 10)
     {
+        trigger_error('Deprecated: Elastica\Query::setLimit() is deprecated. Use setSize method instead. This method will be removed in Elastica 4.0.', E_USER_DEPRECATED);
         return $this->setSize($limit);
     }
 

--- a/lib/Elastica/Query/Bool.php
+++ b/lib/Elastica/Query/Bool.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elastica\Query;
 
+trigger_error('Elastica\Query\Bool is deprecated. Use BoolQuery instead. From PHP7 bool is reserved word and this class will be removed in Elastica 4.0', E_USER_DEPRECATED);
+
 /**
  * Bool query.
  *
@@ -8,7 +10,7 @@ namespace Elastica\Query;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @deprecated Use BoolQuery instead. From PHP7 bool is reserved word.
+ * @deprecated Use BoolQuery instead. From PHP7 bool is reserved word and this class will be removed in Elastica 4.0
  *
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
  */

--- a/lib/Elastica/Query/Builder.php
+++ b/lib/Elastica/Query/Builder.php
@@ -5,13 +5,15 @@ use Elastica\Exception\InvalidException;
 use Elastica\Exception\JSONParseException;
 use Elastica\JSON;
 
+trigger_error('This builder is deprecated and will be removed in Elastica 4.0. Use new Elastica\QueryBuilder instead.', E_USER_DEPRECATED);
+
 /**
  * Query Builder.
  *
  * @author Chris Gedrim <chris@gedr.im>
  *
  * @link http://www.elastic.co/
- * @deprecated This builder is deprecated and will be removed. Use new Elastica\QueryBuilder instead.
+ * @deprecated This builder is deprecated and will be removed in Elastica 4.0. Use new Elastica\QueryBuilder instead.
  **/
 class Builder extends AbstractQuery
 {

--- a/lib/Elastica/Query/FunctionScore.php
+++ b/lib/Elastica/Query/FunctionScore.php
@@ -178,10 +178,11 @@ class FunctionScore extends AbstractQuery
      * @param float          $boostFactor the boost factor value
      * @param AbstractFilter $filter      a filter associated with this function
      *
-     * @deprecated
+     * @deprecated Use addWeightFunction instead. This method will be removed in Elastica 4.0
      */
     public function addBoostFactorFunction($boostFactor, AbstractFilter $filter = null)
     {
+        trigger_error('Query\FunctionScore::addBoostFactorFunction is deprecated. Use addWeightFunction instead. This method will be removed in Elastica 4.0', E_USER_DEPRECATED);
         $this->addWeightFunction($boostFactor, $filter);
     }
 

--- a/lib/Elastica/Query/Fuzzy.php
+++ b/lib/Elastica/Query/Fuzzy.php
@@ -69,7 +69,7 @@ class Fuzzy extends AbstractQuery
     /**
      * Deprecated method of setting a field.
      *
-     * @deprecated
+     * @deprecated Use setField and setFieldOption instead. This method will be removed in Elastica 4.0
      *
      * @param $fieldName
      * @param $args
@@ -78,6 +78,8 @@ class Fuzzy extends AbstractQuery
      */
     public function addField($fieldName, $args)
     {
+        trigger_error('Query\Fuzzy::addField is deprecated. Use setField and setFieldOption instead. This method will be removed in Elastica 4.0', E_USER_DEPRECATED);
+
         if (!array_key_exists('value', $args)) {
             throw new InvalidException('Fuzzy query can only support a single field.');
         }

--- a/lib/Elastica/Query/MoreLikeThis.php
+++ b/lib/Elastica/Query/MoreLikeThis.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Query;
 use Elastica\Document;
+use Elastica\Exception\DeprecatedException;
 
 /**
  * More Like This query.
@@ -28,13 +29,13 @@ class MoreLikeThis extends AbstractQuery
      *
      * @param array $ids Document ids
      *
-     * @deprecated Option "ids" deprecated as of ES 2.0.0-beta1 Use "like" instead.
+     * @deprecated Option "ids" deprecated as of ES 2.0.0-beta1 and will be removed in Elastica 4.0. Use "like" instead.
 
      * @return \Elastica\Query\MoreLikeThis Current object
      */
     public function setIds(array $ids)
     {
-        return $this->setParam('ids', $ids);
+        throw new DeprecatedException('Option "ids" deprecated as of ES 2.0.0-beta1 and will be removed in Elastica 4.0. Use "like" instead.');
     }
 
     /**
@@ -54,15 +55,13 @@ class MoreLikeThis extends AbstractQuery
      *
      * @param string $likeText
      *
-     * @deprecated Option "like_text" deprecated as of ES 2.0.0-beta1 Use "like" instead.
+     * @deprecated Option "like_text" deprecated as of ES 2.0.0-beta1 and will be removed at Elastica 4.0. Use "like" instead.
 
      * @return $this
      */
     public function setLikeText($likeText)
     {
-        $likeText = trim($likeText);
-
-        return $this->setParam('like_text', $likeText);
+        throw new DeprecatedException('Option "like_text" deprecated as of ES 2.0.0-beta1 and will be removed in Elastica 4.0. Use "like" instead.');
     }
 
     /**
@@ -96,11 +95,11 @@ class MoreLikeThis extends AbstractQuery
      *
      * @return $this
      *
-     * @deprecated Option "percent_terms_to_match" deprecated as of ES 1.5. Use "minimum_should_match" instead.
+     * @deprecated Option "percent_terms_to_match" deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "minimum_should_match" instead.
      */
     public function setPercentTermsToMatch($percentTermsToMatch)
     {
-        return $this->setParam('percent_terms_to_match', (float) $percentTermsToMatch);
+        throw new DeprecatedException('Option "percent_terms_to_match" deprecated as of ES 1.5 and will be removed in Elastica 4.0. Use "minimum_should_match" instead.');
     }
 
     /**

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\QueryBuilder\DSL;
 
+use Elastica\Exception\DeprecatedException;
 use Elastica\Exception\NotImplementedException;
 use Elastica\Filter\AbstractFilter;
 use Elastica\Query\AbstractQuery;
@@ -340,11 +341,11 @@ class Query implements DSL
      * more_like_this_field query.
      *
      * @link http://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-mlt-field-query.html
-     * @deprecated More Like This Field query is deprecated as of ES 1.4 and will be removed in ES 2.0
+     * @deprecated More Like This Field query is deprecated as of ES 1.4 and will be removed in ES 2.0. Use MoreLikeThis query instead. This method will be removed in Elastica 4.0
      */
     public function more_like_this_field()
     {
-        throw new NotImplementedException();
+        throw new DeprecatedException('More Like This Field query is deprecated as of ES 1.4 and will be removed in ES 2.0. Use MoreLikeThis query instead. This method will be removed in Elastica 4.0');
     }
 
     /**

--- a/test/lib/Elastica/Test/Filter/BoolFilterTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolFilterTest.php
@@ -194,7 +194,19 @@ class BoolFilterTest extends BaseTest
             self::markTestSkipped('These objects are not supported in PHP 7');
         }
 
+        $err = array();
+
+        set_error_handler(function () use (&$err) {
+            $err[] = func_get_args();
+        });
+
         $filter = new \Elastica\Filter\Bool();
+
+        restore_error_handler();
+
+        $this->assertCount(1, $err);
+        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
+
         $filter->addShould('fail!');
     }
 }

--- a/test/lib/Elastica/Test/Query/BoolQueryTest.php
+++ b/test/lib/Elastica/Test/Query/BoolQueryTest.php
@@ -162,7 +162,18 @@ class BoolQueryTest extends BaseTest
 
         $index->refresh();
 
+        $err = array();
+
+        set_error_handler(function () use (&$err) {
+            $err[] = func_get_args();
+        });
+
         $boolQuery = new \Elastica\Query\Bool();
+
+        restore_error_handler();
+
+        $this->assertCount(1, $err);
+        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
 
         $resultSet = $type->search($boolQuery);
 

--- a/test/lib/Elastica/Test/Query/BuilderTest.php
+++ b/test/lib/Elastica/Test/Query/BuilderTest.php
@@ -13,10 +13,21 @@ class BuilderTest extends BaseTest
      */
     public function testFactory()
     {
+        $err = array();
+
+        set_error_handler(function () use (&$err) {
+            $err[] = func_get_args();
+        });
+
         $this->assertInstanceOf(
             'Elastica\Query\Builder',
             Builder::factory('some string')
         );
+
+        restore_error_handler();
+
+        $this->assertCount(1, $err);
+        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
     }
 
     public function getQueryData()

--- a/test/lib/Elastica/Test/Query/FunctionScoreTest.php
+++ b/test/lib/Elastica/Test/Query/FunctionScoreTest.php
@@ -149,13 +149,42 @@ class FunctionScoreTest extends BaseTest
     }
 
     /**
+     * @group unit
+     */
+    public function testAddBoostFactorFunction()
+    {
+        $filter = new Term(array('price' => 4.5));
+        $query = new FunctionScore();
+        $query->addWeightFunction(5.0, $filter);
+
+        $sameFilter = new Term(array('price' => 4.5));
+        $sameQuery = new FunctionScore();
+
+        $err = array();
+
+        set_error_handler(function () use (&$err) {
+            $err[] = func_get_args();
+        });
+
+        $sameQuery->addBoostFactorFunction(5.0, $sameFilter);
+
+        restore_error_handler();
+
+        $this->assertCount(1, $err);
+        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
+
+
+        $this->assertEquals($query->toArray(), $sameQuery->toArray());
+    }
+
+    /**
      * @group functional
      */
     public function testWeight()
     {
         $filter = new Term(array('price' => 4.5));
         $query = new FunctionScore();
-        $query->addBoostFactorFunction(5.0, $filter);
+        $query->addWeightFunction(5.0, $filter);
         $expected = array(
             'function_score' => array(
                 'functions' => array(

--- a/test/lib/Elastica/Test/Query/FuzzyTest.php
+++ b/test/lib/Elastica/Test/Query/FuzzyTest.php
@@ -10,10 +10,40 @@ class FuzzyTest extends BaseTest
     /**
      * @group unit
      */
+    public function testAddField()
+    {
+        $fuzzy = new Fuzzy();
+
+        $err = array();
+
+        set_error_handler(function () use (&$err) {
+            $err[] = func_get_args();
+        });
+
+        $fuzzy->addField('user', array('value' => 'Nicolas', 'boost' => 1.0));
+
+        restore_error_handler();
+
+        $this->assertCount(1, $err);
+        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
+
+        $sameFuzzy = new Fuzzy();
+        $sameFuzzy->setField('user', 'Nicolas');
+        $sameFuzzy->setFieldOption('boost', 1.0);
+
+        $this->assertEquals($sameFuzzy->toArray(), $fuzzy->toArray());
+    }
+
+    /**
+     * @group unit
+     */
     public function testToArray()
     {
         $fuzzy = new Fuzzy();
-        $fuzzy->addField('user', array('value' => 'Nicolas', 'boost' => 1.0));
+
+        $fuzzy->setField('user', 'Nicolas');
+        $fuzzy->setFieldOption('boost', 1.0);
+
         $expectedArray = array(
             'fuzzy' => array(
                 'user' => array(
@@ -83,7 +113,19 @@ class FuzzyTest extends BaseTest
     {
         $this->setExpectedException('Elastica\Exception\InvalidException');
         $query = new Fuzzy();
+
+        $err = array();
+
+        set_error_handler(function () use (&$err) {
+            $err[] = func_get_args();
+        });
+
         $query->addField('name', array(array('value' => 'Baden')));
+
+        restore_error_handler();
+
+        $this->assertCount(1, $err);
+        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
 
         $this->setExpectedException('Elastica\Exception\InvalidException');
         $query = new Fuzzy();

--- a/test/lib/Elastica/Test/Query/MoreLikeThisTest.php
+++ b/test/lib/Elastica/Test/Query/MoreLikeThisTest.php
@@ -130,15 +130,13 @@ class MoreLikeThisTest extends BaseTest
 
     /**
      * @group unit
+     * @expectedException \Elastica\Exception\DeprecatedException
      */
     public function testSetIds()
     {
         $query = new MoreLikeThis();
         $ids = array(1, 2, 3);
         $query->setIds($ids);
-
-        $data = $query->toArray();
-        $this->assertEquals($ids, $data['more_like_this']['ids']);
     }
 
     /**
@@ -155,14 +153,12 @@ class MoreLikeThisTest extends BaseTest
 
     /**
      * @group unit
+     * @expectedException \Elastica\Exception\DeprecatedException
      */
     public function testSetLikeText()
     {
         $query = new MoreLikeThis();
         $query->setLikeText(' hello world');
-
-        $data = $query->toArray();
-        $this->assertEquals('hello world', $data['more_like_this']['like_text']);
     }
 
     /**
@@ -193,6 +189,7 @@ class MoreLikeThisTest extends BaseTest
 
     /**
      * @group unit
+     * @expectedException \Elastica\Exception\DeprecatedException
      */
     public function testSetPercentTermsToMatch()
     {
@@ -200,8 +197,6 @@ class MoreLikeThisTest extends BaseTest
 
         $match = 0.8;
         $query->setPercentTermsToMatch($match);
-
-        $this->assertEquals($match, $query->getParam('percent_terms_to_match'));
     }
 
     /**


### PR DESCRIPTION
This PR introduce DeprecatedException that prevent hidden unexpected results when used functionality, that not supported by ES and haven't BC layer.

Also this PR add trigger_error to several deprecated methods and announce removing deprecated code at Elastica 4.0