### PR TITLE
fix phpdoc getQuery, it returns object instead array

### DIFF
--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -122,9 +122,9 @@ class Query extends Param
     }
 
     /**
-     * Gets the query array.
+     * Gets the query object.
      *
-     * @return array
+     * @return \Elastica\Query\AbstractQuery
      **/
     public function getQuery()
     {


### PR DESCRIPTION
This behavior was changed in #916