### PR TITLE
Fix Query::addScriptField()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file based on the
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/3.2.0...HEAD)
 
+### Bugfixes
+- Fix fatal error on `Query::addScriptField()` if scripts were already set via `setScriptFields()` #1086
+
 ## [3.2.0](https://github.com/ruflin/Elastica/compare/3.1.1...3.2.0)
 
 ### Backward Compatibility Breaks

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -338,7 +338,11 @@ class Query extends Param
      */
     public function addScriptField($name, AbstractScript $script)
     {
-        $this->_params['script_fields'][$name] = $script;
+        if (isset($this->_params['script_fields'])) {
+            $this->_params['script_fields']->addScript($name, $script);
+        } else {
+            $this->setScriptFields(array($name => $script));
+        }
 
         return $this;
     }

--- a/test/lib/Elastica/Test/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryTest.php
@@ -412,6 +412,31 @@ class QueryTest extends BaseTest
     /**
      * @group unit
      */
+    public function testAddScriptFieldToExistingScriptFields()
+    {
+        $script1 = new Script('s1');
+        $script2 = new Script('s2');
+
+        // add script1, then add script2
+        $query = new Query();
+        $scriptFields1 = new ScriptFields();
+        $scriptFields1->addScript('script1', $script1);
+        $query->setScriptFields($scriptFields1);
+        $query->addScriptField('script2', $script2);
+
+        // add script1 and script2 at once
+        $anotherQuery = new Query();
+        $scriptFields2 = new ScriptFields();
+        $scriptFields2->addScript('script1', $script1);
+        $scriptFields2->addScript('script2', $script2);
+        $anotherQuery->setScriptFields($scriptFields2);
+
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
+    }
+
+    /**
+     * @group unit
+     */
     public function testAddAggregationToArrayCast()
     {
         $query = new Query();


### PR DESCRIPTION
Steps to reproduce:
1. call `$query->setScriptFields(...)`
2. call `$query->addScriptField(...)`
3. fails with message "Fatal error: Cannot use object of type Elastica\Script\ScriptFields as array"

After calling `setScriptFields(...)`, `$this->_params['script_fields']` has type `ScriptFields`, therefore `$this->_params['script_fields'][$name]` fails
