### PR TITLE
Fix bad _log call

### DIFF
--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -653,7 +653,7 @@ class Client
             return $this->request($path, $method, $data, $query);
         }
 
-        $this->_log($request, $response);
+        $this->_log($request);
 
         return $response;
     }


### PR DESCRIPTION
Missed removing $response from one of the _log calls.