### PR TITLE
fix-update-document-options-not-set

### DIFF
--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -380,8 +380,9 @@ class Client
         }
 
         if (!isset($options['retry_on_conflict'])) {
-            $retryOnConflict = $this->getConfig('retryOnConflict');
-            $options['retry_on_conflict'] = $retryOnConflict;
+            if ($retryOnConflict = $this->getConfig('retryOnConflict')) {
+                $options['retry_on_conflict'] = $retryOnConflict;
+            }
         }
 
         $response = $this->request($path, Request::POST, $requestData, $options);


### PR DESCRIPTION
Comes from [1046](https://github.com/ruflin/Elastica/issues/1046)

Improvement for updateDocument method: not set option 'retry_on_conflict' if it is empty in Client's config.
