### PR TITLE
Adding username and password params to connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 ### Improvements
+- Add username and password params to connection
 
 ### Deprecated
 - Elastica\AbstractScript|Script|ScriptFile|ScriptFields deprecated in favor of Elastica\Script|AbstractScript|Script|ScriptFile|ScriptFields [#1028](https://github.com/ruflin/Elastica/pull/1028)

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -38,6 +38,8 @@ class Client
         'log' => false,
         'retryOnConflict' => 0,
         'bigintConversion' => false,
+        'username' => null,
+        'password' => null,
     );
 
     /**

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -342,4 +342,20 @@ class Connection extends Param
 
         return $connection;
     }
+
+    /**
+     * @return string User
+     */
+    public function getUsername()
+    {
+        return $this->hasParam('username') ? $this->getParam('username') : null;
+    }
+
+    /**
+     * @return string Password
+     */
+    public function getPassword()
+    {
+        return $this->hasParam('password') ? $this->getParam('password') : null;
+    }
 }

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -92,6 +92,13 @@ class Http extends AbstractTransport
             curl_setopt($conn, CURLOPT_PROXY, $proxy);
         }
 
+        $username = $connection->getUsername();
+        $password = $connection->getPassword();
+        if (!is_null($username) and !is_null($password)) {
+            curl_setopt($conn, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+            curl_setopt($conn, CURLOPT_USERPWD, "$username:$password");
+        }
+
         $this->_setupCurl($conn);
 
         $headersConfig = $connection->hasConfig('headers') ? $connection->getConfig('headers') : array();

--- a/test/lib/Elastica/Test/ConnectionTest.php
+++ b/test/lib/Elastica/Test/ConnectionTest.php
@@ -151,4 +151,26 @@ class ConnectionTest extends BaseTest
 
         $this->assertTrue($connection->hasCompression());
     }
+
+    /**
+     * @group unit
+     */
+    public function testUsernameFromClient()
+    {
+        $username = 'foo';
+        $client = new \Elastica\Client(array('username' => $username));
+
+        $this->assertEquals($username, $client->getConnection()->getUsername('username'));
+    }
+
+    /**
+     * @group unit
+     */
+    public function testPasswordFromClient()
+    {
+        $password = 'bar';
+        $client = new \Elastica\Client(array('password' => $password));
+
+        $this->assertEquals($password, $client->getConnection()->getPassword('password'));
+    }
 }


### PR DESCRIPTION
Adding username and password params to connection (https://github.com/ruflin/Elastica/issues/949)

I wanted to write functional or at the very least unit tests for Transport\HttpTest.php but I'm unsure the best way to do that. I figured
... a functional test would require a second Elasticsearch instance to test against.
... a unit test isn't possible without pulling the curl_ commands into a wrapper class. I didn't want to blow the scope of this up though.