### PR TITLE
Result Transformations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "~6.0",
-        "aws/aws-sdk-php": "~3.0"
+        "aws/aws-sdk-php": "~3.0",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "suggest": {
-        "guzzlehttp/guzzle": "Allow using guzzle 6 as the http transport (Requires php 5.5)",
+        "aws/aws-sdk-php": "Allow using IAM authentication with Amazon ElasticSearch Service",
         "egeloen/http-adapter": "Allow using httpadapter transport",
-        "monolog/monolog": "Logging request",
-        "aws/aws-sdk-php": "Allow using IAM authentication with Amazon ElasticSearch Service"
+        "guzzlehttp/guzzle": "Allow using guzzle 6 as the http transport (Requires php 5.5)",
+        "monolog/monolog": "Logging request"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Elastica/Cluster.php
+++ b/lib/Elastica/Cluster.php
@@ -7,7 +7,7 @@ use Elastica\Cluster\Settings;
 use Elastica\Exception\NotImplementedException;
 
 /**
- * Cluster informations for elasticsearch.
+ * Cluster information for elasticsearch.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -36,9 +36,7 @@ class Index implements SearchableInterface
      * All the communication to and from an index goes of this object
      *
      * @param \Elastica\Client $client Client object
-     * @param string           $name   Index name
-     *
-     * @throws \Elastica\Exception\InvalidException
+     * @param string $name Index name
      */
     public function __construct(Client $client, $name)
     {

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -15,117 +15,45 @@ use Elastica\Exception\InvalidException;
 class ResultSet implements \Iterator, \Countable, \ArrayAccess
 {
     /**
-     * Class for the static create method to use.
-     *
-     * @var string
-     */
-    protected static $_class = 'Elastica\\ResultSet';
-
-    /**
      * Results.
      *
-     * @var array Results
+     * @var Result[] Results
      */
-    protected $_results = array();
+    private $_results = array();
 
     /**
      * Current position.
      *
      * @var int Current position
      */
-    protected $_position = 0;
+    private $_position = 0;
 
     /**
      * Response.
      *
      * @var \Elastica\Response Response object
      */
-    protected $_response = null;
+    private $_response;
 
     /**
      * Query.
      *
      * @var \Elastica\Query Query object
      */
-    protected $_query;
-
-    /**
-     * @var int
-     */
-    protected $_took = 0;
-
-    /**
-     * @var bool
-     */
-    protected $_timedOut = false;
-
-    /**
-     * @var int
-     */
-    protected $_totalHits = 0;
-
-    /**
-     * @var float
-     */
-    protected $_maxScore = 0;
+    private $_query;
 
     /**
      * Constructs ResultSet object.
      *
-     * @param \Elastica\Response $response Response object
-     * @param \Elastica\Query    $query    Query object
+     * @param Response $response Response object
+     * @param Query $query Query object
+     * @param Result[] $results
      */
-    public function __construct(Response $response, Query $query)
+    public function __construct(Response $response, Query $query, $results)
     {
-        $this->rewind();
-        $this->_init($response);
         $this->_query = $query;
-    }
-
-    /**
-     * Creates a new ResultSet object. Can be configured to return a different
-     * implementation of the ResultSet class.
-     *
-     * @param Response $response
-     * @param Query    $query
-     *
-     * @return ResultSet
-     */
-    public static function create(Response $response, Query $query)
-    {
-        $class = static::$_class;
-
-        return new $class($response, $query);
-    }
-
-    /**
-     * Sets the class to be used for the static create method.
-     *
-     * @param string $class
-     */
-    public static function setClass($class)
-    {
-        static::$_class = $class;
-    }
-
-    /**
-     * Loads all data into the results object (initialisation).
-     *
-     * @param \Elastica\Response $response Response object
-     */
-    protected function _init(Response $response)
-    {
         $this->_response = $response;
-        $result = $response->getData();
-        $this->_totalHits = isset($result['hits']['total']) ? $result['hits']['total'] : 0;
-        $this->_maxScore = isset($result['hits']['max_score']) ? $result['hits']['max_score'] : 0;
-        $this->_took = isset($result['took']) ? $result['took'] : 0;
-        $this->_timedOut = !empty($result['timed_out']);
-        if (isset($result['hits']['hits'])) {
-            foreach ($result['hits']['hits'] as $hit) {
-                $this->_results[] = new Result($hit);
-            }
-        }
+        $this->_results = $results;
     }
 
     /**
@@ -227,7 +155,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      */
     public function getTotalHits()
     {
-        return (int) $this->_totalHits;
+        return isset($result['hits']['total']) ? (int) $result['hits']['total'] : 0;
     }
 
     /**
@@ -237,7 +165,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      */
     public function getMaxScore()
     {
-        return (float) $this->_maxScore;
+        return isset($result['hits']['max_score']) ? (float) $result['hits']['max_score'] : 0;
     }
 
     /**
@@ -247,17 +175,17 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      */
     public function getTotalTime()
     {
-        return (int) $this->_took;
+        return isset($result['took']) ? $result['took'] : 0;
     }
 
     /**
-     * Returns true iff the query has timed out.
+     * Returns true if the query has timed out.
      *
      * @return bool Timed out
      */
     public function hasTimedOut()
     {
-        return (bool) $this->_timedOut;
+        return !empty($result['timed_out']);
     }
 
     /**

--- a/lib/Elastica/ResultSet/Builder.php
+++ b/lib/Elastica/ResultSet/Builder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Elastica\ResultSet;
+
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\Result;
+use Elastica\ResultSet;
+
+class Builder implements BuilderInterface
+{
+    /**
+     * Builds a ResultSet for a given Response.
+     *
+     * @param Response $response
+     * @param Query $query
+     * @return ResultSet
+     */
+    public function buildResultSet(Response $response, Query $query)
+    {
+        $results = $this->buildResults($response);
+        $resultSet = new ResultSet($response, $query, $results);
+
+        return $resultSet;
+    }
+
+    /**
+     * Builds individual result objects.
+     *
+     * @param Response $response
+     * @return Result[]
+     */
+    private function buildResults(Response $response)
+    {
+        $data = $response->getData();
+        $results = [];
+
+        if (!isset($data['hits']['hits'])) {
+            return $results;
+        }
+
+        foreach ($data['hits']['hits'] as $hit) {
+            $results[] = new Result($hit);
+        }
+
+        return $results;
+    }
+}

--- a/lib/Elastica/ResultSet/BuilderInterface.php
+++ b/lib/Elastica/ResultSet/BuilderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Elastica\ResultSet;
+
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\ResultSet;
+
+interface BuilderInterface
+{
+    /**
+     * Builds a ResultSet given a specific response and query.
+     *
+     * @param Response $response
+     * @param Query $query
+     * @return ResultSet
+     */
+    public function buildResultSet(Response $response, Query $query);
+}

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -4,6 +4,7 @@ namespace Elastica;
 
 use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
+use Elastica\ResultSet\BuilderInterface;
 
 /**
  * Elastica search object.
@@ -462,7 +463,7 @@ class Search
             $params
         );
 
-        return ResultSet::create($response, $query);
+        return $this->_client->getResultSetBuilder()->buildResultSet($response, $query);
     }
 
     /**
@@ -484,7 +485,7 @@ class Search
             $query->toArray(),
             array(self::OPTION_SEARCH_TYPE => self::OPTION_SEARCH_TYPE_COUNT)
         );
-        $resultSet = ResultSet::create($response, $query);
+        $resultSet = $this->_client->getResultSetBuilder()->buildResultSet($response, $query);
 
         return $fullResult ? $resultSet : $resultSet->getTotalHits();
     }

--- a/lib/Elastica/Tool/CrossIndex.php
+++ b/lib/Elastica/Tool/CrossIndex.php
@@ -65,7 +65,7 @@ class CrossIndex
         array $options = array()
     ) {
         // prepare search
-        $search = new Search($oldIndex->getClient());
+        $search = $oldIndex->createSearch();
 
         $options = array_merge(
             array(
@@ -77,7 +77,6 @@ class CrossIndex
             $options
         );
 
-        $search->addIndex($oldIndex);
         if (isset($options[self::OPTION_TYPE])) {
             $type = $options[self::OPTION_TYPE];
             $search->addTypes(is_array($type) ? $type : array($type));

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -331,8 +331,7 @@ class Type implements SearchableInterface
      */
     public function createSearch($query = '', $options = null)
     {
-        $search = new Search($this->getIndex()->getClient());
-        $search->addIndex($this->getIndex());
+        $search = $this->getIndex()->createSearch();
         $search->addType($this);
         $search->setOptionsAndQuery($options, $query);
 

--- a/test/lib/Elastica/Test/ResultSet/BuilderTest.php
+++ b/test/lib/Elastica/Test/ResultSet/BuilderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Elastica\Test\ResultSet;
+
+use Elastica\Event\ElasticaEvents;
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\ResultSet\Builder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @group unit
+ */
+class BuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Builder
+     */
+    private $builder;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    protected function setUp()
+    {
+        $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+
+        $this->builder = new Builder($this->dispatcher);
+    }
+
+    public function testEmptyResponse()
+    {
+        $response = new Response('');
+        $query = new Query();
+
+        $this->dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                ElasticaEvents::BUILD_RESULT_SET,
+                $this->isInstanceOf('Elastica\Event\ResultSetEvent')
+            );
+
+        $resultSet = $this->builder->buildResultSet($response, $query);
+
+        $this->assertSame($response, $resultSet->getResponse());
+        $this->assertSame($query, $resultSet->getQuery());
+        $this->assertCount(0, $resultSet->getResults());
+    }
+
+    public function testResponse()
+    {
+        $response = new Response([
+            'hits' => [
+                'hits' => [
+                    ['test' => 1],
+                    ['test' => 2],
+                    ['test' => 3],
+                ]
+            ]
+        ]);
+        $query = new Query();
+
+        $this->dispatcher->expects($this->exactly(4))
+            ->method('dispatch')
+            ->withConsecutive(
+                [ElasticaEvents::BUILD_RESULT, $this->isInstanceOf('Elastica\Event\ResultEvent')],
+                [ElasticaEvents::BUILD_RESULT, $this->isInstanceOf('Elastica\Event\ResultEvent')],
+                [ElasticaEvents::BUILD_RESULT, $this->isInstanceOf('Elastica\Event\ResultEvent')],
+                [ElasticaEvents::BUILD_RESULT_SET, $this->isInstanceOf('Elastica\Event\ResultSetEvent')]
+            );
+
+        $resultSet = $this->builder->buildResultSet($response, $query);
+
+        $this->assertSame($response, $resultSet->getResponse());
+        $this->assertSame($query, $resultSet->getQuery());
+        $this->assertCount(3, $resultSet->getResults());
+    }
+}


### PR DESCRIPTION
Comes from #811 

This is an initial concept for implementing a service that adds a transformed object into a Result.

The first commit moves construction of Result and ResultSet objects into its own service, and is a bit clumsy in the Elastica\Client instance so that appropriate places can get access to it without modifying the current API. It might be worth having a conversation about closing down the Elastica API surface to a single prescribed way of doing things to make adding features like this simpler.

The second commit adds support for a TransformerInterface to be implemented to handle transformation of ResultSet's Result objects based on object identifiers.

The third commit adds ORM and ODM support which fundamentally comes from https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/Doctrine/ORM/ElasticaToModelTransformer.php and https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/Doctrine/MongoDB/ElasticaToModelTransformer.php

There is a lot more to do before its ready, but it shows the direction I've been thinking about. I'd like to see better support for more than just object identifiers, implementing half a dozen transformers like Symfony\Serializer, Doctrine ORM and MongoDB.

The other half of the transformations will require more thought (mixed objects to Elastica Documents) because it needs to have knowledge about ES mappings or be able to introspect the objects passed to do the conversion magically.