### PR TITLE
Lazy load status data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file based on the
   `field` or `script` param.
 - `Elastica\Index->deleteByQuery($query, $options)` $query param can be a query `array` again
 - `Elastica\Query\MoreLikeThis->toArray()` now supports providing a non-indexed document as an input to perform the comparison.
+- `Elastica\Status` will lazy load the `_stats` at when it is needed.
 
 ### Deprecated
 

--- a/lib/Elastica/Status.php
+++ b/lib/Elastica/Status.php
@@ -24,7 +24,7 @@ class Status
      *
      * @var array Data
      */
-    protected $_data = array();
+    protected $_data = null;
 
     /**
      * Client object.
@@ -41,7 +41,6 @@ class Status
     public function __construct(Client $client)
     {
         $this->_client = $client;
-        $this->refresh();
     }
 
     /**
@@ -51,6 +50,9 @@ class Status
      */
     public function getData()
     {
+        if (is_null($this->_data)) {
+            $this->refresh();
+        }
         return $this->_data;
     }
 
@@ -61,7 +63,8 @@ class Status
      */
     public function getIndexNames()
     {
-        return array_keys($this->_data['indices']);
+        $data = $this->getData();
+        return array_keys($data['indices']);
     }
 
     /**
@@ -124,6 +127,9 @@ class Status
      */
     public function getResponse()
     {
+        if (is_null($this->_response)) {
+            $this->refresh();
+        }
         return $this->_response;
     }
 
@@ -134,7 +140,8 @@ class Status
      */
     public function getShards()
     {
-        return $this->_data['shards'];
+        $data = $this->getData();
+        return $data['shards'];
     }
 
     /**


### PR DESCRIPTION
In an elasticsearch instance with large number of indices, getting `_stats` is a huge expense, which `Elastica\Status` will load it for [every instance] (https://github.com/ruflin/Elastica/blob/e2daadc27ba263ab5b33c4afac10b1144078cd5d/lib/Elastica/Status.php#L44)

But some methods of `Elastica\Status` don't use `Status->_data`, e.g. `getIndicesWithAlias`. So it's possible to lazy load `_stats` data at when it's needed, to speed up stats independent function calls.