### PR TITLE
Fixed gzip encoding enable/disable on persistent connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 - Fix fatal error on `Query::addScriptField()` if scripts were already set via `setScriptFields()` #1086
+- Set HTTP headers on each request preventing server error if persistent connection is enabled and compression enabled and later disabled for the same connection. https://github.com/ruflin/Elastica/pull/1106 #1106
 
 ### Added
 - Added the concept of ResultSet Transformers. The Transformer adds more information to a Result, for example the original object or data that created the Result. #1066

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 # Change Log
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/ruflin/Elastica/compare/3.2.0...HEAD)
+## [Unreleased](https://github.com/ruflin/Elastica/compare/3.2.1...HEAD)
+
+### Backward Compatibility Fixes
+
+### Bugfixes
+
+### Added
+
+### Improvements
+
+## [Unreleased](https://github.com/ruflin/Elastica/compare/3.2.0...3.2.1)
 
 ### Backward Compatibility Fixes
 - Reintroduced properties in ResultSet removed in 3.2.0 as deprecated properties to be removed in 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 - Fix fatal error on `Query::addScriptField()` if scripts were already set via `setScriptFields()` #1086
 - Set HTTP headers on each request preventing server error if persistent connection is enabled and compression enabled and later disabled for the same connection. https://github.com/ruflin/Elastica/pull/1106 #1106
+- Fix namespace collision of `Type` in `Query\Ids` #1104
 
 ### Added
 - Added the concept of ResultSet Transformers. The Transformer adds more information to a Result, for example the original object or data that created the Result. #1066

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,40 +10,42 @@ All notable changes to this project will be documented in this file based on the
 - Fix fatal error on `Query::addScriptField()` if scripts were already set via `setScriptFields()` #1086
 - Set HTTP headers on each request preventing server error if persistent connection is enabled and compression enabled and later disabled for the same connection. https://github.com/ruflin/Elastica/pull/1106 #1106
 - Fix namespace collision of `Type` in `Query\Ids` #1104
+- Fix fatal error on `Query::addScriptField()` if scripts were already set via `setScriptFields()` [#1086](https://github.com/ruflin/Elastica/pull/1086)
+- Fix namespace collision of `Type` in `Query\Ids` [#1104](https://github.com/ruflin/Elastica/pull/1104)
 
 ### Added
-- Added the concept of ResultSet Transformers. The Transformer adds more information to a Result, for example the original object or data that created the Result. #1066
+- Added the concept of ResultSet Transformers. The Transformer adds more information to a Result, for example the original object or data that created the Result. [#1066](https://github.com/ruflin/Elastica/pull/1066)
 - Tidied property initialisation in classes where it was duplicated
 
 ## [3.2.0](https://github.com/ruflin/Elastica/compare/3.1.1...3.2.0)
 
 ### Backward Compatibility Breaks
-- Method \Elastica\ResultSet::create and property \Elastica\ResultSet::$class were removed. To change the ResultSet class, implement your own ResultSet Builder. #1065
-- Properties on \Elastica\ResultSet _totalHits, _maxScore, _took and _timedOut that were originally set on object construction are now accessed by the getters on the ResultSet. #1065
+- Method \Elastica\ResultSet::create and property \Elastica\ResultSet::$class were removed. To change the ResultSet class, implement your own ResultSet Builder. [#1065](https://github.com/ruflin/Elastica/pull/1065)
+- Properties on \Elastica\ResultSet _totalHits, _maxScore, _took and _timedOut that were originally set on object construction are now accessed by the getters on the ResultSet. [#1065](https://github.com/ruflin/Elastica/pull/1065)
 
 ### Bugfixes
-- Fix php notice on `\Elastica\Index::getAliases()` if index has no aliases #1078
+- Fix php notice on `\Elastica\Index::getAliases()` if index has no aliases [#1078](https://github.com/ruflin/Elastica/issues/1078)
 
 ### Added
-- Update elasticsearch build dependency to elasticsearch 2.3.2 #1084
+- Update elasticsearch build dependency to elasticsearch 2.3.2 [#1084](https://github.com/ruflin/Elastica/pull/1084)
 
 ### Improvements
-- `Elastica\Type->deleteByQuery($query, $options)` $query param can be a query `array` again https://github.com/ruflin/Elastica/issues/1072 #1073
-- `Elastica\Client->connect()` allows to establish a connection to ES server when the config was set using method `Elastica\Client->setConfigValue()` https://github.com/ruflin/Elastica/issues/1076 #1077
-- Elastica\Client constructor now accepts a LoggerInterface and will log both successful and failed requests. #1069
+- `Elastica\Type->deleteByQuery($query, $options)` $query param can be a query `array` again https://github.com/ruflin/Elastica/issues/1072 [#1073](https://github.com/ruflin/Elastica/pull/1073)
+- `Elastica\Client->connect()` allows to establish a connection to ES server when the config was set using method `Elastica\Client->setConfigValue()` https://github.com/ruflin/Elastica/issues/1076 [#1077](https://github.com/ruflin/Elastica/pull/1077)
+- Elastica\Client constructor now accepts a LoggerInterface and will log both successful and failed requests. [#1069](https://github.com/ruflin/Elastica/pull/1069)
 
 ### Deprecated
-- Configuring the logger in \Elastica\Client $config constructor is deprecated and will be removed. Use the $logger argument instead. #1069
-- Extracted creation of ResultSet objects to a new dedicated ResultSet\Builder implementation. #1065
+- Configuring the logger in \Elastica\Client $config constructor is deprecated and will be removed. Use the $logger argument instead. [#1069](https://github.com/ruflin/Elastica/pull/1069)
+- Extracted creation of ResultSet objects to a new dedicated ResultSet\Builder implementation. [#1065](https://github.com/ruflin/Elastica/pull/1065)
 
 ### Deprecated
-- All properties in the \Elastica\ResultSet class will be moved to private in 4.0. To manipulate the creation of a ResultSet, implement the \Elastica\ResultSet\BuilderInterface and pass your new Builder to the \Elastica\Search instances. #1065
+- All properties in the \Elastica\ResultSet class will be moved to private in 4.0. To manipulate the creation of a ResultSet, implement the \Elastica\ResultSet\BuilderInterface and pass your new Builder to the \Elastica\Search instances. [#1065](https://github.com/ruflin/Elastica/pull/1065)
 
 
 ## [3.1.1](https://github.com/ruflin/Elastica/compare/3.1.0...3.1.1)
 
 ### Added
-- Add an "AwsAuthV4" transport that automatically signs requests using credentials from the environment or from the client config. This allows using Elastica with Amazon ElasticSearch Service domains that are restricted to IAM roles or policies. https://github.com/ruflin/Elastica/pull/1056
+- Add an "AwsAuthV4" transport that automatically signs requests using credentials from the environment or from the client config. This allows using Elastica with Amazon ElasticSearch Service domains that are restricted to IAM roles or policies. [#1056](https://github.com/ruflin/Elastica/pull/1056)
 - Update elasticsearch build dependency to elasticsearch 2.2.1
 
 ### Improvements
@@ -74,8 +76,8 @@ All notable changes to this project will be documented in this file based on the
 ## [3.0.1](https://github.com/ruflin/Elastica/compare/3.0.0...3.0.1)
 
 ### Improvements
-- Update build dependency to elasticsearch 2.1.1 #1022
-- Readd \Elastica\Filter\Nested. See https://github.com/ruflin/Elastica/issues/1001 #1020
+- Update build dependency to elasticsearch 2.1.1 [#1022](https://github.com/ruflin/Elastica/pull/1022)
+- Readd \Elastica\Filter\Nested. See https://github.com/ruflin/Elastica/issues/1001 [#1020](https://github.com/ruflin/Elastica/pull/1020)
 
 
 ## [3.0.0](https://github.com/ruflin/Elastica/compare/3.0.0-beta1...3.0.0)
@@ -84,10 +86,10 @@ All notable changes to this project will be documented in this file based on the
 - Revert getError changes in Response object and make it better BC compatible. See comment [here](https://github.com/ruflin/Elastica/commit/41a7a2075837320bc9bd3bca4150e05a1ec9a115#commitcomment-15136374).
 
 ### Bugfixes
-- Function score query: corrected the `score_method` `average` to `avg` #975
-- Set `json_decode()` assoc parameter to true in `Elastica\Response` #1005
-- Add `bigintConversion` to keys passed to connection config in `Elastica\Client` #1005
-- Use POST instead of PUT to send bulk requests #1010
+- Function score query: corrected the `score_method` `average` to `avg` [#975](https://github.com/ruflin/Elastica/pull/975)
+- Set `json_decode()` assoc parameter to true in `Elastica\Response` [#1005](https://github.com/ruflin/Elastica/pull/1005)
+- Add `bigintConversion` to keys passed to connection config in `Elastica\Client` [#1005](https://github.com/ruflin/Elastica/pull/1005)
+- Use POST instead of PUT to send bulk requests [#1010](https://github.com/ruflin/Elastica/issues/1010)
 
 ### Added
 - Elastica\Query\MultiMatch::setFuzziness now supports being set to `AUTO` with the const `MultiMatch::FUZZINESS_AUTO`
@@ -96,7 +98,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 - More info on Elastica\Exception\PartialShardFailureException. Not just number of failed shards.
-- Allow bool in TopHits::setSource function #1012
+- Allow bool in TopHits::setSource function [#1012](https://github.com/ruflin/Elastica/issues/1012)
 
 ### Deprecated
 - Elastica\Query\Filtered triggers E_USER_DEPRECATED error because filtered query is deprecated since ES 2.0.0-beta1. Use BoolQuery instead.
@@ -162,18 +164,18 @@ All notable changes to this project will be documented in this file based on the
 ## [2.3.1](https://github.com/ruflin/Elastica/releases/tag/2.3.1) - 2015-10-17
 
 ### Bugfixes
-- Filters aggregation: empty name is named bucket #935
-- Prevent mix keys in filters (#936) #939
-- Fix empty string is not anonymous filter #935
-- Filters aggregation: empty name is named bucket #935
+- Filters aggregation: empty name is named bucket [#935](https://github.com/ruflin/Elastica/pull/935)
+- Prevent mix keys in filters ([#936](https://github.com/ruflin/Elastica/pull/936)) [#939](https://github.com/ruflin/Elastica/pull/939)
+- Fix empty string is not anonymous filter [#935](https://github.com/ruflin/Elastica/pull/935)
+- Filters aggregation: empty name is named bucket [#935](https://github.com/ruflin/Elastica/pull/935)
 
 ### Added
-- Support for field_value_factor #953
-- Added setMinDocCount and setExtendedBounds options #947
-- Avoid environment dependecies in tests #938
+- Support for field_value_factor [#953](https://github.com/ruflin/Elastica/pull/953)
+- Added setMinDocCount and setExtendedBounds options [#947](https://github.com/ruflin/Elastica/pull/947)
+- Avoid environment dependecies in tests [#938](https://github.com/ruflin/Elastica/pull/938)
 
 ### Improvements
-- Update elasticsearch dependency to elasticsearch 1.7.3 #957
+- Update elasticsearch dependency to elasticsearch 1.7.3 [#957](https://github.com/ruflin/Elastica/pull/957)
 
 ### Deprecated
 - Added exceptions of deprecated transports to deprecation list
@@ -188,10 +190,10 @@ All notable changes to this project will be documented in this file based on the
   as argument. [#916](https://github.com/ruflin/Elastica/pull/916)
 
 ### Added
-- Add Script File feature #902 #914
+- Add Script File feature [#902](https://github.com/ruflin/Elastica/pull/902) [#914](https://github.com/ruflin/Elastica/pull/914)
 
 ### Improvements
-- Support the http.compression in the Http transport adapter #515
+- Support the http.compression in the Http transport adapter [#515](https://github.com/ruflin/Elastica/issues/515)
 - Introduction of Lazy toArray [#916](https://github.com/ruflin/Elastica/pull/916)
 - Update Elasticsearch dependency to 1.7.2 [#929](https://github.com/ruflin/Elastica/pull/929)
 
@@ -245,17 +247,17 @@ All notable changes to this project will be documented in this file based on the
 - Support for a custom connection timeout through a connectTimeout parameter. [#841](https://github.com/ruflin/Elastica/issues/841/)
 - SignificantTerms Aggregation [#847](https://github.com/ruflin/Elastica/issues/847/)
 - Support for 'precision_threshold' and 'rehash' options for the Cardinality Aggregation [#851]
-- Support for retrieving id node #852
+- Support for retrieving id node [#852](https://github.com/ruflin/Elastica/pull/852)
 - Scroll Iterator [#842](https://github.com/ruflin/Elastica/issues/842/)
 - Gitter Elastica Chat Room add for Elastica discussions: https://gitter.im/ruflin/Elastica
-- Introduce PHP7 compatibility and tests. #837
+- Introduce PHP7 compatibility and tests. [#837](https://github.com/ruflin/Elastica/pull/837)
 - `Tool\CrossIndex` for reindexing and copying data and mapping between indices [#853](https://github.com/ruflin/Elastica/pull/853)
-- CONTIRUBTING.md file added for contributor guidelines. #854
+- CONTIRUBTING.md file added for contributor guidelines. [#854](https://github.com/ruflin/Elastica/pull/854)
 
 ### Improvements
 - Introduction of Changelog standard based on http://keepachangelog.com/. changes.txt moved to CHANGELOG.md [#844](https://github.com/ruflin/Elastica/issues/844/)
-- Make host for all tests dynamic to prepare it for a more dynamic test environment #846
-- Node information is retrieved based on id instead of name as multiple nodes can have the same name. #852
+- Make host for all tests dynamic to prepare it for a more dynamic test environment [#846](https://github.com/ruflin/Elastica/pull/846)
+- Node information is retrieved based on id instead of name as multiple nodes can have the same name. [#852](https://github.com/ruflin/Elastica/pull/852)
 - Guzzle Http dependency updated to 5.3.*
 - Remove NO_DEV builds from travis build matrix to speed up building. All builds include no dev packages.
 - Introduction of benchmark test group to make it easy to run benchmark tests.
@@ -268,7 +270,7 @@ All notable changes to this project will be documented in this file based on the
 ### Deprecated
 - Facets are deprecated. You are encouraged to migrate to aggregations instead. [#855](https://github.com/ruflin/Elastica/pull/855/)
 - Elastica\Query\Builder is deprecated. Use new Elastica\QueryBuilder instead. [#855](https://github.com/ruflin/Elastica/pull/855/)
-- For PHP 7 compatibility Elastica\Query\Bool was renamed to *\BoolQuery, Elastica\Filter\Bool was renamed to BoolFilter, Elastica\Transport\Null was renamed to NullTransport as Null and Bool are reserved phrases in PHP 7. Proxy objects for all three exist to keep backward compatibility. It is recommended to start using the new objects as the proxy classes will be deprecated as soon as PHP 7 is stable. #837
+- For PHP 7 compatibility Elastica\Query\Bool was renamed to *\BoolQuery, Elastica\Filter\Bool was renamed to BoolFilter, Elastica\Transport\Null was renamed to NullTransport as Null and Bool are reserved phrases in PHP 7. Proxy objects for all three exist to keep backward compatibility. It is recommended to start using the new objects as the proxy classes will be deprecated as soon as PHP 7 is stable. [#837](https://github.com/ruflin/Elastica/pull/837)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 - Set PHP 7.0 as default development version
+- Get the root reason from Elasticsearch's error JSON, when available [#1111](https://github.com/ruflin/Elastica/pull/1111)
 
 ## [3.2.1](https://github.com/ruflin/Elastica/compare/3.2.0...3.2.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 ### Improvements
+- Set PHP 7.0 as default development version
 
-## [Unreleased](https://github.com/ruflin/Elastica/compare/3.2.0...3.2.1)
+## [3.2.1](https://github.com/ruflin/Elastica/compare/3.2.0...3.2.1)
 
 ### Backward Compatibility Fixes
 - Reintroduced properties in ResultSet removed in 3.2.0 as deprecated properties to be removed in 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file based on the
 - Fix namespace collision of `Type` in `Query\Ids` #1104
 - Fix fatal error on `Query::addScriptField()` if scripts were already set via `setScriptFields()` [#1086](https://github.com/ruflin/Elastica/pull/1086)
 - Fix namespace collision of `Type` in `Query\Ids` [#1104](https://github.com/ruflin/Elastica/pull/1104)
+- Fix fatal error on `Query::addScriptField()` if scripts were already set via `setScriptFields()` #1086
+- Set HTTP headers on each request preventing server error if persistent connection is enabled and compression enabled and later disabled for the same connection. https://github.com/ruflin/Elastica/pull/1106 #1106
 
 ### Added
 - Added the concept of ResultSet Transformers. The Transformer adds more information to a Result, for example the original object or data that created the Result. [#1066](https://github.com/ruflin/Elastica/pull/1066)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #/bin/bash
 
 SOURCE = "./lib"
-TARGET?=56
+TARGET?=70
 
 # By default docker environment is used to run commands. To run without the predefined environment, set RUN_ENV=" " either as parameter or as environment variable
 ifndef RUN_ENV

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.1.x-dev"
+            "dev-master": "3.2.x-dev"
         }
     }
 }

--- a/env/elastica/Docker54
+++ b/env/elastica/Docker54
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y \
 	graphviz \
 	libxslt-dev \
 	nano \
-	php5-xsl
+	php5-xsl \
+	wget
 	# XSL and Graphviz for PhpDocumentor
 
 RUN docker-php-ext-install sockets xsl
@@ -24,10 +25,13 @@ RUN pecl install xdebug-2.3.2
 RUN echo "memory_limit=1024M" >> /usr/local/etc/php/conf.d/memory-limit.ini
 RUN echo "date.timezone=UTC" >> /usr/local/etc/php/conf.d/timezone.ini
 #RUN echo "extension=/usr/lib/php5/20131226/xsl.so" >> /usr/local/etc/php/conf.d/xsl.ini # TODO: Debian is putting the xsl extension in a different directory, should be in: /usr/local/lib/php/extensions/no-debug-non-zts-20131226
-RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20131226/xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20100525/xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install and setup composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN wget https://getcomposer.org/download/1.0.3/composer.phar
+RUN mv composer.phar /usr/local/bin/composer
+RUN chmod a+x /usr/local/bin/composer
+
 ENV COMPOSER_HOME /root/composer
 
 # Add composer bin to the environment

--- a/env/elastica/Docker70
+++ b/env/elastica/Docker70
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y \
 	graphviz \
 	libxslt-dev \
 	nano \
-	php5-xsl
+	php5-xsl \
+	zip unzip
 	# XSL and Graphviz for PhpDocumentor
 
 RUN docker-php-ext-install sockets xsl
@@ -17,14 +18,13 @@ RUN docker-php-ext-install sockets xsl
 RUN rm -r /var/lib/apt/lists/*
 
 # Xdebug for coverage report
-RUN pecl install xdebug-2.3.2
+RUN pecl install xdebug-2.4.0
 
 ## PHP Configuration
 
 RUN echo "memory_limit=1024M" >> /usr/local/etc/php/conf.d/memory-limit.ini
 RUN echo "date.timezone=UTC" >> /usr/local/etc/php/conf.d/timezone.ini
-#RUN echo "extension=/usr/lib/php5/20131226/xsl.so" >> /usr/local/etc/php/conf.d/xsl.ini # TODO: Debian is putting the xsl extension in a different directory, should be in: /usr/local/lib/php/extensions/no-debug-non-zts-20131226
-RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20131226/xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install and setup composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/lib/Elastica/AbstractScript.php
+++ b/lib/Elastica/AbstractScript.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Script\AbstractScript as BaseAbstractScript;

--- a/lib/Elastica/AbstractUpdateAction.php
+++ b/lib/Elastica/AbstractUpdateAction.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\DeprecatedException;

--- a/lib/Elastica/Aggregation/AbstractAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractAggregation.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Aggregation/AbstractTermsAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractTermsAggregation.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Avg.php
+++ b/lib/Elastica/Aggregation/Avg.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Cardinality.php
+++ b/lib/Elastica/Aggregation/Cardinality.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Children.php
+++ b/lib/Elastica/Aggregation/Children.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/DateHistogram.php
+++ b/lib/Elastica/Aggregation/DateHistogram.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\DeprecatedException;

--- a/lib/Elastica/Aggregation/DateRange.php
+++ b/lib/Elastica/Aggregation/DateRange.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/ExtendedStats.php
+++ b/lib/Elastica/Aggregation/ExtendedStats.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Filter.php
+++ b/lib/Elastica/Aggregation/Filter.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Aggregation/Filters.php
+++ b/lib/Elastica/Aggregation/Filters.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Aggregation/GeoDistance.php
+++ b/lib/Elastica/Aggregation/GeoDistance.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Aggregation/GeohashGrid.php
+++ b/lib/Elastica/Aggregation/GeohashGrid.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/GlobalAggregation.php
+++ b/lib/Elastica/Aggregation/GlobalAggregation.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Histogram.php
+++ b/lib/Elastica/Aggregation/Histogram.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/IpRange.php
+++ b/lib/Elastica/Aggregation/IpRange.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Aggregation/Max.php
+++ b/lib/Elastica/Aggregation/Max.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Min.php
+++ b/lib/Elastica/Aggregation/Min.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Missing.php
+++ b/lib/Elastica/Aggregation/Missing.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Nested.php
+++ b/lib/Elastica/Aggregation/Nested.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Percentiles.php
+++ b/lib/Elastica/Aggregation/Percentiles.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Range.php
+++ b/lib/Elastica/Aggregation/Range.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Aggregation/ReverseNested.php
+++ b/lib/Elastica/Aggregation/ReverseNested.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/ScriptedMetric.php
+++ b/lib/Elastica/Aggregation/ScriptedMetric.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/SignificantTerms.php
+++ b/lib/Elastica/Aggregation/SignificantTerms.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Aggregation/Stats.php
+++ b/lib/Elastica/Aggregation/Stats.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Sum.php
+++ b/lib/Elastica/Aggregation/Sum.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/Terms.php
+++ b/lib/Elastica/Aggregation/Terms.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/Aggregation/TopHits.php
+++ b/lib/Elastica/Aggregation/TopHits.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 use Elastica\Script\AbstractScript;

--- a/lib/Elastica/Aggregation/ValueCount.php
+++ b/lib/Elastica/Aggregation/ValueCount.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Aggregation;
 
 /**

--- a/lib/Elastica/ArrayableInterface.php
+++ b/lib/Elastica/ArrayableInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 /**

--- a/lib/Elastica/Bulk.php
+++ b/lib/Elastica/Bulk.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Bulk\Action;
@@ -76,7 +75,7 @@ class Bulk
      */
     public function hasIndex()
     {
-		return null !== $this->getIndex() && '' !== $this->getIndex();
+        return null !== $this->getIndex() && '' !== $this->getIndex();
     }
 
     /**
@@ -109,7 +108,7 @@ class Bulk
      */
     public function hasType()
     {
-		return null !== $this->getType() && '' !== $this->getType();
+        return null !== $this->getType() && '' !== $this->getType();
     }
 
     /**

--- a/lib/Elastica/Bulk/Action.php
+++ b/lib/Elastica/Bulk/Action.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Bulk;
 
 use Elastica\Bulk;

--- a/lib/Elastica/Bulk/Action/AbstractDocument.php
+++ b/lib/Elastica/Bulk/Action/AbstractDocument.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Bulk\Action;
 
 use Elastica\AbstractUpdateAction;

--- a/lib/Elastica/Bulk/Action/CreateDocument.php
+++ b/lib/Elastica/Bulk/Action/CreateDocument.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Bulk\Action;
 
 class CreateDocument extends IndexDocument

--- a/lib/Elastica/Bulk/Action/DeleteDocument.php
+++ b/lib/Elastica/Bulk/Action/DeleteDocument.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Bulk\Action;
 
 use Elastica\AbstractUpdateAction;

--- a/lib/Elastica/Bulk/Action/IndexDocument.php
+++ b/lib/Elastica/Bulk/Action/IndexDocument.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Bulk\Action;
 
 use Elastica\AbstractUpdateAction;

--- a/lib/Elastica/Bulk/Action/UpdateDocument.php
+++ b/lib/Elastica/Bulk/Action/UpdateDocument.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Bulk\Action;
 
 use Elastica\Document;

--- a/lib/Elastica/Bulk/Response.php
+++ b/lib/Elastica/Bulk/Response.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Bulk;
 
 use Elastica\Response as BaseResponse;

--- a/lib/Elastica/Bulk/ResponseSet.php
+++ b/lib/Elastica/Bulk/ResponseSet.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Bulk;
 
 use Elastica\Response as BaseResponse;

--- a/lib/Elastica/Bulk/ResponseSet.php
+++ b/lib/Elastica/Bulk/ResponseSet.php
@@ -41,16 +41,13 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
      */
     public function getError()
     {
-        $error = '';
-
         foreach ($this->getBulkResponses() as $bulkResponse) {
             if ($bulkResponse->hasError()) {
-                $error = $bulkResponse->getError();
-                break;
+                return $bulkResponse->getError();
             }
         }
 
-        return $error;
+        return '';
     }
 
     /**
@@ -60,16 +57,13 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
      */
     public function getFullError()
     {
-        $error = '';
-
         foreach ($this->getBulkResponses() as $bulkResponse) {
             if ($bulkResponse->hasError()) {
-                $error = $bulkResponse->getFullError();
-                break;
+                return $bulkResponse->getFullError();
             }
         }
 
-        return $error;
+        return '';
     }
 
     /**
@@ -77,16 +71,13 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
      */
     public function isOk()
     {
-        $return = true;
-
         foreach ($this->getBulkResponses() as $bulkResponse) {
             if (!$bulkResponse->isOk()) {
-                $return = false;
-                break;
+                return false;
             }
         }
 
-        return $return;
+        return true;
     }
 
     /**
@@ -94,16 +85,13 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
      */
     public function hasError()
     {
-        $return = false;
-
         foreach ($this->getBulkResponses() as $bulkResponse) {
             if ($bulkResponse->hasError()) {
-                $return = true;
-                break;
+                return true;
             }
         }
 
-        return $return;
+        return false;
     }
 
     /**
@@ -111,11 +99,9 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
      */
     public function current()
     {
-        if ($this->valid()) {
-            return $this->_bulkResponses[$this->key()];
-        } else {
-            return false;
-        }
+        return $this->valid()
+            ? $this->_bulkResponses[$this->key()]
+            : false;
     }
 
     /**

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Bulk\Action;
@@ -71,8 +70,8 @@ class Client
     /**
      * Creates a new Elastica client.
      *
-     * @param array $config OPTIONAL Additional config options
-     * @param callback $callback OPTIONAL Callback function which can be used to be notified about errors (for example connection down)
+     * @param array           $config   OPTIONAL Additional config options
+     * @param callback        $callback OPTIONAL Callback function which can be used to be notified about errors (for example connection down)
      * @param LoggerInterface $logger
      */
     public function __construct(array $config = array(), $callback = null, LoggerInterface $logger = null)
@@ -479,7 +478,7 @@ class Client
     }
 
     /**
-     * Establishes the client connections
+     * Establishes the client connections.
      */
     public function connect()
     {
@@ -668,28 +667,28 @@ class Client
     protected function _log($context)
     {
         if ($context instanceof ConnectionException) {
-            $this->_logger->error('Elastica Request Failure', [
+            $this->_logger->error('Elastica Request Failure', array(
                 'exception' => $context,
                 'request' => $context->getRequest()->toArray(),
-                'retry' => $this->hasConnection()
-            ]);
+                'retry' => $this->hasConnection(),
+            ));
 
             return;
         }
 
         if ($context instanceof Request) {
-            $this->_logger->debug('Elastica Request', [
+            $this->_logger->debug('Elastica Request', array(
                 'request' => $context->toArray(),
                 'response' => $this->_lastResponse ? $this->_lastResponse->getData() : null,
-                'responseStatus' => $this->_lastResponse ? $this->_lastResponse->getStatus() : null
-            ]);
+                'responseStatus' => $this->_lastResponse ? $this->_lastResponse->getStatus() : null,
+            ));
 
             return;
         }
 
-        $this->_logger->debug('Elastica Request', [
-            'message' => $context
-        ]);
+        $this->_logger->debug('Elastica Request', array(
+            'message' => $context,
+        ));
     }
 
     /**

--- a/lib/Elastica/Cluster.php
+++ b/lib/Elastica/Cluster.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Cluster\Health;

--- a/lib/Elastica/Cluster/Health.php
+++ b/lib/Elastica/Cluster/Health.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Cluster;
 
 use Elastica\Client;

--- a/lib/Elastica/Cluster/Health/Index.php
+++ b/lib/Elastica/Cluster/Health/Index.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Cluster\Health;
 
 /**

--- a/lib/Elastica/Cluster/Health/Shard.php
+++ b/lib/Elastica/Cluster/Health/Shard.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Cluster\Health;
 
 /**

--- a/lib/Elastica/Cluster/Settings.php
+++ b/lib/Elastica/Cluster/Settings.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Cluster;
 
 use Elastica\Client;

--- a/lib/Elastica/Cluster/Settings.php
+++ b/lib/Elastica/Cluster/Settings.php
@@ -154,13 +154,9 @@ class Settings
     {
         $key = 'cluster.blocks.read_only';
 
-        if ($persistent) {
-            $response = $this->setPersistent($key, $readOnly);
-        } else {
-            $response = $this->setTransient($key, $readOnly);
-        }
-
-        return $response;
+        return $persistent
+            ? $this->setPersistent($key, $readOnly)
+            : $this->setTransient($key, $readOnly);
     }
 
     /**

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -330,17 +330,15 @@ class Connection extends Param
      */
     public static function create($params = array())
     {
-        $connection = null;
-
-        if ($params instanceof self) {
-            $connection = $params;
-        } elseif (is_array($params)) {
-            $connection = new self($params);
-        } else {
-            throw new InvalidException('Invalid data type');
+        if (is_array($params)) {
+            return new self($params);
         }
 
-        return $connection;
+        if ($params instanceof self) {
+            return $params;
+        }
+
+        throw new InvalidException('Invalid data type');
     }
 
     /**

--- a/lib/Elastica/Connection/ConnectionPool.php
+++ b/lib/Elastica/Connection/ConnectionPool.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Connection;
 
 use Elastica\Client;

--- a/lib/Elastica/Connection/Strategy/CallbackStrategy.php
+++ b/lib/Elastica/Connection/Strategy/CallbackStrategy.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Connection\Strategy;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Connection/Strategy/RoundRobin.php
+++ b/lib/Elastica/Connection/Strategy/RoundRobin.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Connection\Strategy;
 
 /**

--- a/lib/Elastica/Connection/Strategy/Simple.php
+++ b/lib/Elastica/Connection/Strategy/Simple.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Connection\Strategy;
 
 use Elastica\Exception\ClientException;

--- a/lib/Elastica/Connection/Strategy/StrategyFactory.php
+++ b/lib/Elastica/Connection/Strategy/StrategyFactory.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Connection\Strategy;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Connection/Strategy/StrategyInterface.php
+++ b/lib/Elastica/Connection/Strategy/StrategyInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Connection\Strategy;
 
 /**

--- a/lib/Elastica/Document.php
+++ b/lib/Elastica/Document.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Bulk\Action;

--- a/lib/Elastica/Document.php
+++ b/lib/Elastica/Document.php
@@ -350,10 +350,12 @@ class Document extends AbstractUpdateAction
     {
         if ($data instanceof self) {
             return $data;
-        } elseif (is_array($data)) {
-            return new self('', $data);
-        } else {
-            throw new InvalidException('Failed to create document. Invalid data passed.');
         }
+
+        if (is_array($data)) {
+            return new self('', $data);
+        }
+
+        throw new InvalidException('Failed to create document. Invalid data passed.');
     }
 }

--- a/lib/Elastica/Exception/Bulk/Response/ActionException.php
+++ b/lib/Elastica/Exception/Bulk/Response/ActionException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception\Bulk\Response;
 
 use Elastica\Bulk\Response;

--- a/lib/Elastica/Exception/Bulk/ResponseException.php
+++ b/lib/Elastica/Exception/Bulk/ResponseException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception\Bulk;
 
 use Elastica\Bulk\ResponseSet;

--- a/lib/Elastica/Exception/BulkException.php
+++ b/lib/Elastica/Exception/BulkException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 class BulkException extends \RuntimeException implements ExceptionInterface

--- a/lib/Elastica/Exception/ClientException.php
+++ b/lib/Elastica/Exception/ClientException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/Connection/GuzzleException.php
+++ b/lib/Elastica/Exception/Connection/GuzzleException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception\Connection;
 
 use Elastica\Exception\ConnectionException;

--- a/lib/Elastica/Exception/Connection/HttpException.php
+++ b/lib/Elastica/Exception/Connection/HttpException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception\Connection;
 
 use Elastica\Exception\ConnectionException;

--- a/lib/Elastica/Exception/Connection/HttpException.php
+++ b/lib/Elastica/Exception/Connection/HttpException.php
@@ -46,32 +46,22 @@ class HttpException extends ConnectionException
     {
         switch ($error) {
             case CURLE_UNSUPPORTED_PROTOCOL:
-                $error = 'Unsupported protocol';
-                break;
+                return 'Unsupported protocol';
             case CURLE_FAILED_INIT:
-                $error = 'Internal cUrl error?';
-                break;
+                return 'Internal cUrl error?';
             case CURLE_URL_MALFORMAT:
-                $error = 'Malformed URL';
-                break;
+                return 'Malformed URL';
             case CURLE_COULDNT_RESOLVE_PROXY:
-                $error = "Couldn't resolve proxy";
-                break;
+                return "Couldn't resolve proxy";
             case CURLE_COULDNT_RESOLVE_HOST:
-                $error = "Couldn't resolve host";
-                break;
+                return "Couldn't resolve host";
             case CURLE_COULDNT_CONNECT:
-                $error = "Couldn't connect to host, Elasticsearch down?";
-                break;
+                return "Couldn't connect to host, Elasticsearch down?";
             case 28:
-                $error = 'Operation timed out';
-                break;
-            default:
-                $error = 'Unknown error:'.$error;
-                break;
+                return 'Operation timed out';
         }
 
-        return $error;
+        return 'Unknown error:' . $error;
     }
 
     /**

--- a/lib/Elastica/Exception/ConnectionException.php
+++ b/lib/Elastica/Exception/ConnectionException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 use Elastica\Request;

--- a/lib/Elastica/Exception/DeprecatedException.php
+++ b/lib/Elastica/Exception/DeprecatedException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/ElasticsearchException.php
+++ b/lib/Elastica/Exception/ElasticsearchException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/ExceptionInterface.php
+++ b/lib/Elastica/Exception/ExceptionInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/InvalidException.php
+++ b/lib/Elastica/Exception/InvalidException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/JSONParseException.php
+++ b/lib/Elastica/Exception/JSONParseException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/NotFoundException.php
+++ b/lib/Elastica/Exception/NotFoundException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/NotImplementedException.php
+++ b/lib/Elastica/Exception/NotImplementedException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/PartialShardFailureException.php
+++ b/lib/Elastica/Exception/PartialShardFailureException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 use Elastica\JSON;

--- a/lib/Elastica/Exception/QueryBuilderException.php
+++ b/lib/Elastica/Exception/QueryBuilderException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/ResponseException.php
+++ b/lib/Elastica/Exception/ResponseException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 use Elastica\Request;

--- a/lib/Elastica/Exception/RuntimeException.php
+++ b/lib/Elastica/Exception/RuntimeException.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Filter/AbstractFilter.php
+++ b/lib/Elastica/Filter/AbstractFilter.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Filter/AbstractGeoDistance.php
+++ b/lib/Elastica/Filter/AbstractGeoDistance.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Filter/AbstractGeoShape.php
+++ b/lib/Elastica/Filter/AbstractGeoShape.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/AbstractMulti.php
+++ b/lib/Elastica/Filter/AbstractMulti.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/Bool.php
+++ b/lib/Elastica/Filter/Bool.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/BoolAnd.php
+++ b/lib/Elastica/Filter/BoolAnd.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use BoolQuery::addMust. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/BoolFilter.php
+++ b/lib/Elastica/Filter/BoolFilter.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Filter/BoolNot.php
+++ b/lib/Elastica/Filter/BoolNot.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use BoolQuery::addMustNot. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/BoolOr.php
+++ b/lib/Elastica/Filter/BoolOr.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use BoolQuery::addShould. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/Exists.php
+++ b/lib/Elastica/Filter/Exists.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/GeoBoundingBox.php
+++ b/lib/Elastica/Filter/GeoBoundingBox.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Filter/GeoDistance.php
+++ b/lib/Elastica/Filter/GeoDistance.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/GeoDistanceRange.php
+++ b/lib/Elastica/Filter/GeoDistanceRange.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Filter/GeoPolygon.php
+++ b/lib/Elastica/Filter/GeoPolygon.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/GeoShapePreIndexed.php
+++ b/lib/Elastica/Filter/GeoShapePreIndexed.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/GeoShapeProvided.php
+++ b/lib/Elastica/Filter/GeoShapeProvided.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/GeohashCell.php
+++ b/lib/Elastica/Filter/GeohashCell.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/HasChild.php
+++ b/lib/Elastica/Filter/HasChild.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/HasParent.php
+++ b/lib/Elastica/Filter/HasParent.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/Ids.php
+++ b/lib/Elastica/Filter/Ids.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica\Type as ElasticaType;

--- a/lib/Elastica/Filter/Indices.php
+++ b/lib/Elastica/Filter/Indices.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica\Index as ElasticaIndex;

--- a/lib/Elastica/Filter/Limit.php
+++ b/lib/Elastica/Filter/Limit.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/MatchAll.php
+++ b/lib/Elastica/Filter/MatchAll.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/Missing.php
+++ b/lib/Elastica/Filter/Missing.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/Nested.php
+++ b/lib/Elastica/Filter/Nested.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica\Query\AbstractQuery;

--- a/lib/Elastica/Filter/NumericRange.php
+++ b/lib/Elastica/Filter/NumericRange.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/Prefix.php
+++ b/lib/Elastica/Filter/Prefix.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/Query.php
+++ b/lib/Elastica/Filter/Query.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Filter/Range.php
+++ b/lib/Elastica/Filter/Range.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/Regexp.php
+++ b/lib/Elastica/Filter/Regexp.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/Script.php
+++ b/lib/Elastica/Filter/Script.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica;

--- a/lib/Elastica/Filter/Term.php
+++ b/lib/Elastica/Filter/Term.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Filter/Terms.php
+++ b/lib/Elastica/Filter/Terms.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Filter/Type.php
+++ b/lib/Elastica/Filter/Type.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
@@ -37,7 +36,7 @@ class Index implements SearchableInterface
      * All the communication to and from an index goes of this object
      *
      * @param \Elastica\Client $client Client object
-     * @param string $name Index name
+     * @param string           $name   Index name
      */
     public function __construct(Client $client, $name)
     {
@@ -288,8 +287,8 @@ class Index implements SearchableInterface
 
     /**
      * @param string|array|\Elastica\Query $query
-     * @param int|array $options
-     * @param BuilderInterface $builder
+     * @param int|array                    $options
+     * @param BuilderInterface             $builder
      *
      * @return Search
      */

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Index;
 
 use Elastica\Exception\NotFoundException;

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -193,9 +193,9 @@ class Settings
             if (strpos($e->getMessage(), 'ClusterBlockException') !== false) {
                 // hacky way to test if the metadata is blocked since bug 9203 is not fixed
                 return true;
-            } else {
-                throw $e;
             }
+
+            throw $e;
         }
     }
 

--- a/lib/Elastica/Index/Stats.php
+++ b/lib/Elastica/Index/Stats.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Index;
 
 use Elastica\Index as BaseIndex;

--- a/lib/Elastica/IndexTemplate.php
+++ b/lib/Elastica/IndexTemplate.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/JSON.php
+++ b/lib/Elastica/JSON.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\JSONParseException;

--- a/lib/Elastica/Log.php
+++ b/lib/Elastica/Log.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Psr\Log\AbstractLogger;

--- a/lib/Elastica/Multi/MultiBuilder.php
+++ b/lib/Elastica/Multi/MultiBuilder.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Multi;
 
 use Elastica\Response;
@@ -8,8 +7,9 @@ use Elastica\Search as BaseSearch;
 class MultiBuilder implements MultiBuilderInterface
 {
     /**
-     * @param Response $response
+     * @param Response     $response
      * @param BaseSearch[] $searches
+     *
      * @return ResultSet
      */
     public function buildMultiResultSet(Response $response, $searches)
@@ -20,8 +20,9 @@ class MultiBuilder implements MultiBuilderInterface
     }
 
     /**
-     * @param Response $childResponse
+     * @param Response   $childResponse
      * @param BaseSearch $search
+     *
      * @return \Elastica\ResultSet
      */
     private function buildResultSet(Response $childResponse, BaseSearch $search)
@@ -30,13 +31,14 @@ class MultiBuilder implements MultiBuilderInterface
     }
 
     /**
-     * @param Response $response
+     * @param Response     $response
      * @param BaseSearch[] $searches
+     *
      * @return \Elastica\ResultSet[]
      */
     private function buildResultSets(Response $response, $searches)
     {
-        $resultSets = [];
+        $resultSets = array();
 
         $data = $response->getData();
         if (!isset($data['responses']) || !is_array($data['responses'])) {
@@ -46,7 +48,7 @@ class MultiBuilder implements MultiBuilderInterface
         reset($searches);
 
         foreach ($data['responses'] as $index => $responseData) {
-            list ($key, $search) = each($searches);
+            list($key, $search) = each($searches);
 
             $resultSets[$key] = $this->buildResultSet(new Response($responseData), $search);
         }

--- a/lib/Elastica/Multi/MultiBuilderInterface.php
+++ b/lib/Elastica/Multi/MultiBuilderInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Multi;
 
 use Elastica\Response;
@@ -8,8 +7,9 @@ use Elastica\Search as BaseSearch;
 interface MultiBuilderInterface
 {
     /**
-     * @param Response $response
+     * @param Response     $response
      * @param BaseSearch[] $searches
+     *
      * @return ResultSet
      */
     public function buildMultiResultSet(Response $response, $searches);

--- a/lib/Elastica/Multi/ResultSet.php
+++ b/lib/Elastica/Multi/ResultSet.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Multi;
 
 use Elastica\Response;

--- a/lib/Elastica/Multi/ResultSet.php
+++ b/lib/Elastica/Multi/ResultSet.php
@@ -84,11 +84,9 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
      */
     public function current()
     {
-        if ($this->valid()) {
-            return $this->_resultSets[$this->key()];
-        } else {
-            return false;
-        }
+        return $this->valid()
+            ? $this->_resultSets[$this->key()]
+            : false;
     }
 
     /**

--- a/lib/Elastica/Multi/Search.php
+++ b/lib/Elastica/Multi/Search.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Multi;
 
 use Elastica\Client;
@@ -39,7 +38,7 @@ class Search
     /**
      * Constructs search object.
      *
-     * @param \Elastica\Client $client Client object
+     * @param \Elastica\Client      $client  Client object
      * @param MultiBuilderInterface $builder
      */
     public function __construct(Client $client, MultiBuilderInterface $builder = null)

--- a/lib/Elastica/NameableInterface.php
+++ b/lib/Elastica/NameableInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 /**

--- a/lib/Elastica/Node.php
+++ b/lib/Elastica/Node.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Node\Info;

--- a/lib/Elastica/Node/Info.php
+++ b/lib/Elastica/Node/Info.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Node;
 
 use Elastica\Node as BaseNode;

--- a/lib/Elastica/Node/Stats.php
+++ b/lib/Elastica/Node/Stats.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Node;
 
 use Elastica\Node as BaseNode;

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -137,10 +137,6 @@ class Param implements ArrayableInterface
     public function addParam($key, $value)
     {
         if ($key != null) {
-            if (!isset($this->_params[$key])) {
-                $this->_params[$key] = array();
-            }
-
             $this->_params[$key][] = $value;
         } else {
             $this->_params = $value;

--- a/lib/Elastica/Percolator.php
+++ b/lib/Elastica/Percolator.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 /**

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -348,10 +348,6 @@ class Query extends Param
      */
     public function addAggregation(AbstractAggregation $agg)
     {
-        if (!array_key_exists('aggs', $this->_params)) {
-            $this->_params['aggs'] = array();
-        }
-
         $this->_params['aggs'][] = $agg;
 
         return $this;

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Aggregation\AbstractAggregation;

--- a/lib/Elastica/Query/AbstractGeoDistance.php
+++ b/lib/Elastica/Query/AbstractGeoDistance.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/AbstractGeoShape.php
+++ b/lib/Elastica/Query/AbstractGeoShape.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/AbstractQuery.php
+++ b/lib/Elastica/Query/AbstractQuery.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Param;

--- a/lib/Elastica/Query/Bool.php
+++ b/lib/Elastica/Query/Bool.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 trigger_error('Elastica\Query\Bool is deprecated. Use BoolQuery instead. From PHP7 bool is reserved word and this class will be removed in further Elastica releases', E_USER_DEPRECATED);

--- a/lib/Elastica/Query/BoolQuery.php
+++ b/lib/Elastica/Query/BoolQuery.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/Boosting.php
+++ b/lib/Elastica/Query/Boosting.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Builder.php
+++ b/lib/Elastica/Query/Builder.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/Common.php
+++ b/lib/Elastica/Query/Common.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/DisMax.php
+++ b/lib/Elastica/Query/DisMax.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/Exists.php
+++ b/lib/Elastica/Query/Exists.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Filtered.php
+++ b/lib/Elastica/Query/Filtered.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/FunctionScore.php
+++ b/lib/Elastica/Query/FunctionScore.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\DeprecatedException;

--- a/lib/Elastica/Query/Fuzzy.php
+++ b/lib/Elastica/Query/Fuzzy.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/GeoBoundingBox.php
+++ b/lib/Elastica/Query/GeoBoundingBox.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/GeoDistance.php
+++ b/lib/Elastica/Query/GeoDistance.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/GeoDistanceRange.php
+++ b/lib/Elastica/Query/GeoDistanceRange.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/GeoPolygon.php
+++ b/lib/Elastica/Query/GeoPolygon.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/GeoShapePreIndexed.php
+++ b/lib/Elastica/Query/GeoShapePreIndexed.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/GeoShapeProvided.php
+++ b/lib/Elastica/Query/GeoShapeProvided.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/GeohashCell.php
+++ b/lib/Elastica/Query/GeohashCell.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/HasChild.php
+++ b/lib/Elastica/Query/HasChild.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Query as BaseQuery;

--- a/lib/Elastica/Query/HasParent.php
+++ b/lib/Elastica/Query/HasParent.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Query as BaseQuery;

--- a/lib/Elastica/Query/Ids.php
+++ b/lib/Elastica/Query/Ids.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Type as ElasticaType;

--- a/lib/Elastica/Query/Image.php
+++ b/lib/Elastica/Query/Image.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Indices.php
+++ b/lib/Elastica/Query/Indices.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Index as ElasticaIndex;

--- a/lib/Elastica/Query/Limit.php
+++ b/lib/Elastica/Query/Limit.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Match.php
+++ b/lib/Elastica/Query/Match.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/MatchAll.php
+++ b/lib/Elastica/Query/MatchAll.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/MatchPhrase.php
+++ b/lib/Elastica/Query/MatchPhrase.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/MatchPhrasePrefix.php
+++ b/lib/Elastica/Query/MatchPhrasePrefix.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Missing.php
+++ b/lib/Elastica/Query/Missing.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/MoreLikeThis.php
+++ b/lib/Elastica/Query/MoreLikeThis.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Document;

--- a/lib/Elastica/Query/MultiMatch.php
+++ b/lib/Elastica/Query/MultiMatch.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Nested.php
+++ b/lib/Elastica/Query/Nested.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/NumericRange.php
+++ b/lib/Elastica/Query/NumericRange.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Prefix.php
+++ b/lib/Elastica/Query/Prefix.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/QueryString.php
+++ b/lib/Elastica/Query/QueryString.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/Range.php
+++ b/lib/Elastica/Query/Range.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Regexp.php
+++ b/lib/Elastica/Query/Regexp.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Script.php
+++ b/lib/Elastica/Query/Script.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica;

--- a/lib/Elastica/Query/Simple.php
+++ b/lib/Elastica/Query/Simple.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/SimpleQueryString.php
+++ b/lib/Elastica/Query/SimpleQueryString.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/SimpleQueryString.php
+++ b/lib/Elastica/Query/SimpleQueryString.php
@@ -18,7 +18,7 @@ class SimpleQueryString extends AbstractQuery
     public function __construct($query, array $fields = array())
     {
         $this->setQuery($query);
-        if (sizeof($fields)) {
+        if (count($fields)) {
             $this->setFields($fields);
         }
     }

--- a/lib/Elastica/Query/Term.php
+++ b/lib/Elastica/Query/Term.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Terms.php
+++ b/lib/Elastica/Query/Terms.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Query/TopChildren.php
+++ b/lib/Elastica/Query/TopChildren.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 use Elastica\Query as BaseQuery;

--- a/lib/Elastica/Query/Type.php
+++ b/lib/Elastica/Query/Type.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/Wildcard.php
+++ b/lib/Elastica/Query/Wildcard.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/QueryBuilder.php
+++ b/lib/Elastica/QueryBuilder.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\QueryBuilderException;

--- a/lib/Elastica/QueryBuilder/DSL.php
+++ b/lib/Elastica/QueryBuilder/DSL.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder;
 
 /**

--- a/lib/Elastica/QueryBuilder/DSL/Aggregation.php
+++ b/lib/Elastica/QueryBuilder/DSL/Aggregation.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\DSL;
 
 use Elastica\Aggregation\Avg;

--- a/lib/Elastica/QueryBuilder/DSL/Filter.php
+++ b/lib/Elastica/QueryBuilder/DSL/Filter.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\DSL;
 
 use Elastica\Filter\AbstractFilter;

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\DSL;
 
 use Elastica\Exception\DeprecatedException;

--- a/lib/Elastica/QueryBuilder/DSL/Suggest.php
+++ b/lib/Elastica/QueryBuilder/DSL/Suggest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\DSL;
 
 use Elastica\Exception\NotImplementedException;

--- a/lib/Elastica/QueryBuilder/Facade.php
+++ b/lib/Elastica/QueryBuilder/Facade.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder;
 
 use Elastica\Exception\QueryBuilderException;

--- a/lib/Elastica/QueryBuilder/Version.php
+++ b/lib/Elastica/QueryBuilder/Version.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder;
 
 /**

--- a/lib/Elastica/QueryBuilder/Version.php
+++ b/lib/Elastica/QueryBuilder/Version.php
@@ -48,23 +48,17 @@ abstract class Version
     {
         switch ($type) {
             case DSL::TYPE_QUERY:
-                $supports = in_array($name, $this->queries);
-                break;
+                return in_array($name, $this->queries);
             case DSL::TYPE_FILTER:
-                $supports = in_array($name, $this->filters);
-                break;
+                return in_array($name, $this->filters);
             case DSL::TYPE_AGGREGATION:
-                $supports = in_array($name, $this->aggregations);
-                break;
+                return in_array($name, $this->aggregations);
             case DSL::TYPE_SUGGEST:
-                $supports = in_array($name, $this->suggesters);
-                break;
-            default:
-                // disables version check in Facade for custom DSL objects
-                $supports = true;
+                return in_array($name, $this->suggesters);
         }
 
-        return $supports;
+        // disables version check in Facade for custom DSL objects
+        return true;
     }
 
     /**

--- a/lib/Elastica/QueryBuilder/Version/Latest.php
+++ b/lib/Elastica/QueryBuilder/Version/Latest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\Version;
 
 /**

--- a/lib/Elastica/QueryBuilder/Version/Version090.php
+++ b/lib/Elastica/QueryBuilder/Version/Version090.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\Version;
 
 use Elastica\QueryBuilder\Version;

--- a/lib/Elastica/QueryBuilder/Version/Version100.php
+++ b/lib/Elastica/QueryBuilder/Version/Version100.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\Version;
 
 use Elastica\QueryBuilder\Version;

--- a/lib/Elastica/QueryBuilder/Version/Version110.php
+++ b/lib/Elastica/QueryBuilder/Version/Version110.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\Version;
 
 use Elastica\QueryBuilder\Version;

--- a/lib/Elastica/QueryBuilder/Version/Version120.php
+++ b/lib/Elastica/QueryBuilder/Version/Version120.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\Version;
 
 use Elastica\QueryBuilder\Version;

--- a/lib/Elastica/QueryBuilder/Version/Version130.php
+++ b/lib/Elastica/QueryBuilder/Version/Version130.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\Version;
 
 use Elastica\QueryBuilder\Version;

--- a/lib/Elastica/QueryBuilder/Version/Version140.php
+++ b/lib/Elastica/QueryBuilder/Version/Version140.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\Version;
 
 /**

--- a/lib/Elastica/QueryBuilder/Version/Version150.php
+++ b/lib/Elastica/QueryBuilder/Version/Version150.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\QueryBuilder\Version;
 
 /**

--- a/lib/Elastica/Request.php
+++ b/lib/Elastica/Request.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Rescore/AbstractRescore.php
+++ b/lib/Elastica/Rescore/AbstractRescore.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Rescore;
 
 use Elastica\Param;

--- a/lib/Elastica/Rescore/Query.php
+++ b/lib/Elastica/Rescore/Query.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Rescore;
 
 use Elastica\Query as BaseQuery;

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\JSONParseException;

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -44,7 +44,7 @@ class Response
     /**
      * Response.
      *
-     * @var \Elastica\Response Response object
+     * @var array|null Response data array
      */
     protected $_response;
 

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -95,13 +95,18 @@ class Response
             return $error;
         }
 
+        $rootError = $error;
         if (isset($error['root_cause'][0])) {
-            $error = $error['root_cause'][0];
+            $rootError = $error['root_cause'][0];
         }
 
-        $message = $error['reason'];
-        if (isset($error['index'])) {
-            $message .= ' [index: '.$error['index'].']';
+        $message = $rootError['reason'];
+        if (isset($rootError['index'])) {
+            $message .= ' [index: '.$rootError['index'].']';
+        }
+
+        if (isset($error['reason']) && $rootError['reason'] != $error['reason']) {
+            $message .= ' [reason: '.$error['reason'].']';
         }
 
         return $message;

--- a/lib/Elastica/Result.php
+++ b/lib/Elastica/Result.php
@@ -148,10 +148,10 @@ class Result
      */
     public function getData()
     {
-        if (isset($this->_hit['fields']) && !isset($this->_hit['_source'])) {
-            return $this->getFields();
-        } elseif (isset($this->_hit['fields']) && isset($this->_hit['_source'])) {
-            return array_merge($this->getFields(), $this->getSource());
+        if (isset($this->_hit['fields'])) {
+            return isset($this->_hit['_source'])
+                ? array_merge($this->getFields(), $this->getSource())
+                : $this->getFields();
         }
 
         return $this->getSource();

--- a/lib/Elastica/Result.php
+++ b/lib/Elastica/Result.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 /**
@@ -219,7 +218,7 @@ class Result
      * Sets a parameter on the hit.
      *
      * @param string $param
-     * @param mixed $value
+     * @param mixed  $value
      */
     public function setParam($param, $value)
     {

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
@@ -16,6 +15,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
 {
     /**
      * @deprecated This property is deprecated. Use ResultSet->getMaxScore() instead. The property will become removed in 4.0.
+     *
      * @var float
      */
     protected $_maxScore;
@@ -58,18 +58,21 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
 
     /**
      * @deprecated This property is deprecated. Use ResultSet->hasTimedOut() instead. The property will become removed in 4.0.
+     *
      * @var bool
      */
     protected $_timedOut = false;
 
     /**
      * @deprecated This property is deprecated. Use ResultSet->getTotalTime() instead. The property will become removed in 4.0.
+     *
      * @var int
      */
     protected $_took;
 
     /**
      * @deprecated This property is deprecated. Use ResultSet->getTotalHits() instead. The property will become removed in 4.0.
+     *
      * @var int
      */
     protected $_totalHits;
@@ -78,7 +81,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      * Constructs ResultSet object.
      *
      * @param Response $response Response object
-     * @param Query $query Query object
+     * @param Query    $query    Query object
      * @param Result[] $results
      */
     public function __construct(Response $response, Query $query, $results)

--- a/lib/Elastica/ResultSet/BuilderInterface.php
+++ b/lib/Elastica/ResultSet/BuilderInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\ResultSet;
 
 use Elastica\Query;
@@ -12,7 +11,8 @@ interface BuilderInterface
      * Builds a ResultSet given a specific response and query.
      *
      * @param Response $response
-     * @param Query $query
+     * @param Query    $query
+     *
      * @return ResultSet
      */
     public function buildResultSet(Response $response, Query $query);

--- a/lib/Elastica/ResultSet/ChainProcessor.php
+++ b/lib/Elastica/ResultSet/ChainProcessor.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\ResultSet;
 
 use Elastica\ResultSet;
@@ -24,7 +23,7 @@ class ChainProcessor implements ProcessorInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function process(ResultSet $resultSet)
     {

--- a/lib/Elastica/ResultSet/DefaultBuilder.php
+++ b/lib/Elastica/ResultSet/DefaultBuilder.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\ResultSet;
 
 use Elastica\Query;
@@ -13,7 +12,8 @@ class DefaultBuilder implements BuilderInterface
      * Builds a ResultSet for a given Response.
      *
      * @param Response $response
-     * @param Query $query
+     * @param Query    $query
+     *
      * @return ResultSet
      */
     public function buildResultSet(Response $response, Query $query)
@@ -28,12 +28,13 @@ class DefaultBuilder implements BuilderInterface
      * Builds individual result objects.
      *
      * @param Response $response
+     *
      * @return Result[]
      */
     private function buildResults(Response $response)
     {
         $data = $response->getData();
-        $results = [];
+        $results = array();
 
         if (!isset($data['hits']['hits'])) {
             return $results;

--- a/lib/Elastica/ResultSet/ProcessingBuilder.php
+++ b/lib/Elastica/ResultSet/ProcessingBuilder.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\ResultSet;
 
 use Elastica\Query;
@@ -19,7 +18,7 @@ class ProcessingBuilder implements BuilderInterface
     private $processor;
 
     /**
-     * @param BuilderInterface $builder
+     * @param BuilderInterface   $builder
      * @param ProcessorInterface $processor
      */
     public function __construct(BuilderInterface $builder, ProcessorInterface $processor)
@@ -34,7 +33,8 @@ class ProcessingBuilder implements BuilderInterface
      * data into each Result.
      *
      * @param Response $response
-     * @param Query $query
+     * @param Query    $query
+     *
      * @return ResultSet
      */
     public function buildResultSet(Response $response, Query $query)

--- a/lib/Elastica/ResultSet/ProcessorInterface.php
+++ b/lib/Elastica/ResultSet/ProcessorInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\ResultSet;
 
 use Elastica\ResultSet;

--- a/lib/Elastica/ScanAndScroll.php
+++ b/lib/Elastica/ScanAndScroll.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 /**

--- a/lib/Elastica/Script.php
+++ b/lib/Elastica/Script.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Script\Script as BaseScript;

--- a/lib/Elastica/Script/AbstractScript.php
+++ b/lib/Elastica/Script/AbstractScript.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Script;
 
 use Elastica\AbstractUpdateAction;

--- a/lib/Elastica/Script/Script.php
+++ b/lib/Elastica/Script/Script.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Script;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Script/Script.php
+++ b/lib/Elastica/Script/Script.php
@@ -95,16 +95,18 @@ class Script extends AbstractScript
     public static function create($data)
     {
         if ($data instanceof self) {
-            $script = $data;
-        } elseif (is_array($data)) {
-            $script = self::_createFromArray($data);
-        } elseif (is_string($data)) {
-            $script = new self($data);
-        } else {
-            throw new InvalidException('Failed to create script. Invalid data passed.');
+            return $data;
         }
 
-        return $script;
+        if (is_array($data)) {
+            return self::_createFromArray($data);
+        }
+
+        if (is_string($data)) {
+            return new self($data);
+        }
+
+        throw new InvalidException('Failed to create script. Invalid data passed.');
     }
 
     /**

--- a/lib/Elastica/Script/ScriptFields.php
+++ b/lib/Elastica/Script/ScriptFields.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Script;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Script/ScriptFile.php
+++ b/lib/Elastica/Script/ScriptFile.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Script;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Script/ScriptFile.php
+++ b/lib/Elastica/Script/ScriptFile.php
@@ -60,16 +60,18 @@ class ScriptFile extends Script
     public static function create($data)
     {
         if ($data instanceof self) {
-            $scriptFile = $data;
-        } elseif (is_array($data)) {
-            $scriptFile = self::_createFromArray($data);
-        } elseif (is_string($data)) {
-            $scriptFile = new self($data);
-        } else {
-            throw new InvalidException('Failed to create scriptFile. Invalid data passed.');
+            return $data;
         }
 
-        return $scriptFile;
+        if (is_array($data)) {
+            return self::_createFromArray($data);
+        }
+
+        if (is_string($data)) {
+            return new self($data);
+        }
+
+        throw new InvalidException('Failed to create scriptFile. Invalid data passed.');
     }
 
     /**

--- a/lib/Elastica/ScriptFields.php
+++ b/lib/Elastica/ScriptFields.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Script\ScriptFields as BaseScriptFields;

--- a/lib/Elastica/ScriptFile.php
+++ b/lib/Elastica/ScriptFile.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Script\ScriptFile as BaseScriptFile;

--- a/lib/Elastica/Scroll.php
+++ b/lib/Elastica/Scroll.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 /**

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -1,11 +1,10 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
 use Elastica\Filter\AbstractFilter;
-use Elastica\ResultSet\DefaultBuilder;
 use Elastica\ResultSet\BuilderInterface;
+use Elastica\ResultSet\DefaultBuilder;
 
 /**
  * Elastica search object.
@@ -80,7 +79,7 @@ class Search
     /**
      * Constructs search object.
      *
-     * @param \Elastica\Client $client Client object
+     * @param \Elastica\Client $client  Client object
      * @param BuilderInterface $builder
      */
     public function __construct(Client $client, BuilderInterface $builder = null)

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -235,10 +235,6 @@ class Search
     {
         $this->_validateOption($key);
 
-        if (!isset($this->_options[$key])) {
-            $this->_options[$key] = array();
-        }
-
         $this->_options[$key][] = $value;
 
         return $this;

--- a/lib/Elastica/SearchableInterface.php
+++ b/lib/Elastica/SearchableInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 /**

--- a/lib/Elastica/Snapshot.php
+++ b/lib/Elastica/Snapshot.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\NotFoundException;

--- a/lib/Elastica/Status.php
+++ b/lib/Elastica/Status.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\ResponseException;

--- a/lib/Elastica/Suggest.php
+++ b/lib/Elastica/Suggest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\NotImplementedException;

--- a/lib/Elastica/Suggest/AbstractSuggest.php
+++ b/lib/Elastica/Suggest/AbstractSuggest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Suggest;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Suggest/CandidateGenerator/AbstractCandidateGenerator.php
+++ b/lib/Elastica/Suggest/CandidateGenerator/AbstractCandidateGenerator.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Suggest\CandidateGenerator;
 
 use Elastica\Param;

--- a/lib/Elastica/Suggest/CandidateGenerator/DirectGenerator.php
+++ b/lib/Elastica/Suggest/CandidateGenerator/DirectGenerator.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Suggest\CandidateGenerator;
 
 /**

--- a/lib/Elastica/Suggest/Completion.php
+++ b/lib/Elastica/Suggest/Completion.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Suggest;
 
 /**

--- a/lib/Elastica/Suggest/Phrase.php
+++ b/lib/Elastica/Suggest/Phrase.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Suggest;
 
 use Elastica\Suggest\CandidateGenerator\AbstractCandidateGenerator;

--- a/lib/Elastica/Suggest/Phrase.php
+++ b/lib/Elastica/Suggest/Phrase.php
@@ -174,10 +174,6 @@ class Phrase extends AbstractSuggest
             $keys = array_keys($generator);
             $values = array_values($generator);
 
-            if (!isset($array[$baseName][$keys[0]])) {
-                $array[$baseName][$keys[0]] = array();
-            }
-
             $array[$baseName][$keys[0]][] = $values[0];
         }
 

--- a/lib/Elastica/Suggest/Term.php
+++ b/lib/Elastica/Suggest/Term.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Suggest;
 
 /**

--- a/lib/Elastica/Tool/CrossIndex.php
+++ b/lib/Elastica/Tool/CrossIndex.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Tool;
 
 use Elastica\Bulk;

--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Transport;
 
 use Elastica\Connection;

--- a/lib/Elastica/Transport/AwsAuthV4.php
+++ b/lib/Elastica/Transport/AwsAuthV4.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Transport;
 
 use Aws\Credentials\CredentialProvider;

--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Transport;
 
 use Elastica\Connection;
@@ -149,7 +148,7 @@ class Guzzle extends AbstractTransport
      * Return Guzzle resource.
      *
      * @param string $baseUrl
-     * @param bool $persistent False if not persistent connection
+     * @param bool   $persistent False if not persistent connection
      *
      * @return Client
      */

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -103,14 +103,13 @@ class Http extends AbstractTransport
         $this->_setupCurl($conn);
 
         $headersConfig = $connection->hasConfig('headers') ? $connection->getConfig('headers') : array();
+        $headers = [];
 
         if (!empty($headersConfig)) {
             $headers = array();
             while (list($header, $headerValue) = each($headersConfig)) {
                 array_push($headers, $header.': '.$headerValue);
             }
-
-            curl_setopt($conn, CURLOPT_HTTPHEADER, $headers);
         }
 
         // TODO: REFACTOR
@@ -136,13 +135,15 @@ class Http extends AbstractTransport
                 curl_setopt($conn, CURLOPT_POSTFIELDS, gzencode($content));
 
                 // ... and tell ES that it is compressed
-                curl_setopt($conn, CURLOPT_HTTPHEADER, array('Content-Encoding: gzip'));
+                array_push($headers, 'Content-Encoding: gzip');
             } else {
                 curl_setopt($conn, CURLOPT_POSTFIELDS, $content);
             }
         } else {
             curl_setopt($conn, CURLOPT_POSTFIELDS, '');
         }
+
+        curl_setopt($conn, CURLOPT_HTTPHEADER, $headers);
 
         curl_setopt($conn, CURLOPT_NOBODY, $httpMethod == 'HEAD');
 

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Transport;
 
 use Elastica\Exception\Connection\HttpException;

--- a/lib/Elastica/Transport/HttpAdapter.php
+++ b/lib/Elastica/Transport/HttpAdapter.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Transport;
 
 use Elastica\Connection;

--- a/lib/Elastica/Transport/Https.php
+++ b/lib/Elastica/Transport/Https.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Transport;
 
 /**

--- a/lib/Elastica/Transport/Null.php
+++ b/lib/Elastica/Transport/Null.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Transport;
 
 /**

--- a/lib/Elastica/Transport/NullTransport.php
+++ b/lib/Elastica/Transport/NullTransport.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Transport;
 
 use Elastica\JSON;

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -545,6 +545,6 @@ class Type implements SearchableInterface
         $response = $this->getIndex()->request($this->getName(), Request::HEAD);
         $info = $response->getTransferInfo();
 
-        return (bool) ($info['http_code'] == 200);
+        return $info['http_code'] == 200;
     }
 }

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\DeprecatedException;
@@ -325,9 +324,9 @@ class Type implements SearchableInterface
     /**
      * Create search object.
      *
-     * @param string|array|\Elastica\Query $query Array with all query data inside or a Elastica\Query object
-     * @param int|array $options OPTIONAL Limit or associative array of options (option=>value)
-     * @param BuilderInterface $builder
+     * @param string|array|\Elastica\Query $query   Array with all query data inside or a Elastica\Query object
+     * @param int|array                    $options OPTIONAL Limit or associative array of options (option=>value)
+     * @param BuilderInterface             $builder
      *
      * @return Search
      */

--- a/lib/Elastica/Type/AbstractType.php
+++ b/lib/Elastica/Type/AbstractType.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Type;
 
 use Elastica\Client;

--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Type;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -286,14 +286,13 @@ class Mapping
         if (is_array($mapping)) {
             $mappingObject = new self();
             $mappingObject->setProperties($mapping);
-        } else {
-            $mappingObject = $mapping;
+            return $mappingObject;
         }
 
-        if (!$mappingObject instanceof self) {
-            throw new InvalidException('Invalid object type');
+        if ($mapping instanceof self) {
+            return $mapping;
         }
 
-        return $mappingObject;
+        throw new InvalidException('Invalid object type');
     }
 }

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 /**

--- a/test/lib/Elastica/Test/Aggregation/AbstractSimpleAggregationTest.php
+++ b/test/lib/Elastica/Test/Aggregation/AbstractSimpleAggregationTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 class AbstractSimpleAggregationTest extends BaseAggregationTest

--- a/test/lib/Elastica/Test/Aggregation/AvgTest.php
+++ b/test/lib/Elastica/Test/Aggregation/AvgTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;

--- a/test/lib/Elastica/Test/Aggregation/BaseAggregationTest.php
+++ b/test/lib/Elastica/Test/Aggregation/BaseAggregationTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Test\Base;

--- a/test/lib/Elastica/Test/Aggregation/CardinalityTest.php
+++ b/test/lib/Elastica/Test/Aggregation/CardinalityTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Cardinality;

--- a/test/lib/Elastica/Test/Aggregation/ChildrenTest.php
+++ b/test/lib/Elastica/Test/Aggregation/ChildrenTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace Elastica\Test\Aggregation;
 
-use Elastica\Aggregation\Terms;
 use Elastica\Aggregation\Children;
+use Elastica\Aggregation\Terms;
 use Elastica\Document;
 use Elastica\Query;
 use Elastica\Type\Mapping;

--- a/test/lib/Elastica/Test/Aggregation/DateHistogramTest.php
+++ b/test/lib/Elastica/Test/Aggregation/DateHistogramTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\DateHistogram;

--- a/test/lib/Elastica/Test/Aggregation/DateRangeTest.php
+++ b/test/lib/Elastica/Test/Aggregation/DateRangeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\DateRange;

--- a/test/lib/Elastica/Test/Aggregation/ExtendedStatsTest.php
+++ b/test/lib/Elastica/Test/Aggregation/ExtendedStatsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\ExtendedStats;

--- a/test/lib/Elastica/Test/Aggregation/FilterTest.php
+++ b/test/lib/Elastica/Test/Aggregation/FilterTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;

--- a/test/lib/Elastica/Test/Aggregation/FiltersTest.php
+++ b/test/lib/Elastica/Test/Aggregation/FiltersTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;

--- a/test/lib/Elastica/Test/Aggregation/GeoDistanceTest.php
+++ b/test/lib/Elastica/Test/Aggregation/GeoDistanceTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\GeoDistance;

--- a/test/lib/Elastica/Test/Aggregation/GeohashGridTest.php
+++ b/test/lib/Elastica/Test/Aggregation/GeohashGridTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\GeohashGrid;

--- a/test/lib/Elastica/Test/Aggregation/GlobalAggregationTest.php
+++ b/test/lib/Elastica/Test/Aggregation/GlobalAggregationTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;

--- a/test/lib/Elastica/Test/Aggregation/HistogramTest.php
+++ b/test/lib/Elastica/Test/Aggregation/HistogramTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Histogram;

--- a/test/lib/Elastica/Test/Aggregation/IpRangeTest.php
+++ b/test/lib/Elastica/Test/Aggregation/IpRangeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\IpRange;

--- a/test/lib/Elastica/Test/Aggregation/MaxTest.php
+++ b/test/lib/Elastica/Test/Aggregation/MaxTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Max;

--- a/test/lib/Elastica/Test/Aggregation/MinTest.php
+++ b/test/lib/Elastica/Test/Aggregation/MinTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Min;

--- a/test/lib/Elastica/Test/Aggregation/MissingTest.php
+++ b/test/lib/Elastica/Test/Aggregation/MissingTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Missing;

--- a/test/lib/Elastica/Test/Aggregation/NestedTest.php
+++ b/test/lib/Elastica/Test/Aggregation/NestedTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Min;

--- a/test/lib/Elastica/Test/Aggregation/PercentilesTest.php
+++ b/test/lib/Elastica/Test/Aggregation/PercentilesTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Percentiles;

--- a/test/lib/Elastica/Test/Aggregation/RangeTest.php
+++ b/test/lib/Elastica/Test/Aggregation/RangeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Range;

--- a/test/lib/Elastica/Test/Aggregation/ReverseNestedTest.php
+++ b/test/lib/Elastica/Test/Aggregation/ReverseNestedTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Nested;

--- a/test/lib/Elastica/Test/Aggregation/ScriptTest.php
+++ b/test/lib/Elastica/Test/Aggregation/ScriptTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Sum;

--- a/test/lib/Elastica/Test/Aggregation/ScriptedMetricTest.php
+++ b/test/lib/Elastica/Test/Aggregation/ScriptedMetricTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\ScriptedMetric;

--- a/test/lib/Elastica/Test/Aggregation/SignificantTermsTest.php
+++ b/test/lib/Elastica/Test/Aggregation/SignificantTermsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\SignificantTerms;

--- a/test/lib/Elastica/Test/Aggregation/StatsTest.php
+++ b/test/lib/Elastica/Test/Aggregation/StatsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Stats;

--- a/test/lib/Elastica/Test/Aggregation/SumTest.php
+++ b/test/lib/Elastica/Test/Aggregation/SumTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Sum;

--- a/test/lib/Elastica/Test/Aggregation/TermsTest.php
+++ b/test/lib/Elastica/Test/Aggregation/TermsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Terms;

--- a/test/lib/Elastica/Test/Aggregation/TopHitsTest.php
+++ b/test/lib/Elastica/Test/Aggregation/TopHitsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Terms;

--- a/test/lib/Elastica/Test/Aggregation/ValueCountTest.php
+++ b/test/lib/Elastica/Test/Aggregation/ValueCountTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\ValueCount;

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Client;
@@ -55,8 +54,8 @@ class Base extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param array $params Additional configuration params. Host and Port are already set
-     * @param callback $callback
+     * @param array           $params   Additional configuration params. Host and Port are already set
+     * @param callback        $callback
      * @param LoggerInterface $logger
      *
      * @return Client

--- a/test/lib/Elastica/Test/Bulk/ActionTest.php
+++ b/test/lib/Elastica/Test/Bulk/ActionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Bulk;
 
 use Elastica\Bulk\Action;

--- a/test/lib/Elastica/Test/Bulk/ResponseSetTest.php
+++ b/test/lib/Elastica/Test/Bulk/ResponseSetTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Bulk;
 
 use Elastica\Bulk;

--- a/test/lib/Elastica/Test/BulkTest.php
+++ b/test/lib/Elastica/Test/BulkTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Bulk;

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Client;
@@ -1197,7 +1196,7 @@ class ClientTest extends BaseTest
     public function testLogger()
     {
         $logger = $this->getMock('Psr\\Log\\LoggerInterface');
-        $client = $this->_getClient([], null, $logger);
+        $client = $this->_getClient(array(), null, $logger);
 
         $logger->expects($this->once())
             ->method('debug')

--- a/test/lib/Elastica/Test/Cluster/Health/IndexTest.php
+++ b/test/lib/Elastica/Test/Cluster/Health/IndexTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Cluster\Health;
 
 use Elastica\Cluster\Health\Index as HealthIndex;

--- a/test/lib/Elastica/Test/Cluster/Health/ShardTest.php
+++ b/test/lib/Elastica/Test/Cluster/Health/ShardTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Cluster\Health;
 
 use Elastica\Cluster\Health\Shard as HealthShard;

--- a/test/lib/Elastica/Test/Cluster/HealthTest.php
+++ b/test/lib/Elastica/Test/Cluster/HealthTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Cluster;
 
 use Elastica\Test\Base as BaseTest;

--- a/test/lib/Elastica/Test/Cluster/SettingsTest.php
+++ b/test/lib/Elastica/Test/Cluster/SettingsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Cluster;
 
 use Elastica\Cluster\Settings;

--- a/test/lib/Elastica/Test/ClusterTest.php
+++ b/test/lib/Elastica/Test/ClusterTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Cluster;

--- a/test/lib/Elastica/Test/Connection/ConnectionPoolTest.php
+++ b/test/lib/Elastica/Test/Connection/ConnectionPoolTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Connection;
 
 use Elastica\Connection;

--- a/test/lib/Elastica/Test/Connection/Strategy/CallbackStrategyTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/CallbackStrategyTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection\Strategy\CallbackStrategy;

--- a/test/lib/Elastica/Test/Connection/Strategy/CallbackStrategyTestHelper.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/CallbackStrategyTestHelper.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Connection\Strategy;
 
 class CallbackStrategyTestHelper

--- a/test/lib/Elastica/Test/Connection/Strategy/EmptyStrategy.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/EmptyStrategy.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection\Strategy\StrategyInterface;

--- a/test/lib/Elastica/Test/Connection/Strategy/RoundRobinTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/RoundRobinTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection;

--- a/test/lib/Elastica/Test/Connection/Strategy/SimpleTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/SimpleTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection;

--- a/test/lib/Elastica/Test/Connection/Strategy/StrategyFactoryTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/StrategyFactoryTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection\Strategy\StrategyFactory;

--- a/test/lib/Elastica/Test/ConnectionTest.php
+++ b/test/lib/Elastica/Test/ConnectionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Connection;

--- a/test/lib/Elastica/Test/DeprecatedClassBase.php
+++ b/test/lib/Elastica/Test/DeprecatedClassBase.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 /**

--- a/test/lib/Elastica/Test/DocumentTest.php
+++ b/test/lib/Elastica/Test/DocumentTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/ErrorsCollector.php
+++ b/test/lib/Elastica/Test/ErrorsCollector.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 /**

--- a/test/lib/Elastica/Test/ExampleTest.php
+++ b/test/lib/Elastica/Test/ExampleTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Exception/AbstractExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/AbstractExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 use Elastica\Test\Base as BaseTest;

--- a/test/lib/Elastica/Test/Exception/Bulk/Response/ActionExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Bulk/Response/ActionExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception\Bulk\Response;
 
 use Elastica\Test\Exception\AbstractExceptionTest;

--- a/test/lib/Elastica/Test/Exception/Bulk/ResponseExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Bulk/ResponseExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception\Bulk;
 
 use Elastica\Test\Exception\AbstractExceptionTest;

--- a/test/lib/Elastica/Test/Exception/BulkExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/BulkExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 class BulkExceptionTest extends AbstractExceptionTest

--- a/test/lib/Elastica/Test/Exception/ClientExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ClientExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 class ClientExceptionTest extends AbstractExceptionTest

--- a/test/lib/Elastica/Test/Exception/Connection/GuzzleExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/GuzzleExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception\Connection;
 
 use Elastica\Test\Exception\AbstractExceptionTest;

--- a/test/lib/Elastica/Test/Exception/Connection/HttpExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/Connection/HttpExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception\Connection;
 
 use Elastica\Test\Exception\AbstractExceptionTest;

--- a/test/lib/Elastica/Test/Exception/ConnectionExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ConnectionExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 class ConnectionExceptionTest extends AbstractExceptionTest

--- a/test/lib/Elastica/Test/Exception/ElasticsearchExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ElasticsearchExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 class ElasticsearchExceptionTest extends AbstractExceptionTest

--- a/test/lib/Elastica/Test/Exception/InvalidExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/InvalidExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 class InvalidExceptionTest extends AbstractExceptionTest

--- a/test/lib/Elastica/Test/Exception/JSONParseExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/JSONParseExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 class JSONParseExceptionTest extends AbstractExceptionTest

--- a/test/lib/Elastica/Test/Exception/NotFoundExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/NotFoundExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 class NotFoundExceptionTest extends AbstractExceptionTest

--- a/test/lib/Elastica/Test/Exception/NotImplementedExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/NotImplementedExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 use Elastica\Exception\NotImplementedException;

--- a/test/lib/Elastica/Test/Exception/PartialShardFailureExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/PartialShardFailureExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Exception/QueryBuilderExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/QueryBuilderExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 class QueryBuilderExceptionTest extends AbstractExceptionTest

--- a/test/lib/Elastica/Test/Exception/ResponseExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ResponseExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Exception/RuntimeExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/RuntimeExceptionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Exception;
 
 class RuntimeExceptionTest extends AbstractExceptionTest

--- a/test/lib/Elastica/Test/Filter/AbstractGeoDistanceTest.php
+++ b/test/lib/Elastica/Test/Filter/AbstractGeoDistanceTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Test\DeprecatedClassBase as BaseTest;

--- a/test/lib/Elastica/Test/Filter/AbstractGeoShapeTest.php
+++ b/test/lib/Elastica/Test/Filter/AbstractGeoShapeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Test\DeprecatedClassBase as BaseTest;

--- a/test/lib/Elastica/Test/Filter/AbstractTest.php
+++ b/test/lib/Elastica/Test/Filter/AbstractTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Test\DeprecatedClassBase as BaseTest;

--- a/test/lib/Elastica/Test/Filter/BoolAndTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolAndTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/BoolFilterTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolFilterTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/BoolNotTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolNotTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\BoolNot;

--- a/test/lib/Elastica/Test/Filter/BoolOrTest.php
+++ b/test/lib/Elastica/Test/Filter/BoolOrTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/ExistsTest.php
+++ b/test/lib/Elastica/Test/Filter/ExistsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Exists;

--- a/test/lib/Elastica/Test/Filter/GeoBoundingBoxTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoBoundingBoxTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\GeoBoundingBox;

--- a/test/lib/Elastica/Test/Filter/GeoDistanceRangeTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoDistanceRangeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/GeoDistanceTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoDistanceTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/GeoPolygonTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoPolygonTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/GeoShapePreIndexedTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoShapePreIndexedTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\AbstractGeoShape;

--- a/test/lib/Elastica/Test/Filter/GeoShapeProvidedTest.php
+++ b/test/lib/Elastica/Test/Filter/GeoShapeProvidedTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/GeohashCellTest.php
+++ b/test/lib/Elastica/Test/Filter/GeohashCellTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/HasChildTest.php
+++ b/test/lib/Elastica/Test/Filter/HasChildTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/HasParentTest.php
+++ b/test/lib/Elastica/Test/Filter/HasParentTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/IdsTest.php
+++ b/test/lib/Elastica/Test/Filter/IdsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/IndicesTest.php
+++ b/test/lib/Elastica/Test/Filter/IndicesTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/LimitTest.php
+++ b/test/lib/Elastica/Test/Filter/LimitTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Limit;

--- a/test/lib/Elastica/Test/Filter/MatchAllTest.php
+++ b/test/lib/Elastica/Test/Filter/MatchAllTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\MatchAll;

--- a/test/lib/Elastica/Test/Filter/MissingTest.php
+++ b/test/lib/Elastica/Test/Filter/MissingTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Missing;

--- a/test/lib/Elastica/Test/Filter/MultiTest.php
+++ b/test/lib/Elastica/Test/Filter/MultiTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\AbstractMulti;

--- a/test/lib/Elastica/Test/Filter/NestedFilterWithSetFilterTest.php
+++ b/test/lib/Elastica/Test/Filter/NestedFilterWithSetFilterTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/NestedTest.php
+++ b/test/lib/Elastica/Test/Filter/NestedTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/NumericRangeTest.php
+++ b/test/lib/Elastica/Test/Filter/NumericRangeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\NumericRange;

--- a/test/lib/Elastica/Test/Filter/PrefixTest.php
+++ b/test/lib/Elastica/Test/Filter/PrefixTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/QueryTest.php
+++ b/test/lib/Elastica/Test/Filter/QueryTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Query;

--- a/test/lib/Elastica/Test/Filter/RangeTest.php
+++ b/test/lib/Elastica/Test/Filter/RangeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Range;

--- a/test/lib/Elastica/Test/Filter/RegexpTest.php
+++ b/test/lib/Elastica/Test/Filter/RegexpTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/ScriptTest.php
+++ b/test/lib/Elastica/Test/Filter/ScriptTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Script as ScriptFilter;

--- a/test/lib/Elastica/Test/Filter/TermTest.php
+++ b/test/lib/Elastica/Test/Filter/TermTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Term;

--- a/test/lib/Elastica/Test/Filter/TermsTest.php
+++ b/test/lib/Elastica/Test/Filter/TermsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Filter/TypeTest.php
+++ b/test/lib/Elastica/Test/Filter/TypeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Filter;
 
 use Elastica\Filter\Type;

--- a/test/lib/Elastica/Test/Index/SettingsTest.php
+++ b/test/lib/Elastica/Test/Index/SettingsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Index;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Index/StatsTest.php
+++ b/test/lib/Elastica/Test/Index/StatsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Index;
 
 use Elastica\Test\Base as BaseTest;

--- a/test/lib/Elastica/Test/IndexTemplateTest.php
+++ b/test/lib/Elastica/Test/IndexTemplateTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Client;

--- a/test/lib/Elastica/Test/IndexTest.php
+++ b/test/lib/Elastica/Test/IndexTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/LegacyScriptFieldsTest.php
+++ b/test/lib/Elastica/Test/LegacyScriptFieldsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace lib\Elastica\Test;
 
 use Elastica\ScriptFields as LegacyScriptFields;

--- a/test/lib/Elastica/Test/LegacyScriptFileTest.php
+++ b/test/lib/Elastica/Test/LegacyScriptFileTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace lib\Elastica\Test;
 
 use Elastica\ScriptFile as LegacyScriptFile;

--- a/test/lib/Elastica/Test/LegacyScriptTest.php
+++ b/test/lib/Elastica/Test/LegacyScriptTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Script as LegacyScript;

--- a/test/lib/Elastica/Test/LogTest.php
+++ b/test/lib/Elastica/Test/LogTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Log;

--- a/test/lib/Elastica/Test/Multi/MultiBuilderTest.php
+++ b/test/lib/Elastica/Test/Multi/MultiBuilderTest.php
@@ -1,9 +1,7 @@
 <?php
-
 namespace Elastica\Test\Multi;
 
 use Elastica\Multi\MultiBuilder;
-use Elastica\Query;
 use Elastica\Response;
 use Elastica\ResultSet;
 use Elastica\ResultSet\BuilderInterface;
@@ -38,8 +36,8 @@ class MultiBuilderTest extends BaseTest
         $this->builder->expects($this->never())
             ->method('buildResultSet');
 
-        $response = new Response([]);
-        $searches = [];
+        $response = new Response(array());
+        $searches = array();
 
         $result = $this->multiBuilder->buildMultiResultSet($response, $searches);
 
@@ -48,27 +46,26 @@ class MultiBuilderTest extends BaseTest
 
     public function testBuildMultiResultSet()
     {
-        $response = new Response([
-            'responses' => [
-                [],
-                []
-            ]
-        ]);
-        $searches = [
+        $response = new Response(array(
+            'responses' => array(
+                array(),
+                array(),
+            ),
+        ));
+        $searches = array(
             $s1 = new Search($this->_getClient(), $this->builder),
-            $s2 = new Search($this->_getClient(), $this->builder)
-        ];
-        $resultSet1 = new ResultSet(new Response([]), $s1->getQuery(), []);
-        $resultSet2 = new ResultSet(new Response([]), $s2->getQuery(), []);
+            $s2 = new Search($this->_getClient(), $this->builder),
+        );
+        $resultSet1 = new ResultSet(new Response(array()), $s1->getQuery(), array());
+        $resultSet2 = new ResultSet(new Response(array()), $s2->getQuery(), array());
 
         $this->builder->expects($this->exactly(2))
             ->method('buildResultSet')
             ->withConsecutive(
-                [$this->isInstanceOf('Elastica\\Response'), $s1->getQuery()],
-                [$this->isInstanceOf('Elastica\\Response'), $s2->getQuery()]
+                array($this->isInstanceOf('Elastica\\Response'), $s1->getQuery()),
+                array($this->isInstanceOf('Elastica\\Response'), $s2->getQuery())
             )
             ->willReturnOnConsecutiveCalls($resultSet1, $resultSet2);
-
 
         $result = $this->multiBuilder->buildMultiResultSet($response, $searches);
 

--- a/test/lib/Elastica/Test/Multi/SearchTest.php
+++ b/test/lib/Elastica/Test/Multi/SearchTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Multi;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Node/InfoTest.php
+++ b/test/lib/Elastica/Test/Node/InfoTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Node;
 
 use Elastica\Node;

--- a/test/lib/Elastica/Test/NodeTest.php
+++ b/test/lib/Elastica/Test/NodeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Node;

--- a/test/lib/Elastica/Test/ParamTest.php
+++ b/test/lib/Elastica/Test/ParamTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Param;

--- a/test/lib/Elastica/Test/PercolatorTest.php
+++ b/test/lib/Elastica/Test/PercolatorTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/BoolQueryTest.php
+++ b/test/lib/Elastica/Test/Query/BoolQueryTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/BoostingTest.php
+++ b/test/lib/Elastica/Test/Query/BoostingTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/BuilderTest.php
+++ b/test/lib/Elastica/Test/Query/BuilderTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Builder;

--- a/test/lib/Elastica/Test/Query/CommonTest.php
+++ b/test/lib/Elastica/Test/Query/CommonTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/ConstantScoreTest.php
+++ b/test/lib/Elastica/Test/Query/ConstantScoreTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/DisMaxTest.php
+++ b/test/lib/Elastica/Test/Query/DisMaxTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/EscapeStringTest.php
+++ b/test/lib/Elastica/Test/Query/EscapeStringTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/ExistsTest.php
+++ b/test/lib/Elastica/Test/Query/ExistsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Exists;

--- a/test/lib/Elastica/Test/Query/FilteredTest.php
+++ b/test/lib/Elastica/Test/Query/FilteredTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/FunctionScoreTest.php
+++ b/test/lib/Elastica/Test/Query/FunctionScoreTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/FuzzyTest.php
+++ b/test/lib/Elastica/Test/Query/FuzzyTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/GeoBoundingBoxTest.php
+++ b/test/lib/Elastica/Test/Query/GeoBoundingBoxTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\GeoBoundingBox;

--- a/test/lib/Elastica/Test/Query/GeoDistanceRangeTest.php
+++ b/test/lib/Elastica/Test/Query/GeoDistanceRangeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/GeoDistanceTest.php
+++ b/test/lib/Elastica/Test/Query/GeoDistanceTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/GeoPolygonTest.php
+++ b/test/lib/Elastica/Test/Query/GeoPolygonTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/GeoShapePreIndexedTest.php
+++ b/test/lib/Elastica/Test/Query/GeoShapePreIndexedTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\AbstractGeoShape;

--- a/test/lib/Elastica/Test/Query/GeoShapeProvidedTest.php
+++ b/test/lib/Elastica/Test/Query/GeoShapeProvidedTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/GeohashCellTest.php
+++ b/test/lib/Elastica/Test/Query/GeohashCellTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/HasChildTest.php
+++ b/test/lib/Elastica/Test/Query/HasChildTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/HasParentTest.php
+++ b/test/lib/Elastica/Test/Query/HasParentTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/HighlightTest.php
+++ b/test/lib/Elastica/Test/Query/HighlightTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/IdsTest.php
+++ b/test/lib/Elastica/Test/Query/IdsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/ImageTest.php
+++ b/test/lib/Elastica/Test/Query/ImageTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/IndicesTest.php
+++ b/test/lib/Elastica/Test/Query/IndicesTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/LimitTest.php
+++ b/test/lib/Elastica/Test/Query/LimitTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Limit;

--- a/test/lib/Elastica/Test/Query/MatchAllTest.php
+++ b/test/lib/Elastica/Test/Query/MatchAllTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/MatchTest.php
+++ b/test/lib/Elastica/Test/Query/MatchTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/MissingTest.php
+++ b/test/lib/Elastica/Test/Query/MissingTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Missing;

--- a/test/lib/Elastica/Test/Query/MoreLikeThisTest.php
+++ b/test/lib/Elastica/Test/Query/MoreLikeThisTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/MultiMatchTest.php
+++ b/test/lib/Elastica/Test/Query/MultiMatchTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/NestedTest.php
+++ b/test/lib/Elastica/Test/Query/NestedTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Nested;

--- a/test/lib/Elastica/Test/Query/NumericRangeTest.php
+++ b/test/lib/Elastica/Test/Query/NumericRangeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\NumericRange;

--- a/test/lib/Elastica/Test/Query/PostFilterTest.php
+++ b/test/lib/Elastica/Test/Query/PostFilterTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/PrefixTest.php
+++ b/test/lib/Elastica/Test/Query/PrefixTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Prefix;

--- a/test/lib/Elastica/Test/Query/QueryStringTest.php
+++ b/test/lib/Elastica/Test/Query/QueryStringTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/RangeTest.php
+++ b/test/lib/Elastica/Test/Query/RangeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/RegexpTest.php
+++ b/test/lib/Elastica/Test/Query/RegexpTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Regexp;

--- a/test/lib/Elastica/Test/Query/RescoreTest.php
+++ b/test/lib/Elastica/Test/Query/RescoreTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query;

--- a/test/lib/Elastica/Test/Query/ScriptTest.php
+++ b/test/lib/Elastica/Test/Query/ScriptTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Script as ScriptQuery;

--- a/test/lib/Elastica/Test/Query/SimpleQueryStringTest.php
+++ b/test/lib/Elastica/Test/Query/SimpleQueryStringTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/SimpleTest.php
+++ b/test/lib/Elastica/Test/Query/SimpleTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Simple;

--- a/test/lib/Elastica/Test/Query/TermTest.php
+++ b/test/lib/Elastica/Test/Query/TermTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Term;

--- a/test/lib/Elastica/Test/Query/TermsTest.php
+++ b/test/lib/Elastica/Test/Query/TermsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Query/TypeTest.php
+++ b/test/lib/Elastica/Test/Query/TypeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Type;

--- a/test/lib/Elastica/Test/Query/WildcardTest.php
+++ b/test/lib/Elastica/Test/Query/WildcardTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/AbstractDSLTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/AbstractDSLTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\Exception\NotImplementedException;

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/AggregationTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/AggregationTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\Filter\Exists;

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/FilterTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/FilterTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\Filter\Exists;

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/QueryTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\Filter\Exists;

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/SuggestTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/SuggestTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\QueryBuilder\DSL;

--- a/test/lib/Elastica/Test/QueryBuilder/VersionTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/VersionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\QueryBuilder;
 
 use Elastica\QueryBuilder\DSL;

--- a/test/lib/Elastica/Test/QueryBuilderTest.php
+++ b/test/lib/Elastica/Test/QueryBuilderTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Exception\QueryBuilderException;

--- a/test/lib/Elastica/Test/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/RequestTest.php
+++ b/test/lib/Elastica/Test/RequestTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Connection;

--- a/test/lib/Elastica/Test/ResponseTest.php
+++ b/test/lib/Elastica/Test/ResponseTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/ResultSet/BuilderTest.php
+++ b/test/lib/Elastica/Test/ResultSet/BuilderTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\ResultSet;
 
 use Elastica\Query;
@@ -38,15 +37,15 @@ class BuilderTest extends BaseTest
 
     public function testResponse()
     {
-        $response = new Response([
-            'hits' => [
-                'hits' => [
-                    ['test' => 1],
-                    ['test' => 2],
-                    ['test' => 3],
-                ]
-            ]
-        ]);
+        $response = new Response(array(
+            'hits' => array(
+                'hits' => array(
+                    array('test' => 1),
+                    array('test' => 2),
+                    array('test' => 3),
+                ),
+            ),
+        ));
         $query = new Query();
 
         $resultSet = $this->builder->buildResultSet($response, $query);

--- a/test/lib/Elastica/Test/ResultSet/ChainProcessorTest.php
+++ b/test/lib/Elastica/Test/ResultSet/ChainProcessorTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Transformer;
 
 use Elastica\Query;
@@ -15,11 +14,11 @@ class ChainProcessorTest extends BaseTest
 {
     public function testProcessor()
     {
-        $processor = new ChainProcessor([
+        $processor = new ChainProcessor(array(
             $processor1 = $this->getMock('Elastica\\ResultSet\\ProcessorInterface'),
-            $processor2 = $this->getMock('Elastica\\ResultSet\\ProcessorInterface')
-        ]);
-        $resultSet = new ResultSet(new Response(''), new Query(), []);
+            $processor2 = $this->getMock('Elastica\\ResultSet\\ProcessorInterface'),
+        ));
+        $resultSet = new ResultSet(new Response(''), new Query(), array());
 
         $processor1->expects($this->once())
             ->method('process')

--- a/test/lib/Elastica/Test/ResultSet/ProcessingBuilderTest.php
+++ b/test/lib/Elastica/Test/ResultSet/ProcessingBuilderTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\ResultSet;
 
 use Elastica\Query;
@@ -42,7 +41,7 @@ class ProcessingBuilderTest extends BaseTest
     {
         $response = new Response('');
         $query = new Query();
-        $resultSet = new ResultSet($response, $query, []);
+        $resultSet = new ResultSet($response, $query, array());
 
         $this->innerBuilder->expects($this->once())
             ->method('buildResultSet')

--- a/test/lib/Elastica/Test/ResultSetTest.php
+++ b/test/lib/Elastica/Test/ResultSetTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/ResultTest.php
+++ b/test/lib/Elastica/Test/ResultTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/ScanAndScrollTest.php
+++ b/test/lib/Elastica/Test/ScanAndScrollTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Script/ScriptFieldsTest.php
+++ b/test/lib/Elastica/Test/Script/ScriptFieldsTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Script/ScriptFileTest.php
+++ b/test/lib/Elastica/Test/Script/ScriptFileTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Script/ScriptTest.php
+++ b/test/lib/Elastica/Test/Script/ScriptTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Script\Script;

--- a/test/lib/Elastica/Test/ScrollTest.php
+++ b/test/lib/Elastica/Test/ScrollTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/SearchTest.php
+++ b/test/lib/Elastica/Test/SearchTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/SnapshotTest.php
+++ b/test/lib/Elastica/Test/SnapshotTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/StatusTest.php
+++ b/test/lib/Elastica/Test/StatusTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Exception\ResponseException;

--- a/test/lib/Elastica/Test/Suggest/CompletionTest.php
+++ b/test/lib/Elastica/Test/Suggest/CompletionTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Suggest;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Suggest/PhraseTest.php
+++ b/test/lib/Elastica/Test/Suggest/PhraseTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Suggest;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Suggest/TermTest.php
+++ b/test/lib/Elastica/Test/Suggest/TermTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Suggest;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/SuggestTest.php
+++ b/test/lib/Elastica/Test/SuggestTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Exception\NotImplementedException;

--- a/test/lib/Elastica/Test/Tool/CrossIndexTest.php
+++ b/test/lib/Elastica/Test/Tool/CrossIndexTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Tool;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Transport/AbstractTransportTest.php
+++ b/test/lib/Elastica/Test/Transport/AbstractTransportTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Transport;
 
 use Elastica\Connection;

--- a/test/lib/Elastica/Test/Transport/AwsAuthV4Test.php
+++ b/test/lib/Elastica/Test/Transport/AwsAuthV4Test.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Transport;
 
 use Elastica\Exception\Connection\GuzzleException;

--- a/test/lib/Elastica/Test/Transport/GuzzleTest.php
+++ b/test/lib/Elastica/Test/Transport/GuzzleTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Transport;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Transport/HttpTest.php
+++ b/test/lib/Elastica/Test/Transport/HttpTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Transport;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Transport/NullTransportTest.php
+++ b/test/lib/Elastica/Test/Transport/NullTransportTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Transport;
 
 use Elastica\Connection;

--- a/test/lib/Elastica/Test/Transport/TransportBenchmarkTest.php
+++ b/test/lib/Elastica/Test/Transport/TransportBenchmarkTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Transport;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/Type/MappingTest.php
+++ b/test/lib/Elastica/Test/Type/MappingTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test\Type;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/UtilTest.php
+++ b/test/lib/Elastica/Test/UtilTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Connection;


### PR DESCRIPTION
When using a persistent connection and you enable compression with setCompression, make a request and then disable the compression, the next requests are sent without encoding as gzip (because compression is disabled) but the headers are persisted with the Content-Encoding: gzip, because we are reusing the same curl client and no headers are sent, so $headerConfig is empty and the CURLOPT_HTTPHEADER is never reached.