### PR TITLE
Fix inconsistently failing IndexExists test

### DIFF
--- a/test/lib/Elastica/Test/StatusTest.php
+++ b/test/lib/Elastica/Test/StatusTest.php
@@ -62,6 +62,7 @@ class StatusTest extends BaseTest
         $this->assertFalse($status->indexExists($indexName));
         $index->create();
 
+        usleep(10000);
         $status->refresh();
         $this->assertTrue($status->indexExists($indexName));
     }


### PR DESCRIPTION
Elasticsearch HTTP calls are asynchronous.

Previously the IndexExists test was calling
```
$index->create();
$status->refresh();
$this->assertTrue($status->indexExists($indexName));
```
Due to the index being created asynchronously it was possible for the index not to have been created when the `refresh()` was called. Causing the test to sometimes fail.
This PR adds a small 10ms sleep to allow elasticsearch to create the index before calling `refresh()`.