### PR TITLE
Accept query parameters to send with Mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Added
 - Elastica\Query\MultiMatch::setFuzziness now supports being set to `AUTO` with the const `MultiMatch::FUZZINESS_AUTO`
+- Elastica\Type\Mapping::send now accepts query string parameters to send along with the mapping request
 
 ### Improvements
 

--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -261,13 +261,14 @@ class Mapping
     /**
      * Submits the mapping and sends it to the server.
      *
+     * @param array $query Query string parameters to send with mapping
      * @return \Elastica\Response Response object
      */
-    public function send()
+    public function send(array $query = array())
     {
         $path = '_mapping';
 
-        return $this->getType()->request($path, Request::PUT, $this->toArray());
+        return $this->getType()->request($path, Request::PUT, $this->toArray(), $query);
     }
 
     /**


### PR DESCRIPTION
It can be necessary in some clusters to bump the master_timeout
on mapping updates. This change allows the master_timeout to be
specified when sending the mapping request.