### PR TITLE
check aggregation parameters early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 ### Improvements
+- `Elastica\Exception\InvalidException` will be thrown if you try using an
+  `Elastica\Aggregation\AbstractSimpleAggregation` without setting either the
+  `field` or `script` param.
 
 ### Deprecated
 

--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elastica\Aggregation;
 
+use Elastica\Exception\InvalidException;
+
 abstract class AbstractSimpleAggregation extends AbstractAggregation
 {
     /**
@@ -32,6 +34,11 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
      */
     public function toArray()
     {
+        if (!$this->hasParam('field') && !$this->hasParam('script')) {
+            throw new InvalidException(
+                'Either the field param or the script param should be set'
+            );
+        }
         $array = parent::toArray();
 
         $baseName = $this->_getBaseName();

--- a/test/lib/Elastica/Test/Aggregation/AbstractSimpleAggregationTest.php
+++ b/test/lib/Elastica/Test/Aggregation/AbstractSimpleAggregationTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Elastica\Test\Aggregation;
+
+use Elastica\Aggregation\AbstractSimpleAggregation;
+use Elastica\Exception\InvalidException;
+
+class AbstractSimpleAggregationTest extends BaseAggregationTest
+{
+    public function setUp()
+    {
+        $this->aggregation = $this->getMockForAbstractClass(
+            'Elastica\Aggregation\AbstractSimpleAggregation',
+            ['whatever']
+        );
+    }
+
+    public function testToArrayThrowsExceptionOnUnsetParams()
+    {
+        $this->setExpectedException(
+            'Elastica\Exception\InvalidException',
+            'Either the field param or the script param should be set'
+        );
+
+        $this->aggregation->toArray();
+    }
+}

--- a/test/lib/Elastica/Test/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryTest.php
@@ -415,6 +415,7 @@ class QueryTest extends BaseTest
     {
         $query = new Query();
         $aggregation = new \Elastica\Aggregation\Terms('text');
+        $aggregation->setField('field');
 
         $query->addAggregation($aggregation);
 


### PR DESCRIPTION
Instead of querying ES with something invalid, throw a meaningful
exception.
Fixes #1043 