### PR TITLE
Fix PHP notice on getAliases if index has no aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Breaks
 
 ### Bugfixes
+- Fix php notice on `\Elastica\Index::getAliases()` if index has no aliases #1078
 
 ### Added
 

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -434,6 +434,10 @@ class Index implements SearchableInterface
     {
         $responseData = $this->request('_alias/*', \Elastica\Request::GET)->getData();
 
+        if (!isset($responseData[$this->getName()])) {
+            return array();
+        }
+
         $data = $responseData[$this->getName()];
         if (!empty($data['aliases'])) {
             return array_keys($data['aliases']);

--- a/test/lib/Elastica/Test/IndexTest.php
+++ b/test/lib/Elastica/Test/IndexTest.php
@@ -941,4 +941,22 @@ class IndexTest extends BaseTest
         $this->assertEquals('1', $index->getName());
         $this->assertInternalType('string', $index->getName());
     }
+
+    /**
+     * @group functional
+     */
+    public function testGetEmptyAliases()
+    {
+        $indexName = 'test-getaliases';
+
+        $client = $this->_getClient();
+        $index = $client->getIndex($indexName);
+
+        $index->create(array(), true);
+        $this->_waitForAllocation($index);
+        $index->refresh();
+        $index->optimize();
+
+        $this->assertEquals(array(), $index->getAliases());
+    }
 }


### PR DESCRIPTION
cf https://github.com/ruflin/Elastica/issues/1078

A php notice is triggered in `\Elastica\Index::getAliases()` if index
has no aliases.
Only happens if php `error_reporting` setting is set to `-1`.