### PR TITLE
Extract ClientInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file based on the
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/3.2.0...HEAD)
 
+### Backward Compatibility Breaks
+- All classes that depend on \Elastica\Client by typehint have been updated to accept a ClientInterface. Any classes that extend Elastica classes that depend on this typehint will need to be updated.
+
 ### Backward Compatibility Fixes
 - Reintroduced properties in ResultSet removed in 3.2.0 as deprecated properties to be removed in 4.0
 
@@ -11,6 +14,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Added
 - Added the concept of ResultSet Transformers. The Transformer adds more information to a Result, for example the original object or data that created the Result. #1066
+- \Elastica\Client now implements ClientInterface and all Elastica classes accept any implementation of ClientInterface
 
 ## [3.2.0](https://github.com/ruflin/Elastica/compare/3.1.1...3.2.0)
 

--- a/lib/Elastica/Bulk.php
+++ b/lib/Elastica/Bulk.php
@@ -15,7 +15,7 @@ class Bulk
     const DELIMITER = "\n";
 
     /**
-     * @var \Elastica\Client
+     * @var \Elastica\ClientInterface
      */
     protected $_client;
 
@@ -40,9 +40,9 @@ class Bulk
     protected $_requestParams = array();
 
     /**
-     * @param \Elastica\Client $client
+     * @param \Elastica\ClientInterface $client
      */
-    public function __construct(Client $client)
+    public function __construct(ClientInterface $client)
     {
         $this->_client = $client;
     }

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -14,7 +14,7 @@ use Psr\Log\NullLogger;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  */
-class Client
+class Client implements ClientInterface
 {
     /**
      * Config with defaults.

--- a/lib/Elastica/ClientInterface.php
+++ b/lib/Elastica/ClientInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Elastica;
+
+/**
+ * Client to connect the the Elasticsearch server.
+ *
+ * @author Nicolas Ruflin <spam@ruflin.com>
+ */
+interface ClientInterface
+{
+    /**
+     * Returns the index for the given connection.
+     *
+     * @param string $name Index name to create connection to
+     *
+     * @return \Elastica\Index Index for the given name
+     */
+    public function getIndex($name);
+
+    /**
+     * Makes calls to the Elasticsearch server based on this index.
+     *
+     * It's possible to make any REST query directly over this method
+     *
+     * @param string $path Path to call
+     * @param string $method Rest method to use (GET, POST, DELETE, PUT)
+     * @param array $data OPTIONAL Arguments as array
+     * @param array $query OPTIONAL Query params
+     *
+     * @throws Exception\ConnectionException|\Exception
+     *
+     * @return Response Response object
+     */
+    public function request($path, $method = Request::GET, $data = [], array $query = []);
+}

--- a/lib/Elastica/Cluster.php
+++ b/lib/Elastica/Cluster.php
@@ -18,7 +18,7 @@ class Cluster
     /**
      * Client.
      *
-     * @var \Elastica\Client Client object
+     * @var ClientInterface Client object
      */
     protected $_client = null;
 
@@ -39,9 +39,9 @@ class Cluster
     /**
      * Creates a cluster object.
      *
-     * @param \Elastica\Client $client Connection client object
+     * @param ClientInterface $client Connection client object
      */
-    public function __construct(Client $client)
+    public function __construct(ClientInterface $client)
     {
         $this->_client = $client;
         $this->refresh();
@@ -132,7 +132,7 @@ class Cluster
     /**
      * Returns the client object.
      *
-     * @return \Elastica\Client Client object
+     * @return ClientInterface Client object
      */
     public function getClient()
     {

--- a/lib/Elastica/Cluster/Health.php
+++ b/lib/Elastica/Cluster/Health.php
@@ -2,7 +2,7 @@
 
 namespace Elastica\Cluster;
 
-use Elastica\Client;
+use Elastica\ClientInterface;
 use Elastica\Cluster\Health\Index;
 use Elastica\Request;
 
@@ -16,7 +16,7 @@ use Elastica\Request;
 class Health
 {
     /**
-     * @var \Elastica\Client Client object.
+     * @var ClientInterface Client object.
      */
     protected $_client = null;
 
@@ -26,9 +26,9 @@ class Health
     protected $_data = null;
 
     /**
-     * @param \Elastica\Client $client The Elastica client.
+     * @param ClientInterface $client The Elastica client.
      */
-    public function __construct(Client $client)
+    public function __construct(ClientInterface $client)
     {
         $this->_client = $client;
         $this->refresh();

--- a/lib/Elastica/Cluster/Settings.php
+++ b/lib/Elastica/Cluster/Settings.php
@@ -2,7 +2,7 @@
 
 namespace Elastica\Cluster;
 
-use Elastica\Client;
+use Elastica\ClientInterface;
 use Elastica\Request;
 
 /**
@@ -15,16 +15,16 @@ use Elastica\Request;
 class Settings
 {
     /**
-     * @var \Elastica\Client Client object
+     * @var ClientInterface Client object
      */
     protected $_client = null;
 
     /**
      * Creates a cluster object.
      *
-     * @param \Elastica\Client $client Connection client object
+     * @param ClientInterface $client Connection client object
      */
-    public function __construct(Client $client)
+    public function __construct(ClientInterface $client)
     {
         $this->_client = $client;
     }

--- a/lib/Elastica/Connection/ConnectionPool.php
+++ b/lib/Elastica/Connection/ConnectionPool.php
@@ -2,7 +2,7 @@
 
 namespace Elastica\Connection;
 
-use Elastica\Client;
+use Elastica\ClientInterface;
 use Elastica\Connection;
 use Elastica\Connection\Strategy\StrategyInterface;
 use Exception;
@@ -102,9 +102,9 @@ class ConnectionPool
     /**
      * @param \Elastica\Connection $connection
      * @param \Exception           $e
-     * @param Client               $client
+     * @param ClientInterface $client
      */
-    public function onFail(Connection $connection, Exception $e, Client $client)
+    public function onFail(Connection $connection, Exception $e, ClientInterface $client)
     {
         $connection->setEnabled(false);
 

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -27,7 +27,7 @@ class Index implements SearchableInterface
     /**
      * Client object.
      *
-     * @var \Elastica\Client Client object
+     * @var ClientInterface Client object
      */
     protected $_client = null;
 
@@ -36,10 +36,10 @@ class Index implements SearchableInterface
      *
      * All the communication to and from an index goes of this object
      *
-     * @param \Elastica\Client $client Client object
+     * @param ClientInterface $client Client object
      * @param string $name Index name
      */
-    public function __construct(Client $client, $name)
+    public function __construct(ClientInterface $client, $name)
     {
         $this->_client = $client;
 
@@ -372,7 +372,7 @@ class Index implements SearchableInterface
     /**
      * Returns index client.
      *
-     * @return \Elastica\Client Index client object
+     * @return ClientInterface Index client object
      */
     public function getClient()
     {

--- a/lib/Elastica/IndexTemplate.php
+++ b/lib/Elastica/IndexTemplate.php
@@ -23,19 +23,19 @@ class IndexTemplate
     /**
      * Client object.
      *
-     * @var \Elastica\Client Client object
+     * @var ClientInterface Client object
      */
     protected $_client = null;
 
     /**
      * Creates a new index template object.
      *
-     * @param \Elastica\Client $client Client object
+     * @param ClientInterface $client Client object
      * @param string           $name   Index template name
      *
      * @throws \Elastica\Exception\InvalidException
      */
-    public function __construct(Client $client, $name)
+    public function __construct(ClientInterface $client, $name)
     {
         $this->_client = $client;
 
@@ -97,7 +97,7 @@ class IndexTemplate
     /**
      * Returns index template client.
      *
-     * @return \Elastica\Client Index client object
+     * @return ClientInterface Index client object
      */
     public function getClient()
     {

--- a/lib/Elastica/Multi/Search.php
+++ b/lib/Elastica/Multi/Search.php
@@ -2,7 +2,7 @@
 
 namespace Elastica\Multi;
 
-use Elastica\Client;
+use Elastica\ClientInterface;
 use Elastica\JSON;
 use Elastica\Request;
 use Elastica\Search as BaseSearch;
@@ -39,17 +39,17 @@ class Search
     /**
      * Constructs search object.
      *
-     * @param \Elastica\Client $client Client object
+     * @param ClientInterface $client Client object
      * @param MultiBuilderInterface $builder
      */
-    public function __construct(Client $client, MultiBuilderInterface $builder = null)
+    public function __construct(ClientInterface $client, MultiBuilderInterface $builder = null)
     {
         $this->_builder = $builder ?: new MultiBuilder();
         $this->_client = $client;
     }
 
     /**
-     * @return \Elastica\Client
+     * @return ClientInterface
      */
     public function getClient()
     {

--- a/lib/Elastica/Node.php
+++ b/lib/Elastica/Node.php
@@ -15,7 +15,7 @@ class Node
     /**
      * Client.
      *
-     * @var \Elastica\Client
+     * @var ClientInterface
      */
     protected $_client = null;
 
@@ -49,9 +49,9 @@ class Node
      * Create a new node object.
      *
      * @param string           $id     Node id or name
-     * @param \Elastica\Client $client Node object
+     * @param ClientInterface $client Node object
      */
-    public function __construct($id, Client $client)
+    public function __construct($id, ClientInterface $client)
     {
         $this->_client = $client;
         $this->setId($id);
@@ -73,8 +73,7 @@ class Node
     public function setId($id)
     {
         $this->_id = $id;
-
-        return $this->refresh();
+        $this->refresh();
     }
 
     /**
@@ -94,7 +93,7 @@ class Node
     /**
      * Returns the current client object.
      *
-     * @return \Elastica\Client Client
+     * @return ClientInterface Client
      */
     public function getClient()
     {

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -73,17 +73,17 @@ class Search
     /**
      * Client object.
      *
-     * @var \Elastica\Client
+     * @var ClientInterface
      */
     protected $_client;
 
     /**
      * Constructs search object.
      *
-     * @param \Elastica\Client $client Client object
+     * @param ClientInterface $client Client object
      * @param BuilderInterface $builder
      */
-    public function __construct(Client $client, BuilderInterface $builder = null)
+    public function __construct(ClientInterface $client, BuilderInterface $builder = null)
     {
         $this->_builder = $builder ?: new DefaultBuilder();
         $this->_client = $client;
@@ -310,7 +310,7 @@ class Search
     /**
      * Return client object.
      *
-     * @return \Elastica\Client Client object
+     * @return ClientInterface Client object
      */
     public function getClient()
     {

--- a/lib/Elastica/Snapshot.php
+++ b/lib/Elastica/Snapshot.php
@@ -13,14 +13,14 @@ use Elastica\Exception\ResponseException;
 class Snapshot
 {
     /**
-     * @var Client
+     * @var ClientInterface
      */
     protected $_client;
 
     /**
-     * @param Client $client
+     * @param ClientInterface $client
      */
-    public function __construct(Client $client)
+    public function __construct(ClientInterface $client)
     {
         $this->_client = $client;
     }

--- a/lib/Elastica/Status.php
+++ b/lib/Elastica/Status.php
@@ -30,16 +30,16 @@ class Status
     /**
      * Client object.
      *
-     * @var \Elastica\Client Client object
+     * @var ClientInterface Client object
      */
     protected $_client = null;
 
     /**
      * Constructs Status object.
      *
-     * @param \Elastica\Client $client Client object
+     * @param ClientInterface $client Client object
      */
-    public function __construct(Client $client)
+    public function __construct(ClientInterface $client)
     {
         $this->_client = $client;
     }

--- a/lib/Elastica/Type/AbstractType.php
+++ b/lib/Elastica/Type/AbstractType.php
@@ -3,6 +3,7 @@
 namespace Elastica\Type;
 
 use Elastica\Client;
+use Elastica\ClientInterface;
 use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\SearchableInterface;
@@ -48,7 +49,7 @@ abstract class AbstractType implements SearchableInterface
     /**
      * Client.
      *
-     * @var \Elastica\Client Client object
+     * @var ClientInterface Client object
      */
     protected $_client = null;
 
@@ -93,11 +94,11 @@ abstract class AbstractType implements SearchableInterface
      * Reads index and type name from protected vars _indexName and _typeName.
      * Has to be set in child class
      *
-     * @param \Elastica\Client $client OPTIONAL Client object
+     * @param ClientInterface $client OPTIONAL Client object
      *
      * @throws \Elastica\Exception\InvalidException
      */
-    public function __construct(Client $client = null)
+    public function __construct(ClientInterface $client = null)
     {
         if (!$client) {
             $client = new Client();
@@ -112,8 +113,8 @@ abstract class AbstractType implements SearchableInterface
         }
 
         $this->_client = $client;
-        $this->_index = new Index($this->_client, $this->_indexName);
-        $this->_type = new BaseType($this->_index, $this->_typeName);
+        $this->_index = $client->getIndex($this->_indexName);
+        $this->_type = $this->_index->getType($this->_typeName);
     }
 
     /**


### PR DESCRIPTION
Moving further towards support for elasticsearch-php's client library, this codifies the purpose of the Client by defining an interface we expect to see implemented and contains all methods required by the Elastica codebase on the Client.

This is also a potential solution to @aguvillalba's problem with #1070, allowing anyone to implement their own Client decorators to handle runtime initialisation if implementation of a ConnectionPoolInterface is not appropriate, or otherwise swap out a Client implementation for something else.

I'm also personally of the opinion that we should mark Client as final, but that might be a bit much :)

This is a BC break because any extension of a class with a typehint change will need to update its typehints.
