### PR TITLE
Tidy properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Added
 - Added the concept of ResultSet Transformers. The Transformer adds more information to a Result, for example the original object or data that created the Result. #1066
+- Tidied property initialisation in classes where it was duplicated
 
 ## [3.2.0](https://github.com/ruflin/Elastica/compare/3.1.1...3.2.0)
 

--- a/lib/Elastica/Aggregation/Filters.php
+++ b/lib/Elastica/Aggregation/Filters.php
@@ -19,7 +19,7 @@ class Filters extends AbstractAggregation
     /**
      * @var int Type of bucket keys - named, or anonymous
      */
-    private $_type = null;
+    private $_type;
 
     /**
      * Add a filter.

--- a/lib/Elastica/Bulk.php
+++ b/lib/Elastica/Bulk.php
@@ -27,12 +27,12 @@ class Bulk
     /**
      * @var string
      */
-    protected $_index = '';
+    protected $_index;
 
     /**
      * @var string
      */
-    protected $_type = '';
+    protected $_type;
 
     /**
      * @var array request parameters to the bulk api

--- a/lib/Elastica/Cluster.php
+++ b/lib/Elastica/Cluster.php
@@ -20,7 +20,7 @@ class Cluster
      *
      * @var \Elastica\Client Client object
      */
-    protected $_client = null;
+    protected $_client;
 
     /**
      * Cluster state response.

--- a/lib/Elastica/Cluster/Health.php
+++ b/lib/Elastica/Cluster/Health.php
@@ -18,12 +18,12 @@ class Health
     /**
      * @var \Elastica\Client Client object.
      */
-    protected $_client = null;
+    protected $_client;
 
     /**
      * @var array The cluster health data.
      */
-    protected $_data = null;
+    protected $_data;
 
     /**
      * @param \Elastica\Client $client The Elastica client.

--- a/lib/Elastica/Exception/ResponseException.php
+++ b/lib/Elastica/Exception/ResponseException.php
@@ -15,12 +15,12 @@ class ResponseException extends \RuntimeException implements ExceptionInterface
     /**
      * @var \Elastica\Request Request object
      */
-    protected $_request = null;
+    protected $_request;
 
     /**
      * @var \Elastica\Response Response object
      */
-    protected $_response = null;
+    protected $_response;
 
     /**
      * Construct Exception.

--- a/lib/Elastica/Filter/AbstractGeoDistance.php
+++ b/lib/Elastica/Filter/AbstractGeoDistance.php
@@ -27,35 +27,35 @@ abstract class AbstractGeoDistance extends AbstractFilter
      *
      * @var string
      */
-    protected $_locationType = null;
+    protected $_locationType;
 
     /**
      * Key.
      *
      * @var string
      */
-    protected $_key = null;
+    protected $_key;
 
     /**
      * Latitude.
      *
      * @var float
      */
-    protected $_latitude = null;
+    protected $_latitude;
 
     /**
      * Longitude.
      *
      * @var float
      */
-    protected $_longitude = null;
+    protected $_longitude;
 
     /**
      * Geohash.
      *
      * @var string
      */
-    protected $_geohash = null;
+    protected $_geohash;
 
     /**
      * Create GeoDistance object.
@@ -67,7 +67,6 @@ abstract class AbstractGeoDistance extends AbstractFilter
      */
     public function __construct($key, $location)
     {
-        // Key
         $this->setKey($key);
         $this->setLocation($location);
     }

--- a/lib/Elastica/Filter/Terms.php
+++ b/lib/Elastica/Filter/Terms.php
@@ -24,13 +24,6 @@ class Terms extends AbstractFilter
     protected $_terms = array();
 
     /**
-     * Params.
-     *
-     * @var array Params
-     */
-    protected $_params = array();
-
-    /**
      * Terms key.
      *
      * @var string Terms key

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -22,14 +22,14 @@ class Index implements SearchableInterface
      *
      * @var string Index name
      */
-    protected $_name = '';
+    protected $_name;
 
     /**
      * Client object.
      *
      * @var \Elastica\Client Client object
      */
-    protected $_client = null;
+    protected $_client;
 
     /**
      * Creates a new index object.

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -21,12 +21,14 @@ use Elastica\Request;
  */
 class Settings
 {
+    const DEFAULT_REFRESH_INTERVAL = '1s';
+
     /**
      * Response.
      *
      * @var \Elastica\Response Response object
      */
-    protected $_response = null;
+    protected $_response;
 
     /**
      * Stats info.
@@ -40,9 +42,7 @@ class Settings
      *
      * @var \Elastica\Index Index object
      */
-    protected $_index = null;
-
-    const DEFAULT_REFRESH_INTERVAL = '1s';
+    protected $_index;
 
     /**
      * Construct.

--- a/lib/Elastica/Index/Stats.php
+++ b/lib/Elastica/Index/Stats.php
@@ -19,7 +19,7 @@ class Stats
      *
      * @var \Elastica\Response Response object
      */
-    protected $_response = null;
+    protected $_response;
 
     /**
      * Stats info.
@@ -33,7 +33,7 @@ class Stats
      *
      * @var \Elastica\Index Index object
      */
-    protected $_index = null;
+    protected $_index;
 
     /**
      * Construct.

--- a/lib/Elastica/IndexTemplate.php
+++ b/lib/Elastica/IndexTemplate.php
@@ -18,14 +18,14 @@ class IndexTemplate
      *
      * @var string Index pattern
      */
-    protected $_name = '';
+    protected $_name;
 
     /**
      * Client object.
      *
      * @var \Elastica\Client Client object
      */
-    protected $_client = null;
+    protected $_client;
 
     /**
      * Creates a new index template object.

--- a/lib/Elastica/Log.php
+++ b/lib/Elastica/Log.php
@@ -16,14 +16,14 @@ class Log extends AbstractLogger
      *
      * @var string|bool
      */
-    protected $_log = true;
+    protected $_log;
 
     /**
      * Last logged message.
      *
      * @var string Last logged message
      */
-    protected $_lastMessage = '';
+    protected $_lastMessage;
 
     /**
      * Inits log object.

--- a/lib/Elastica/Node.php
+++ b/lib/Elastica/Node.php
@@ -17,33 +17,33 @@ class Node
      *
      * @var \Elastica\Client
      */
-    protected $_client = null;
+    protected $_client;
 
     /**
      * @var string Unique node id
      */
-    protected $_id = '';
+    protected $_id;
 
     /**
      * Node name.
      *
      * @var string Node name
      */
-    protected $_name = '';
+    protected $_name;
 
     /**
      * Node stats.
      *
      * @var \Elastica\Node\Stats Node Stats
      */
-    protected $_stats = null;
+    protected $_stats;
 
     /**
      * Node info.
      *
      * @var \Elastica\Node\Info Node info
      */
-    protected $_info = null;
+    protected $_info;
 
     /**
      * Create a new node object.

--- a/lib/Elastica/Node/Info.php
+++ b/lib/Elastica/Node/Info.php
@@ -19,7 +19,7 @@ class Info
      *
      * @var \Elastica\Response Response object
      */
-    protected $_response = null;
+    protected $_response;
 
     /**
      * Stats data.
@@ -33,7 +33,7 @@ class Info
      *
      * @var \Elastica\Node Node object
      */
-    protected $_node = null;
+    protected $_node;
 
     /**
      * Query parameters.

--- a/lib/Elastica/Node/Stats.php
+++ b/lib/Elastica/Node/Stats.php
@@ -19,7 +19,7 @@ class Stats
      *
      * @var \Elastica\Response Response object
      */
-    protected $_response = null;
+    protected $_response;
 
     /**
      * Stats data.
@@ -33,7 +33,7 @@ class Stats
      *
      * @var \Elastica\Node Node object
      */
-    protected $_node = null;
+    protected $_node;
 
     /**
      * Create new stats for node.

--- a/lib/Elastica/Percolator.php
+++ b/lib/Elastica/Percolator.php
@@ -34,7 +34,7 @@ class Percolator
      *
      * @var \Elastica\Index
      */
-    protected $_index = null;
+    protected $_index;
 
     /**
      * Construct new percolator.

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -25,13 +25,6 @@ use Elastica\Suggest\AbstractSuggest;
 class Query extends Param
 {
     /**
-     * Params.
-     *
-     * @var array Params
-     */
-    protected $_params = array();
-
-    /**
      * Suggest query or not.
      *
      * @var int Suggest

--- a/lib/Elastica/Query/AbstractGeoDistance.php
+++ b/lib/Elastica/Query/AbstractGeoDistance.php
@@ -24,35 +24,35 @@ abstract class AbstractGeoDistance extends AbstractQuery
      *
      * @var string
      */
-    protected $_locationType = null;
+    protected $_locationType;
 
     /**
      * Key.
      *
      * @var string
      */
-    protected $_key = null;
+    protected $_key;
 
     /**
      * Latitude.
      *
      * @var float
      */
-    protected $_latitude = null;
+    protected $_latitude;
 
     /**
      * Longitude.
      *
      * @var float
      */
-    protected $_longitude = null;
+    protected $_longitude;
 
     /**
      * Geohash.
      *
      * @var string
      */
-    protected $_geohash = null;
+    protected $_geohash;
 
     /**
      * Create GeoDistance object.
@@ -64,7 +64,6 @@ abstract class AbstractGeoDistance extends AbstractQuery
      */
     public function __construct($key, $location)
     {
-        // Key
         $this->setKey($key);
         $this->setLocation($location);
     }

--- a/lib/Elastica/Query/GeoPolygon.php
+++ b/lib/Elastica/Query/GeoPolygon.php
@@ -16,14 +16,14 @@ class GeoPolygon extends AbstractQuery
      *
      * @var string Key
      */
-    protected $_key = '';
+    protected $_key;
 
     /**
      * Points making up polygon.
      *
      * @var array Points making up polygon
      */
-    protected $_points = array();
+    protected $_points;
 
     /**
      * Construct polygon query.

--- a/lib/Elastica/Query/Ids.php
+++ b/lib/Elastica/Query/Ids.php
@@ -16,13 +16,6 @@ use Elastica\Type;
 class Ids extends AbstractQuery
 {
     /**
-     * Params.
-     *
-     * @var array Params
-     */
-    protected $_params = array();
-
-    /**
      * Creates filter object.
      *
      * @param string|\Elastica\Type $type Type to filter on

--- a/lib/Elastica/Query/QueryString.php
+++ b/lib/Elastica/Query/QueryString.php
@@ -18,7 +18,7 @@ class QueryString extends AbstractQuery
      *
      * @var string Query string
      */
-    protected $_queryString = '';
+    protected $_queryString;
 
     /**
      * Creates query string object. Calls setQuery with argument.

--- a/lib/Elastica/Query/Script.php
+++ b/lib/Elastica/Query/Script.php
@@ -14,13 +14,6 @@ use Elastica;
 class Script extends AbstractQuery
 {
     /**
-     * Query object.
-     *
-     * @var array|AbstractQuery
-     */
-    protected $_query = null;
-
-    /**
      * Construct script query.
      *
      * @param array|string|\Elastica\Script\AbstractScript $script OPTIONAL Script

--- a/lib/Elastica/Query/Terms.php
+++ b/lib/Elastica/Query/Terms.php
@@ -21,13 +21,6 @@ class Terms extends AbstractQuery
     protected $_terms;
 
     /**
-     * Params.
-     *
-     * @var array Params
-     */
-    protected $_params = array();
-
-    /**
      * Terms key.
      *
      * @var string Terms key

--- a/lib/Elastica/Query/Terms.php
+++ b/lib/Elastica/Query/Terms.php
@@ -18,7 +18,7 @@ class Terms extends AbstractQuery
      *
      * @var array Terms
      */
-    protected $_terms = array();
+    protected $_terms;
 
     /**
      * Params.
@@ -32,7 +32,7 @@ class Terms extends AbstractQuery
      *
      * @var string Terms key
      */
-    protected $_key = '';
+    protected $_key;
 
     /**
      * Construct terms query.

--- a/lib/Elastica/Query/Type.php
+++ b/lib/Elastica/Query/Type.php
@@ -16,7 +16,7 @@ class Type extends AbstractQuery
      *
      * @var string
      */
-    protected $_type = null;
+    protected $_type;
 
     /**
      * Construct Type Query.

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -19,7 +19,7 @@ class Response
      *
      * @var float Query time
      */
-    protected $_queryTime = null;
+    protected $_queryTime;
 
     /**
      * Response string (json).
@@ -47,14 +47,14 @@ class Response
      *
      * @var \Elastica\Response Response object
      */
-    protected $_response = null;
+    protected $_response;
 
     /**
      * HTTP response status code.
      *
      * @var int
      */
-    protected $_status = null;
+    protected $_status;
 
     /**
      * Whether or not to convert bigint results to string (see issue #717).

--- a/lib/Elastica/Scroll.php
+++ b/lib/Elastica/Scroll.php
@@ -24,12 +24,12 @@ class Scroll implements \Iterator
     /**
      * @var null|string
      */
-    protected $_nextScrollId = null;
+    protected $_nextScrollId;
 
     /**
      * @var null|ResultSet
      */
-    protected $_currentResultSet = null;
+    protected $_currentResultSet;
 
     /**
      * 0: scroll<br>

--- a/lib/Elastica/Status.php
+++ b/lib/Elastica/Status.php
@@ -18,21 +18,21 @@ class Status
      *
      * @var \Elastica\Response Response object
      */
-    protected $_response = null;
+    protected $_response;
 
     /**
      * Data.
      *
      * @var array Data
      */
-    protected $_data = null;
+    protected $_data;
 
     /**
      * Client object.
      *
      * @var \Elastica\Client Client object
      */
-    protected $_client = null;
+    protected $_client;
 
     /**
      * Constructs Status object.

--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -33,7 +33,7 @@ class Guzzle extends AbstractTransport
      *
      * @var Client Guzzle client to reuse
      */
-    protected static $_guzzleClientConnection = null;
+    protected static $_guzzleClientConnection;
 
     /**
      * Makes calls to the elasticsearch server.
@@ -148,6 +148,7 @@ class Guzzle extends AbstractTransport
     /**
      * Return Guzzle resource.
      *
+     * @param string $baseUrl
      * @param bool $persistent False if not persistent connection
      *
      * @return Client

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -28,7 +28,7 @@ class Http extends AbstractTransport
      *
      * @var resource Curl resource to reuse
      */
-    protected static $_curlConnection = null;
+    protected static $_curlConnection;
 
     /**
      * Makes calls to the elasticsearch server.

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -26,14 +26,14 @@ class Type implements SearchableInterface
      *
      * @var \Elastica\Index Index object
      */
-    protected $_index = null;
+    protected $_index;
 
     /**
      * Type name.
      *
      * @var string Type name
      */
-    protected $_name = '';
+    protected $_name;
 
     /**
      * @var array|string A callable that serializes an object passed to it

--- a/lib/Elastica/Type/AbstractType.php
+++ b/lib/Elastica/Type/AbstractType.php
@@ -36,35 +36,35 @@ abstract class AbstractType implements SearchableInterface
      *
      * @var string Index name
      */
-    protected $_indexName = '';
+    protected $_indexName;
 
     /**
      * Index name.
      *
      * @var string Index name
      */
-    protected $_typeName = '';
+    protected $_typeName;
 
     /**
      * Client.
      *
      * @var \Elastica\Client Client object
      */
-    protected $_client = null;
+    protected $_client;
 
     /**
      * Index.
      *
      * @var \Elastica\Index Index object
      */
-    protected $_index = null;
+    protected $_index;
 
     /**
      * Type.
      *
      * @var \Elastica\Type Type object
      */
-    protected $_type = null;
+    protected $_type;
 
     /**
      * Mapping.

--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -27,7 +27,7 @@ class Mapping
      *
      * @var \Elastica\Type Type object
      */
-    protected $_type = null;
+    protected $_type;
 
     /**
      * Construct Mapping.


### PR DESCRIPTION
Just some tidying of properties where they are set in the constructor and there is no point setting them in the property definition, removing `= null` since it is implicit and removing $_params; redefinitions in classes that extend Param.