### PR TITLE
Add resultset transforming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 - Fix fatal error on `Query::addScriptField()` if scripts were already set via `setScriptFields()` #1086
 
+### Added
+- Added the concept of ResultSet Transformers. The Transformer adds more information to a Result, for example the original object or data that created the Result. #1066
+
 ## [3.2.0](https://github.com/ruflin/Elastica/compare/3.1.1...3.2.0)
 
 ### Backward Compatibility Breaks

--- a/lib/Elastica/Result.php
+++ b/lib/Elastica/Result.php
@@ -191,11 +191,11 @@ class Result
     /**
      * Returns Document.
      * 
-     * @return \Elastica\Document
+     * @return Document
      */
     public function getDocument()
     {
-        $doc = new \Elastica\Document();
+        $doc = new Document();
         $doc->setData($this->getSource());
         $hit = $this->getHit();
         if ($this->hasParam('_source')) {
@@ -213,6 +213,17 @@ class Result
         $doc->setParams($hit);
 
         return $doc;
+    }
+
+    /**
+     * Sets a parameter on the hit.
+     *
+     * @param string $param
+     * @param mixed $value
+     */
+    public function setParam($param, $value)
+    {
+        $this->_hit[$param] = $value;
     }
 
     /**

--- a/lib/Elastica/ResultSet/ChainProcessor.php
+++ b/lib/Elastica/ResultSet/ChainProcessor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Elastica\ResultSet;
+
+use Elastica\ResultSet;
+
+/**
+ * Allows multiple ProcessorInterface instances to operate on the same
+ * ResultSet, calling each in turn.
+ */
+class ChainProcessor implements ProcessorInterface
+{
+    /**
+     * @var ProcessorInterface[]
+     */
+    private $processors;
+
+    /**
+     * @param ProcessorInterface[] $processors
+     */
+    public function __construct($processors)
+    {
+        $this->processors = $processors;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function process(ResultSet $resultSet)
+    {
+        foreach ($this->processors as $processor) {
+            $processor->process($resultSet);
+        }
+    }
+}

--- a/lib/Elastica/ResultSet/DefaultBuilder.php
+++ b/lib/Elastica/ResultSet/DefaultBuilder.php
@@ -7,7 +7,7 @@ use Elastica\Response;
 use Elastica\Result;
 use Elastica\ResultSet;
 
-class Builder implements BuilderInterface
+class DefaultBuilder implements BuilderInterface
 {
     /**
      * Builds a ResultSet for a given Response.

--- a/lib/Elastica/ResultSet/ProcessingBuilder.php
+++ b/lib/Elastica/ResultSet/ProcessingBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Elastica\ResultSet;
+
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\ResultSet;
+
+class ProcessingBuilder implements BuilderInterface
+{
+    /**
+     * @var BuilderInterface
+     */
+    private $builder;
+
+    /**
+     * @var ProcessorInterface
+     */
+    private $processor;
+
+    /**
+     * @param BuilderInterface $builder
+     * @param ProcessorInterface $processor
+     */
+    public function __construct(BuilderInterface $builder, ProcessorInterface $processor)
+    {
+        $this->builder = $builder;
+        $this->processor = $processor;
+    }
+
+    /**
+     * Runs any registered transformers on the ResultSet before
+     * returning it, allowing the transformers to inject additional
+     * data into each Result.
+     *
+     * @param Response $response
+     * @param Query $query
+     * @return ResultSet
+     */
+    public function buildResultSet(Response $response, Query $query)
+    {
+        $resultSet = $this->builder->buildResultSet($response, $query);
+
+        $this->processor->process($resultSet);
+
+        return $resultSet;
+    }
+}

--- a/lib/Elastica/ResultSet/ProcessorInterface.php
+++ b/lib/Elastica/ResultSet/ProcessorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Elastica\ResultSet;
+
+use Elastica\ResultSet;
+
+interface ProcessorInterface
+{
+    /**
+     * Iterates over a ResultSet allowing a processor to iterate over any
+     * Results as required.
+     *
+     * @param ResultSet $resultSet
+     */
+    public function process(ResultSet $resultSet);
+}

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -4,7 +4,7 @@ namespace Elastica;
 
 use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
-use Elastica\ResultSet\Builder;
+use Elastica\ResultSet\DefaultBuilder;
 use Elastica\ResultSet\BuilderInterface;
 
 /**
@@ -85,7 +85,7 @@ class Search
      */
     public function __construct(Client $client, BuilderInterface $builder = null)
     {
-        $this->_builder = $builder ?: new Builder();
+        $this->_builder = $builder ?: new DefaultBuilder();
         $this->_client = $client;
     }
 

--- a/test/lib/Elastica/Test/Exception/PartialShardFailureExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/PartialShardFailureExceptionTest.php
@@ -50,7 +50,7 @@ class PartialShardFailureExceptionTest extends AbstractExceptionTest
 
             $this->fail('PartialShardFailureException should have been thrown');
         } catch (PartialShardFailureException $e) {
-            $builder = new ResultSet\Builder();
+            $builder = new ResultSet\DefaultBuilder();
             $resultSet = $builder->buildResultSet($e->getResponse(), $query);
             $this->assertEquals(0, count($resultSet->getResults()));
 

--- a/test/lib/Elastica/Test/ResultSet/BuilderTest.php
+++ b/test/lib/Elastica/Test/ResultSet/BuilderTest.php
@@ -4,7 +4,7 @@ namespace Elastica\Test\ResultSet;
 
 use Elastica\Query;
 use Elastica\Response;
-use Elastica\ResultSet\Builder;
+use Elastica\ResultSet\DefaultBuilder;
 use Elastica\Test\Base as BaseTest;
 
 /**
@@ -13,7 +13,7 @@ use Elastica\Test\Base as BaseTest;
 class BuilderTest extends BaseTest
 {
     /**
-     * @var Builder
+     * @var DefaultBuilder
      */
     private $builder;
 
@@ -21,7 +21,7 @@ class BuilderTest extends BaseTest
     {
         parent::setUp();
 
-        $this->builder = new Builder();
+        $this->builder = new DefaultBuilder();
     }
 
     public function testEmptyResponse()

--- a/test/lib/Elastica/Test/ResultSet/ChainProcessorTest.php
+++ b/test/lib/Elastica/Test/ResultSet/ChainProcessorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Elastica\Test\Transformer;
+
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\ResultSet;
+use Elastica\ResultSet\ChainProcessor;
+use Elastica\Test\Base as BaseTest;
+
+/**
+ * @group unit
+ */
+class ChainProcessorTest extends BaseTest
+{
+    public function testProcessor()
+    {
+        $processor = new ChainProcessor([
+            $processor1 = $this->getMock('Elastica\\ResultSet\\ProcessorInterface'),
+            $processor2 = $this->getMock('Elastica\\ResultSet\\ProcessorInterface')
+        ]);
+        $resultSet = new ResultSet(new Response(''), new Query(), []);
+
+        $processor1->expects($this->once())
+            ->method('process')
+            ->with($resultSet);
+        $processor2->expects($this->once())
+            ->method('process')
+            ->with($resultSet);
+
+        $processor->process($resultSet);
+    }
+}

--- a/test/lib/Elastica/Test/ResultSet/ProcessingBuilderTest.php
+++ b/test/lib/Elastica/Test/ResultSet/ProcessingBuilderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Elastica\Test\ResultSet;
+
+use Elastica\Query;
+use Elastica\Response;
+use Elastica\ResultSet;
+use Elastica\ResultSet\BuilderInterface;
+use Elastica\Test\Base as BaseTest;
+
+/**
+ * @group unit
+ */
+class ProcessingBuilderTest extends BaseTest
+{
+    /**
+     * @var ResultSet\ProcessingBuilder
+     */
+    private $builder;
+
+    /**
+     * @var BuilderInterface
+     */
+    private $innerBuilder;
+
+    /**
+     * @var ResultSet\ProcessorInterface
+     */
+    private $processor;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->innerBuilder = $this->getMock('Elastica\\ResultSet\\BuilderInterface');
+        $this->processor = $this->getMock('Elastica\\ResultSet\\ProcessorInterface');
+
+        $this->builder = new ResultSet\ProcessingBuilder($this->innerBuilder, $this->processor);
+    }
+
+    public function testProcessors()
+    {
+        $response = new Response('');
+        $query = new Query();
+        $resultSet = new ResultSet($response, $query, []);
+
+        $this->innerBuilder->expects($this->once())
+            ->method('buildResultSet')
+            ->with($response, $query)
+            ->willReturn($resultSet);
+        $this->processor->expects($this->once())
+            ->method('process')
+            ->with($resultSet);
+
+        $this->builder->buildResultSet($response, $query);
+    }
+}

--- a/test/lib/Elastica/Test/Transport/GuzzleTest.php
+++ b/test/lib/Elastica/Test/Transport/GuzzleTest.php
@@ -161,7 +161,7 @@ class GuzzleTest extends BaseTest
 
         $response = $index->request('/_search', 'POST');
 
-        $builder = new ResultSet\Builder();
+        $builder = new ResultSet\DefaultBuilder();
         $resultSet = $builder->buildResultSet($response, Query::create(array()));
 
         $this->assertEquals(1, $resultSet->getTotalHits());

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -221,7 +221,7 @@ class HttpTest extends BaseTest
 
         $response = $index->request('/_search', 'POST');
 
-        $builder = new ResultSet\Builder();
+        $builder = new ResultSet\DefaultBuilder();
         $resultSet = $builder->buildResultSet($response, Query::create(array()));
 
         $this->assertEquals(1, $resultSet->getTotalHits());


### PR DESCRIPTION
The first commit is contained in #1065 and should be merged first.

This PR adds the capability to "transform" results, which for FOSElasticaBundle allows us to insert the original object that generated the result into a new property on the Result object.

It could be that someone would want to somehow transform the $hit returned by ElasticSearch into something else and this mechanism allows that to occur. The primary magic occurs in 'TransformingBuilder' which decorates a real Builder and calls any registered Transformer for each ResultSet.