### PR TITLE
Add tests for Bulk hasIndex() and hasType()

### DIFF
--- a/lib/Elastica/Bulk.php
+++ b/lib/Elastica/Bulk.php
@@ -25,12 +25,12 @@ class Bulk
     protected $_actions = array();
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $_index;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $_type;
 
@@ -64,7 +64,7 @@ class Bulk
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getIndex()
     {
@@ -76,7 +76,7 @@ class Bulk
      */
     public function hasIndex()
     {
-        return '' !== $this->getIndex();
+		return null !== $this->getIndex() && '' !== $this->getIndex();
     }
 
     /**
@@ -97,7 +97,7 @@ class Bulk
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getType()
     {
@@ -109,7 +109,7 @@ class Bulk
      */
     public function hasType()
     {
-        return '' !== $this->_type;
+		return null !== $this->getType() && '' !== $this->getType();
     }
 
     /**

--- a/test/lib/Elastica/Test/BulkTest.php
+++ b/test/lib/Elastica/Test/BulkTest.php
@@ -680,4 +680,30 @@ class BulkTest extends BaseTest
         $this->markTestIncomplete('Failed asserting that 2.2414096568375803 is less than 1.3.');
         $this->assertLessThan(1.3, $endMemory / $startMemory);
     }
+
+    /**
+     * @group unit
+     */
+    public function testHasIndex()
+    {
+        $client = $this->_getClient();
+        $bulk = new Bulk($client);
+
+        $this->assertFalse($bulk->hasIndex());
+        $bulk->setIndex('unittest');
+        $this->assertTrue($bulk->hasIndex());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testHasType()
+    {
+        $client = $this->_getClient();
+        $bulk = new Bulk($client);
+
+        $this->assertFalse($bulk->hasType());
+        $bulk->setType('unittest');
+        $this->assertTrue($bulk->hasType());
+    }
 }


### PR DESCRIPTION
The two functions wern't returning what i would expect, because
the tests check explicitly for the empty string and the default values
were null. Added a couple tests to assert their proper behavior and
then fixed the code to pass the tests.