### PR TITLE
Filters deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Backward Compatibility Breaks
 - Update Guzzle transport to use Guzzle 6
+- Elastica\Query\FunctionScore::setFilter - deprecated and will throw DeprecatedException since not supported by Elasticsearch. Use setQuery instead.
 
 ### Bugfixes
 
@@ -17,7 +18,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Deprecated
 - Elastica\AbstractScript|Script|ScriptFile|ScriptFields deprecated in favor of Elastica\Script|AbstractScript|Script|ScriptFile|ScriptFields [#1028](https://github.com/ruflin/Elastica/pull/1028)
-
+- Elastica\Filter\* are deprecated. You can use proper queries instead. Backward compatibility layer provided, but will be removed in next Elastica releases. See https://www.elastic.co/blog/better-query-execution-coming-elasticsearch-2-0 and https://github.com/ruflin/Elastica/issues/1001
 
 ## [3.0.1](https://github.com/ruflin/Elastica/compare/3.0.0...3.0.1)
 

--- a/lib/Elastica/Aggregation/Filter.php
+++ b/lib/Elastica/Aggregation/Filter.php
@@ -3,6 +3,7 @@ namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
+use Elastica\Query\AbstractQuery;
 
 /**
  * Class Filter.
@@ -13,13 +14,19 @@ class Filter extends AbstractAggregation
 {
     /**
      * @param string         $name
-     * @param AbstractFilter $filter
+     * @param AbstractQuery $filter
      */
-    public function __construct($name, AbstractFilter $filter = null)
+    public function __construct($name, $filter = null)
     {
         parent::__construct($name);
 
         if ($filter !== null) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Aggregation\Filter passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+
             $this->setFilter($filter);
         }
     }
@@ -27,12 +34,18 @@ class Filter extends AbstractAggregation
     /**
      * Set the filter for this aggregation.
      *
-     * @param AbstractFilter $filter
+     * @param AbstractQuery $filter
      *
      * @return $this
      */
-    public function setFilter(AbstractFilter $filter)
+    public function setFilter($filter)
     {
+        if ($filter instanceof AbstractFilter) {
+            trigger_error('Deprecated: Elastica\Aggregation\Filter\setFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.', E_USER_DEPRECATED);
+        } elseif (!($filter instanceof AbstractQuery)) {
+            throw new InvalidException('Filter must be instance of AbstractQuery');
+        }
+
         return $this->setParam('filter', $filter);
     }
 

--- a/lib/Elastica/Aggregation/Filters.php
+++ b/lib/Elastica/Aggregation/Filters.php
@@ -3,6 +3,7 @@ namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
+use Elastica\Query\AbstractQuery;
 
 /**
  * Class Filters.
@@ -24,13 +25,19 @@ class Filters extends AbstractAggregation
      *
      * If a name is given, it will be added as a key, otherwise considered as an anonymous filter
      *
-     * @param AbstractFilter $filter
+     * @param AbstractQuery $filter
      * @param string         $name
      *
      * @return $this
      */
-    public function addFilter(AbstractFilter $filter, $name = null)
+    public function addFilter($filter, $name = null)
     {
+        if ($filter instanceof AbstractFilter) {
+            trigger_error('Deprecated: Elastica\Aggregation\Filters\addFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.', E_USER_DEPRECATED);
+        } elseif (!($filter instanceof AbstractQuery)) {
+            throw new InvalidException('Filter must be instance of AbstractQuery');
+        }
+
         if (null !== $name && !is_string($name)) {
             throw new InvalidException('Name must be a string');
         }

--- a/lib/Elastica/Aggregation/SignificantTerms.php
+++ b/lib/Elastica/Aggregation/SignificantTerms.php
@@ -1,7 +1,9 @@
 <?php
 namespace Elastica\Aggregation;
 
+use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
+use Elastica\Query\AbstractQuery;
 
 /**
  * Class SignificantTerms.
@@ -14,14 +16,20 @@ class SignificantTerms extends AbstractTermsAggregation
      * The default source of statistical information for background term frequencies is the entire index and this scope can
      * be narrowed through the use of a background_filter to focus in on significant terms within a narrower context.
      *
-     * @param AbstractFilter $filter
+     * @param AbstractQuery $filter
      *
      * @return $this
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html#_custom_background_context
      */
-    public function setBackgroundFilter(AbstractFilter $filter)
+    public function setBackgroundFilter($filter)
     {
+        if ($filter instanceof AbstractFilter) {
+            trigger_error('Deprecated: Elastica\Aggregation\SignificantTerms::setBackgroundFilter passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.', E_USER_DEPRECATED);
+        } elseif (!($filter instanceof AbstractQuery)) {
+            throw new InvalidException('Filter must be instance of AbstractQuery');
+        }
+
         return $this->setParam('background_filter', $filter);
     }
 }

--- a/lib/Elastica/Filter/AbstractFilter.php
+++ b/lib/Elastica/Filter/AbstractFilter.php
@@ -4,12 +4,16 @@ namespace Elastica\Filter;
 use Elastica\Exception\InvalidException;
 use Elastica\Param;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Abstract filter object. Should be extended by all filter types.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-filters.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 abstract class AbstractFilter extends Param
 {

--- a/lib/Elastica/Filter/AbstractGeoDistance.php
+++ b/lib/Elastica/Filter/AbstractGeoDistance.php
@@ -3,12 +3,16 @@ namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Geo distance filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 abstract class AbstractGeoDistance extends AbstractFilter
 {

--- a/lib/Elastica/Filter/AbstractGeoShape.php
+++ b/lib/Elastica/Filter/AbstractGeoShape.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * geo_shape filter.
  *
@@ -9,6 +11,8 @@ namespace Elastica\Filter;
  * @author Bennie Krijger <benniekrijger@gmail.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 abstract class AbstractGeoShape extends AbstractFilter
 {

--- a/lib/Elastica/Filter/AbstractMulti.php
+++ b/lib/Elastica/Filter/AbstractMulti.php
@@ -1,10 +1,14 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Multi Abstract filter object. Should be extended by filter types composed of an array of sub filters.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 abstract class AbstractMulti extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Bool.php
+++ b/lib/Elastica/Filter/Bool.php
@@ -1,7 +1,7 @@
 <?php
 namespace Elastica\Filter;
 
-trigger_error('Use BoolFilter instead. From PHP7 bool is reserved word and this class will be removed in further Elastica releases', E_USER_DEPRECATED);
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
 
 /**
  * Bool Filter.

--- a/lib/Elastica/Filter/BoolAnd.php
+++ b/lib/Elastica/Filter/BoolAnd.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use BoolQuery::addMust. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * And Filter.
  *
  * @author Lee Parker, Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-and-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class BoolAnd extends AbstractMulti
 {

--- a/lib/Elastica/Filter/BoolFilter.php
+++ b/lib/Elastica/Filter/BoolFilter.php
@@ -3,12 +3,16 @@ namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Bool Filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class BoolFilter extends AbstractFilter
 {

--- a/lib/Elastica/Filter/BoolNot.php
+++ b/lib/Elastica/Filter/BoolNot.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use BoolQuery::addMustNot. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Not Filter.
  *
  * @author Lee Parker, Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-not-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class BoolNot extends AbstractFilter
 {

--- a/lib/Elastica/Filter/BoolOr.php
+++ b/lib/Elastica/Filter/BoolOr.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use BoolQuery::addShould. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Or Filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-or-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class BoolOr extends AbstractMulti
 {

--- a/lib/Elastica/Filter/Exists.php
+++ b/lib/Elastica/Filter/Exists.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Exists query.
  *
  * @author Oleg Cherniy <oleg.cherniy@gmail.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Exists extends AbstractFilter
 {

--- a/lib/Elastica/Filter/GeoBoundingBox.php
+++ b/lib/Elastica/Filter/GeoBoundingBox.php
@@ -3,12 +3,16 @@ namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Geo bounding box filter.
  *
  * @author Fabian Vogler <fabian@equivalence.ch>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class GeoBoundingBox extends AbstractFilter
 {

--- a/lib/Elastica/Filter/GeoDistance.php
+++ b/lib/Elastica/Filter/GeoDistance.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Geo distance filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class GeoDistance extends AbstractGeoDistance
 {

--- a/lib/Elastica/Filter/GeoDistanceRange.php
+++ b/lib/Elastica/Filter/GeoDistanceRange.php
@@ -3,12 +3,16 @@ namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Geo distance filter.
  *
  * @author munkie
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-range-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class GeoDistanceRange extends AbstractGeoDistance
 {

--- a/lib/Elastica/Filter/GeoPolygon.php
+++ b/lib/Elastica/Filter/GeoPolygon.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Geo polygon filter.
  *
  * @author Michael Maclean <mgdm@php.net>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class GeoPolygon extends AbstractFilter
 {

--- a/lib/Elastica/Filter/GeoShapePreIndexed.php
+++ b/lib/Elastica/Filter/GeoShapePreIndexed.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * geo_shape filter for pre-indexed shapes.
  *
@@ -9,6 +11,8 @@ namespace Elastica\Filter;
  * @author Bennie Krijger <benniekrijger@gmail.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class GeoShapePreIndexed extends AbstractGeoShape
 {

--- a/lib/Elastica/Filter/GeoShapeProvided.php
+++ b/lib/Elastica/Filter/GeoShapeProvided.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * geo_shape filter or provided shapes.
  *
@@ -9,6 +11,8 @@ namespace Elastica\Filter;
  * @author BennieKrijger <benniekrijger@gmail.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class GeoShapeProvided extends AbstractGeoShape
 {

--- a/lib/Elastica/Filter/GeohashCell.php
+++ b/lib/Elastica/Filter/GeohashCell.php
@@ -1,10 +1,14 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Class GeohashCell.
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geohash-cell-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class GeohashCell extends AbstractGeoDistance
 {

--- a/lib/Elastica/Filter/HasChild.php
+++ b/lib/Elastica/Filter/HasChild.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Returns parent documents having child docs matching the query.
  *
  * @author Fabian Vogler <fabian@equivalence.ch>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class HasChild extends AbstractFilter
 {

--- a/lib/Elastica/Filter/HasParent.php
+++ b/lib/Elastica/Filter/HasParent.php
@@ -1,10 +1,14 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Returns child documents having parent docs matching the query.
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class HasParent extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Ids.php
+++ b/lib/Elastica/Filter/Ids.php
@@ -3,12 +3,16 @@ namespace Elastica\Filter;
 
 use Elastica\Type as ElasticaType;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Ids Filter.
  *
  * @author Lee Parker, Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Ids extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Indices.php
+++ b/lib/Elastica/Filter/Indices.php
@@ -3,10 +3,14 @@ namespace Elastica\Filter;
 
 use Elastica\Index as ElasticaIndex;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Class Indices.
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-indices-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Indices extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Limit.php
+++ b/lib/Elastica/Filter/Limit.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Limit Filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-limit-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Limit extends AbstractFilter
 {

--- a/lib/Elastica/Filter/MatchAll.php
+++ b/lib/Elastica/Filter/MatchAll.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Match all filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class MatchAll extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Missing.php
+++ b/lib/Elastica/Filter/Missing.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Missing Filter.
  *
  * @author Maciej Wiercinski <maciej@wiercinski.net>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-missing-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Missing extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Nested.php
+++ b/lib/Elastica/Filter/Nested.php
@@ -3,12 +3,16 @@ namespace Elastica\Filter;
 
 use Elastica\Query\AbstractQuery;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Nested filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Nested extends AbstractFilter
 {

--- a/lib/Elastica/Filter/NumericRange.php
+++ b/lib/Elastica/Filter/NumericRange.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Numeric Range Filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class NumericRange extends Range
 {

--- a/lib/Elastica/Filter/Prefix.php
+++ b/lib/Elastica/Filter/Prefix.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Prefix filter.
  *
  * @author Jasper van Wanrooy <jasper@vanwanrooy.net>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Prefix extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Query.php
+++ b/lib/Elastica/Filter/Query.php
@@ -4,12 +4,16 @@ namespace Elastica\Filter;
 use Elastica\Exception\InvalidException;
 use Elastica\Query\AbstractQuery;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Query filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Query extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Range.php
+++ b/lib/Elastica/Filter/Range.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Range Filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Range extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Regexp.php
+++ b/lib/Elastica/Filter/Regexp.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Regexp filter.
  *
  * @author Timothy Lamb <trash80@gmail.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Regexp extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Script.php
+++ b/lib/Elastica/Filter/Script.php
@@ -3,12 +3,16 @@ namespace Elastica\Filter;
 
 use Elastica;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Script filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Script extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Term.php
+++ b/lib/Elastica/Filter/Term.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Term query.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Term extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Terms.php
+++ b/lib/Elastica/Filter/Terms.php
@@ -3,12 +3,16 @@ namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Terms filter.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Terms extends AbstractFilter
 {

--- a/lib/Elastica/Filter/Type.php
+++ b/lib/Elastica/Filter/Type.php
@@ -1,12 +1,16 @@
 <?php
 namespace Elastica\Filter;
 
+trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
+
 /**
  * Type Filter.
  *
  * @author James Wilson <jwilson556@gmail.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-filter.html
+ *
+ * @deprecated Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html
  */
 class Type extends AbstractFilter
 {

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -72,9 +72,9 @@ class Query extends Param
             case $query instanceof AbstractQuery:
                 return new self($query);
             case $query instanceof AbstractFilter:
+                trigger_error('Deprecated: Elastica\Query::create() passing filter is deprecated. Create query and use setPostFilter with AbstractQuery instead.', E_USER_DEPRECATED);
                 $newQuery = new self();
                 $newQuery->setPostFilter($query);
-
                 return $newQuery;
             case empty($query):
                 return new self(new MatchAll());
@@ -133,15 +133,21 @@ class Query extends Param
     /**
      * Set Filter.
      *
-     * @param \Elastica\Filter\AbstractFilter $filter Filter object
+     * @param \Elastica\Query\AbstractQuery $filter Filter object
      *
      * @return $this
      *
      * @link    https://github.com/elasticsearch/elasticsearch/issues/7422
      * @deprecated Use Elastica\Query::setPostFilter() instead, this method will be removed in further Elastica releases
      */
-    public function setFilter(AbstractFilter $filter)
+    public function setFilter($filter)
     {
+        if ($filter instanceof AbstractFilter) {
+            trigger_error('Deprecated: Elastica\Query::setFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.', E_USER_DEPRECATED);
+        } elseif (!($filter instanceof AbstractQuery)) {
+            throw new InvalidException('Filter must be instance of AbstractQuery');
+        }
+
         trigger_error('Deprecated: Elastica\Query::setFilter() is deprecated and will be removed in further Elastica releases. Use Elastica\Query::setPostFilter() instead.', E_USER_DEPRECATED);
 
         return $this->setPostFilter($filter);
@@ -450,7 +456,7 @@ class Query extends Param
     /**
      * Sets post_filter argument for the query. The filter is applied after the query has executed.
      *
-     * @param array|\Elastica\Filter\AbstractFilter $filter
+     * @param array|\Elastica\Query\AbstractQuery $filter
      *
      * @return $this
      *
@@ -458,8 +464,12 @@ class Query extends Param
      */
     public function setPostFilter($filter)
     {
-        if (!($filter instanceof AbstractFilter)) {
-            trigger_error('Deprecated: Elastica\Query::setPostFilter() passing filter as array is deprecated. Pass instance of AbstractFilter instead.', E_USER_DEPRECATED);
+        if (is_array($filter)) {
+            trigger_error('Deprecated: Elastica\Query::setPostFilter() passing filter as array is deprecated. Pass instance of AbstractQuery instead.', E_USER_DEPRECATED);
+        } elseif ($filter instanceof AbstractFilter) {
+            trigger_error('Deprecated: Elastica\Query::setPostFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.', E_USER_DEPRECATED);
+        } elseif (!($filter instanceof AbstractQuery)) {
+            throw new InvalidException('Filter must be instance of AbstractQuery');
         }
 
         return $this->setParam('post_filter', $filter);

--- a/lib/Elastica/Query/AbstractGeoDistance.php
+++ b/lib/Elastica/Query/AbstractGeoDistance.php
@@ -1,0 +1,198 @@
+<?php
+namespace Elastica\Query;
+
+use Elastica\Exception\InvalidException;
+
+/**
+ * Geo distance query.
+ *
+ * @author Nicolas Ruflin <spam@ruflin.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html
+ */
+abstract class AbstractGeoDistance extends AbstractQuery
+{
+    const LOCATION_TYPE_GEOHASH = 'geohash';
+    const LOCATION_TYPE_LATLON = 'latlon';
+
+    /**
+     * Location type.
+     *
+     * Decides if this query uses latitude/longitude or geohash for the location.
+     * Values are "latlon" or "geohash".
+     *
+     * @var string
+     */
+    protected $_locationType = null;
+
+    /**
+     * Key.
+     *
+     * @var string
+     */
+    protected $_key = null;
+
+    /**
+     * Latitude.
+     *
+     * @var float
+     */
+    protected $_latitude = null;
+
+    /**
+     * Longitude.
+     *
+     * @var float
+     */
+    protected $_longitude = null;
+
+    /**
+     * Geohash.
+     *
+     * @var string
+     */
+    protected $_geohash = null;
+
+    /**
+     * Create GeoDistance object.
+     *
+     * @param string       $key      Key
+     * @param array|string $location Location as array or geohash: array('lat' => 48.86, 'lon' => 2.35) OR 'drm3btev3e86'
+     *
+     * @internal param string $distance Distance
+     */
+    public function __construct($key, $location)
+    {
+        // Key
+        $this->setKey($key);
+        $this->setLocation($location);
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return $this
+     */
+    public function setKey($key)
+    {
+        $this->_key = $key;
+
+        return $this;
+    }
+
+    /**
+     * @param array|string $location
+     *
+     * @throws \Elastica\Exception\InvalidException
+     *
+     * @return $this
+     */
+    public function setLocation($location)
+    {
+        // Location
+        if (is_array($location)) { // Latitude/Longitude
+            // Latitude
+            if (isset($location['lat'])) {
+                $this->setLatitude($location['lat']);
+            } else {
+                throw new InvalidException('$location[\'lat\'] has to be set');
+            }
+
+            // Longitude
+            if (isset($location['lon'])) {
+                $this->setLongitude($location['lon']);
+            } else {
+                throw new InvalidException('$location[\'lon\'] has to be set');
+            }
+        } elseif (is_string($location)) { // Geohash
+            $this->setGeohash($location);
+        } else { // Invalid location
+            throw new InvalidException('$location has to be an array (latitude/longitude) or a string (geohash)');
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param float $latitude
+     *
+     * @return $this
+     */
+    public function setLatitude($latitude)
+    {
+        $this->_latitude = (float) $latitude;
+        $this->_locationType = self::LOCATION_TYPE_LATLON;
+
+        return $this;
+    }
+
+    /**
+     * @param float $longitude
+     *
+     * @return $this
+     */
+    public function setLongitude($longitude)
+    {
+        $this->_longitude = (float) $longitude;
+        $this->_locationType = self::LOCATION_TYPE_LATLON;
+
+        return $this;
+    }
+
+    /**
+     * @param string $geohash
+     *
+     * @return $this
+     */
+    public function setGeohash($geohash)
+    {
+        $this->_geohash = $geohash;
+        $this->_locationType = self::LOCATION_TYPE_GEOHASH;
+
+        return $this;
+    }
+
+    /**
+     * @throws \Elastica\Exception\InvalidException
+     *
+     * @return array|string
+     */
+    protected function _getLocationData()
+    {
+        if ($this->_locationType === self::LOCATION_TYPE_LATLON) { // Latitude/longitude
+            $location = array();
+
+            if (isset($this->_latitude)) { // Latitude
+                $location['lat'] = $this->_latitude;
+            } else {
+                throw new InvalidException('Latitude has to be set');
+            }
+
+            if (isset($this->_longitude)) { // Geohash
+                $location['lon'] = $this->_longitude;
+            } else {
+                throw new InvalidException('Longitude has to be set');
+            }
+        } elseif ($this->_locationType === self::LOCATION_TYPE_GEOHASH) { // Geohash
+            $location = $this->_geohash;
+        } else { // Invalid location type
+            throw new InvalidException('Invalid location type');
+        }
+
+        return $location;
+    }
+
+    /**
+     * @see \Elastica\Param::toArray()
+     *
+     * @throws \Elastica\Exception\InvalidException
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        $this->setParam($this->_key, $this->_getLocationData());
+
+        return parent::toArray();
+    }
+}

--- a/lib/Elastica/Query/AbstractGeoShape.php
+++ b/lib/Elastica/Query/AbstractGeoShape.php
@@ -1,0 +1,52 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * geo_shape query.
+ *
+ * Query pre-indexed shape definitions
+ *
+ * @author Bennie Krijger <benniekrijger@gmail.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
+ */
+abstract class AbstractGeoShape extends AbstractQuery
+{
+    const RELATION_INTERSECT = 'intersects';
+    const RELATION_DISJOINT = 'disjoint';
+    const RELATION_CONTAINS = 'within';
+
+    /**
+     * @var string
+     *
+     * elasticsearch path of the pre-indexed shape
+     */
+    protected $_path;
+
+    /**
+     * @var string
+     *
+     * the relation of the 2 shaped: intersects, disjoint, within
+     */
+    protected $_relation = self::RELATION_INTERSECT;
+
+    /**
+     * @param string $relation
+     *
+     * @return $this
+     */
+    public function setRelation($relation)
+    {
+        $this->_relation = $relation;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRelation()
+    {
+        return $this->_relation;
+    }
+}

--- a/lib/Elastica/Query/BoolQuery.php
+++ b/lib/Elastica/Query/BoolQuery.php
@@ -52,12 +52,18 @@ class BoolQuery extends AbstractQuery
     /**
      * Sets the filter.
      *
-     * @param \Elastica\Filter\AbstractFilter $filter Filter object
+     * @param \Elastica\Query\AbstractQuery $filter Filter object
      *
      * @return $this
      */
-    public function addFilter(AbstractFilter $filter)
+    public function addFilter($filter)
     {
+        if ($filter instanceof AbstractFilter) {
+            trigger_error('Deprecated: Elastica\Query\BoolQuery::addFilter passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+        } elseif (!($filter instanceof AbstractQuery)) {
+            throw new InvalidException('Filter must be instance of AbstractQuery');
+        }
+
         return $this->addParam('filter', $filter);
     }
 

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -2,6 +2,7 @@
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
+use Elastica\Filter\AbstractFilter;
 
 /**
  * Constant score query.
@@ -15,11 +16,17 @@ class ConstantScore extends AbstractQuery
     /**
      * Construct constant score query.
      *
-     * @param null|\Elastica\Filter\AbstractFilter|array $filter
+     * @param null|\Elastica\Query\AbstractQuery|array $filter
      */
     public function __construct($filter = null)
     {
         if (!is_null($filter)) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Query\ConstantScore passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!is_array($filter) && !($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+
             $this->setFilter($filter);
         }
     }
@@ -27,12 +34,18 @@ class ConstantScore extends AbstractQuery
     /**
      * Set filter.
      *
-     * @param array|\Elastica\Filter\AbstractFilter $filter
+     * @param array|\Elastica\Query\AbstractQuery $filter
      *
      * @return $this
      */
     public function setFilter($filter)
     {
+        if ($filter instanceof AbstractFilter) {
+            trigger_error('Deprecated: Elastica\Query\ConstantScore::setFilter passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+        } elseif (!is_array($filter) && !($filter instanceof AbstractQuery)) {
+            throw new InvalidException('Filter must be instance of AbstractQuery or array');
+        }
+
         return $this->setParam('filter', $filter);
     }
 

--- a/lib/Elastica/Query/Exists.php
+++ b/lib/Elastica/Query/Exists.php
@@ -1,0 +1,34 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * Exists query.
+ *
+ * @author Oleg Cherniy <oleg.cherniy@gmail.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html
+ */
+class Exists extends AbstractQuery
+{
+    /**
+     * Construct exists query.
+     *
+     * @param string $field
+     */
+    public function __construct($field)
+    {
+        $this->setField($field);
+    }
+
+    /**
+     * Set field.
+     *
+     * @param string $field
+     *
+     * @return $this
+     */
+    public function setField($field)
+    {
+        return $this->setParam('field', $field);
+    }
+}

--- a/lib/Elastica/Query/Filtered.php
+++ b/lib/Elastica/Query/Filtered.php
@@ -21,11 +21,20 @@ class Filtered extends AbstractQuery
      * Constructs a filtered query.
      *
      * @param \Elastica\Query\AbstractQuery   $query  OPTIONAL Query object
-     * @param \Elastica\Filter\AbstractFilter $filter OPTIONAL Filter object
+     * @param \Elastica\Query\AbstractQuery $filter OPTIONAL Filter object
      */
-    public function __construct(AbstractQuery $query = null, AbstractFilter $filter = null)
+    public function __construct(AbstractQuery $query = null, $filter = null)
     {
         $this->setQuery($query);
+
+        if (null !== $filter) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Query\Filtered passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+        }
+
         $this->setFilter($filter);
     }
 
@@ -44,19 +53,27 @@ class Filtered extends AbstractQuery
     /**
      * Sets the filter.
      *
-     * @param \Elastica\Filter\AbstractFilter $filter Filter object
+     * @param \Elastica\Query\AbstractQuery $filter Filter object
      *
      * @return $this
      */
-    public function setFilter(AbstractFilter $filter = null)
+    public function setFilter($filter = null)
     {
+        if (null !== $filter) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Query\Filtered::setFilter passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+        }
+
         return $this->setParam('filter', $filter);
     }
 
     /**
      * Gets the filter.
      *
-     * @return \Elastica\Filter\AbstractFilter
+     * @return \Elastica\Query\AbstractQuery|\Elastica\Filter\AbstractFilter
      */
     public function getFilter()
     {
@@ -88,7 +105,7 @@ class Filtered extends AbstractQuery
             $filtered['query'] = $this->getParam('query')->toArray();
         }
 
-        if ($this->hasParam('filter') && $this->getParam('filter') instanceof AbstractFilter) {
+        if ($this->hasParam('filter') && ($this->getParam('filter') instanceof AbstractQuery || $this->getParam('filter') instanceof AbstractFilter)) {
             $filtered['filter'] = $this->getParam('filter')->toArray();
         }
 

--- a/lib/Elastica/Query/FunctionScore.php
+++ b/lib/Elastica/Query/FunctionScore.php
@@ -1,7 +1,9 @@
 <?php
 namespace Elastica\Query;
 
+use Elastica\Exception\DeprecatedException;
 use Elastica\Script\AbstractScript;
+use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
 
 /**
@@ -56,12 +58,13 @@ class FunctionScore extends AbstractQuery
 
     /**
      * @param AbstractFilter $filter
+     * @deprecated Elastica\Query\FunctionScore::setFilter is deprecated. Use setQuery instead
      *
      * @return $this
      */
     public function setFilter(AbstractFilter $filter)
     {
-        return $this->setParam('filter', $filter);
+        throw new DeprecatedException('Deprecated: Elastica\Query\FunctionScore::setFilter is deprecated. Use setQuery instead.');
     }
 
     /**
@@ -69,19 +72,27 @@ class FunctionScore extends AbstractQuery
      *
      * @param string         $functionType   valid values are DECAY_* constants and script_score
      * @param array|float    $functionParams the body of the function. See documentation for proper syntax.
-     * @param AbstractFilter $filter         optional filter to apply to the function
+     * @param AbstractQuery  $filter         optional filter to apply to the function
      * @param float          $weight         function weight
      *
      * @return $this
      */
-    public function addFunction($functionType, $functionParams, AbstractFilter $filter = null, $weight = null)
+    public function addFunction($functionType, $functionParams, $filter = null, $weight = null)
     {
         $function = array(
             $functionType => $functionParams,
         );
+
         if (!is_null($filter)) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Query\FunctionScore::addFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+
             $function['filter'] = $filter;
         }
+
         if ($weight !== null) {
             $function['weight'] = $weight;
         }
@@ -95,13 +106,21 @@ class FunctionScore extends AbstractQuery
      * Add a script_score function to the query.
      *
      * @param \Elastica\Script\AbstractScript    $script a Script object
-     * @param AbstractFilter                     $filter an optional filter to apply to the function
-     * @param float                              $weight the weight of the function
+     * @param AbstractQuery  $filter an optional filter to apply to the function
+     * @param float          $weight the weight of the function
      *
      * @return $this
      */
-    public function addScriptScoreFunction(AbstractScript $script, AbstractFilter $filter = null, $weight = null)
+    public function addScriptScoreFunction(AbstractScript $script, $filter = null, $weight = null)
     {
+        if (null !== $filter) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Query\FunctionScore::addScriptScoreFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+        }
+
         return $this->addFunction('script_score', $script, $filter, $weight);
     }
 
@@ -115,7 +134,7 @@ class FunctionScore extends AbstractQuery
      * @param string         $offset   If defined, this function will only be computed for documents with a distance from the origin greater than this value
      * @param float          $decay    optionally defines how documents are scored at the distance given by the $scale parameter
      * @param float          $weight   optional factor by which to multiply the score at the value provided by the $scale parameter
-     * @param AbstractFilter $filter   a filter associated with this function
+     * @param AbstractQuery  $filter   a filter associated with this function
      *
      * @return $this
      */
@@ -127,8 +146,16 @@ class FunctionScore extends AbstractQuery
         $offset = null,
         $decay = null,
         $weight = null,
-        AbstractFilter $filter = null
+        $filter = null
     ) {
+        if (null !== $filter) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Query\FunctionScore::addDecayFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+        }
+
         $functionParams = array(
             $field => array(
                 'origin' => $origin,
@@ -151,8 +178,16 @@ class FunctionScore extends AbstractQuery
         $modifier = null,
         $missing = null,
         $weight = null,
-        AbstractFilter $filter = null
+        $filter = null
     ) {
+        if (null !== $filter) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Query\FunctionScore::addFieldValueFactorFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+        }
+
         $functionParams = array(
             'field' => $field,
         );
@@ -176,22 +211,38 @@ class FunctionScore extends AbstractQuery
      * Add a boost_factor function to the query.
      *
      * @param float          $boostFactor the boost factor value
-     * @param AbstractFilter $filter      a filter associated with this function
+     * @param AbstractQuery  $filter      a filter associated with this function
      *
      * @deprecated Use addWeightFunction instead. This method will be removed in further Elastica releases
      */
-    public function addBoostFactorFunction($boostFactor, AbstractFilter $filter = null)
+    public function addBoostFactorFunction($boostFactor, $filter = null)
     {
+        if (null !== $filter) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Query\FunctionScore::addBoostFactorFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+        }
+
         trigger_error('Query\FunctionScore::addBoostFactorFunction is deprecated. Use addWeightFunction instead. This method will be removed in further Elastica releases', E_USER_DEPRECATED);
         $this->addWeightFunction($boostFactor, $filter);
     }
 
     /**
      * @param float          $weight the weight of the function
-     * @param AbstractFilter $filter a filter associated with this function
+     * @param AbstractQuery  $filter a filter associated with this function
      */
-    public function addWeightFunction($weight, AbstractFilter $filter = null)
+    public function addWeightFunction($weight, $filter = null)
     {
+        if (null !== $filter) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Query\FunctionScore::addWeightFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+        }
+
         $this->addFunction('weight', $weight, $filter);
     }
 
@@ -199,11 +250,19 @@ class FunctionScore extends AbstractQuery
      * Add a random_score function to the query.
      *
      * @param number         $seed   the seed value
-     * @param AbstractFilter $filter a filter associated with this function
+     * @param AbstractQuery  $filter a filter associated with this function
      * @param float          $weight an optional boost value associated with this function
      */
-    public function addRandomScoreFunction($seed, AbstractFilter $filter = null, $weight = null)
+    public function addRandomScoreFunction($seed, $filter = null, $weight = null)
     {
+        if (null !== $filter) {
+            if ($filter instanceof AbstractFilter) {
+                trigger_error('Deprecated: Elastica\Query\FunctionScore::addRandomScoreFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.', E_USER_DEPRECATED);
+            } elseif (!($filter instanceof AbstractQuery)) {
+                throw new InvalidException('Filter must be instance of AbstractQuery');
+            }
+        }
+
         $this->addFunction('random_score', array('seed' => $seed), $filter, $weight);
     }
 

--- a/lib/Elastica/Query/GeoBoundingBox.php
+++ b/lib/Elastica/Query/GeoBoundingBox.php
@@ -1,0 +1,49 @@
+<?php
+namespace Elastica\Query;
+
+use Elastica\Exception\InvalidException;
+
+/**
+ * Geo bounding box query.
+ *
+ * @author Fabian Vogler <fabian@equivalence.ch>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html
+ */
+class GeoBoundingBox extends AbstractQuery
+{
+    /**
+     * Construct BoundingBoxQuery.
+     *
+     * @param string $key         Key
+     * @param array  $coordinates Array with top left coordinate as first and bottom right coordinate as second element
+     */
+    public function __construct($key, array $coordinates)
+    {
+        $this->addCoordinates($key, $coordinates);
+    }
+
+    /**
+     * Add coordinates.
+     *
+     * @param string $key         Key
+     * @param array  $coordinates Array with top left coordinate as first and bottom right coordinate as second element
+     *
+     * @throws \Elastica\Exception\InvalidException If $coordinates doesn't have two elements
+     *
+     * @return $this
+     */
+    public function addCoordinates($key, array $coordinates)
+    {
+        if (!isset($coordinates[0]) || !isset($coordinates[1])) {
+            throw new InvalidException('expected $coordinates to be an array with two elements');
+        }
+
+        $this->setParam($key, array(
+            'top_left' => $coordinates[0],
+            'bottom_right' => $coordinates[1],
+        ));
+
+        return $this;
+    }
+}

--- a/lib/Elastica/Query/GeoDistance.php
+++ b/lib/Elastica/Query/GeoDistance.php
@@ -1,0 +1,76 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * Geo distance query.
+ *
+ * @author Nicolas Ruflin <spam@ruflin.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html
+ */
+class GeoDistance extends AbstractGeoDistance
+{
+    const DISTANCE_TYPE_ARC = 'arc';
+    const DISTANCE_TYPE_PLANE = 'plane';
+    const DISTANCE_TYPE_SLOPPY_ARC = 'sloppy_arc';
+
+    const OPTIMIZE_BBOX_MEMORY = 'memory';
+    const OPTIMIZE_BBOX_INDEXED = 'indexed';
+    const OPTIMIZE_BBOX_NONE = 'none';
+
+    /**
+     * Create GeoDistance object.
+     *
+     * @param string       $key      Key
+     * @param array|string $location Location as array or geohash: array('lat' => 48.86, 'lon' => 2.35) OR 'drm3btev3e86'
+     * @param string       $distance Distance
+     *
+     * @throws \Elastica\Exception\InvalidException
+     */
+    public function __construct($key, $location, $distance)
+    {
+        parent::__construct($key, $location);
+
+        $this->setDistance($distance);
+    }
+
+    /**
+     * @param string $distance
+     *
+     * @return $this
+     */
+    public function setDistance($distance)
+    {
+        $this->setParam('distance', $distance);
+
+        return $this;
+    }
+
+    /**
+     * See DISTANCE_TYPE_* constants.
+     *
+     * @param string $distanceType
+     *
+     * @return $this
+     */
+    public function setDistanceType($distanceType)
+    {
+        $this->setParam('distance_type', $distanceType);
+
+        return $this;
+    }
+
+    /**
+     * See OPTIMIZE_BBOX_* constants.
+     *
+     * @param string $optimizeBbox
+     *
+     * @return $this
+     */
+    public function setOptimizeBbox($optimizeBbox)
+    {
+        $this->setParam('optimize_bbox', $optimizeBbox);
+
+        return $this;
+    }
+}

--- a/lib/Elastica/Query/GeoDistanceRange.php
+++ b/lib/Elastica/Query/GeoDistanceRange.php
@@ -1,0 +1,103 @@
+<?php
+namespace Elastica\Query;
+
+use Elastica\Exception\InvalidException;
+
+/**
+ * Geo distance query.
+ *
+ * @author munkie
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-range-query.html
+ */
+class GeoDistanceRange extends AbstractGeoDistance
+{
+    const RANGE_FROM = 'from';
+    const RANGE_TO = 'to';
+    const RANGE_LT = 'lt';
+    const RANGE_LTE = 'lte';
+    const RANGE_GT = 'gt';
+    const RANGE_GTE = 'gte';
+
+    const RANGE_INCLUDE_LOWER = 'include_lower';
+    const RANGE_INCLUDE_UPPER = 'include_upper';
+
+    /**
+     * @var array
+     */
+    protected $_ranges = array();
+
+    /**
+     * @param string       $key
+     * @param array|string $location
+     * @param array        $ranges
+     *
+     * @internal param string $distance
+     */
+    public function __construct($key, $location, array $ranges = array())
+    {
+        parent::__construct($key, $location);
+
+        if (!empty($ranges)) {
+            $this->setRanges($ranges);
+        }
+    }
+
+    /**
+     * @param array $ranges
+     *
+     * @return $this
+     */
+    public function setRanges(array $ranges)
+    {
+        $this->_ranges = array();
+
+        foreach ($ranges as $key => $value) {
+            $this->setRange($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @throws \Elastica\Exception\InvalidException
+     *
+     * @return $this
+     */
+    public function setRange($key, $value)
+    {
+        switch ($key) {
+            case self::RANGE_TO:
+            case self::RANGE_FROM:
+            case self::RANGE_GT:
+            case self::RANGE_GTE:
+            case self::RANGE_LT:
+            case self::RANGE_LTE:
+                break;
+            case self::RANGE_INCLUDE_LOWER:
+            case self::RANGE_INCLUDE_UPPER:
+                $value = (boolean) $value;
+                break;
+            default:
+                throw new InvalidException('Invalid range parameter given: '.$key);
+        }
+        $this->_ranges[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        foreach ($this->_ranges as $key => $value) {
+            $this->setParam($key, $value);
+        }
+
+        return parent::toArray();
+    }
+}

--- a/lib/Elastica/Query/GeoPolygon.php
+++ b/lib/Elastica/Query/GeoPolygon.php
@@ -1,0 +1,56 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * Geo polygon query.
+ *
+ * @author Michael Maclean <mgdm@php.net>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-query.html
+ */
+class GeoPolygon extends AbstractQuery
+{
+    /**
+     * Key.
+     *
+     * @var string Key
+     */
+    protected $_key = '';
+
+    /**
+     * Points making up polygon.
+     *
+     * @var array Points making up polygon
+     */
+    protected $_points = array();
+
+    /**
+     * Construct polygon query.
+     *
+     * @param string $key    Key
+     * @param array  $points Points making up polygon
+     */
+    public function __construct($key, array $points)
+    {
+        $this->_key = $key;
+        $this->_points = $points;
+    }
+
+    /**
+     * Converts query to array.
+     *
+     * @see \Elastica\Query\AbstractQuery::toArray()
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            'geo_polygon' => array(
+                $this->_key => array(
+                    'points' => $this->_points,
+                ),
+            ),
+        );
+    }
+}

--- a/lib/Elastica/Query/GeoShapePreIndexed.php
+++ b/lib/Elastica/Query/GeoShapePreIndexed.php
@@ -1,0 +1,84 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * geo_shape query for pre-indexed shapes.
+ *
+ * Query pre-indexed shape definitions
+ *
+ * @author Bennie Krijger <benniekrijger@gmail.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
+ */
+class GeoShapePreIndexed extends AbstractGeoShape
+{
+    /**
+     * elasticsearch id of the pre-indexed shape.
+     *
+     * @var string
+     */
+    protected $_indexedId;
+
+    /**
+     * elasticsearch type of the pre-indexed shape.
+     *
+     * @var string
+     */
+    protected $_indexedType;
+
+    /**
+     *  elasticsearch index of the pre-indexed shape.
+     *
+     * @var string
+     */
+    protected $_indexedIndex;
+
+    /**
+     *  elasticsearch path/field name of the pre-indexed shape.
+     *
+     * @var string
+     */
+    protected $_indexedPath;
+
+    /**
+     * Construct geo_shape query with a pre-indexed shape.
+     *
+     * @param string $path         The path/field of the shape searched
+     * @param string $indexedId    Id of the pre-indexed shape
+     * @param string $indexedType  Type of the pre-indexed shape
+     * @param string $indexedIndex Index of the pre-indexed shape
+     * @param string $indexedPath  Path of the pre-indexed shape
+     */
+    public function __construct($path, $indexedId, $indexedType, $indexedIndex, $indexedPath)
+    {
+        $this->_path = $path;
+        $this->_indexedId = $indexedId;
+        $this->_indexedType = $indexedType;
+        $this->_indexedIndex = $indexedIndex;
+        $this->_indexedPath = $indexedPath;
+    }
+
+    /**
+     * Converts query to array.
+     *
+     * @see \Elastica\Query\AbstractQuery::toArray()
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            'geo_shape' => array(
+                $this->_path => array(
+                    'indexed_shape' => array(
+                        'id' => $this->_indexedId,
+                        'type' => $this->_indexedType,
+                        'index' => $this->_indexedIndex,
+                        'path' => $this->_indexedPath,
+                    ),
+                    'relation' => $this->_relation,
+                ),
+            ),
+        );
+    }
+}

--- a/lib/Elastica/Query/GeoShapeProvided.php
+++ b/lib/Elastica/Query/GeoShapeProvided.php
@@ -1,0 +1,73 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * geo_shape query or provided shapes.
+ *
+ * Query provided shape definitions
+ *
+ * @author BennieKrijger <benniekrijger@gmail.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
+ */
+class GeoShapeProvided extends AbstractGeoShape
+{
+    const TYPE_ENVELOPE = 'envelope';
+    const TYPE_MULTIPOINT = 'multipoint';
+    const TYPE_POINT = 'point';
+    const TYPE_MULTIPOLYGON = 'multipolygon';
+    const TYPE_LINESTRING = 'linestring';
+    const TYPE_POLYGON = 'polygon';
+
+    /**
+     * Type of the geo_shape.
+     *
+     * @var string
+     */
+    protected $_shapeType;
+
+    /**
+     * Coordinates making up geo_shape.
+     *
+     * @var array Coordinates making up geo_shape
+     */
+    protected $_coordinates;
+
+    /**
+     * Construct geo_shape query.
+     *
+     * @param string $path        The path/field of the shape searched
+     * @param array  $coordinates Points making up the shape
+     * @param string $shapeType   Type of the geo_shape:
+     *                            point, envelope, linestring, polygon,
+     *                            multipoint or multipolygon
+     */
+    public function __construct($path, array $coordinates, $shapeType = self::TYPE_ENVELOPE)
+    {
+        $this->_path = $path;
+        $this->_shapeType = $shapeType;
+        $this->_coordinates = $coordinates;
+    }
+
+    /**
+     * Converts query to array.
+     *
+     * @see \Elastica\Query\AbstractQuery::toArray()
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return array(
+            'geo_shape' => array(
+                $this->_path => array(
+                    'shape' => array(
+                        'type' => $this->_shapeType,
+                        'coordinates' => $this->_coordinates,
+                        'relation' => $this->_relation,
+                    ),
+                ),
+            ),
+        );
+    }
+}

--- a/lib/Elastica/Query/GeohashCell.php
+++ b/lib/Elastica/Query/GeohashCell.php
@@ -1,0 +1,47 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * Class GeohashCell.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geohash-cell-query.html
+ */
+class GeohashCell extends AbstractGeoDistance
+{
+    /**
+     * @param string       $key       The field on which to query
+     * @param array|string $location  Location as coordinates array or geohash string ['lat' => 40.3, 'lon' => 45.2]
+     * @param string|int   $precision Integer length of geohash prefix or distance (3, or "50m")
+     * @param bool         $neighbors If true, queries cells next to the given cell.
+     */
+    public function __construct($key, $location, $precision = -1, $neighbors = false)
+    {
+        parent::__construct($key, $location);
+        $this->setPrecision($precision);
+        $this->setNeighbors($neighbors);
+    }
+
+    /**
+     * Set the precision for this query.
+     *
+     * @param string|int $precision Integer length of geohash prefix or distance (3, or "50m")
+     *
+     * @return $this
+     */
+    public function setPrecision($precision)
+    {
+        return $this->setParam('precision', $precision);
+    }
+
+    /**
+     * Set the neighbors option for this query.
+     *
+     * @param bool $neighbors If true, queries cells next to the given cell.
+     *
+     * @return $this
+     */
+    public function setNeighbors($neighbors)
+    {
+        return $this->setParam('neighbors', (bool) $neighbors);
+    }
+}

--- a/lib/Elastica/Query/Indices.php
+++ b/lib/Elastica/Query/Indices.php
@@ -1,0 +1,78 @@
+<?php
+namespace Elastica\Query;
+
+use Elastica\Index as ElasticaIndex;
+
+/**
+ * Class Indices.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-indices-query.html
+ */
+class Indices extends AbstractQuery
+{
+    /**
+     * @param AbstractQuery $query  Query which will be applied to docs in the specified indices
+     * @param mixed[]        $indices
+     */
+    public function __construct(AbstractQuery $query, array $indices)
+    {
+        $this->setIndices($indices)->setQuery($query);
+    }
+
+    /**
+     * Set the indices on which this query should be applied.
+     *
+     * @param mixed[] $indices
+     *
+     * @return $this
+     */
+    public function setIndices(array $indices)
+    {
+        $this->setParam('indices', array());
+        foreach ($indices as $index) {
+            $this->addIndex($index);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Adds one more index on which this query should be applied.
+     *
+     * @param string|\Elastica\Index $index
+     *
+     * @return $this
+     */
+    public function addIndex($index)
+    {
+        if ($index instanceof ElasticaIndex) {
+            $index = $index->getName();
+        }
+
+        return $this->addParam('indices', (string) $index);
+    }
+
+    /**
+     * Set the query to be applied to docs in the specified indices.
+     *
+     * @param AbstractQuery $query
+     *
+     * @return $this
+     */
+    public function setQuery(AbstractQuery $query)
+    {
+        return $this->setParam('query', $query);
+    }
+
+    /**
+     * Set the query to be applied to docs in indices which do not match those specified in the "indices" parameter.
+     *
+     * @param AbstractQuery $query
+     *
+     * @return $this
+     */
+    public function setNoMatchQuery(AbstractQuery $query)
+    {
+        return $this->setParam('no_match_query', $query);
+    }
+}

--- a/lib/Elastica/Query/Limit.php
+++ b/lib/Elastica/Query/Limit.php
@@ -1,0 +1,34 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * Limit Query.
+ *
+ * @author Nicolas Ruflin <spam@ruflin.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-limit-query.html
+ */
+class Limit extends AbstractQuery
+{
+    /**
+     * Construct limit query.
+     *
+     * @param int $limit Limit
+     */
+    public function __construct($limit)
+    {
+        $this->setLimit($limit);
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param int $limit Limit
+     *
+     * @return $this
+     */
+    public function setLimit($limit)
+    {
+        return $this->setParam('value', (int) $limit);
+    }
+}

--- a/lib/Elastica/Query/Missing.php
+++ b/lib/Elastica/Query/Missing.php
@@ -1,0 +1,60 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * Missing Query.
+ *
+ * @author Maciej Wiercinski <maciej@wiercinski.net>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-missing-query.html
+ */
+class Missing extends AbstractQuery
+{
+    /**
+     * Construct missing query.
+     *
+     * @param string $field OPTIONAL
+     */
+    public function __construct($field = '')
+    {
+        if (strlen($field)) {
+            $this->setField($field);
+        }
+    }
+
+    /**
+     * Set field.
+     *
+     * @param string $field
+     *
+     * @return $this
+     */
+    public function setField($field)
+    {
+        return $this->setParam('field', (string) $field);
+    }
+
+    /**
+     * Set "existence" parameter.
+     *
+     * @param bool $existence
+     *
+     * @return $this
+     */
+    public function setExistence($existence)
+    {
+        return $this->setParam('existence', (bool) $existence);
+    }
+
+    /**
+     * Set "null_value" parameter.
+     *
+     * @param bool $nullValue
+     *
+     * @return $this
+     */
+    public function setNullValue($nullValue)
+    {
+        return $this->setParam('null_value', (bool) $nullValue);
+    }
+}

--- a/lib/Elastica/Query/NumericRange.php
+++ b/lib/Elastica/Query/NumericRange.php
@@ -1,0 +1,13 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * Numeric Range Query.
+ *
+ * @author Nicolas Ruflin <spam@ruflin.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
+ */
+class NumericRange extends Range
+{
+}

--- a/lib/Elastica/Query/Script.php
+++ b/lib/Elastica/Query/Script.php
@@ -1,0 +1,59 @@
+<?php
+namespace Elastica\Query;
+
+use Elastica;
+
+/**
+ * Script query.
+ *
+ * @author Nicolas Ruflin <spam@ruflin.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-query.html
+ */
+class Script extends AbstractQuery
+{
+    /**
+     * Query object.
+     *
+     * @var array|AbstractQuery
+     */
+    protected $_query = null;
+
+    /**
+     * Construct script query.
+     *
+     * @param array|string|\Elastica\Script\AbstractScript $script OPTIONAL Script
+     */
+    public function __construct($script = null)
+    {
+        if ($script) {
+            $this->setScript($script);
+        }
+    }
+
+    /**
+     * Sets script object.
+     *
+     * @param \Elastica\Script\Script|string|array $script
+     *
+     * @return $this
+     */
+    public function setScript($script)
+    {
+        return $this->setParam('script', Elastica\Script\Script::create($script));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray()
+    {
+        $array = parent::toArray();
+
+        if (isset($array['script'])) {
+            $array['script'] = $array['script']['script'];
+        }
+
+        return $array;
+    }
+}

--- a/lib/Elastica/Query/Type.php
+++ b/lib/Elastica/Query/Type.php
@@ -1,0 +1,59 @@
+<?php
+namespace Elastica\Query;
+
+/**
+ * Type Query.
+ *
+ * @author James Wilson <jwilson556@gmail.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html
+ */
+class Type extends AbstractQuery
+{
+    /**
+     * Type name.
+     *
+     * @var string
+     */
+    protected $_type = null;
+
+    /**
+     * Construct Type Query.
+     *
+     * @param string $type Type name
+     */
+    public function __construct($type = null)
+    {
+        if ($type) {
+            $this->setType($type);
+        }
+    }
+
+    /**
+     * Ads a field with arguments to the range query.
+     *
+     * @param string $typeName Type name
+     *
+     * @return $this
+     */
+    public function setType($typeName)
+    {
+        $this->_type = $typeName;
+
+        return $this;
+    }
+
+    /**
+     * Convert object to array.
+     *
+     * @see \Elastica\Query\AbstractQuery::toArray()
+     *
+     * @return array Query array
+     */
+    public function toArray()
+    {
+        return array(
+            'type' => array('value' => $this->_type),
+        );
+    }
+}

--- a/lib/Elastica/QueryBuilder/DSL/Aggregation.php
+++ b/lib/Elastica/QueryBuilder/DSL/Aggregation.php
@@ -258,7 +258,7 @@ class Aggregation implements DSL
      *
      * @return FilterAggregation
      */
-    public function filter($name, AbstractFilter $filter = null)
+    public function filter($name, $filter = null)
     {
         return new FilterAggregation($name, $filter);
     }

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -196,7 +196,7 @@ class Query implements DSL
      *
      * @return Filtered
      */
-    public function filtered(AbstractQuery $query = null, AbstractFilter $filter = null)
+    public function filtered(AbstractQuery $query = null, $filter = null)
     {
         trigger_error('Use bool() instead. Filtered query is deprecated since ES 2.0.0-beta1 and this method will be removed in further Elastica releases.', E_USER_DEPRECATED);
 

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -2,6 +2,7 @@
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
+use Elastica\Filter\AbstractFilter;
 
 /**
  * Elastica search object.
@@ -159,12 +160,16 @@ class Search
     }
 
     /**
-     * @param string|array|\Elastica\Query|\Elastica\Suggest|\Elastica\Query\AbstractQuery|\Elastica\Filter\AbstractFilter $query|
+     * @param string|array|\Elastica\Query|\Elastica\Suggest|\Elastica\Query\AbstractQuery $query
      *
      * @return $this
      */
     public function setQuery($query)
     {
+        if ($query instanceof AbstractFilter) {
+            trigger_error('Deprecated: Elastica\Search::setQuery() passing AbstractFilter is deprecated. Create query and use setPostFilter with AbstractQuery instead.', E_USER_DEPRECATED);
+        }
+
         $this->_query = Query::create($query);
 
         return $this;

--- a/test/lib/Elastica/Test/Aggregation/FilterTest.php
+++ b/test/lib/Elastica/Test/Aggregation/FilterTest.php
@@ -4,8 +4,11 @@ namespace Elastica\Test\Aggregation;
 use Elastica\Aggregation\Avg;
 use Elastica\Aggregation\Filter;
 use Elastica\Document;
+use Elastica\Filter\Exists;
 use Elastica\Filter\Range;
 use Elastica\Filter\Term;
+use Elastica\Query\Range as RangeQuery;
+use Elastica\Query\Term as TermQuery;
 use Elastica\Query;
 
 class FilterTest extends BaseAggregationTest
@@ -28,6 +31,68 @@ class FilterTest extends BaseAggregationTest
 
     /**
      * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testConstructorFilterInvalid()
+    {
+        new Filter('test', $this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testConstructorWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $errorsCollector = $this->startCollectErrors();
+        new Filter('test', $existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Aggregation\Filter passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.',
+                'Deprecated: Elastica\Aggregation\Filter\setFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testSetFilterInvalid()
+    {
+        $agg = new Filter('test');
+        $agg->setFilter($this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetFilterWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $agg = new Filter('test');
+
+        $errorsCollector = $this->startCollectErrors();
+        $agg->setFilter($existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Aggregation\Filter\setFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
      */
     public function testToArray()
     {
@@ -39,7 +104,30 @@ class FilterTest extends BaseAggregationTest
         );
 
         $agg = new Filter('in_stock_products');
+        $agg->setFilter(new RangeQuery('stock', array('gt' => 0)));
+        $avg = new Avg('avg_price');
+        $avg->setField('price');
+        $agg->addAggregation($avg);
+
+        $this->assertEquals($expected, $agg->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testToArrayWithLegacy()
+    {
+        $expected = array(
+            'filter' => array('range' => array('stock' => array('gt' => 0))),
+            'aggs' => array(
+                'avg_price' => array('avg' => array('field' => 'price')),
+            ),
+        );
+
+        $agg = new Filter('in_stock_products');
+        $this->hideDeprecated();
         $agg->setFilter(new Range('stock', array('gt' => 0)));
+        $this->showDeprecated();
         $avg = new Avg('avg_price');
         $avg->setField('price');
         $agg->addAggregation($avg);
@@ -53,7 +141,29 @@ class FilterTest extends BaseAggregationTest
     public function testFilterAggregation()
     {
         $agg = new Filter('filter');
+        $agg->setFilter(new TermQuery(array('color' => 'blue')));
+        $avg = new Avg('price');
+        $avg->setField('price');
+        $agg->addAggregation($avg);
+
+        $query = new Query();
+        $query->addAggregation($agg);
+
+        $results = $this->_getIndexForTest()->search($query)->getAggregation('filter');
+        $results = $results['price']['value'];
+
+        $this->assertEquals((5 + 8) / 2.0, $results);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testFilterAggregationWithLegacyFilter()
+    {
+        $agg = new Filter('filter');
+        $this->hideDeprecated();
         $agg->setFilter(new Term(array('color' => 'blue')));
+        $this->showDeprecated();
         $avg = new Avg('price');
         $avg->setField('price');
         $agg->addAggregation($avg);
@@ -89,7 +199,27 @@ class FilterTest extends BaseAggregationTest
      */
     public function testConstruct()
     {
+        $agg = new Filter('foo', new TermQuery(array('color' => 'blue')));
+
+        $expected = array(
+            'filter' => array(
+                'term' => array(
+                    'color' => 'blue',
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $agg->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testConstructWithLegacyFilter()
+    {
+        $this->hideDeprecated();
         $agg = new Filter('foo', new Term(array('color' => 'blue')));
+        $this->showDeprecated();
 
         $expected = array(
             'filter' => array(

--- a/test/lib/Elastica/Test/Aggregation/FiltersTest.php
+++ b/test/lib/Elastica/Test/Aggregation/FiltersTest.php
@@ -2,9 +2,9 @@
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;
-use Elastica\Aggregation\Filter;
 use Elastica\Aggregation\Filters;
 use Elastica\Document;
+use Elastica\Filter\Exists;
 use Elastica\Filter\Term;
 use Elastica\Query;
 
@@ -24,6 +24,38 @@ class FiltersTest extends BaseAggregationTest
         $index->refresh();
 
         return $index;
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testAddFilterInvalid()
+    {
+        $filters = new Filters('test');
+        $filters->addFilter($this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetFilterWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $agg = new Filters('test');
+
+        $errorsCollector = $this->startCollectErrors();
+        $agg->addFilter($existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Aggregation\Filters\addFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.'
+            )
+        );
     }
 
     /**
@@ -54,10 +86,11 @@ class FiltersTest extends BaseAggregationTest
         );
 
         $agg = new Filters('by_color');
-        $agg->addFilter(new Term(array('color' => '')), '');
-        $agg->addFilter(new Term(array('color' => '0')), '0');
-        $agg->addFilter(new Term(array('color' => 'blue')), 'blue');
-        $agg->addFilter(new Term(array('color' => 'red')), 'red');
+
+        $agg->addFilter(new Query\Term(array('color' => '')), '');
+        $agg->addFilter(new Query\Term(array('color' => '0')), '0');
+        $agg->addFilter(new Query\Term(array('color' => 'blue')), 'blue');
+        $agg->addFilter(new Query\Term(array('color' => 'red')), 'red');
 
         $avg = new Avg('avg_price');
         $avg->setField('price');
@@ -68,37 +101,125 @@ class FiltersTest extends BaseAggregationTest
 
     /**
      * @group unit
-     * @expectedException Elastica\Exception\InvalidException
+     */
+    public function testToArrayUsingNamedFiltersWithLegacyFilters()
+    {
+        $expected = array(
+            'filters' => array(
+                'filters' => array(
+                    '' => array(
+                        'term' => array('color' => ''),
+                    ),
+                    '0' => array(
+                        'term' => array('color' => '0'),
+                    ),
+                    'blue' => array(
+                        'term' => array('color' => 'blue'),
+                    ),
+                    'red' => array(
+                        'term' => array('color' => 'red'),
+                    ),
+                ),
+            ),
+            'aggs' => array(
+                'avg_price' => array('avg' => array('field' => 'price')),
+            ),
+        );
+
+        $agg = new Filters('by_color');
+
+        $this->hideDeprecated();
+        $agg->addFilter(new Term(array('color' => '')), '');
+        $agg->addFilter(new Term(array('color' => '0')), '0');
+        $agg->addFilter(new Term(array('color' => 'blue')), 'blue');
+        $agg->addFilter(new Term(array('color' => 'red')), 'red');
+        $this->showDeprecated();
+
+        $avg = new Avg('avg_price');
+        $avg->setField('price');
+        $agg->addAggregation($avg);
+
+        $this->assertEquals($expected, $agg->toArray());
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
      * @expectedExceptionMessage Name must be a string
      */
     public function testWrongName()
     {
         $agg = new Filters('by_color');
-        $agg->addFilter(new Term(array('color' => '0')), 0);
+        $this->hideDeprecated();
+        $agg->addFilter(new Query\Term(array('color' => '0')), 0);
+        $this->showDeprecated();
     }
 
     /**
      * @group unit
-     * @expectedException Elastica\Exception\InvalidException
+     * @expectedException \Elastica\Exception\InvalidException
+     * @expectedExceptionMessage Name must be a string
+     */
+    public function testWrongNameWithLegacyFilter()
+    {
+        $agg = new Filters('by_color');
+        $this->hideDeprecated();
+        $agg->addFilter(new Term(array('color' => '0')), 0);
+        $this->showDeprecated();
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
      * @expectedExceptionMessage Mix named and anonymous keys are not allowed
      */
     public function testMixNamedAndAnonymousFilters()
     {
         $agg = new Filters('by_color');
-        $agg->addFilter(new Term(array('color' => '0')), '0');
-        $agg->addFilter(new Term(array('color' => '0')));
+        $agg->addFilter(new Query\Term(array('color' => '0')), '0');
+        $agg->addFilter(new Query\Term(array('color' => '0')));
     }
 
     /**
      * @group unit
-     * @expectedException Elastica\Exception\InvalidException
+     * @expectedException \Elastica\Exception\InvalidException
+     * @expectedExceptionMessage Mix named and anonymous keys are not allowed
+     */
+    public function testMixNamedAndAnonymousFiltersWithLegacyFilters()
+    {
+        $agg = new Filters('by_color');
+        $this->hideDeprecated();
+        $agg->addFilter(new Term(array('color' => '0')), '0');
+        $agg->addFilter(new Term(array('color' => '0')));
+        $this->showDeprecated();
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
      * @expectedExceptionMessage Mix named and anonymous keys are not allowed
      */
     public function testMixAnonymousAndNamedFilters()
     {
         $agg = new Filters('by_color');
+
+        $agg->addFilter(new Query\Term(array('color' => '0')));
+        $agg->addFilter(new Query\Term(array('color' => '0')), '0');
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     * @expectedExceptionMessage Mix named and anonymous keys are not allowed
+     */
+    public function testMixAnonymousAndNamedFiltersWithLegacyFilters()
+    {
+        $agg = new Filters('by_color');
+
+        $this->hideDeprecated();
         $agg->addFilter(new Term(array('color' => '0')));
         $agg->addFilter(new Term(array('color' => '0')), '0');
+        $this->showDeprecated();
     }
 
     /**
@@ -123,8 +244,44 @@ class FiltersTest extends BaseAggregationTest
         );
 
         $agg = new Filters('by_color');
+
+        $agg->addFilter(new Query\Term(array('color' => 'blue')));
+        $agg->addFilter(new Query\Term(array('color' => 'red')));
+
+        $avg = new Avg('avg_price');
+        $avg->setField('price');
+        $agg->addAggregation($avg);
+
+        $this->assertEquals($expected, $agg->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testToArrayUsingAnonymousFiltersWithLegacyFilters()
+    {
+        $expected = array(
+            'filters' => array(
+                'filters' => array(
+                    array(
+                        'term' => array('color' => 'blue'),
+                    ),
+                    array(
+                        'term' => array('color' => 'red'),
+                    ),
+                ),
+            ),
+            'aggs' => array(
+                'avg_price' => array('avg' => array('field' => 'price')),
+            ),
+        );
+
+        $agg = new Filters('by_color');
+
+        $this->hideDeprecated();
         $agg->addFilter(new Term(array('color' => 'blue')));
         $agg->addFilter(new Term(array('color' => 'red')));
+        $this->showDeprecated();
 
         $avg = new Avg('avg_price');
         $avg->setField('price');
@@ -139,8 +296,38 @@ class FiltersTest extends BaseAggregationTest
     public function testFilterAggregation()
     {
         $agg = new Filters('by_color');
+        $agg->addFilter(new Query\Term(array('color' => 'blue')), 'blue');
+        $agg->addFilter(new Query\Term(array('color' => 'red')), 'red');
+
+        $avg = new Avg('avg_price');
+        $avg->setField('price');
+        $agg->addAggregation($avg);
+
+        $query = new Query();
+        $query->addAggregation($agg);
+
+        $results = $this->_getIndexForTest()->search($query)->getAggregation('by_color');
+
+        $resultsForBlue = $results['buckets']['blue'];
+        $resultsForRed = $results['buckets']['red'];
+
+        $this->assertEquals(2, $resultsForBlue['doc_count']);
+        $this->assertEquals(1, $resultsForRed['doc_count']);
+
+        $this->assertEquals((5 + 8) / 2, $resultsForBlue['avg_price']['value']);
+        $this->assertEquals(1, $resultsForRed['avg_price']['value']);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testFilterAggregationWithLegacyFilters()
+    {
+        $agg = new Filters('by_color');
+        $this->hideDeprecated();
         $agg->addFilter(new Term(array('color' => 'blue')), 'blue');
         $agg->addFilter(new Term(array('color' => 'red')), 'red');
+        $this->showDeprecated();
 
         $avg = new Avg('avg_price');
         $avg->setField('price');

--- a/test/lib/Elastica/Test/DeprecatedClassBase.php
+++ b/test/lib/Elastica/Test/DeprecatedClassBase.php
@@ -1,0 +1,24 @@
+<?php
+namespace Elastica\Test;
+
+/**
+ * Base test for test deprecated classes. Supress deprecated error during run test case
+ *
+ * @author Evgeniy Sokolov <ewgraf@gmail.com>
+ */
+class DeprecatedClassBase extends Base
+{
+    private $isDeprecatedVisible = false;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->hideDeprecated();
+    }
+
+    protected function tearDown()
+    {
+        $this->showDeprecated();
+        parent::tearDown();
+    }
+}

--- a/test/lib/Elastica/Test/ErrorsCollector.php
+++ b/test/lib/Elastica/Test/ErrorsCollector.php
@@ -1,0 +1,73 @@
+<?php
+namespace Elastica\Test;
+
+/**
+ * Errors collector for testing.
+ *
+ * @author Evgeniy Sokolov <ewgraf@gmail.com>
+ */
+class ErrorsCollector
+{
+    private $errors = array();
+
+    /**
+     * @var \PHPUnit_Framework_TestCase
+     */
+    private $testCase;
+
+    public function __construct(\PHPUnit_Framework_TestCase $testCase = null)
+    {
+        $this->testCase = $testCase;
+    }
+
+    public function add($error)
+    {
+        $this->errors[] = $error;
+    }
+
+    public function getCount()
+    {
+        return count($this->errors);
+    }
+
+    public function assertOnlyOneDeprecatedError($deprecationMessage)
+    {
+        $this->testCase->assertSame(1, $this->getCount());
+        $this->testCase->assertSame(1, $this->getDeprecatedCount());
+        $this->testCase->assertSame($deprecationMessage, $this->getMessage(0));
+
+    }
+
+    public function assertOnlyDeprecatedErrors(array $deprecationMessages)
+    {
+        $this->testCase->assertSame(count($deprecationMessages), $this->getCount());
+        $this->testCase->assertSame(count($deprecationMessages), $this->getDeprecatedCount());
+
+        foreach ($deprecationMessages as $index => $message) {
+            $this->testCase->assertSame($message, $this->getMessage($index));
+        }
+    }
+
+    public function getDeprecatedCount()
+    {
+        $count = 0;
+
+        foreach ($this->errors as $error) {
+            if (E_USER_DEPRECATED === $error[0]) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    public function getType($index)
+    {
+        return $this->errors[$index][0];
+    }
+
+    public function getMessage($index)
+    {
+        return $this->errors[$index][1];
+    }
+}

--- a/test/lib/Elastica/Test/Filter/AbstractGeoDistanceTest.php
+++ b/test/lib/Elastica/Test/Filter/AbstractGeoDistanceTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Elastica\Test\Filter;
+
+use Elastica\Test\DeprecatedClassBase as BaseTest;
+
+class AbstractGeoDistanceTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass('Elastica\Filter\AbstractGeoDistance');
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+}

--- a/test/lib/Elastica/Test/Filter/AbstractGeoShapeTest.php
+++ b/test/lib/Elastica/Test/Filter/AbstractGeoShapeTest.php
@@ -1,0 +1,16 @@
+<?php
+namespace Elastica\Test\Filter;
+
+use Elastica\Test\DeprecatedClassBase as BaseTest;
+
+class AbstractGeoShapeTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass('Elastica\Filter\AbstractGeoShape');
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+}

--- a/test/lib/Elastica/Test/Filter/AbstractTest.php
+++ b/test/lib/Elastica/Test/Filter/AbstractTest.php
@@ -1,10 +1,19 @@
 <?php
 namespace Elastica\Test\Filter;
 
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class AbstractTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass('Elastica\Filter\AbstractFilter');
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/BoolAndTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolAndTest.php
@@ -4,10 +4,19 @@ namespace Elastica\Test\Filter;
 use Elastica\Document;
 use Elastica\Filter\BoolAnd;
 use Elastica\Filter\Ids;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class BoolAndTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new BoolAnd());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use BoolQuery::addMust. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/BoolFilterTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolFilterTest.php
@@ -7,15 +7,26 @@ use Elastica\Filter\Ids;
 use Elastica\Filter\Term;
 use Elastica\Filter\Terms;
 use Elastica\Query;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class BoolFilterTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new BoolFilter());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @return array
      */
     public function getTestToArrayData()
     {
+        $this->hideDeprecated();
+
         $out = array();
 
         // case #0
@@ -29,6 +40,7 @@ class BoolFilterTest extends BaseTest
         $idsFilter3->setIds(3);
 
         $childBool = new BoolFilter();
+
         $childBool->addShould(array($idsFilter1, $idsFilter2));
         $mainBool->addShould(array($childBool, $idsFilter3));
 
@@ -75,6 +87,7 @@ class BoolFilterTest extends BaseTest
         );
         $out[] = array($bool, $expected);
 
+        $this->showDeprecated();
         return $out;
     }
 
@@ -194,19 +207,21 @@ class BoolFilterTest extends BaseTest
             self::markTestSkipped('These objects are not supported in PHP 7');
         }
 
-        $err = array();
-
-        set_error_handler(function () use (&$err) {
-            $err[] = func_get_args();
-        });
-
         $filter = new \Elastica\Filter\Bool();
 
-        restore_error_handler();
-
-        $this->assertCount(1, $err);
-        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
-
         $filter->addShould('fail!');
+    }
+
+    /**
+     * @group unit
+     */
+    public function testOldObjectDeprecated()
+    {
+        if (version_compare(phpversion(), 7, '>=')) {
+            self::markTestSkipped('These objects are not supported in PHP 7');
+        }
+
+        $reflection = new \ReflectionClass(new \Elastica\Filter\Bool());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
     }
 }

--- a/test/lib/Elastica/Test/Filter/BoolNotTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolNotTest.php
@@ -2,11 +2,21 @@
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\BoolNot;
+use Elastica\Filter\Exists;
 use Elastica\Filter\Ids;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class BoolNotTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new BoolNot(new Exists('a')));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use BoolQuery::addMustNot. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/BoolOrTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolOrTest.php
@@ -4,10 +4,19 @@ namespace Elastica\Test\Filter;
 use Elastica\Document;
 use Elastica\Filter\BoolOr;
 use Elastica\Filter\Ids;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class BoolOrTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new BoolOr());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use BoolQuery::addShould. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/ExistsTest.php
+++ b/test/lib/Elastica/Test/Filter/ExistsTest.php
@@ -2,10 +2,23 @@
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Exists;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class ExistsTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Exists('test'));
+
+        $this->assertFileDeprecated(
+            $reflection->getFileName(),
+            'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html'
+        );
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/GeoBoundingBoxTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoBoundingBoxTest.php
@@ -2,10 +2,19 @@
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\GeoBoundingBox;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class GeoBoundingBoxTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new GeoBoundingBox('a', array(1, 2)));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/GeoDistanceRangeTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoDistanceRangeTest.php
@@ -5,10 +5,19 @@ use Elastica\Document;
 use Elastica\Filter\GeoDistanceRange;
 use Elastica\Query;
 use Elastica\Query\MatchAll;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class GeoDistanceRangeTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new GeoDistanceRange('a', array('lat' => 30, 'lon' => 40)));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group functional
      */

--- a/test/lib/Elastica/Test/Filter/GeoDistanceTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoDistanceTest.php
@@ -5,10 +5,19 @@ use Elastica\Document;
 use Elastica\Filter\GeoDistance;
 use Elastica\Query;
 use Elastica\Query\MatchAll;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class GeoDistanceTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new GeoDistance('point', array('lat' => 30, 'lon' => 40), '40000km'));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group functional
      */

--- a/test/lib/Elastica/Test/Filter/GeoPolygonTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoPolygonTest.php
@@ -5,10 +5,19 @@ use Elastica\Document;
 use Elastica\Filter\GeoPolygon;
 use Elastica\Query;
 use Elastica\Query\MatchAll;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class GeoPolygonTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new GeoPolygon('location', array(array(16, 16))));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group functional
      */

--- a/test/lib/Elastica/Test/Filter/GeoShapePreIndexedTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoShapePreIndexedTest.php
@@ -4,10 +4,19 @@ namespace Elastica\Test\Filter;
 use Elastica\Filter\AbstractGeoShape;
 use Elastica\Filter\GeoShapePreIndexed;
 use Elastica\Query\BoolQuery;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class GeoShapePreIndexedTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new GeoShapePreIndexed('location', '1', 'type', 'a', 'location'));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group functional
      */

--- a/test/lib/Elastica/Test/Filter/GeoShapeProvidedTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoShapeProvidedTest.php
@@ -5,11 +5,20 @@ use Elastica\Document;
 use Elastica\Filter\AbstractGeoShape;
 use Elastica\Filter\GeoShapeProvided;
 use Elastica\Query\BoolQuery;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 use Elastica\Type\Mapping;
 
 class GeoShapeProvidedTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new GeoShapeProvided('location', array()));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group functional
      */

--- a/test/lib/Elastica/Test/Filter/GeohashCellTest.php
+++ b/test/lib/Elastica/Test/Filter/GeohashCellTest.php
@@ -4,11 +4,20 @@ namespace Elastica\Test\Filter;
 use Elastica\Document;
 use Elastica\Filter\GeohashCell;
 use Elastica\Query;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 use Elastica\Type\Mapping;
 
 class GeohashCellTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new GeohashCell('pin', array('lat' => 37.789018, 'lon' => -122.391506), '50m'));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/HasChildTest.php
+++ b/test/lib/Elastica/Test/Filter/HasChildTest.php
@@ -4,10 +4,19 @@ namespace Elastica\Test\Filter;
 use Elastica\Document;
 use Elastica\Filter\HasChild;
 use Elastica\Query\MatchAll;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class HasChildTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new HasChild(new MatchAll(), 'test'));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/HasParentTest.php
+++ b/test/lib/Elastica/Test/Filter/HasParentTest.php
@@ -4,10 +4,19 @@ namespace Elastica\Test\Filter;
 use Elastica\Document;
 use Elastica\Filter\HasParent;
 use Elastica\Query\MatchAll;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class HasParentTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new HasParent(new MatchAll(), 'test'));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/IdsTest.php
+++ b/test/lib/Elastica/Test/Filter/IdsTest.php
@@ -5,10 +5,19 @@ use Elastica\Document;
 use Elastica\Filter\Ids;
 use Elastica\Filter\Type;
 use Elastica\Query;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class IdsTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Ids());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();

--- a/test/lib/Elastica/Test/Filter/IndicesTest.php
+++ b/test/lib/Elastica/Test/Filter/IndicesTest.php
@@ -7,10 +7,19 @@ use Elastica\Filter\Indices;
 use Elastica\Filter\Term;
 use Elastica\Index;
 use Elastica\Query;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class IndicesTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Indices(new Term(), array()));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/LimitTest.php
+++ b/test/lib/Elastica/Test/Filter/LimitTest.php
@@ -2,10 +2,19 @@
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Limit;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class LimitTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Limit(10));
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/MatchAllTest.php
+++ b/test/lib/Elastica/Test/Filter/MatchAllTest.php
@@ -2,10 +2,19 @@
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\MatchAll;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class MatchAllTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new MatchAll());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/MissingTest.php
+++ b/test/lib/Elastica/Test/Filter/MissingTest.php
@@ -2,10 +2,19 @@
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Missing;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class MissingTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Missing());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/MultiTest.php
+++ b/test/lib/Elastica/Test/Filter/MultiTest.php
@@ -3,10 +3,20 @@ namespace Elastica\Test\Filter;
 
 use Elastica\Filter\AbstractMulti;
 use Elastica\Filter\MatchAll;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\Base;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class AbstractMultiTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass('Elastica\Filter\AbstractMulti');
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */
@@ -100,6 +110,8 @@ class AbstractMultiTest extends BaseTest
     }
 }
 
+Base::hideDeprecated();
+
 class AbstractMultiDebug extends AbstractMulti
 {
     public function getBaseName()
@@ -107,3 +119,5 @@ class AbstractMultiDebug extends AbstractMulti
         return parent::_getBaseName();
     }
 }
+
+Base::showDeprecated();

--- a/test/lib/Elastica/Test/Filter/NestedFilterWithSetFilterTest.php
+++ b/test/lib/Elastica/Test/Filter/NestedFilterWithSetFilterTest.php
@@ -54,7 +54,9 @@ class NestedFilterWithSetFilterTest extends BaseTest
      */
     public function testToArray()
     {
+        $this->hideDeprecated();
         $filter = new Nested();
+        $this->showDeprecated();
         $this->assertEquals(array('nested' => array()), $filter->toArray());
         $query = new Terms();
         $query->setTerms('hobby', array('guitar'));
@@ -78,6 +80,8 @@ class NestedFilterWithSetFilterTest extends BaseTest
      */
     public function testShouldReturnTheRightNumberOfResult()
     {
+        $this->hideDeprecated();
+
         $filter = new Nested();
         $this->assertEquals(array('nested' => array()), $filter->toArray());
         $query = new Terms();
@@ -105,6 +109,8 @@ class NestedFilterWithSetFilterTest extends BaseTest
         $index = $this->_getIndexForTest();
         $search->addIndex($index);
         $resultSet = $search->search($filter);
+
+        $this->showDeprecated();
 
         $this->assertEquals(2, $resultSet->getTotalHits());
     }

--- a/test/lib/Elastica/Test/Filter/NestedTest.php
+++ b/test/lib/Elastica/Test/Filter/NestedTest.php
@@ -5,11 +5,20 @@ use Elastica\Document;
 use Elastica\Filter\Nested;
 use Elastica\Query\Terms;
 use Elastica\Search;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 use Elastica\Type\Mapping;
 
 class NestedTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Nested());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex('elastica_test_filter_nested');

--- a/test/lib/Elastica/Test/Filter/NumericRangeTest.php
+++ b/test/lib/Elastica/Test/Filter/NumericRangeTest.php
@@ -2,10 +2,19 @@
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\NumericRange;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class NumericRangeTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new NumericRange());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/PrefixTest.php
+++ b/test/lib/Elastica/Test/Filter/PrefixTest.php
@@ -3,11 +3,20 @@ namespace Elastica\Test\Filter;
 
 use Elastica\Document;
 use Elastica\Filter\Prefix;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 use Elastica\Type\Mapping;
 
 class PrefixTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Prefix());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/QueryTest.php
+++ b/test/lib/Elastica/Test/Filter/QueryTest.php
@@ -3,10 +3,19 @@ namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Query;
 use Elastica\Query\QueryString;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class QueryTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Query());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/RangeTest.php
+++ b/test/lib/Elastica/Test/Filter/RangeTest.php
@@ -2,10 +2,19 @@
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Range;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class RangeTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Range());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/RegexpTest.php
+++ b/test/lib/Elastica/Test/Filter/RegexpTest.php
@@ -3,11 +3,20 @@ namespace Elastica\Test\Filter;
 
 use Elastica\Document;
 use Elastica\Filter\Regexp;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 use Elastica\Type\Mapping;
 
 class RegexpTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Regexp());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/ScriptTest.php
+++ b/test/lib/Elastica/Test/Filter/ScriptTest.php
@@ -3,10 +3,19 @@ namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Script as ScriptFilter;
 use Elastica\Script\Script;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class ScriptTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new ScriptFilter());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/TermTest.php
+++ b/test/lib/Elastica/Test/Filter/TermTest.php
@@ -1,11 +1,25 @@
 <?php
+
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Term;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class TermTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Term());
+
+        $this->assertFileDeprecated(
+            $reflection->getFileName(),
+            'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html'
+        );
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Filter/TermsTest.php
+++ b/test/lib/Elastica/Test/Filter/TermsTest.php
@@ -4,10 +4,19 @@ namespace Elastica\Test\Filter;
 use Elastica\Document;
 use Elastica\Filter\Terms;
 use Elastica\Query;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class TermsTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Terms());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group functional
      */

--- a/test/lib/Elastica/Test/Filter/TypeTest.php
+++ b/test/lib/Elastica/Test/Filter/TypeTest.php
@@ -2,10 +2,19 @@
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Type;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class TypeTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
+    {
+        $reflection = new \ReflectionClass(new Type());
+        $this->assertFileDeprecated($reflection->getFileName(), 'Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html');
+    }
+
     /**
      * @group unit
      */

--- a/test/lib/Elastica/Test/Query/BoolQueryTest.php
+++ b/test/lib/Elastica/Test/Query/BoolQueryTest.php
@@ -2,16 +2,50 @@
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
+use Elastica\Filter\Exists;
 use Elastica\Filter\Term as TermFilter;
 use Elastica\Index;
 use Elastica\Query\BoolQuery;
 use Elastica\Query\Ids;
 use Elastica\Query\Term as TermQuery;
+use Elastica\Query\Term;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Type;
 
 class BoolQueryTest extends BaseTest
 {
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testAddFilterInvalid()
+    {
+        $query = new BoolQuery();
+        $query->addFilter($this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testAddFilterWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new BoolQuery('test');
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->addFilter($existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query\BoolQuery::addFilter passing AbstractFilter is deprecated. Pass AbstractQuery instead.'
+            )
+        );
+    }
+
     /**
      * @group unit
      */
@@ -28,10 +62,10 @@ class BoolQueryTest extends BaseTest
         $idsQuery3 = new Ids();
         $idsQuery3->setIds(3);
 
-        $filter1 = new TermFilter();
+        $filter1 = new Term();
         $filter1->setTerm('test', '1');
 
-        $filter2 = new TermFilter();
+        $filter2 = new Term();
         $filter2->setTerm('username', 'ruth');
 
         $boost = 1.2;
@@ -44,6 +78,58 @@ class BoolQueryTest extends BaseTest
         $query->addShould($idsQuery3->toArray());
         $query->addFilter($filter1);
         $query->addFilter($filter2);
+
+        $expectedArray = array(
+            'bool' => array(
+                'must' => array($idsQuery1->toArray()),
+                'should' => array($idsQuery3->toArray()),
+                'filter' => array($filter1->toArray(), $filter2->toArray()),
+                'minimum_number_should_match' => $minMatch,
+                'must_not' => array($idsQuery2->toArray()),
+                'boost' => $boost,
+            ),
+        );
+
+        $this->assertEquals($expectedArray, $query->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testToArrayWithLegacyFilter()
+    {
+        $query = new BoolQuery();
+
+        $idsQuery1 = new Ids();
+        $idsQuery1->setIds(1);
+
+        $idsQuery2 = new Ids();
+        $idsQuery2->setIds(2);
+
+        $idsQuery3 = new Ids();
+        $idsQuery3->setIds(3);
+
+        $this->hideDeprecated();
+        $filter1 = new TermFilter();
+        $filter1->setTerm('test', '1');
+
+        $filter2 = new TermFilter();
+        $filter2->setTerm('username', 'ruth');
+        $this->showDeprecated();
+
+        $boost = 1.2;
+        $minMatch = 2;
+
+        $query->setBoost($boost);
+        $query->setMinimumNumberShouldMatch($minMatch);
+        $query->addMust($idsQuery1);
+        $query->addMustNot($idsQuery2);
+        $query->addShould($idsQuery3->toArray());
+
+        $this->hideDeprecated();
+        $query->addFilter($filter1);
+        $query->addFilter($filter2);
+        $this->showDeprecated();
 
         $expectedArray = array(
             'bool' => array(
@@ -112,7 +198,7 @@ class BoolQueryTest extends BaseTest
 
         $this->assertEquals(3, $resultSet->count());
 
-        $termFilter = new TermFilter(array('test' => '4'));
+        $termFilter = new Term(array('test' => '4'));
         $boolQuery->addFilter($termFilter);
         $resultSet = $type->search($boolQuery);
 
@@ -135,6 +221,45 @@ class BoolQueryTest extends BaseTest
         $resultSet = $type->search($boolQuery);
 
         $this->assertEquals(0, $resultSet->count());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testSearchWithLegacyFilter()
+    {
+        $client = $this->_getClient();
+        $index = new Index($client, 'test');
+        $index->create(array(), true);
+
+        $type = new Type($index, 'helloworld');
+
+        $doc = new Document(1, array('id' => 1, 'email' => 'hans@test.com', 'username' => 'hans', 'test' => array('2', '4', '5')));
+        $type->addDocument($doc);
+        $doc = new Document(2, array('id' => 2, 'email' => 'emil@test.com', 'username' => 'emil', 'test' => array('1', '3', '6')));
+        $type->addDocument($doc);
+        $doc = new Document(3, array('id' => 3, 'email' => 'ruth@test.com', 'username' => 'ruth', 'test' => array('2', '3', '7')));
+        $type->addDocument($doc);
+        $doc = new Document(4, array('id' => 4, 'email' => 'john@test.com', 'username' => 'john', 'test' => array('2', '4', '8')));
+        $type->addDocument($doc);
+
+        // Refresh index
+        $index->refresh();
+
+        $boolQuery = new BoolQuery();
+        $termQuery1 = new TermQuery(array('test' => '2'));
+        $boolQuery->addMust($termQuery1);
+        $resultSet = $type->search($boolQuery);
+
+        $this->assertEquals(3, $resultSet->count());
+
+        $this->hideDeprecated();
+        $termFilter = new TermFilter(array('test' => '4'));
+        $boolQuery->addFilter($termFilter);
+        $this->showDeprecated();
+        $resultSet = $type->search($boolQuery);
+
+        $this->assertEquals(2, $resultSet->count());
     }
 
     /**
@@ -180,21 +305,28 @@ class BoolQueryTest extends BaseTest
 
         $index->refresh();
 
-        $err = array();
-
-        set_error_handler(function () use (&$err) {
-            $err[] = func_get_args();
-        });
-
+        $this->hideDeprecated();
         $boolQuery = new \Elastica\Query\Bool();
-
-        restore_error_handler();
-
-        $this->assertCount(1, $err);
-        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
+        $this->showDeprecated();
 
         $resultSet = $type->search($boolQuery);
 
         $this->assertEquals($resultSet->count(), $docNumber);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testOldObjectDeprecated()
+    {
+        if (version_compare(phpversion(), 7, '>=')) {
+            self::markTestSkipped('These objects are not supported in PHP 7');
+        }
+
+        $this->hideDeprecated();
+        $reflection = new \ReflectionClass(new \Elastica\Query\Bool());
+        $this->showDeprecated();
+
+        $this->assertFileDeprecated($reflection->getFileName(), 'Elastica\Query\Bool is deprecated. Use BoolQuery instead. From PHP7 bool is reserved word and this class will be removed in further Elastica releases');
     }
 }

--- a/test/lib/Elastica/Test/Query/BuilderTest.php
+++ b/test/lib/Elastica/Test/Query/BuilderTest.php
@@ -8,26 +8,27 @@ class BuilderTest extends BaseTest
 {
     /**
      * @group unit
+     */
+    public function testDeprecated()
+    {
+        $this->hideDeprecated();
+        $reflection = new \ReflectionClass(new Builder());
+        $this->showDeprecated();
+
+        $this->assertFileDeprecated($reflection->getFileName(), 'This builder is deprecated and will be removed in further Elastica releases. Use new Elastica\QueryBuilder instead.');
+    }
+
+    /**
+     * @group unit
      * @covers \Elastica\Query\Builder::factory
      * @covers \Elastica\Query\Builder::__construct
      */
     public function testFactory()
     {
-        $err = array();
-
-        set_error_handler(function () use (&$err) {
-            $err[] = func_get_args();
-        });
-
         $this->assertInstanceOf(
             'Elastica\Query\Builder',
             Builder::factory('some string')
         );
-
-        restore_error_handler();
-
-        $this->assertCount(1, $err);
-        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
     }
 
     public function getQueryData()

--- a/test/lib/Elastica/Test/Query/ExistsTest.php
+++ b/test/lib/Elastica/Test/Query/ExistsTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Query\Exists;
+use Elastica\Test\Base as BaseTest;
+
+class ExistsTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $field = 'test';
+        $query = new Exists($field);
+
+        $expectedArray = array('exists' => array('field' => $field));
+        $this->assertEquals($expectedArray, $query->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetField()
+    {
+        $field = 'test';
+        $query = new Exists($field);
+
+        $this->assertEquals($field, $query->getParam('field'));
+
+        $newField = 'hello world';
+        $this->assertInstanceOf('Elastica\Query\Exists', $query->setField($newField));
+
+        $this->assertEquals($newField, $query->getParam('field'));
+    }
+}

--- a/test/lib/Elastica/Test/Query/FilteredTest.php
+++ b/test/lib/Elastica/Test/Query/FilteredTest.php
@@ -1,33 +1,89 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
+use Elastica\Filter\Exists;
 use Elastica\Filter\Term;
 use Elastica\Query\Filtered;
 use Elastica\Query\QueryString;
-use Elastica\Test\Base as BaseTest;
+use Elastica\Test\DeprecatedClassBase as BaseTest;
 
 class FilteredTest extends BaseTest
 {
-    private $errors = array();
-
-    private function setErrorHandler()
+    /**
+     * @group unit
+     */
+    public function testDeprecated()
     {
-        set_error_handler(function () {
-            $this->errors[] = func_get_args();
-        });
+        $reflection = new \ReflectionClass(get_class(new Filtered()));
+
+        $this->assertFileDeprecated(
+            $reflection->getFileName(),
+            'Use BoolQuery instead. Filtered query is deprecated since ES 2.0.0-beta1 and this class will be removed in further Elastica releases.'
+        );
     }
 
-    private function restoreErrorHandler()
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testConstructInvalid()
     {
-        restore_error_handler();
+        new Filtered(null, $this);
+    }
 
-        if (count($this->errors) > 0) {
-            $this->assertCount(1, $this->errors);
-            $this->assertEquals(E_USER_DEPRECATED, $this->errors[0][0]);
-            $this->assertEquals('Use BoolQuery instead. Filtered query is deprecated since ES 2.0.0-beta1 and this class will be removed in further Elastica releases.', $this->errors[0][1]);
-            $this->errors = array();
-        }
+    /**
+     * @group unit
+     */
+    public function testConstructWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $errorsCollector = $this->startCollectErrors();
+        new Filtered(null, $existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query\Filtered passing AbstractFilter is deprecated. Pass AbstractQuery instead.',
+                'Deprecated: Elastica\Query\Filtered::setFilter passing AbstractFilter is deprecated. Pass AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testSetFilterInvalid()
+    {
+        $query = new Filtered();
+        $query->setFilter($this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetFilterWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new Filtered();
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->setFilter($existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query\Filtered::setFilter passing AbstractFilter is deprecated. Pass AbstractQuery instead.'
+            )
+        );
     }
 
     /**
@@ -53,9 +109,7 @@ class FilteredTest extends BaseTest
         $filter2 = new Term();
         $filter2->setTerm('username', 'qwerqwer');
 
-        $this->setErrorHandler();
         $query1 = new Filtered($queryString, $filter1);
-        $this->restoreErrorHandler();
         $query2 = new Filtered($queryString, $filter2);
 
         $resultSet = $type->search($queryString);
@@ -81,9 +135,7 @@ class FilteredTest extends BaseTest
         $filter2 = new Term();
         $filter2->setTerm('username', 'qwerqwer');
 
-        $this->setErrorHandler();
         $query1 = new Filtered($queryString, $filter1);
-        $this->restoreErrorHandler();
         $query2 = new Filtered($queryString, $filter2);
 
         $this->assertEquals($query1->getQuery(), $queryString);
@@ -120,9 +172,7 @@ class FilteredTest extends BaseTest
         $filter = new Term();
         $filter->setTerm('username', 'peter');
 
-        $this->setErrorHandler();
         $query = new Filtered(null, $filter);
-        $this->restoreErrorHandler();
 
         $resultSet = $type->search($query);
         $this->assertEquals(1, $resultSet->count());
@@ -145,9 +195,7 @@ class FilteredTest extends BaseTest
 
         $queryString = new QueryString('hans*');
 
-        $this->setErrorHandler();
         $query = new Filtered($queryString);
-        $this->restoreErrorHandler();
 
         $resultSet = $type->search($query);
         $this->assertEquals(1, $resultSet->count());

--- a/test/lib/Elastica/Test/Query/FunctionScoreTest.php
+++ b/test/lib/Elastica/Test/Query/FunctionScoreTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
+use Elastica\Filter\Exists;
 use Elastica\Filter\Term;
 use Elastica\Query\FunctionScore;
 use Elastica\Query\MatchAll;
@@ -42,6 +43,253 @@ class FunctionScoreTest extends BaseTest
         $index->refresh();
 
         return $index;
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\DeprecatedException
+     */
+    public function testSetFilterWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new FunctionScore('test');
+
+        $query->setFilter($existsFilter);
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testAddFunctionInvalid()
+    {
+        $query = new FunctionScore('test');
+        $query->addFunction('f', 1, $this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testAddFunctionWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new FunctionScore('test');
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->addFunction('f', 1, $existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query\FunctionScore::addFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testAddDecayFunctionInvalid()
+    {
+        $query = new FunctionScore('test');
+        $query->addDecayFunction(FunctionScore::DECAY_GAUSS, 'location', $this->locationOrigin, '2mi', null, null, null, $this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testAddDecayFunctionWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new FunctionScore('test');
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->addDecayFunction(FunctionScore::DECAY_GAUSS, 'location', $this->locationOrigin, '2mi', null, null, null, $existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query\FunctionScore::addDecayFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.',
+                'Deprecated: Elastica\Query\FunctionScore::addFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testScriptScoreFunctionInvalid()
+    {
+        $query = new FunctionScore('test');
+        $query->addScriptScoreFunction(new Script('t'), $this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testScriptScoreFunctionWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new FunctionScore('test');
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->addScriptScoreFunction(new Script('t'), $existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query\FunctionScore::addScriptScoreFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.',
+                'Deprecated: Elastica\Query\FunctionScore::addFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testAddFieldValueFactorFunctionInvalid()
+    {
+        $query = new FunctionScore('test');
+        $query->addFieldValueFactorFunction('popularity', 1.2, FunctionScore::FIELD_VALUE_FACTOR_MODIFIER_SQRT, 0.1, null, $this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testAddFieldValueFactorFunctionWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new FunctionScore('test');
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->addFieldValueFactorFunction('popularity', 1.2, FunctionScore::FIELD_VALUE_FACTOR_MODIFIER_SQRT, 0.1, null, $existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query\FunctionScore::addFieldValueFactorFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.',
+                'Deprecated: Elastica\Query\FunctionScore::addFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testAddBoostFactorFunctionFunctionInvalid()
+    {
+        $query = new FunctionScore('test');
+        $query->addBoostFactorFunction(5.0, $this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testAddBoostFactorFunctionWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new FunctionScore('test');
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->addBoostFactorFunction(5.0, $existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query\FunctionScore::addBoostFactorFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.',
+                'Query\FunctionScore::addBoostFactorFunction is deprecated. Use addWeightFunction instead. This method will be removed in further Elastica releases',
+                'Deprecated: Elastica\Query\FunctionScore::addWeightFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.',
+                'Deprecated: Elastica\Query\FunctionScore::addFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testAddWeightFunctionFunctionInvalid()
+    {
+        $query = new FunctionScore('test');
+        $query->addWeightFunction(5.0, $this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testAddWeightFunctionWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new FunctionScore('test');
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->addWeightFunction(5.0, $existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query\FunctionScore::addWeightFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.',
+                'Deprecated: Elastica\Query\FunctionScore::addFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testAddRandomScoreFunctionInvalid()
+    {
+        $query = new FunctionScore('test');
+        $query->addRandomScoreFunction(5.0, $this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testAddRandomScoreFunctionWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new FunctionScore('test');
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->addRandomScoreFunction(5.0, $existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query\FunctionScore::addRandomScoreFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.',
+                'Deprecated: Elastica\Query\FunctionScore::addFunction passing AbstractFilter is deprecated. Pass AbstractQuery instead.'
+            )
+        );
     }
 
     /**
@@ -153,25 +401,35 @@ class FunctionScoreTest extends BaseTest
      */
     public function testAddBoostFactorFunction()
     {
-        $filter = new Term(array('price' => 4.5));
+        $filter = new \Elastica\Query\Term(array('price' => 4.5));
         $query = new FunctionScore();
         $query->addWeightFunction(5.0, $filter);
 
-        $sameFilter = new Term(array('price' => 4.5));
+        $sameFilter = new \Elastica\Query\Term(array('price' => 4.5));
         $sameQuery = new FunctionScore();
-
-        $err = array();
-
-        set_error_handler(function () use (&$err) {
-            $err[] = func_get_args();
-        });
-
+        $this->hideDeprecated();
         $sameQuery->addBoostFactorFunction(5.0, $sameFilter);
+        $this->showDeprecated();
 
-        restore_error_handler();
+        $this->assertEquals($query->toArray(), $sameQuery->toArray());
+    }
 
-        $this->assertCount(1, $err);
-        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
+    /**
+     * @group unit
+     */
+    public function testLegacyFilterAddBoostFactorFunction()
+    {
+        $query = new FunctionScore();
+        $this->hideDeprecated();
+        $filter = new Term(array('price' => 4.5));
+        $query->addWeightFunction(5.0, $filter);
+        $this->showDeprecated();
+
+        $sameQuery = new FunctionScore();
+        $this->hideDeprecated();
+        $sameFilter = new Term(array('price' => 4.5));
+        $sameQuery->addBoostFactorFunction(5.0, $sameFilter);
+        $this->showDeprecated();
 
         $this->assertEquals($query->toArray(), $sameQuery->toArray());
     }
@@ -181,9 +439,46 @@ class FunctionScoreTest extends BaseTest
      */
     public function testWeight()
     {
+        $filter = new \Elastica\Query\Term(array('price' => 4.5));
+        $query = new FunctionScore();
+        $query->addWeightFunction(5.0, $filter);
+
+        $expected = array(
+            'function_score' => array(
+                'functions' => array(
+                    array(
+                        'weight' => 5.0,
+                        'filter' => array(
+                            'term' => array(
+                                'price' => 4.5,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $query->toArray());
+
+        $response = $this->_getIndexForTest()->search($query);
+        $results = $response->getResults();
+
+        // the document with price = 4.5 should be scored highest
+        $result0 = $results[0]->getData();
+        $this->assertEquals("Mr. Frostie's", $result0['name']);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testWeightWithLegacyFilter()
+    {
+        $this->hideDeprecated();
         $filter = new Term(array('price' => 4.5));
         $query = new FunctionScore();
         $query->addWeightFunction(5.0, $filter);
+        $this->showDeprecated();
+
         $expected = array(
             'function_score' => array(
                 'functions' => array(
@@ -214,9 +509,49 @@ class FunctionScoreTest extends BaseTest
      */
     public function testRandomScore()
     {
+        $filter = new \Elastica\Query\Term(array('price' => 4.5));
+        $query = new FunctionScore();
+        $query->addRandomScoreFunction(2, $filter);
+
+        $expected = array(
+            'function_score' => array(
+                'functions' => array(
+                    array(
+                        'random_score' => array(
+                            'seed' => 2,
+                        ),
+                        'filter' => array(
+                            'term' => array(
+                                'price' => 4.5,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $query->toArray());
+
+        $response = $this->_getIndexForTest()->search($query);
+        $results = $response->getResults();
+
+        // the document with the random score should have a score > 1, means it is the first result
+        $result0 = $results[0]->getData();
+
+        $this->assertEquals("Miller's Field", $result0['name']);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testRandomScoreWithLegacyFilter()
+    {
+        $this->hideDeprecated();
         $filter = new Term(array('price' => 4.5));
         $query = new FunctionScore();
         $query->addRandomScoreFunction(2, $filter);
+        $this->showDeprecated();
+
         $expected = array(
             'function_score' => array(
                 'functions' => array(
@@ -250,9 +585,42 @@ class FunctionScoreTest extends BaseTest
      */
     public function testRandomScoreWeight()
     {
+        $filter = new \Elastica\Query\Term(array('price' => 4.5));
+        $query = new FunctionScore();
+        $query->addRandomScoreFunction(2, $filter, 2);
+
+        $expected = array(
+            'function_score' => array(
+                'functions' => array(
+                    array(
+                        'random_score' => array(
+                            'seed' => 2,
+                        ),
+                        'filter' => array(
+                            'term' => array(
+                                'price' => 4.5,
+                            ),
+                        ),
+                        'weight' => 2,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $query->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testRandomScoreWeightWithLegacyFilter()
+    {
+        $this->hideDeprecated();
         $filter = new Term(array('price' => 4.5));
         $query = new FunctionScore();
         $query->addRandomScoreFunction(2, $filter, 2);
+        $this->showDeprecated();
+
         $expected = array(
             'function_score' => array(
                 'functions' => array(

--- a/test/lib/Elastica/Test/Query/FuzzyTest.php
+++ b/test/lib/Elastica/Test/Query/FuzzyTest.php
@@ -14,18 +14,9 @@ class FuzzyTest extends BaseTest
     {
         $fuzzy = new Fuzzy();
 
-        $err = array();
-
-        set_error_handler(function () use (&$err) {
-            $err[] = func_get_args();
-        });
-
+        $this->hideDeprecated();
         $fuzzy->addField('user', array('value' => 'Nicolas', 'boost' => 1.0));
-
-        restore_error_handler();
-
-        $this->assertCount(1, $err);
-        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
+        $this->showDeprecated();
 
         $sameFuzzy = new Fuzzy();
         $sameFuzzy->setField('user', 'Nicolas');
@@ -114,18 +105,9 @@ class FuzzyTest extends BaseTest
         $this->setExpectedException('Elastica\Exception\InvalidException');
         $query = new Fuzzy();
 
-        $err = array();
-
-        set_error_handler(function () use (&$err) {
-            $err[] = func_get_args();
-        });
-
+        $this->hideDeprecated();
         $query->addField('name', array(array('value' => 'Baden')));
-
-        restore_error_handler();
-
-        $this->assertCount(1, $err);
-        $this->assertEquals(E_USER_DEPRECATED, $err[0][0]);
+        $this->showDeprecated();
 
         $this->setExpectedException('Elastica\Exception\InvalidException');
         $query = new Fuzzy();
@@ -135,5 +117,18 @@ class FuzzyTest extends BaseTest
         $query = new Fuzzy();
         $query->setField('name', 'value');
         $query->setField('name1', 'value1');
+    }
+
+    /**
+     * @group unit
+     */
+    public function testAddFieldDeprecated()
+    {
+        $query = new Fuzzy();
+        $errorCollector = $this->startCollectErrors();
+        $query->addField('user', array('value' => 'Nicolas', 'boost' => 1.0));
+        $this->finishCollectErrors();
+
+        $errorCollector->assertOnlyOneDeprecatedError('Query\Fuzzy::addField is deprecated. Use setField and setFieldOption instead. This method will be removed in further Elastica releases');
     }
 }

--- a/test/lib/Elastica/Test/Query/GeoBoundingBoxTest.php
+++ b/test/lib/Elastica/Test/Query/GeoBoundingBoxTest.php
@@ -1,0 +1,55 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Query\GeoBoundingBox;
+use Elastica\Test\Base as BaseTest;
+
+class GeoBoundingBoxTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testAddCoordinates()
+    {
+        $key = 'pin.location';
+        $coords = array('40.73, -74.1', '40.01, -71.12');
+        $query = new GeoBoundingBox($key, array('1,2', '3,4'));
+
+        $query->addCoordinates($key, $coords);
+        $expectedArray = array('top_left' => $coords[0], 'bottom_right' => $coords[1]);
+        $this->assertEquals($expectedArray, $query->getParam($key));
+
+        $returnValue = $query->addCoordinates($key, $coords);
+        $this->assertInstanceOf('Elastica\Query\GeoBoundingBox', $returnValue);
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testAddCoordinatesInvalidException()
+    {
+        $query = new GeoBoundingBox('foo', array());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $key = 'pin.location';
+        $coords = array('40.73, -74.1', '40.01, -71.12');
+        $query = new GeoBoundingBox($key, $coords);
+
+        $expectedArray = array(
+            'geo_bounding_box' => array(
+                $key => array(
+                    'top_left' => $coords[0],
+                    'bottom_right' => $coords[1],
+                ),
+            ),
+        );
+
+        $this->assertEquals($expectedArray, $query->toArray());
+    }
+}

--- a/test/lib/Elastica/Test/Query/GeoDistanceRangeTest.php
+++ b/test/lib/Elastica/Test/Query/GeoDistanceRangeTest.php
@@ -1,0 +1,220 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Document;
+use Elastica\Query\GeoDistanceRange;
+use Elastica\Query;
+use Elastica\Query\MatchAll;
+use Elastica\Test\Base as BaseTest;
+
+class GeoDistanceRangeTest extends BaseTest
+{
+    /**
+     * @group functional
+     */
+    public function testGeoPoint()
+    {
+        $index = $this->_createIndex();
+        $type = $index->getType('test');
+
+        // Set mapping
+        $type->setMapping(array('point' => array('type' => 'geo_point')));
+
+        // Add doc 1
+        $doc1 = new Document(1,
+            array(
+                'name' => 'ruflin',
+            )
+        );
+
+        $doc1->addGeoPoint('point', 17, 19);
+        $type->addDocument($doc1);
+
+        // Add doc 2
+        $doc2 = new Document(2,
+            array(
+                'name' => 'ruflin',
+            )
+        );
+
+        $doc2->addGeoPoint('point', 30, 40);
+        $type->addDocument($doc2);
+
+        $index->optimize();
+        $index->refresh();
+
+        // Only one point should be in radius
+        $query = new Query();
+        $geoQuery = new GeoDistanceRange(
+            'point',
+            array('lat' => 30, 'lon' => 40),
+            array('from' => '0km', 'to' => '2km')
+        );
+
+        $query = new Query(new MatchAll());
+        $query->setPostFilter($geoQuery);
+        $this->assertEquals(1, $type->search($query)->count());
+
+        // Both points should be inside
+        $query = new Query();
+        $geoQuery = new GeoDistanceRange(
+            'point',
+            array('lat' => 30, 'lon' => 40),
+            array('gte' => '0km', 'lte' => '40000km')
+        );
+        $query = new Query(new MatchAll());
+        $query->setPostFilter($geoQuery);
+        $index->refresh();
+
+        $this->assertEquals(2, $type->search($query)->count());
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testInvalidRange()
+    {
+        $geoQuery = new GeoDistanceRange(
+            'point',
+            array('lat' => 30, 'lon' => 40),
+            array('invalid' => '0km', 'lte' => '40000km')
+        );
+    }
+
+    /**
+     * @group unit
+     * @dataProvider invalidLocationDataProvider
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testInvalidLocation($location)
+    {
+        $geoQuery = new GeoDistanceRange(
+            'point',
+            $location,
+            array('gt' => '0km', 'lte' => '40000km')
+        );
+    }
+
+    /**
+     * @group unit
+     * @dataProvider constructDataProvider
+     */
+    public function testConstruct($key, $location, $ranges, $expected)
+    {
+        $query = new GeoDistanceRange($key, $location, $ranges);
+
+        $data = $query->toArray();
+
+        $this->assertEquals($expected, $data);
+    }
+
+    public function invalidLocationDataProvider()
+    {
+        return array(
+            array(
+                array('lat' => 1.0),
+            ),
+            array(
+                array('lon' => 1.0),
+            ),
+            array(
+                array(),
+            ),
+            array(
+                new \stdClass(),
+            ),
+            array(
+                null,
+            ),
+            array(
+                true,
+            ),
+            array(
+                false,
+            ),
+        );
+    }
+
+    public function constructDataProvider()
+    {
+        return array(
+            array(
+                'location',
+                'u09tvqx',
+                array(
+                    'from' => '10km',
+                    'to' => '20km',
+                ),
+                array(
+                    'geo_distance_range' => array(
+                        'from' => '10km',
+                        'to' => '20km',
+                        'location' => 'u09tvqx',
+                    ),
+                ),
+            ),
+            array(
+                'location',
+                'u09tvqx',
+                array(
+                    'to' => '20km',
+                    'include_upper' => 0,
+                    'from' => '10km',
+                    'include_lower' => 1,
+                ),
+                array(
+                    'geo_distance_range' => array(
+                        'to' => '20km',
+                        'include_upper' => false,
+                        'from' => '10km',
+                        'include_lower' => true,
+                        'location' => 'u09tvqx',
+                    ),
+                ),
+            ),
+            array(
+                'location',
+                array(
+                    'lon' => 2.35,
+                    'lat' => 48.86,
+                ),
+                array(
+                    'lte' => '20km',
+                    'gt' => '10km',
+                ),
+                array(
+                    'geo_distance_range' => array(
+                        'lte' => '20km',
+                        'gt' => '10km',
+                        'location' => array(
+                            'lat' => 48.86,
+                            'lon' => 2.35,
+                        ),
+                    ),
+                ),
+            ),
+            array(
+                'location',
+                array(
+                    'lat' => 48.86,
+                    'lon' => 2.35,
+                ),
+                array(
+                    'lt' => '20km',
+                    'gte' => '10km',
+                ),
+                array(
+                    'geo_distance_range' => array(
+                        'lt' => '20km',
+                        'gte' => '10km',
+                        'location' => array(
+                            'lat' => 48.86,
+                            'lon' => 2.35,
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+}

--- a/test/lib/Elastica/Test/Query/GeoDistanceTest.php
+++ b/test/lib/Elastica/Test/Query/GeoDistanceTest.php
@@ -1,0 +1,140 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Document;
+use Elastica\Query\GeoDistance;
+use Elastica\Query;
+use Elastica\Query\MatchAll;
+use Elastica\Test\Base as BaseTest;
+
+class GeoDistanceTest extends BaseTest
+{
+    /**
+     * @group functional
+     */
+    public function testGeoPoint()
+    {
+        $index = $this->_createIndex();
+
+        $type = $index->getType('test');
+
+        // Set mapping
+        $type->setMapping(array('point' => array('type' => 'geo_point')));
+
+        // Add doc 1
+        $doc1 = new Document(1,
+            array(
+                'name' => 'ruflin',
+            )
+        );
+
+        $doc1->addGeoPoint('point', 17, 19);
+        $type->addDocument($doc1);
+
+        // Add doc 2
+        $doc2 = new Document(2,
+            array(
+                'name' => 'ruflin',
+            )
+        );
+
+        $doc2->addGeoPoint('point', 30, 40);
+        $type->addDocument($doc2);
+
+        $index->optimize();
+        $index->refresh();
+
+        // Only one point should be in radius
+        $geoQuery = new GeoDistance('point', array('lat' => 30, 'lon' => 40), '1km');
+
+        $query = new Query(new MatchAll());
+        $query->setPostFilter($geoQuery);
+        $this->assertEquals(1, $type->search($query)->count());
+
+        // Both points should be inside
+        $query = new Query();
+        $geoQuery = new GeoDistance('point', array('lat' => 30, 'lon' => 40), '40000km');
+        $query = new Query(new MatchAll());
+        $query->setPostFilter($geoQuery);
+        $index->refresh();
+
+        $this->assertEquals(2, $type->search($query)->count());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testConstructLatlon()
+    {
+        $key = 'location';
+        $location = array(
+            'lat' => 48.86,
+            'lon' => 2.35,
+        );
+        $distance = '10km';
+
+        $query = new GeoDistance($key, $location, $distance);
+
+        $expected = array(
+            'geo_distance' => array(
+                $key => $location,
+                'distance' => $distance,
+            ),
+        );
+
+        $data = $query->toArray();
+
+        $this->assertEquals($expected, $data);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testConstructGeohash()
+    {
+        $key = 'location';
+        $location = 'u09tvqx';
+        $distance = '10km';
+
+        $query = new GeoDistance($key, $location, $distance);
+
+        $expected = array(
+            'geo_distance' => array(
+                $key => $location,
+                'distance' => $distance,
+            ),
+        );
+
+        $data = $query->toArray();
+
+        $this->assertEquals($expected, $data);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetDistanceType()
+    {
+        $query = new GeoDistance('location', array('lat' => 48.86, 'lon' => 2.35), '10km');
+        $distanceType = GeoDistance::DISTANCE_TYPE_ARC;
+        $query->setDistanceType($distanceType);
+
+        $data = $query->toArray();
+
+        $this->assertEquals($distanceType, $data['geo_distance']['distance_type']);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetOptimizeBbox()
+    {
+        $query = new GeoDistance('location', array('lat' => 48.86, 'lon' => 2.35), '10km');
+        $optimizeBbox = GeoDistance::OPTIMIZE_BBOX_MEMORY;
+        $query->setOptimizeBbox($optimizeBbox);
+
+        $data = $query->toArray();
+
+        $this->assertEquals($optimizeBbox, $data['geo_distance']['optimize_bbox']);
+    }
+}

--- a/test/lib/Elastica/Test/Query/GeoPolygonTest.php
+++ b/test/lib/Elastica/Test/Query/GeoPolygonTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Document;
+use Elastica\Query\GeoPolygon;
+use Elastica\Query;
+use Elastica\Query\MatchAll;
+use Elastica\Test\Base as BaseTest;
+
+class GeoPolygonTest extends BaseTest
+{
+    /**
+     * @group functional
+     */
+    public function testGeoPoint()
+    {
+        $index = $this->_createIndex();
+
+        $type = $index->getType('test');
+
+        // Set mapping
+        $type->setMapping(array('location' => array('type' => 'geo_point')));
+
+        // Add doc 1
+        $doc1 = new Document(1,
+            array(
+                'name' => 'ruflin',
+            )
+        );
+
+        $doc1->addGeoPoint('location', 17, 19);
+        $type->addDocument($doc1);
+
+        // Add doc 2
+        $doc2 = new Document(2,
+            array(
+                'name' => 'ruflin',
+            )
+        );
+
+        $doc2->addGeoPoint('location', 30, 40);
+        $type->addDocument($doc2);
+
+        $index->refresh();
+
+        // Only one point should be in polygon
+        $points = array(array(16, 16), array(16, 20), array(20, 20), array(20, 16), array(16, 16));
+        $geoQuery = new GeoPolygon('location', $points);
+
+        $query = new Query(new MatchAll());
+        $query->setPostFilter($geoQuery);
+        $this->assertEquals(1, $type->search($query)->count());
+
+        // Both points should be inside
+        $query = new Query();
+        $points = array(array(16, 16), array(16, 40), array(40, 40), array(40, 16), array(16, 16));
+        $geoQuery = new GeoPolygon('location', $points);
+
+        $query = new Query(new MatchAll());
+        $query->setPostFilter($geoQuery);
+
+        $this->assertEquals(2, $type->search($query)->count());
+    }
+}

--- a/test/lib/Elastica/Test/Query/GeoShapePreIndexedTest.php
+++ b/test/lib/Elastica/Test/Query/GeoShapePreIndexedTest.php
@@ -1,0 +1,102 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Query\AbstractGeoShape;
+use Elastica\Query\GeoShapePreIndexed;
+use Elastica\Query\BoolQuery;
+use Elastica\Test\Base as BaseTest;
+
+class GeoShapePreIndexedTest extends BaseTest
+{
+    /**
+     * @group functional
+     */
+    public function testGeoProvided()
+    {
+        $index = $this->_createIndex();
+        $indexName = $index->getName();
+        $type = $index->getType('type');
+        $otherType = $index->getType('other_type');
+
+        // create mapping
+        $mapping = new \Elastica\Type\Mapping($type, array(
+            'location' => array(
+                'type' => 'geo_shape',
+            ),
+        ));
+        $type->setMapping($mapping);
+
+        // create other type mapping
+        $otherMapping = new \Elastica\Type\Mapping($type, array(
+            'location' => array(
+                'type' => 'geo_shape',
+            ),
+        ));
+        $otherType->setMapping($otherMapping);
+
+        // add type docs
+        $type->addDocument(new \Elastica\Document('1', array(
+            'location' => array(
+                'type' => 'envelope',
+                'coordinates' => array(
+                    array(0.0, 50.0),
+                    array(50.0, 0.0),
+                ),
+            ),
+        )));
+
+        // add other type docs
+        $otherType->addDocument(new \Elastica\Document('2', array(
+            'location' => array(
+                'type' => 'envelope',
+                'coordinates' => array(
+                    array(25.0, 75.0),
+                    array(75.0, 25.0),
+                ),
+            ),
+        )));
+
+        $index->optimize();
+        $index->refresh();
+
+        $gsp = new GeoShapePreIndexed(
+            'location', '1', 'type', $indexName, 'location'
+        );
+        $gsp->setRelation(AbstractGeoShape::RELATION_INTERSECT);
+
+        $expected = array(
+            'geo_shape' => array(
+                'location' => array(
+                    'indexed_shape' => array(
+                        'id' => '1',
+                        'type' => 'type',
+                        'index' => $indexName,
+                        'path' => 'location',
+                    ),
+                    'relation' => $gsp->getRelation(),
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $gsp->toArray());
+
+        $query = new BoolQuery();
+        $query->addFilter($gsp);
+        $results = $index->getType('type')->search($query);
+
+        $this->assertEquals(1, $results->count());
+
+        $index->delete();
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetRelation()
+    {
+        $gsp = new GeoShapePreIndexed('location', '1', 'type', 'indexName', 'location');
+        $gsp->setRelation(AbstractGeoShape::RELATION_INTERSECT);
+        $this->assertEquals(AbstractGeoShape::RELATION_INTERSECT, $gsp->getRelation());
+        $this->assertInstanceOf('Elastica\Query\GeoShapePreIndexed', $gsp->setRelation(AbstractGeoShape::RELATION_INTERSECT));
+    }
+}

--- a/test/lib/Elastica/Test/Query/GeoShapeProvidedTest.php
+++ b/test/lib/Elastica/Test/Query/GeoShapeProvidedTest.php
@@ -1,0 +1,103 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Document;
+use Elastica\Query\AbstractGeoShape;
+use Elastica\Query\GeoShapeProvided;
+use Elastica\Query\BoolQuery;
+use Elastica\Test\Base as BaseTest;
+use Elastica\Type\Mapping;
+
+class GeoShapeProvidedTest extends BaseTest
+{
+    /**
+     * @group functional
+     */
+    public function testConstructEnvelope()
+    {
+        $index = $this->_createIndex();
+        $type = $index->getType('test');
+
+        // create mapping
+        $mapping = new Mapping($type, array(
+            'location' => array(
+                'type' => 'geo_shape',
+            ),
+        ));
+        $type->setMapping($mapping);
+
+        // add docs
+        $type->addDocument(new Document(1, array(
+            'location' => array(
+                'type' => 'envelope',
+                'coordinates' => array(
+                    array(-50.0, 50.0),
+                    array(50.0, -50.0),
+                ),
+            ),
+        )));
+
+        $index->optimize();
+        $index->refresh();
+
+        $envelope = array(
+            array(25.0, 75.0),
+            array(75.0, 25.0),
+        );
+        $gsp = new GeoShapeProvided('location', $envelope);
+
+        $expected = array(
+            'geo_shape' => array(
+                'location' => array(
+                    'shape' => array(
+                        'type' => GeoShapeProvided::TYPE_ENVELOPE,
+                        'coordinates' => $envelope,
+                        'relation' => AbstractGeoShape::RELATION_INTERSECT,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $gsp->toArray());
+
+        $query = new BoolQuery();
+        $query->addFilter($gsp);
+        $results = $type->search($query);
+
+        $this->assertEquals(1, $results->count());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testConstructPolygon()
+    {
+        $polygon = array(array(102.0, 2.0), array(103.0, 2.0), array(103.0, 3.0), array(103.0, 3.0), array(102.0, 2.0));
+        $gsp = new GeoShapeProvided('location', $polygon, GeoShapeProvided::TYPE_POLYGON);
+
+        $expected = array(
+            'geo_shape' => array(
+                'location' => array(
+                    'shape' => array(
+                        'type' => GeoShapeProvided::TYPE_POLYGON,
+                        'coordinates' => $polygon,
+                        'relation' => $gsp->getRelation(),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertEquals($expected, $gsp->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetRelation()
+    {
+        $gsp = new GeoShapeProvided('location', array(array(25.0, 75.0), array(75.0, 25.0)));
+        $gsp->setRelation(AbstractGeoShape::RELATION_INTERSECT);
+        $this->assertEquals(AbstractGeoShape::RELATION_INTERSECT, $gsp->getRelation());
+        $this->assertInstanceOf('Elastica\Query\GeoShapeProvided', $gsp->setRelation(AbstractGeoShape::RELATION_INTERSECT));
+    }
+}

--- a/test/lib/Elastica/Test/Query/GeohashCellTest.php
+++ b/test/lib/Elastica/Test/Query/GeohashCellTest.php
@@ -1,0 +1,68 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Document;
+use Elastica\Query\GeohashCell;
+use Elastica\Query;
+use Elastica\Test\Base as BaseTest;
+use Elastica\Type\Mapping;
+
+class GeohashCellTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $query = new GeohashCell('pin', array('lat' => 37.789018, 'lon' => -122.391506), '50m');
+        $expected = array(
+            'geohash_cell' => array(
+                'pin' => array(
+                    'lat' => 37.789018,
+                    'lon' => -122.391506,
+                ),
+                'precision' => '50m',
+                'neighbors' => false,
+            ),
+        );
+        $this->assertEquals($expected, $query->toArray());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testQuery()
+    {
+        $index = $this->_createIndex();
+        $type = $index->getType('test');
+        $mapping = new Mapping($type, array(
+            'pin' => array(
+                'type' => 'geo_point',
+                'geohash' => true,
+                'geohash_prefix' => true,
+            ),
+        ));
+        $type->setMapping($mapping);
+
+        $type->addDocument(new Document(1, array('pin' => '9q8yyzm0zpw8')));
+        $type->addDocument(new Document(2, array('pin' => '9mudgb0yued0')));
+        $index->refresh();
+
+        $geoQuery = new GeohashCell('pin', array('lat' => 32.828326, 'lon' => -117.255854));
+        $query = new Query();
+        $query->setPostFilter($geoQuery);
+        $results = $type->search($query);
+
+        $this->assertEquals(1, $results->count());
+
+        //test precision parameter
+        $geoQuery = new GeohashCell('pin', '9', 1);
+        $query = new Query();
+        $query->setPostFilter($geoQuery);
+        $results = $type->search($query);
+
+        $this->assertEquals(2, $results->count());
+
+        $index->delete();
+    }
+}

--- a/test/lib/Elastica/Test/Query/IndicesTest.php
+++ b/test/lib/Elastica/Test/Query/IndicesTest.php
@@ -1,0 +1,131 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Document;
+use Elastica\Query\Indices;
+use Elastica\Query\Term;
+use Elastica\Index;
+use Elastica\Query;
+use Elastica\Test\Base as BaseTest;
+
+class IndicesTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $expected = array(
+            'indices' => array(
+                'indices' => array('index1', 'index2'),
+                'query' => array(
+                    'term' => array('tag' => 'wow'),
+                ),
+                'no_match_query' => array(
+                    'term' => array('tag' => 'such filter'),
+                ),
+            ),
+        );
+        $query = new Indices(new Term(array('tag' => 'wow')), array('index1', 'index2'));
+        $query->setNoMatchQuery(new Term(array('tag' => 'such filter')));
+        $this->assertEquals($expected, $query->toArray());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testIndicesQuery()
+    {
+        $docs = array(
+            new Document(1, array('color' => 'blue')),
+            new Document(2, array('color' => 'green')),
+            new Document(3, array('color' => 'blue')),
+            new Document(4, array('color' => 'yellow')),
+        );
+
+        $index1 = $this->_createIndex();
+        $index1->addAlias('indices_query');
+        $index1->getType('test')->addDocuments($docs);
+        $index1->refresh();
+
+        $index2 = $this->_createIndex();
+        $index2->addAlias('indices_query');
+        $index2->getType('test')->addDocuments($docs);
+        $index2->refresh();
+
+        $boolQuery = new Query\BoolQuery();
+        $boolQuery->addMustNot(new Term(array('color' => 'blue')));
+
+        $indicesQuery = new Indices($boolQuery, array($index1->getName()));
+
+        $boolQuery = new Query\BoolQuery();
+        $boolQuery->addMustNot(new Term(array('color' => 'yellow')));
+        $indicesQuery->setNoMatchQuery($boolQuery);
+
+        $query = new Query();
+        $query->setPostFilter($indicesQuery);
+
+        // search over the alias
+        $index = $this->_getClient()->getIndex('indices_query');
+        $results = $index->search($query);
+
+        // ensure that the proper docs have been filtered out for each index
+        $this->assertEquals(5, $results->count());
+        foreach ($results->getResults() as $result) {
+            $data = $result->getData();
+            $color = $data['color'];
+            if ($result->getIndex() === $index1->getName()) {
+                $this->assertNotEquals('blue', $color);
+            } else {
+                $this->assertNotEquals('yellow', $color);
+            }
+        }
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetIndices()
+    {
+        $client = $this->_getClient();
+        $index1 = $client->getIndex('index1');
+        $index2 = $client->getIndex('index2');
+
+        $indices = array('one', 'two');
+        $query = new Indices(new Term(array('color' => 'blue')), $indices);
+        $this->assertEquals($indices, $query->getParam('indices'));
+
+        $indices[] = 'three';
+        $query->setIndices($indices);
+        $this->assertEquals($indices, $query->getParam('indices'));
+
+        $query->setIndices(array($index1, $index2));
+        $expected = array($index1->getName(), $index2->getName());
+        $this->assertEquals($expected, $query->getParam('indices'));
+
+        $returnValue = $query->setIndices($indices);
+        $this->assertInstanceOf('Elastica\Query\Indices', $returnValue);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testAddIndex()
+    {
+        $client = $this->_getClient();
+        $index = $client->getIndex('someindex');
+
+        $query = new Indices(new Term(array('color' => 'blue')), array());
+
+        $query->addIndex($index);
+        $expected = array($index->getName());
+        $this->assertEquals($expected, $query->getParam('indices'));
+
+        $query->addIndex('foo');
+        $expected = array($index->getName(), 'foo');
+        $this->assertEquals($expected, $query->getParam('indices'));
+
+        $returnValue = $query->addIndex('bar');
+        $this->assertInstanceOf('Elastica\Query\Indices', $returnValue);
+    }
+}

--- a/test/lib/Elastica/Test/Query/LimitTest.php
+++ b/test/lib/Elastica/Test/Query/LimitTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Query\Limit;
+use Elastica\Test\Base as BaseTest;
+
+class LimitTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testSetType()
+    {
+        $query = new Limit(10);
+        $this->assertEquals(10, $query->getParam('value'));
+
+        $this->assertInstanceOf('Elastica\Query\Limit', $query->setLimit(20));
+        $this->assertEquals(20, $query->getParam('value'));
+    }
+
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $query = new Limit(15);
+
+        $expectedArray = array(
+            'limit' => array('value' => 15),
+        );
+
+        $this->assertEquals($expectedArray, $query->toArray());
+    }
+}

--- a/test/lib/Elastica/Test/Query/MissingTest.php
+++ b/test/lib/Elastica/Test/Query/MissingTest.php
@@ -1,0 +1,78 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Query\Missing;
+use Elastica\Test\Base as BaseTest;
+
+class MissingTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $query = new Missing('field_name');
+        $expectedArray = array('missing' => array('field' => 'field_name'));
+        $this->assertEquals($expectedArray, $query->toArray());
+
+        $query = new Missing('field_name');
+        $query->setExistence(true);
+        $expectedArray = array('missing' => array('field' => 'field_name', 'existence' => true));
+        $this->assertEquals($expectedArray, $query->toArray());
+
+        $query = new Missing('field_name');
+        $query->setNullValue(true);
+        $expectedArray = array('missing' => array('field' => 'field_name', 'null_value' => true));
+        $this->assertEquals($expectedArray, $query->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetField()
+    {
+        $query = new Missing('field_name');
+
+        $this->assertEquals('field_name', $query->getParam('field'));
+
+        $query->setField('new_field_name');
+        $this->assertEquals('new_field_name', $query->getParam('field'));
+
+        $returnValue = $query->setField('very_new_field_name');
+        $this->assertInstanceOf('Elastica\Query\Missing', $returnValue);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetExistence()
+    {
+        $query = new Missing('field_name');
+
+        $query->setExistence(true);
+        $this->assertTrue($query->getParam('existence'));
+
+        $query->setExistence(false);
+        $this->assertFalse($query->getParam('existence'));
+
+        $returnValue = $query->setExistence(true);
+        $this->assertInstanceOf('Elastica\Query\Missing', $returnValue);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetNullValue()
+    {
+        $query = new Missing('field_name');
+
+        $query->setNullValue(true);
+        $this->assertTrue($query->getParam('null_value'));
+
+        $query->setNullValue(false);
+        $this->assertFalse($query->getParam('null_value'));
+
+        $returnValue = $query->setNullValue(true);
+        $this->assertInstanceOf('Elastica\Query\Missing', $returnValue);
+    }
+}

--- a/test/lib/Elastica/Test/Query/MoreLikeThisTest.php
+++ b/test/lib/Elastica/Test/Query/MoreLikeThisTest.php
@@ -104,13 +104,35 @@ class MoreLikeThisTest extends BaseTest
 
         $query = new Query\BoolQuery();
         $query->addMust($mltQuery);
+        $this->hideDeprecated();
+        // Return just the visible similar
+        $filter = new Query\BoolQuery();
+        $filterTerm = new Query\Term();
+        $filterTerm->setTerm('visible', true);
+        $filter->addMust($filterTerm);
+        $query->addFilter($filter);
+        $this->showDeprecated();
+        $resultSet = $type->search($query);
+        $this->assertEquals(2, $resultSet->count());
+
+        // Legacy test with filter
+        $mltQuery = new MoreLikeThis();
+
+        $mltQuery->setMinTermFrequency(1);
+        $mltQuery->setMinDocFrequency(1);
+
+        $mltQuery->setLike($doc);
+
+        $query = new Query\BoolQuery();
+        $query->addMust($mltQuery);
+        $this->hideDeprecated();
         // Return just the visible similar
         $filter = new BoolFilter();
         $filterTerm = new Term();
         $filterTerm->setTerm('visible', true);
         $filter->addMust($filterTerm);
         $query->addFilter($filter);
-
+        $this->showDeprecated();
         $resultSet = $type->search($query);
         $this->assertEquals(2, $resultSet->count());
     }

--- a/test/lib/Elastica/Test/Query/NumericRangeTest.php
+++ b/test/lib/Elastica/Test/Query/NumericRangeTest.php
@@ -1,0 +1,37 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Query\NumericRange;
+use Elastica\Test\Base as BaseTest;
+
+class NumericRangeTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testAddField()
+    {
+        $rangeQuery = new NumericRange();
+        $returnValue = $rangeQuery->addField('fieldName', array('to' => 'value'));
+        $this->assertInstanceOf('Elastica\Query\NumericRange', $returnValue);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $query = new NumericRange();
+
+        $fromTo = array('from' => 'ra', 'to' => 'ru');
+        $query->addField('name', $fromTo);
+
+        $expectedArray = array(
+            'numeric_range' => array(
+                'name' => $fromTo,
+            ),
+        );
+
+        $this->assertEquals($expectedArray, $query->toArray());
+    }
+}

--- a/test/lib/Elastica/Test/Query/ScriptTest.php
+++ b/test/lib/Elastica/Test/Query/ScriptTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Query\Script as ScriptQuery;
+use Elastica\Script\Script;
+use Elastica\Test\Base as BaseTest;
+
+class ScriptTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $string = '_score * 2.0';
+
+        $query = new ScriptQuery($string);
+
+        $array = $query->toArray();
+        $this->assertInternalType('array', $array);
+
+        $expected = array(
+            'script' => array(
+                'script' => $string,
+            ),
+        );
+        $this->assertEquals($expected, $array);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetScript()
+    {
+        $string = '_score * 2.0';
+        $params = array(
+            'param1' => 'one',
+            'param2' => 1,
+        );
+        $lang = 'mvel';
+        $script = new Script($string, $params, $lang);
+
+        $query = new ScriptQuery();
+        $query->setScript($script);
+
+        $array = $query->toArray();
+
+        $expected = array(
+            'script' => array(
+                'script' => $string,
+                'params' => $params,
+                'lang' => $lang,
+            ),
+        );
+        $this->assertEquals($expected, $array);
+    }
+}

--- a/test/lib/Elastica/Test/Query/TypeTest.php
+++ b/test/lib/Elastica/Test/Query/TypeTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Query\Type;
+use Elastica\Test\Base as BaseTest;
+
+class TypeTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testSetType()
+    {
+        $typeQuery = new Type();
+        $returnValue = $typeQuery->setType('type_name');
+        $this->assertInstanceOf('Elastica\Query\Type', $returnValue);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $typeQuery = new Type('type_name');
+
+        $expectedArray = array(
+            'type' => array('value' => 'type_name'),
+        );
+
+        $this->assertEquals($expectedArray, $typeQuery->toArray());
+    }
+}

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/AggregationTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/AggregationTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\Filter\Exists;
+use Elastica\Query\Term;
 use Elastica\QueryBuilder\DSL;
 
 class AggregationTest extends AbstractDSLTest
@@ -19,6 +20,16 @@ class AggregationTest extends AbstractDSLTest
 
     /**
      * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testFilteredInvalid()
+    {
+        $queryDSL = new DSL\Aggregation();
+        $queryDSL->filter(null, $this);
+    }
+
+    /**
+     * @group unit
      */
     public function testInterface()
     {
@@ -29,7 +40,12 @@ class AggregationTest extends AbstractDSLTest
         $this->_assertImplemented($aggregationDSL, 'date_histogram', 'Elastica\Aggregation\DateHistogram', array('name', 'field', 1));
         $this->_assertImplemented($aggregationDSL, 'date_range', 'Elastica\Aggregation\DateRange', array('name'));
         $this->_assertImplemented($aggregationDSL, 'extended_stats', 'Elastica\Aggregation\ExtendedStats', array('name'));
+        $this->hideDeprecated();
         $this->_assertImplemented($aggregationDSL, 'filter', 'Elastica\Aggregation\Filter', array('name', new Exists('field')));
+        $this->showDeprecated();
+
+        $this->_assertImplemented($aggregationDSL, 'filter', 'Elastica\Aggregation\Filter', array('name', new Term()));
+
         $this->_assertImplemented($aggregationDSL, 'filters', 'Elastica\Aggregation\Filters', array('name'));
         $this->_assertImplemented($aggregationDSL, 'geo_distance', 'Elastica\Aggregation\GeoDistance', array('name', 'field', 'origin'));
         $this->_assertImplemented($aggregationDSL, 'geohash_grid', 'Elastica\Aggregation\GeohashGrid', array('name', 'field'));

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/FilterTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/FilterTest.php
@@ -25,6 +25,7 @@ class FilterTest extends AbstractDSLTest
     {
         $filterDSL = new DSL\Filter();
 
+        $this->hideDeprecated();
         $this->_assertImplemented($filterDSL, 'bool', 'Elastica\Filter\BoolFilter', array());
         $this->_assertImplemented($filterDSL, 'bool_and', 'Elastica\Filter\BoolAnd', array(array(new Exists('field'))));
         $this->_assertImplemented($filterDSL, 'bool_not', 'Elastica\Filter\BoolNot', array(new Exists('field')));
@@ -54,5 +55,6 @@ class FilterTest extends AbstractDSLTest
         $this->_assertImplemented($filterDSL, 'term', 'Elastica\Filter\Term', array());
         $this->_assertImplemented($filterDSL, 'terms', 'Elastica\Filter\Terms', array('field', array()));
         $this->_assertImplemented($filterDSL, 'type', 'Elastica\Filter\Type', array('type'));
+        $this->showDeprecated();
     }
 }

--- a/test/lib/Elastica/Test/QueryBuilderTest.php
+++ b/test/lib/Elastica/Test/QueryBuilderTest.php
@@ -6,7 +6,7 @@ use Elastica\Query;
 use Elastica\QueryBuilder;
 use Elastica\Suggest;
 
-class QueryBuilderTest extends \PHPUnit_Framework_TestCase
+class QueryBuilderTest extends Base
 {
     /**
      * @group unit
@@ -40,7 +40,9 @@ class QueryBuilderTest extends \PHPUnit_Framework_TestCase
 
         // test one example QueryBuilder flow for each default DSL type
         $this->assertInstanceOf('Elastica\Query\AbstractQuery', $qb->query()->match());
+        $this->hideDeprecated();
         $this->assertInstanceOf('Elastica\Filter\AbstractFilter', $qb->filter()->bool());
+        $this->showDeprecated();
         $this->assertInstanceOf('Elastica\Aggregation\AbstractAggregation', $qb->aggregation()->avg('name'));
         $this->assertInstanceOf('Elastica\Suggest\AbstractSuggest', $qb->suggest()->term('name', 'field'));
     }

--- a/test/lib/Elastica/Test/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryTest.php
@@ -3,6 +3,7 @@ namespace Elastica\Test;
 
 use Elastica\Document;
 use Elastica\Exception\InvalidException;
+use Elastica\Filter\Exists;
 use Elastica\Query;
 use Elastica\Query\Builder;
 use Elastica\Query\Term;
@@ -15,6 +16,94 @@ use Elastica\Type;
 
 class QueryTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testCreateWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+
+        $errorsCollector = $this->startCollectErrors();
+        Query::create($existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query::create() passing filter is deprecated. Create query and use setPostFilter with AbstractQuery instead.',
+                'Deprecated: Elastica\Query::setPostFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testSetFilterInvalid()
+    {
+        $query = new Query();
+        $query->setFilter($this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetFilterWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new Query();
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->setFilter($existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query::setFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.',
+                'Deprecated: Elastica\Query::setFilter() is deprecated and will be removed in further Elastica releases. Use Elastica\Query::setPostFilter() instead.',
+                'Deprecated: Elastica\Query::setPostFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.'
+            )
+        );
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testSetPostFilterInvalid()
+    {
+        $query = new Query();
+        $query->setPostFilter($this);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetPostFilterWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $query = new Query();
+
+        $errorsCollector = $this->startCollectErrors();
+        $query->setPostFilter($existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Query::setPostFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.'
+            )
+        );
+    }
+
     /**
      * @group unit
      */
@@ -382,6 +471,26 @@ class QueryTest extends BaseTest
     public function testSetPostFilterToArrayCast()
     {
         $query = new Query();
+        $postFilter = new \Elastica\Query\Terms();
+        $postFilter->setTerms('key', array('term'));
+        $query->setPostFilter($postFilter);
+
+        $postFilter->setTerms('another key', array('another term'));
+
+        $anotherQuery = new Query();
+        $anotherQuery->setPostFilter($postFilter);
+
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testLegacySetPostFilterToArrayCast()
+    {
+        $this->hideDeprecated();
+
+        $query = new Query();
         $postFilter = new \Elastica\Filter\Terms();
         $postFilter->setTerms('key', array('term'));
         $query->setPostFilter($postFilter);
@@ -391,6 +500,7 @@ class QueryTest extends BaseTest
         $anotherQuery = new Query();
         $anotherQuery->setPostFilter($postFilter);
 
+        $this->showDeprecated();
         $this->assertEquals($query->toArray(), $anotherQuery->toArray());
     }
 

--- a/test/lib/Elastica/Test/SearchTest.php
+++ b/test/lib/Elastica/Test/SearchTest.php
@@ -3,6 +3,7 @@ namespace Elastica\Test;
 
 use Elastica\Document;
 use Elastica\Exception\ResponseException;
+use Elastica\Filter\Exists;
 use Elastica\Index;
 use Elastica\Query;
 use Elastica\Query\FunctionScore;
@@ -15,6 +16,31 @@ use Elastica\Type;
 
 class SearchTest extends BaseTest
 {
+    /**
+     * @group unit
+     */
+    public function testSetQueryWithLegacyFilterDeprecated()
+    {
+        $this->hideDeprecated();
+        $existsFilter = new Exists('test');
+        $this->showDeprecated();
+
+        $client = $this->_getClient();
+        $search = new Search($client);
+
+        $errorsCollector = $this->startCollectErrors();
+        $search->setQuery($existsFilter);
+        $this->finishCollectErrors();
+
+        $errorsCollector->assertOnlyDeprecatedErrors(
+            array(
+                'Deprecated: Elastica\Search::setQuery() passing AbstractFilter is deprecated. Create query and use setPostFilter with AbstractQuery instead.',
+                'Deprecated: Elastica\Query::create() passing filter is deprecated. Create query and use setPostFilter with AbstractQuery instead.',
+                'Deprecated: Elastica\Query::setPostFilter() passing filter as AbstractFilter is deprecated. Pass instance of AbstractQuery instead.'
+            )
+        );
+    }
+
     /**
      * @group unit
      */


### PR DESCRIPTION
PR for #1001.

Review it carefully please.

Two things left: changelog and QueryBuilder DSL.

I haven't experience with QueryBuilder, so any help would be appreciated.

1. QueryBuilder/DSL/Filter - must be deprecated? If yes, in QueryBuilder constructor it must be not created, so, need make it lazy or something.

2. DSL::TYPE_FILTER - must be deprecated?

3. Version::getFilters, Version::filters, Version::supports (with filter type) - must be deprecated? Seems not, because there is support of old versions.
