### PR TITLE
Added connect() method to allow the client to connect to server when …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 ### Improvements
-- `Elastica\Type->deleteByQuery($query, $options)` $query param can be a query `array` again https://github.com/ruflin/Elastica/issues/1072
+- `Elastica\Client->connect()` allows to establish a connection to the server when the config was set using method `Elastica\Client->setConfigValue()` https://github.com/ruflin/Elastica/issues/1076
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 - `Elastica\Type->deleteByQuery($query, $options)` $query param can be a query `array` again https://github.com/ruflin/Elastica/issues/1072
-- `Elastica\Client->connect()` allows to establish a connection to the server when the config was set using method `Elastica\Client->setConfigValue()` https://github.com/ruflin/Elastica/issues/1076
+- `Elastica\Client->connect()` allows to establish a connection to ES server when the config was set using method `Elastica\Client->setConfigValue()` https://github.com/ruflin/Elastica/issues/1076
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 ### Improvements
+- `Elastica\Type->deleteByQuery($query, $options)` $query param can be a query `array` again https://github.com/ruflin/Elastica/issues/1072
 - `Elastica\Client->connect()` allows to establish a connection to the server when the config was set using method `Elastica\Client->setConfigValue()` https://github.com/ruflin/Elastica/issues/1076
 
 ### Deprecated

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -471,6 +471,14 @@ class Client
     }
 
     /**
+     * Establishes the client connections
+     */
+    public function connect()
+    {
+        return $this->_initConnections();
+    }
+
+    /**
      * @param \Elastica\Connection $connection
      *
      * @return $this

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -1172,4 +1172,22 @@ class ClientTest extends BaseTest
 
         $this->assertTrue($client->getConnection()->getConfig('bigintConversion'));
     }
+
+    /**
+     * @group unit
+     */
+    public function testClientConnectWithConfigSetByMethod()
+    {
+        $client = new Client();
+        $client->setConfigValue('host', $this->_getHost());
+        $client->setConfigValue('port',$this->_getPort());
+
+        $client->connect();
+        $this->assertTrue($client->hasConnection());
+
+        $connection = $client->getConnection();
+        $this->assertInstanceOf('\Elastica\Connection', $connection);
+        $this->assertEquals($this->_getHost(), $connection->getHost());
+        $this->assertEquals($this->_getPort(), $connection->getPort());
+    }
 }


### PR DESCRIPTION
…config not set via class constructor

So, when user sets the connection config using the method Client::setConfigValue then can establish the connection to server.