### PR TITLE
Fix isset result for null value when key exist

### DIFF
--- a/lib/Elastica/Result.php
+++ b/lib/Elastica/Result.php
@@ -214,6 +214,6 @@ class Result
     {
         $source = $this->getData();
 
-        return array_key_exists($key, $source) && $source[$key] !== null;
+        return array_key_exists($key, $source);
     }
 }


### PR DESCRIPTION
Hi,
I think the interpretation of __isset is wrong.
Indeed a key can be null but in array.

Before the fix, the value given was "false" when in fact it is null and exist


Can imagine merge, and tag this fix in 3.0.2 ?

Thanx