### PR TITLE
Fix deleteByQuery fatal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file based on the
 - `Elastica\Exception\InvalidException` will be thrown if you try using an
   `Elastica\Aggregation\AbstractSimpleAggregation` without setting either the
   `field` or `script` param.
+- `Elastica\Index->deleteByQuery($query, $options)` $query param can be a query `array` again
 
 ### Deprecated
 

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -142,8 +142,8 @@ class Index implements SearchableInterface
     /**
      * Deletes entries in the db based on a query.
      *
-     * @param \Elastica\Query|string $query   Query object
-     * @param array                  $options Optional params
+     * @param \Elastica\Query|string|array $query   Query object or array
+     * @param array                        $options Optional params
      *
      * @return \Elastica\Response
      *
@@ -157,9 +157,9 @@ class Index implements SearchableInterface
 
             return $this->request('_query', Request::DELETE, array(), $options);
         }
-        $query = Query::create($query);
+        $query = Query::create($query)->getQuery();
 
-        return $this->request('_query', Request::DELETE, array('query' => $query->getQuery()->toArray()), $options);
+        return $this->request('_query', Request::DELETE, array('query' => is_array($query) ? $query : $query->toArray()), $options);
     }
 
     /**

--- a/test/lib/Elastica/Test/IndexTest.php
+++ b/test/lib/Elastica/Test/IndexTest.php
@@ -423,6 +423,42 @@ class IndexTest extends BaseTest
     /**
      * @group functional
      */
+    public function testDeleteByQueryWithArrayQuery()
+    {
+        $this->_checkPlugin('delete-by-query');
+
+        $index = $this->_createIndex();
+        $type1 = new Type($index, 'test1');
+        $type1->addDocument(new Document(1, array('name' => 'ruflin nicolas')));
+        $type1->addDocument(new Document(2, array('name' => 'ruflin')));
+        $type2 = new Type($index, 'test2');
+        $type2->addDocument(new Document(1, array('name' => 'ruflin nicolas')));
+        $type2->addDocument(new Document(2, array('name' => 'ruflin')));
+        $index->refresh();
+
+        $response = $index->search('ruflin*');
+        $this->assertEquals(4, $response->count());
+
+        $response = $index->search('nicolas');
+        $this->assertEquals(2, $response->count());
+
+        // Delete first document
+        $response = $index->deleteByQuery(array('query' => array('query_string' => array('query' => 'nicolas'))));
+        $this->assertTrue($response->isOk());
+
+        $index->refresh();
+
+        // Makes sure, document is deleted
+        $response = $index->search('ruflin*');
+        $this->assertEquals(2, $response->count());
+
+        $response = $index->search('nicolas');
+        $this->assertEquals(0, $response->count());
+    }
+
+    /**
+     * @group functional
+     */
     public function testDeleteByQueryWithQueryAndOptions()
     {
         $this->_checkPlugin('delete-by-query');


### PR DESCRIPTION
deleteByQuery was always throwing `Call to a member function toArray()  on a non-object` since $query->getQuery() returns array. Should probably also change Query->getQuery() phpdoc to typehint the return value as array.