### PR TITLE
Allow using IAM Authentication with Amazon ElasticSearch service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 
 ### Added
+- Add an "AwsAuthV4" transport that automatically signs requests using credentials from the environment or from the client config. This allows using Elastica with Amazon ElasticSearch Service domains that are restricted to IAM roles or policies.
 
 ### Improvements
 - `Elastica\Exception\InvalidException` will be thrown if you try using an

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,14 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.0",
+        "aws/aws-sdk-php": "~3.0"
     },
     "suggest": {
         "guzzlehttp/guzzle": "Allow using guzzle 6 as the http transport (Requires php 5.5)",
         "egeloen/http-adapter": "Allow using httpadapter transport",
-        "monolog/monolog": "Logging request"
+        "monolog/monolog": "Logging request",
+        "aws/aws-sdk-php": "Allow using IAM authentication with Amazon ElasticSearch Service"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Elastica/Transport/AwsAuthV4.php
+++ b/lib/Elastica/Transport/AwsAuthV4.php
@@ -1,0 +1,88 @@
+<?php
+namespace Elastica\Transport;
+
+use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\Credentials;
+use Aws\Signature\SignatureV4;
+use Elastica\Connection;
+use GuzzleHttp;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Psr\Http\Message\RequestInterface;
+
+class AwsAuthV4 extends Guzzle
+{
+    protected function _getGuzzleClient($baseUrl, $persistent = true)
+    {
+        if (!$persistent || !self::$_guzzleClientConnection) {
+            $stack = HandlerStack::create(GuzzleHttp\choose_handler());
+            $stack->push($this->getSigningMiddleware(), 'sign');
+
+            self::$_guzzleClientConnection = new Client([
+                'base_uri' => $baseUrl,
+                'handler' => $stack,
+            ]);
+        }
+
+        return self::$_guzzleClientConnection;
+    }
+
+    protected function _getBaseUrl(Connection $connection)
+    {
+        $this->initializePortAndScheme();
+
+        return parent::_getBaseUrl($connection);
+    }
+
+    private function getSigningMiddleware()
+    {
+        $region = $this->getConnection()->hasParam('aws_region')
+            ? $this->getConnection()->getParam('aws_region')
+            : getenv('AWS_REGION');
+        $signer = new SignatureV4('es', $region);
+        $credProvider = $this->getCredentialProvider();
+
+        return Middleware::mapRequest(function (RequestInterface $req) use (
+            $signer,
+            $credProvider
+        ) {
+            return $signer->signRequest($req, $credProvider()->wait());
+        });
+    }
+
+    private function getCredentialProvider()
+    {
+        $connection = $this->getConnection();
+        if ($connection->hasParam('aws_secret_access_key')) {
+            return CredentialProvider::fromCredentials(new Credentials(
+                $connection->getParam('aws_access_key_id'),
+                $connection->getParam('aws_secret_access_key'),
+                $connection->hasParam('aws_session_token')
+                    ? $connection->getParam('aws_session_token')
+                    : null
+            ));
+        }
+
+        return CredentialProvider::defaultProvider();
+    }
+
+    private function initializePortAndScheme()
+    {
+        $connection = $this->getConnection();
+        if (true === $this->getConfig($connection, 'ssl')) {
+            $this->_scheme = 'https';
+            $connection->setPort(443);
+        } else {
+            $this->_scheme = 'http';
+            $connection->setPort(80);
+        }
+    }
+
+    private function getConfig(Connection $conn, $key, $default = null)
+    {
+        return $conn->hasConfig($key)
+            ? $conn->getConfig($key)
+            : $default;
+    }
+}

--- a/test/lib/Elastica/Test/Transport/AwsAuthV4Test.php
+++ b/test/lib/Elastica/Test/Transport/AwsAuthV4Test.php
@@ -1,0 +1,86 @@
+<?php
+namespace Elastica\Test\Transport;
+
+use Elastica\Exception\Connection\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+
+class AwsAuthV4Test extends GuzzleTest
+{
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists('Aws\\Sdk')) {
+            self::markTestSkipped('aws/aws-sdk-php package should be installed to run SignatureV4 transport tests');
+        }
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSignsWithProvidedCredentials()
+    {
+        $config = array(
+            'persistent' => false,
+            'transport' => 'AwsAuthV4',
+            'aws_access_key_id' => 'foo',
+            'aws_secret_access_key' => 'bar',
+            'aws_session_token' => 'baz',
+            'aws_region' => 'us-east-1',
+        );
+
+        $client = $this->_getClient($config);
+        try {
+            $client->request('_status', 'GET');
+        } catch (GuzzleException $e) {
+            $guzzleException = $e->getGuzzleException();
+            if ($guzzleException instanceof RequestException) {
+                $request = $guzzleException->getRequest();
+                $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
+                    . date('Ymd') . '/us-east-1/es/aws4_request, ';
+                $this->assertStringStartsWith(
+                    $expected,
+                    $request->getHeaderLine('Authorization')
+                );
+                $this->assertSame(
+                    'baz',
+                    $request->getHeaderLine('X-Amz-Security-Token')
+                );
+            } else {
+                throw $e;
+            }
+        }
+    }
+
+    public function testSignsWithEnvironmentalCredentials()
+    {
+        $config = array(
+            'persistent' => false,
+            'transport' => 'AwsAuthV4',
+        );
+        putenv('AWS_REGION=us-east-1');
+        putenv('AWS_ACCESS_KEY_ID=foo');
+        putenv('AWS_SECRET_ACCESS_KEY=bar');
+        putenv('AWS_SESSION_TOKEN=baz');
+
+        $client = $this->_getClient($config);
+        try {
+            $client->request('_status', 'GET');
+        } catch (GuzzleException $e) {
+            $guzzleException = $e->getGuzzleException();
+            if ($guzzleException instanceof RequestException) {
+                $request = $guzzleException->getRequest();
+                $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
+                    . date('Ymd') . '/us-east-1/es/aws4_request, ';
+                $this->assertStringStartsWith(
+                    $expected,
+                    $request->getHeaderLine('Authorization')
+                );
+                $this->assertSame(
+                    'baz',
+                    $request->getHeaderLine('X-Amz-Security-Token')
+                );
+            } else {
+                throw $e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an optional dependency on the AWS SDK for PHP and adds support for AWS Auth signing of requests sent to the Amazon ElasticSearch Service.

This would resolve #948.