### PR TITLE
[POC/RFC] Simplify Client logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file based on the
 - Elastica\Client constructor now accepts a LoggerInterface and will log both successful and failed requests. #1069
 
 ### Deprecated
-
+- Configuring the logger in \Elastica\Client $config constructor is deprecated and will be removed. Use the $logger argument instead.
 
 ## [3.1.1](https://github.com/ruflin/Elastica/compare/3.1.0...3.1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 - `Elastica\Type->deleteByQuery($query, $options)` $query param can be a query `array` again https://github.com/ruflin/Elastica/issues/1072
 - `Elastica\Client->connect()` allows to establish a connection to ES server when the config was set using method `Elastica\Client->setConfigValue()` https://github.com/ruflin/Elastica/issues/1076
+- Elastica\Client constructor now accepts a LoggerInterface and will log both successful and failed requests. #1069
 
 ### Deprecated
 

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -5,9 +5,9 @@ namespace Elastica;
 use Elastica\Bulk\Action;
 use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
-use Elastica\Exception\RuntimeException;
 use Elastica\Script\AbstractScript;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Client to connect the the elasticsearch server.
@@ -46,7 +46,7 @@ class Client
     /**
      * @var callback
      */
-    protected $_callback = null;
+    protected $_callback;
 
     /**
      * @var \Elastica\Request
@@ -61,22 +61,30 @@ class Client
     /**
      * @var LoggerInterface
      */
-    protected $_logger = null;
+    protected $_logger;
+
     /**
      * @var Connection\ConnectionPool
      */
-    protected $_connectionPool = null;
+    protected $_connectionPool;
 
     /**
      * Creates a new Elastica client.
      *
-     * @param array    $config   OPTIONAL Additional config options
+     * @param array $config OPTIONAL Additional config options
      * @param callback $callback OPTIONAL Callback function which can be used to be notified about errors (for example connection down)
+     * @param LoggerInterface $logger
      */
-    public function __construct(array $config = array(), $callback = null)
+    public function __construct(array $config = array(), $callback = null, LoggerInterface $logger = null)
     {
-        $this->setConfig($config);
         $this->_callback = $callback;
+
+        if (!$logger && isset($config['log']) && $config['log']) {
+            $logger = new Log($config['log']);
+        }
+        $this->_logger = $logger ?: new NullLogger();
+
+        $this->setConfig($config);
         $this->_initConnections();
     }
 
@@ -622,24 +630,23 @@ class Client
      *
      * @throws Exception\ConnectionException|\Exception
      *
-     * @return \Elastica\Response Response object
+     * @return Response Response object
      */
     public function request($path, $method = Request::GET, $data = array(), array $query = array())
     {
         $connection = $this->getConnection();
+        $request = $this->_lastRequest = new Request($path, $method, $data, $query, $connection);
+
         try {
-            $request = new Request($path, $method, $data, $query, $connection);
-
-            $this->_log($request);
-
-            $response = $request->send();
-
-            $this->_lastRequest = $request;
-            $this->_lastResponse = $response;
-
-            return $response;
+            $response = $this->_lastResponse = $request->send();
         } catch (ConnectionException $e) {
             $this->_connectionPool->onFail($connection, $e, $this);
+
+            $this->_logger->error('Elastica Request Failure', [
+                'exception' => $e,
+                'request' => $request->toArray(),
+                'retry' => $this->hasConnection()
+            ]);
 
             // In case there is no valid connection left, throw exception which caused the disabling of the connection.
             if (!$this->hasConnection()) {
@@ -648,6 +655,14 @@ class Client
 
             return $this->request($path, $method, $data, $query);
         }
+
+        $this->_logger->debug('Elastica Request', [
+            'request' => $request->toArray(),
+            'response' => $response->getData(),
+            'responseStatus' => $response->getStatus()
+        ]);
+
+        return $response;
     }
 
     /**
@@ -677,32 +692,7 @@ class Client
     }
 
     /**
-     * logging.
-     *
-     * @param string|\Elastica\Request $context
-     *
-     * @throws Exception\RuntimeException
-     */
-    protected function _log($context)
-    {
-        $log = $this->getConfig('log');
-        if ($log && !class_exists('Psr\Log\AbstractLogger')) {
-            throw new RuntimeException('Class Psr\Log\AbstractLogger not found');
-        } elseif (!$this->_logger && $log) {
-            $this->setLogger(new Log($this->getConfig('log')));
-        }
-        if ($this->_logger) {
-            if ($context instanceof Request) {
-                $data = $context->toArray();
-            } else {
-                $data = array('message' => $context);
-            }
-            $this->_logger->debug('logging Request', $data);
-        }
-    }
-
-    /**
-     * @return \Elastica\Request
+     * @return Request
      */
     public function getLastRequest()
     {
@@ -710,7 +700,7 @@ class Client
     }
 
     /**
-     * @return \Elastica\Response
+     * @return Response
      */
     public function getLastResponse()
     {
@@ -718,7 +708,7 @@ class Client
     }
 
     /**
-     * set Logger.
+     * Replace the existing logger.
      *
      * @param LoggerInterface $logger
      *

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -5,6 +5,7 @@ namespace Elastica\Test;
 use Elastica\Client;
 use Elastica\Connection;
 use Elastica\Index;
+use Psr\Log\LoggerInterface;
 
 class Base extends \PHPUnit_Framework_TestCase
 {
@@ -54,12 +55,13 @@ class Base extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param array    $params   Additional configuration params. Host and Port are already set
+     * @param array $params Additional configuration params. Host and Port are already set
      * @param callback $callback
+     * @param LoggerInterface $logger
      *
      * @return Client
      */
-    protected function _getClient(array $params = array(), $callback = null)
+    protected function _getClient(array $params = array(), $callback = null, LoggerInterface $logger = null)
     {
         $config = array(
             'host' => $this->_getHost(),
@@ -68,7 +70,7 @@ class Base extends \PHPUnit_Framework_TestCase
 
         $config = array_merge($config, $params);
 
-        return new Client($config, $callback);
+        return new Client($config, $callback, $logger);
     }
 
     /**


### PR DESCRIPTION
*Not for merging* (yet).

While working elsewhere, I've run into a few things that could be cleaned up and simplified. I've chosen 2 things I've noticed to send initial POC PRs to start a discussion about potential directions.

In this case, there is no point in having complicated configurations for logging in Elastica - lets move the heavy lifting of logging to the PSR logger and just pass one in at Client construction.

This could be implemented differently again: if we end up with a ClientInterface, we could wrap the Client with a LoggingClient decorator instead. I realise this may lead to more boilerplate for simple projects but there are solutions to talk about for that if the direction is a good one for this project.