### PR TITLE
Extract and Implement ResultSetBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/3.1.1...HEAD)
 
 ### Backward Compatibility Breaks
+- Method \Elastica\ResultSet::create and property \Elastica\ResultSet::$class were removed. To change the ResultSet class, implement your own ResultSet Builder. #1065
+- Properties on \Elastica\ResultSet _totalHits, _maxScore, _took and _timedOut that were originally set on object construction are now accessed by the getters on the ResultSet.
 
 ### Bugfixes
 - Fix php notice on `\Elastica\Index::getAliases()` if index has no aliases #1078
@@ -17,6 +19,10 @@ All notable changes to this project will be documented in this file based on the
 
 ### Deprecated
 - Configuring the logger in \Elastica\Client $config constructor is deprecated and will be removed. Use the $logger argument instead.
+- Extracted creation of ResultSet objects to a new dedicated ResultSet\Builder implementation. #1065
+
+### Deprecated
+- All properties in the \Elastica\ResultSet class will be moved to private in 4.0. To manipulate the creation of a ResultSet, implement the \Elastica\ResultSet\BuilderInterface and pass your new Builder to the \Elastica\Search instances.
 
 ## [3.1.1](https://github.com/ruflin/Elastica/compare/3.1.0...3.1.1)
 

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "~6.0",
-        "aws/aws-sdk-php": "~3.0"
+        "aws/aws-sdk-php": "~3.0",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "suggest": {
-        "guzzlehttp/guzzle": "Allow using guzzle 6 as the http transport (Requires php 5.5)",
+        "aws/aws-sdk-php": "Allow using IAM authentication with Amazon ElasticSearch Service",
         "egeloen/http-adapter": "Allow using httpadapter transport",
-        "monolog/monolog": "Logging request",
-        "aws/aws-sdk-php": "Allow using IAM authentication with Amazon ElasticSearch Service"
+        "guzzlehttp/guzzle": "Allow using guzzle 6 as the http transport (Requires php 5.5)",
+        "monolog/monolog": "Logging request"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -49,6 +49,11 @@ class Client
     protected $_callback;
 
     /**
+     * @var Connection\ConnectionPool
+     */
+    protected $_connectionPool;
+
+    /**
      * @var \Elastica\Request
      */
     protected $_lastRequest;
@@ -62,11 +67,6 @@ class Client
      * @var LoggerInterface
      */
     protected $_logger;
-
-    /**
-     * @var Connection\ConnectionPool
-     */
-    protected $_connectionPool;
 
     /**
      * Creates a new Elastica client.

--- a/lib/Elastica/Cluster.php
+++ b/lib/Elastica/Cluster.php
@@ -7,7 +7,7 @@ use Elastica\Cluster\Settings;
 use Elastica\Exception\NotImplementedException;
 
 /**
- * Cluster informations for elasticsearch.
+ * Cluster information for elasticsearch.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -6,6 +6,7 @@ use Elastica\Exception\InvalidException;
 use Elastica\Exception\ResponseException;
 use Elastica\Index\Settings as IndexSettings;
 use Elastica\Index\Stats as IndexStats;
+use Elastica\ResultSet\BuilderInterface;
 
 /**
  * Elastica index object.
@@ -36,9 +37,7 @@ class Index implements SearchableInterface
      * All the communication to and from an index goes of this object
      *
      * @param \Elastica\Client $client Client object
-     * @param string           $name   Index name
-     *
-     * @throws \Elastica\Exception\InvalidException
+     * @param string $name Index name
      */
     public function __construct(Client $client, $name)
     {
@@ -289,13 +288,14 @@ class Index implements SearchableInterface
 
     /**
      * @param string|array|\Elastica\Query $query
-     * @param int|array                    $options
+     * @param int|array $options
+     * @param BuilderInterface $builder
      *
-     * @return \Elastica\Search
+     * @return Search
      */
-    public function createSearch($query = '', $options = null)
+    public function createSearch($query = '', $options = null, BuilderInterface $builder = null)
     {
-        $search = new Search($this->getClient());
+        $search = new Search($this->getClient(), $builder);
         $search->addIndex($this);
         $search->setOptionsAndQuery($options, $query);
 

--- a/lib/Elastica/Multi/MultiBuilder.php
+++ b/lib/Elastica/Multi/MultiBuilder.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Elastica\Multi;
+
+use Elastica\Response;
+use Elastica\Search as BaseSearch;
+
+class MultiBuilder implements MultiBuilderInterface
+{
+    /**
+     * @param Response $response
+     * @param BaseSearch[] $searches
+     * @return ResultSet
+     */
+    public function buildMultiResultSet(Response $response, $searches)
+    {
+        $resultSets = $this->buildResultSets($response, $searches);
+
+        return new ResultSet($response, $resultSets);
+    }
+
+    /**
+     * @param Response $childResponse
+     * @param BaseSearch $search
+     * @return \Elastica\ResultSet
+     */
+    private function buildResultSet(Response $childResponse, BaseSearch $search)
+    {
+        return $search->getResultSetBuilder()->buildResultSet($childResponse, $search->getQuery());
+    }
+
+    /**
+     * @param Response $response
+     * @param BaseSearch[] $searches
+     * @return \Elastica\ResultSet[]
+     */
+    private function buildResultSets(Response $response, $searches)
+    {
+        $resultSets = [];
+
+        $data = $response->getData();
+        if (!isset($data['responses']) || !is_array($data['responses'])) {
+            return $resultSets;
+        }
+
+        reset($searches);
+
+        foreach ($data['responses'] as $index => $responseData) {
+            list ($key, $search) = each($searches);
+
+            $resultSets[$key] = $this->buildResultSet(new Response($responseData), $search);
+        }
+
+        return $resultSets;
+    }
+}

--- a/lib/Elastica/Multi/MultiBuilderInterface.php
+++ b/lib/Elastica/Multi/MultiBuilderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Elastica\Multi;
+
+use Elastica\Response;
+use Elastica\Search as BaseSearch;
+
+interface MultiBuilderInterface
+{
+    /**
+     * @param Response $response
+     * @param BaseSearch[] $searches
+     * @return ResultSet
+     */
+    public function buildMultiResultSet(Response $response, $searches);
+}

--- a/lib/Elastica/Multi/ResultSet.php
+++ b/lib/Elastica/Multi/ResultSet.php
@@ -2,10 +2,8 @@
 
 namespace Elastica\Multi;
 
-use Elastica\Exception\InvalidException;
 use Elastica\Response;
 use Elastica\ResultSet as BaseResultSet;
-use Elastica\Search as BaseSearch;
 
 /**
  * Elastica multi search result set
@@ -39,44 +37,13 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     /**
      * Constructs ResultSet object.
      *
-     * @param \Elastica\Response       $response
-     * @param array|\Elastica\Search[] $searches
+     * @param \Elastica\Response $response
+     * @param BaseResultSet[]
      */
-    public function __construct(Response $response, array $searches)
-    {
-        $this->rewind();
-        $this->_init($response, $searches);
-    }
-
-    /**
-     * @param \Elastica\Response       $response
-     * @param array|\Elastica\Search[] $searches
-     *
-     * @throws \Elastica\Exception\InvalidException
-     */
-    protected function _init(Response $response, array $searches)
+    public function __construct(Response $response, $resultSets)
     {
         $this->_response = $response;
-        $responseData = $response->getData();
-
-        if (isset($responseData['responses']) && is_array($responseData['responses'])) {
-            reset($searches);
-            foreach ($responseData['responses'] as $key => $responseData) {
-                $currentSearch = each($searches);
-
-                if ($currentSearch === false) {
-                    throw new InvalidException('No result found for search #'.$key);
-                } elseif (!$currentSearch['value'] instanceof BaseSearch) {
-                    throw new InvalidException('Invalid object for search #'.$key.' provided. Should be Elastica\Search');
-                }
-
-                $search = $currentSearch['value'];
-                $query = $search->getQuery();
-
-                $response = new Response($responseData);
-                $this->_resultSets[$currentSearch['key']] = new BaseResultSet($response, $query);
-            }
-        }
+        $this->_resultSets = $resultSets;
     }
 
     /**

--- a/lib/Elastica/Multi/Search.php
+++ b/lib/Elastica/Multi/Search.php
@@ -17,14 +17,9 @@ use Elastica\Search as BaseSearch;
 class Search
 {
     /**
-     * @var array|\Elastica\Search[]
+     * @var MultiBuilderInterface
      */
-    protected $_searches = array();
-
-    /**
-     * @var array
-     */
-    protected $_options = array();
+    private $_builder;
 
     /**
      * @var \Elastica\Client
@@ -32,13 +27,25 @@ class Search
     protected $_client;
 
     /**
+     * @var array
+     */
+    protected $_options = array();
+
+    /**
+     * @var array|\Elastica\Search[]
+     */
+    protected $_searches = array();
+
+    /**
      * Constructs search object.
      *
      * @param \Elastica\Client $client Client object
+     * @param MultiBuilderInterface $builder
      */
-    public function __construct(Client $client)
+    public function __construct(Client $client, MultiBuilderInterface $builder = null)
     {
-        $this->setClient($client);
+        $this->_builder = $builder ?: new MultiBuilder();
+        $this->_client = $client;
     }
 
     /**
@@ -47,18 +54,6 @@ class Search
     public function getClient()
     {
         return $this->_client;
-    }
-
-    /**
-     * @param \Elastica\Client $client
-     *
-     * @return $this
-     */
-    public function setClient(Client $client)
-    {
-        $this->_client = $client;
-
-        return $this;
     }
 
     /**
@@ -149,7 +144,7 @@ class Search
             $this->_options
         );
 
-        return new ResultSet($response, $this->getSearches());
+        return $this->_builder->buildMultiResultSet($response, $this->getSearches());
     }
 
     /**

--- a/lib/Elastica/ResultSet/Builder.php
+++ b/lib/Elastica/ResultSet/Builder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Elastica\ResultSet;
+
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\Result;
+use Elastica\ResultSet;
+
+class Builder implements BuilderInterface
+{
+    /**
+     * Builds a ResultSet for a given Response.
+     *
+     * @param Response $response
+     * @param Query $query
+     * @return ResultSet
+     */
+    public function buildResultSet(Response $response, Query $query)
+    {
+        $results = $this->buildResults($response);
+        $resultSet = new ResultSet($response, $query, $results);
+
+        return $resultSet;
+    }
+
+    /**
+     * Builds individual result objects.
+     *
+     * @param Response $response
+     * @return Result[]
+     */
+    private function buildResults(Response $response)
+    {
+        $data = $response->getData();
+        $results = [];
+
+        if (!isset($data['hits']['hits'])) {
+            return $results;
+        }
+
+        foreach ($data['hits']['hits'] as $hit) {
+            $results[] = new Result($hit);
+        }
+
+        return $results;
+    }
+}

--- a/lib/Elastica/ResultSet/BuilderInterface.php
+++ b/lib/Elastica/ResultSet/BuilderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Elastica\ResultSet;
+
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\ResultSet;
+
+interface BuilderInterface
+{
+    /**
+     * Builds a ResultSet given a specific response and query.
+     *
+     * @param Response $response
+     * @param Query $query
+     * @return ResultSet
+     */
+    public function buildResultSet(Response $response, Query $query);
+}

--- a/lib/Elastica/Tool/CrossIndex.php
+++ b/lib/Elastica/Tool/CrossIndex.php
@@ -65,7 +65,7 @@ class CrossIndex
         array $options = array()
     ) {
         // prepare search
-        $search = new Search($oldIndex->getClient());
+        $search = $oldIndex->createSearch();
 
         $options = array_merge(
             array(
@@ -77,7 +77,6 @@ class CrossIndex
             $options
         );
 
-        $search->addIndex($oldIndex);
         if (isset($options[self::OPTION_TYPE])) {
             $type = $options[self::OPTION_TYPE];
             $search->addTypes(is_array($type) ? $type : array($type));

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -6,6 +6,7 @@ use Elastica\Exception\DeprecatedException;
 use Elastica\Exception\InvalidException;
 use Elastica\Exception\NotFoundException;
 use Elastica\Exception\RuntimeException;
+use Elastica\ResultSet\BuilderInterface;
 use Elastica\Script\AbstractScript;
 use Elastica\Type\Mapping;
 
@@ -324,17 +325,16 @@ class Type implements SearchableInterface
     /**
      * Create search object.
      *
-     * @param string|array|\Elastica\Query $query   Array with all query data inside or a Elastica\Query object
-     * @param int|array                    $options OPTIONAL Limit or associative array of options (option=>value)
+     * @param string|array|\Elastica\Query $query Array with all query data inside or a Elastica\Query object
+     * @param int|array $options OPTIONAL Limit or associative array of options (option=>value)
+     * @param BuilderInterface $builder
      *
-     * @return \Elastica\Search
+     * @return Search
      */
-    public function createSearch($query = '', $options = null)
+    public function createSearch($query = '', $options = null, BuilderInterface $builder = null)
     {
-        $search = new Search($this->getIndex()->getClient());
-        $search->addIndex($this->getIndex());
+        $search = $this->getIndex()->createSearch($query, $options, $builder);
         $search->addType($this);
-        $search->setOptionsAndQuery($options, $query);
 
         return $search;
     }

--- a/test/lib/Elastica/Test/Exception/PartialShardFailureExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/PartialShardFailureExceptionTest.php
@@ -50,7 +50,8 @@ class PartialShardFailureExceptionTest extends AbstractExceptionTest
 
             $this->fail('PartialShardFailureException should have been thrown');
         } catch (PartialShardFailureException $e) {
-            $resultSet = new ResultSet($e->getResponse(), $query);
+            $builder = new ResultSet\Builder();
+            $resultSet = $builder->buildResultSet($e->getResponse(), $query);
             $this->assertEquals(0, count($resultSet->getResults()));
 
             $message = JSON::parse($e->getMessage());

--- a/test/lib/Elastica/Test/Multi/MultiBuilderTest.php
+++ b/test/lib/Elastica/Test/Multi/MultiBuilderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Elastica\Test\Multi;
+
+use Elastica\Multi\MultiBuilder;
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\ResultSet;
+use Elastica\ResultSet\BuilderInterface;
+use Elastica\Search;
+use Elastica\Test\Base as BaseTest;
+
+/**
+ * @group unit
+ */
+class MultiBuilderTest extends BaseTest
+{
+    /**
+     * @var BuilderInterface
+     */
+    private $builder;
+
+    /**
+     * @var MultiBuilder
+     */
+    private $multiBuilder;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->builder = $this->getMock('Elastica\\ResultSet\\BuilderInterface');
+        $this->multiBuilder = new MultiBuilder($this->builder);
+    }
+
+    public function testBuildEmptyMultiResultSet()
+    {
+        $this->builder->expects($this->never())
+            ->method('buildResultSet');
+
+        $response = new Response([]);
+        $searches = [];
+
+        $result = $this->multiBuilder->buildMultiResultSet($response, $searches);
+
+        $this->assertInstanceOf('Elastica\\Multi\\ResultSet', $result);
+    }
+
+    public function testBuildMultiResultSet()
+    {
+        $response = new Response([
+            'responses' => [
+                [],
+                []
+            ]
+        ]);
+        $searches = [
+            $s1 = new Search($this->_getClient(), $this->builder),
+            $s2 = new Search($this->_getClient(), $this->builder)
+        ];
+        $resultSet1 = new ResultSet(new Response([]), $s1->getQuery(), []);
+        $resultSet2 = new ResultSet(new Response([]), $s2->getQuery(), []);
+
+        $this->builder->expects($this->exactly(2))
+            ->method('buildResultSet')
+            ->withConsecutive(
+                [$this->isInstanceOf('Elastica\\Response'), $s1->getQuery()],
+                [$this->isInstanceOf('Elastica\\Response'), $s2->getQuery()]
+            )
+            ->willReturnOnConsecutiveCalls($resultSet1, $resultSet2);
+
+
+        $result = $this->multiBuilder->buildMultiResultSet($response, $searches);
+
+        $this->assertInstanceOf('Elastica\\Multi\\ResultSet', $result);
+        $this->assertSame($resultSet1, $result[0]);
+        $this->assertSame($resultSet2, $result[1]);
+    }
+}

--- a/test/lib/Elastica/Test/ResultSet/BuilderTest.php
+++ b/test/lib/Elastica/Test/ResultSet/BuilderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Elastica\Test\ResultSet;
+
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\ResultSet\Builder;
+use Elastica\Test\Base as BaseTest;
+
+/**
+ * @group unit
+ */
+class BuilderTest extends BaseTest
+{
+    /**
+     * @var Builder
+     */
+    private $builder;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->builder = new Builder();
+    }
+
+    public function testEmptyResponse()
+    {
+        $response = new Response('');
+        $query = new Query();
+
+        $resultSet = $this->builder->buildResultSet($response, $query);
+
+        $this->assertSame($response, $resultSet->getResponse());
+        $this->assertSame($query, $resultSet->getQuery());
+        $this->assertCount(0, $resultSet->getResults());
+    }
+
+    public function testResponse()
+    {
+        $response = new Response([
+            'hits' => [
+                'hits' => [
+                    ['test' => 1],
+                    ['test' => 2],
+                    ['test' => 3],
+                ]
+            ]
+        ]);
+        $query = new Query();
+
+        $resultSet = $this->builder->buildResultSet($response, $query);
+
+        $this->assertSame($response, $resultSet->getResponse());
+        $this->assertSame($query, $resultSet->getQuery());
+        $this->assertCount(3, $resultSet->getResults());
+    }
+}

--- a/test/lib/Elastica/Test/Transport/GuzzleTest.php
+++ b/test/lib/Elastica/Test/Transport/GuzzleTest.php
@@ -160,7 +160,9 @@ class GuzzleTest extends BaseTest
         $this->assertEquals(0, $resultSet->getTotalHits());
 
         $response = $index->request('/_search', 'POST');
-        $resultSet = new ResultSet($response, Query::create(array()));
+
+        $builder = new ResultSet\Builder();
+        $resultSet = $builder->buildResultSet($response, Query::create(array()));
 
         $this->assertEquals(1, $resultSet->getTotalHits());
     }

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -220,7 +220,9 @@ class HttpTest extends BaseTest
         $this->assertEquals(0, $resultSet->getTotalHits());
 
         $response = $index->request('/_search', 'POST');
-        $resultSet = new ResultSet($response, Query::create(array()));
+
+        $builder = new ResultSet\Builder();
+        $resultSet = $builder->buildResultSet($response, Query::create(array()));
 
         $this->assertEquals(1, $resultSet->getTotalHits());
     }


### PR DESCRIPTION
As per #1017, this PR contains the extraction of ResultSetBuilder.

Please consider this for merging.

This PR technically creates a BC break for anyone using ResultSet::$_class and ResultSet::create().