### PR TITLE
Support for non-string error responses.

### DIFF
--- a/lib/Elastica/Exception/ResponseException.php
+++ b/lib/Elastica/Exception/ResponseException.php
@@ -1,308 +1,70 @@
 <?php
-    namespace Elastica;
+namespace Elastica\Exception;
 
-    use Elastica\Exception\JSONParseException;
-    use Elastica\Exception\NotFoundException;
+use Elastica\Request;
+use Elastica\Response;
+
+/**
+ * Response exception.
+ *
+ * @author Nicolas Ruflin <spam@ruflin.com>
+ */
+class ResponseException extends \RuntimeException implements ExceptionInterface
+{
+    /**
+     * @var \Elastica\Request Request object
+     */
+    protected $_request = null;
 
     /**
-     * Elastica Response object.
-     *
-     * Stores query time, and result array -> is given to result set, returned by ...
-     *
-     * @author Nicolas Ruflin <spam@ruflin.com>
+     * @var \Elastica\Response Response object
      */
-    class Response
+    protected $_response = null;
+
+    /**
+     * Construct Exception.
+     *
+     * @param \Elastica\Request  $request
+     * @param \Elastica\Response $response
+     */
+    public function __construct(Request $request, Response $response)
     {
-        /**
-         * Query time.
-         *
-         * @var float Query time
-         */
-        protected $_queryTime = null;
-
-        /**
-         * Response string (json).
-         *
-         * @var string Response
-         */
-        protected $_responseString = '';
-
-        /**
-         * Error.
-         *
-         * @var bool Error
-         */
-        protected $_error = false;
-
-        /**
-         * Transfer info.
-         *
-         * @var array transfer info
-         */
-        protected $_transferInfo = array();
-
-        /**
-         * Response.
-         *
-         * @var \Elastica\Response Response object
-         */
-        protected $_response = null;
-
-        /**
-         * HTTP response status code.
-         *
-         * @var int
-         */
-        protected $_status = null;
-
-        /**
-         * Construct.
-         *
-         * @param string|array $responseString Response string (json)
-         * @param int          $responseStatus http status code
-         */
-        public function __construct($responseString, $responseStatus = null)
-        {
-            if (is_array($responseString)) {
-                $this->_response = $responseString;
-            } else {
-                $this->_responseString = $responseString;
-            }
-            $this->_status = $responseStatus;
-        }
-
-        /**
-         * Error message.
-         *
-         * @return string Error message
-         */
-        public function getError()
-        {
-            $message = '';
-            $response = $this->getData();
-
-            if (isset($response['error'])) {
-                $message = $response['error'];
-            }
-
-            return $message;
-        }
-
-        /**
-         * True if response has error.
-         *
-         * @return bool True if response has error
-         */
-        public function hasError()
-        {
-            $response = $this->getData();
-
-            if (isset($response['error'])) {
-                return true;
-            }
-
-            return false;
-        }
-
-        /**
-         * True if response has failed shards.
-         *
-         * @return bool True if response has failed shards
-         */
-        public function hasFailedShards()
-        {
-            try {
-                $shardsStatistics = $this->getShardsStatistics();
-            } catch (NotFoundException $e) {
-                return false;
-            }
-
-            return array_key_exists('failures', $shardsStatistics);
-        }
-
-        /**
-         * Checks if the query returned ok.
-         *
-         * @return bool True if ok
-         */
-        public function isOk()
-        {
-            $data = $this->getData();
-
-            // Bulk insert checks. Check every item
-            if (isset($data['status'])) {
-                if ($data['status'] >= 200 && $data['status'] <= 300) {
-                    return true;
-                }
-
-                return false;
-            }
-
-            if (isset($data['items'])) {
-                if (isset($data['errors']) && true === $data['errors']) {
-                    return false;
-                }
-
-                foreach ($data['items'] as $item) {
-                    if (isset($item['index']['ok']) && false == $item['index']['ok']) {
-                        return false;
-                    } elseif (isset($item['index']['status']) && ($item['index']['status'] < 200 || $item['index']['status'] >= 300)) {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            if ($this->_status >= 200 && $this->_status <= 300) {
-                // http status is ok
-                return true;
-            }
-
-            return (isset($data['ok']) && $data['ok']);
-        }
-
-        /**
-         * @return int
-         */
-        public function getStatus()
-        {
-            return $this->_status;
-        }
-
-        /**
-         * Response data array.
-         *
-         * @return array Response data array
-         */
-        public function getData()
-        {
-            if ($this->_response == null) {
-                $response = $this->_responseString;
-                if ($response === false) {
-                    $this->_error = true;
-                } else {
-                    try {
-                        $response = JSON::parse($response);
-                    } catch (JSONParseException $e) {
-                        // leave response as is if parse fails
-                    }
-                }
-
-                if (empty($response)) {
-                    $response = array();
-                }
-
-                if (is_string($response)) {
-                    $response = array('message' => $response);
-                }
-
-                $this->_response = $response;
-            }
-
-            return $this->_response;
-        }
-
-        /**
-         * Gets the transfer information.
-         *
-         * @return array Information about the curl request.
-         */
-        public function getTransferInfo()
-        {
-            return $this->_transferInfo;
-        }
-
-        /**
-         * Sets the transfer info of the curl request. This function is called
-         * from the \Elastica\Client::_callService .
-         *
-         * @param array $transferInfo The curl transfer information.
-         *
-         * @return $this
-         */
-        public function setTransferInfo(array $transferInfo)
-        {
-            $this->_transferInfo = $transferInfo;
-
-            return $this;
-        }
-
-        /**
-         * Returns query execution time.
-         *
-         * @return float Query time
-         */
-        public function getQueryTime()
-        {
-            return $this->_queryTime;
-        }
-
-        /**
-         * Sets the query time.
-         *
-         * @param float $queryTime Query time
-         *
-         * @return $this
-         */
-        public function setQueryTime($queryTime)
-        {
-            $this->_queryTime = $queryTime;
-
-            return $this;
-        }
-
-        /**
-         * Time request took.
-         *
-         * @throws \Elastica\Exception\NotFoundException
-         *
-         * @return int Time request took
-         */
-        public function getEngineTime()
-        {
-            $data = $this->getData();
-
-            if (!isset($data['took'])) {
-                throw new NotFoundException('Unable to find the field [took]from the response');
-            }
-
-            return $data['took'];
-        }
-
-        /**
-         * Get the _shard statistics for the response.
-         *
-         * @throws \Elastica\Exception\NotFoundException
-         *
-         * @return array
-         */
-        public function getShardsStatistics()
-        {
-            $data = $this->getData();
-
-            if (!isset($data['_shards'])) {
-                throw new NotFoundException('Unable to find the field [_shards] from the response');
-            }
-
-            return $data['_shards'];
-        }
-
-        /**
-         * Get the _scroll value for the response.
-         *
-         * @throws \Elastica\Exception\NotFoundException
-         *
-         * @return string
-         */
-        public function getScrollId()
-        {
-            $data = $this->getData();
-
-            if (!isset($data['_scroll_id'])) {
-                throw new NotFoundException('Unable to find the field [_scroll_id] from the response');
-            }
-
-            return $data['_scroll_id'];
-        }
+        $this->_request = $request;
+        $this->_response = $response;
+        parent::__construct($response->getErrorMessage());
     }
+
+    /**
+     * Returns request object.
+     *
+     * @return \Elastica\Request Request object
+     */
+    public function getRequest()
+    {
+        return $this->_request;
+    }
+
+    /**
+     * Returns response object.
+     *
+     * @return \Elastica\Response Response object
+     */
+    public function getResponse()
+    {
+        return $this->_response;
+    }
+
+    /**
+     * Returns elasticsearch exception.
+     *
+     * @return ElasticsearchException
+     */
+    public function getElasticsearchException()
+    {
+        $response = $this->getResponse();
+        $transfer = $response->getTransferInfo();
+        $code = array_key_exists('http_code', $transfer) ? $transfer['http_code'] : 0;
+
+        return new ElasticsearchException($code, $response->getErrorMessage());
+    }
+}

--- a/lib/Elastica/Exception/ResponseException.php
+++ b/lib/Elastica/Exception/ResponseException.php
@@ -1,70 +1,308 @@
 <?php
-namespace Elastica\Exception;
+    namespace Elastica;
 
-use Elastica\Request;
-use Elastica\Response;
-
-/**
- * Response exception.
- *
- * @author Nicolas Ruflin <spam@ruflin.com>
- */
-class ResponseException extends \RuntimeException implements ExceptionInterface
-{
-    /**
-     * @var \Elastica\Request Request object
-     */
-    protected $_request = null;
+    use Elastica\Exception\JSONParseException;
+    use Elastica\Exception\NotFoundException;
 
     /**
-     * @var \Elastica\Response Response object
-     */
-    protected $_response = null;
-
-    /**
-     * Construct Exception.
+     * Elastica Response object.
      *
-     * @param \Elastica\Request  $request
-     * @param \Elastica\Response $response
-     */
-    public function __construct(Request $request, Response $response)
-    {
-        $this->_request = $request;
-        $this->_response = $response;
-        parent::__construct($response->getError());
-    }
-
-    /**
-     * Returns request object.
+     * Stores query time, and result array -> is given to result set, returned by ...
      *
-     * @return \Elastica\Request Request object
+     * @author Nicolas Ruflin <spam@ruflin.com>
      */
-    public function getRequest()
+    class Response
     {
-        return $this->_request;
-    }
+        /**
+         * Query time.
+         *
+         * @var float Query time
+         */
+        protected $_queryTime = null;
 
-    /**
-     * Returns response object.
-     *
-     * @return \Elastica\Response Response object
-     */
-    public function getResponse()
-    {
-        return $this->_response;
-    }
+        /**
+         * Response string (json).
+         *
+         * @var string Response
+         */
+        protected $_responseString = '';
 
-    /**
-     * Returns elasticsearch exception.
-     *
-     * @return ElasticsearchException
-     */
-    public function getElasticsearchException()
-    {
-        $response = $this->getResponse();
-        $transfer = $response->getTransferInfo();
-        $code = array_key_exists('http_code', $transfer) ? $transfer['http_code'] : 0;
+        /**
+         * Error.
+         *
+         * @var bool Error
+         */
+        protected $_error = false;
 
-        return new ElasticsearchException($code, $response->getError());
+        /**
+         * Transfer info.
+         *
+         * @var array transfer info
+         */
+        protected $_transferInfo = array();
+
+        /**
+         * Response.
+         *
+         * @var \Elastica\Response Response object
+         */
+        protected $_response = null;
+
+        /**
+         * HTTP response status code.
+         *
+         * @var int
+         */
+        protected $_status = null;
+
+        /**
+         * Construct.
+         *
+         * @param string|array $responseString Response string (json)
+         * @param int          $responseStatus http status code
+         */
+        public function __construct($responseString, $responseStatus = null)
+        {
+            if (is_array($responseString)) {
+                $this->_response = $responseString;
+            } else {
+                $this->_responseString = $responseString;
+            }
+            $this->_status = $responseStatus;
+        }
+
+        /**
+         * Error message.
+         *
+         * @return string Error message
+         */
+        public function getError()
+        {
+            $message = '';
+            $response = $this->getData();
+
+            if (isset($response['error'])) {
+                $message = $response['error'];
+            }
+
+            return $message;
+        }
+
+        /**
+         * True if response has error.
+         *
+         * @return bool True if response has error
+         */
+        public function hasError()
+        {
+            $response = $this->getData();
+
+            if (isset($response['error'])) {
+                return true;
+            }
+
+            return false;
+        }
+
+        /**
+         * True if response has failed shards.
+         *
+         * @return bool True if response has failed shards
+         */
+        public function hasFailedShards()
+        {
+            try {
+                $shardsStatistics = $this->getShardsStatistics();
+            } catch (NotFoundException $e) {
+                return false;
+            }
+
+            return array_key_exists('failures', $shardsStatistics);
+        }
+
+        /**
+         * Checks if the query returned ok.
+         *
+         * @return bool True if ok
+         */
+        public function isOk()
+        {
+            $data = $this->getData();
+
+            // Bulk insert checks. Check every item
+            if (isset($data['status'])) {
+                if ($data['status'] >= 200 && $data['status'] <= 300) {
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (isset($data['items'])) {
+                if (isset($data['errors']) && true === $data['errors']) {
+                    return false;
+                }
+
+                foreach ($data['items'] as $item) {
+                    if (isset($item['index']['ok']) && false == $item['index']['ok']) {
+                        return false;
+                    } elseif (isset($item['index']['status']) && ($item['index']['status'] < 200 || $item['index']['status'] >= 300)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            if ($this->_status >= 200 && $this->_status <= 300) {
+                // http status is ok
+                return true;
+            }
+
+            return (isset($data['ok']) && $data['ok']);
+        }
+
+        /**
+         * @return int
+         */
+        public function getStatus()
+        {
+            return $this->_status;
+        }
+
+        /**
+         * Response data array.
+         *
+         * @return array Response data array
+         */
+        public function getData()
+        {
+            if ($this->_response == null) {
+                $response = $this->_responseString;
+                if ($response === false) {
+                    $this->_error = true;
+                } else {
+                    try {
+                        $response = JSON::parse($response);
+                    } catch (JSONParseException $e) {
+                        // leave response as is if parse fails
+                    }
+                }
+
+                if (empty($response)) {
+                    $response = array();
+                }
+
+                if (is_string($response)) {
+                    $response = array('message' => $response);
+                }
+
+                $this->_response = $response;
+            }
+
+            return $this->_response;
+        }
+
+        /**
+         * Gets the transfer information.
+         *
+         * @return array Information about the curl request.
+         */
+        public function getTransferInfo()
+        {
+            return $this->_transferInfo;
+        }
+
+        /**
+         * Sets the transfer info of the curl request. This function is called
+         * from the \Elastica\Client::_callService .
+         *
+         * @param array $transferInfo The curl transfer information.
+         *
+         * @return $this
+         */
+        public function setTransferInfo(array $transferInfo)
+        {
+            $this->_transferInfo = $transferInfo;
+
+            return $this;
+        }
+
+        /**
+         * Returns query execution time.
+         *
+         * @return float Query time
+         */
+        public function getQueryTime()
+        {
+            return $this->_queryTime;
+        }
+
+        /**
+         * Sets the query time.
+         *
+         * @param float $queryTime Query time
+         *
+         * @return $this
+         */
+        public function setQueryTime($queryTime)
+        {
+            $this->_queryTime = $queryTime;
+
+            return $this;
+        }
+
+        /**
+         * Time request took.
+         *
+         * @throws \Elastica\Exception\NotFoundException
+         *
+         * @return int Time request took
+         */
+        public function getEngineTime()
+        {
+            $data = $this->getData();
+
+            if (!isset($data['took'])) {
+                throw new NotFoundException('Unable to find the field [took]from the response');
+            }
+
+            return $data['took'];
+        }
+
+        /**
+         * Get the _shard statistics for the response.
+         *
+         * @throws \Elastica\Exception\NotFoundException
+         *
+         * @return array
+         */
+        public function getShardsStatistics()
+        {
+            $data = $this->getData();
+
+            if (!isset($data['_shards'])) {
+                throw new NotFoundException('Unable to find the field [_shards] from the response');
+            }
+
+            return $data['_shards'];
+        }
+
+        /**
+         * Get the _scroll value for the response.
+         *
+         * @throws \Elastica\Exception\NotFoundException
+         *
+         * @return string
+         */
+        public function getScrollId()
+        {
+            $data = $this->getData();
+
+            if (!isset($data['_scroll_id'])) {
+                throw new NotFoundException('Unable to find the field [_scroll_id] from the response');
+            }
+
+            return $data['_scroll_id'];
+        }
     }
-}

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -1,308 +1,350 @@
 <?php
-namespace Elastica;
+    namespace Elastica;
 
-use Elastica\Exception\JSONParseException;
-use Elastica\Exception\NotFoundException;
-
-/**
- * Elastica Response object.
- *
- * Stores query time, and result array -> is given to result set, returned by ...
- *
- * @author Nicolas Ruflin <spam@ruflin.com>
- */
-class Response
-{
-    /**
-     * Query time.
-     *
-     * @var float Query time
-     */
-    protected $_queryTime = null;
+    use Elastica\Exception\JSONParseException;
+    use Elastica\Exception\NotFoundException;
 
     /**
-     * Response string (json).
+     * Elastica Response object.
      *
-     * @var string Response
-     */
-    protected $_responseString = '';
-
-    /**
-     * Error.
+     * Stores query time, and result array -> is given to result set, returned by ...
      *
-     * @var bool Error
+     * @author Nicolas Ruflin <spam@ruflin.com>
      */
-    protected $_error = false;
-
-    /**
-     * Transfer info.
-     *
-     * @var array transfer info
-     */
-    protected $_transferInfo = array();
-
-    /**
-     * Response.
-     *
-     * @var \Elastica\Response Response object
-     */
-    protected $_response = null;
-
-    /**
-     * HTTP response status code.
-     *
-     * @var int
-     */
-    protected $_status = null;
-
-    /**
-     * Construct.
-     *
-     * @param string|array $responseString Response string (json)
-     * @param int          $responseStatus http status code
-     */
-    public function __construct($responseString, $responseStatus = null)
+    class Response
     {
-        if (is_array($responseString)) {
-            $this->_response = $responseString;
-        } else {
-            $this->_responseString = $responseString;
-        }
-        $this->_status = $responseStatus;
-    }
+        /**
+         * Query time.
+         *
+         * @var float Query time
+         */
+        protected $_queryTime = null;
 
-    /**
-     * Error message.
-     *
-     * @return string Error message
-     */
-    public function getError()
-    {
-        $message = '';
-        $response = $this->getData();
+        /**
+         * Response string (json).
+         *
+         * @var string Response
+         */
+        protected $_responseString = '';
 
-        if (isset($response['error'])) {
-            $message = $response['error'];
+        /**
+         * Error.
+         *
+         * @var bool Error
+         */
+        protected $_error = false;
+
+        /**
+         * Transfer info.
+         *
+         * @var array transfer info
+         */
+        protected $_transferInfo = array();
+
+        /**
+         * Response.
+         *
+         * @var \Elastica\Response Response object
+         */
+        protected $_response = null;
+
+        /**
+         * HTTP response status code.
+         *
+         * @var int
+         */
+        protected $_status = null;
+
+        /**
+         * Construct.
+         *
+         * @param string|array $responseString Response string (json)
+         * @param int          $responseStatus http status code
+         */
+        public function __construct($responseString, $responseStatus = null)
+        {
+            if (is_array($responseString)) {
+                $this->_response = $responseString;
+            } else {
+                $this->_responseString = $responseString;
+            }
+            $this->_status = $responseStatus;
         }
 
-        return $message;
-    }
+        /**
+         * Error message.
+         *
+         * @return string Error message
+         */
+        public function getError()
+        {
+            $error = $this->getFullError();
 
-    /**
-     * True if response has error.
-     *
-     * @return bool True if response has error
-     */
-    public function hasError()
-    {
-        $response = $this->getData();
+            if (!$error) {
+                return '';
+            }
 
-        if (isset($response['error'])) {
-            return true;
+            if (is_string($error)) {
+                return $error;
+            }
+
+            if (isset($error['root_cause'][0])) {
+                $error = $error['root_cause'][0];
+            }
+
+            $message = $error['reason'];
+            if (isset($error['index'])) {
+                $message .= ' [index: '.$error['index'].']';
+            }
+
+            return $message;
         }
 
-        return false;
-    }
+        /**
+         * A keyed array representing any errors that occured.
+         *
+         * In case of http://localhost:9200/_alias/test the error is a string
+         *
+         * @return array|string Error data
+         */
+        public function getFullError()
+        {
+            $response = $this->getData();
 
-    /**
-     * True if response has failed shards.
-     *
-     * @return bool True if response has failed shards
-     */
-    public function hasFailedShards()
-    {
-        try {
-            $shardsStatistics = $this->getShardsStatistics();
-        } catch (NotFoundException $e) {
-            return false;
+            if (isset($response['error'])) {
+                return $response['error'];
+            }
         }
 
-        return array_key_exists('failures', $shardsStatistics);
-    }
+        /**
+         * @return string Error string based on the error object
+         */
+        public function getErrorMessage()
+        {
+            $error = $this->getError();
 
-    /**
-     * Checks if the query returned ok.
-     *
-     * @return bool True if ok
-     */
-    public function isOk()
-    {
-        $data = $this->getData();
+            if (!is_string($error)) {
+                $error = json_encode($error);
+            }
 
-        // Bulk insert checks. Check every item
-        if (isset($data['status'])) {
-            if ($data['status'] >= 200 && $data['status'] <= 300) {
+            return $error;
+        }
+
+        /**
+         * True if response has error.
+         *
+         * @return bool True if response has error
+         */
+        public function hasError()
+        {
+            $response = $this->getData();
+
+            if (isset($response['error'])) {
                 return true;
             }
 
             return false;
         }
 
-        if (isset($data['items'])) {
-            if (isset($data['errors']) && true === $data['errors']) {
+        /**
+         * True if response has failed shards.
+         *
+         * @return bool True if response has failed shards
+         */
+        public function hasFailedShards()
+        {
+            try {
+                $shardsStatistics = $this->getShardsStatistics();
+            } catch (NotFoundException $e) {
                 return false;
             }
 
-            foreach ($data['items'] as $item) {
-                if (isset($item['index']['ok']) && false == $item['index']['ok']) {
-                    return false;
-                } elseif (isset($item['index']['status']) && ($item['index']['status'] < 200 || $item['index']['status'] >= 300)) {
+            return array_key_exists('failures', $shardsStatistics);
+        }
+
+        /**
+         * Checks if the query returned ok.
+         *
+         * @return bool True if ok
+         */
+        public function isOk()
+        {
+            $data = $this->getData();
+
+            // Bulk insert checks. Check every item
+            if (isset($data['status'])) {
+                if ($data['status'] >= 200 && $data['status'] <= 300) {
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (isset($data['items'])) {
+                if (isset($data['errors']) && true === $data['errors']) {
                     return false;
                 }
-            }
 
-            return true;
-        }
-
-        if ($this->_status >= 200 && $this->_status <= 300) {
-            // http status is ok
-            return true;
-        }
-
-        return (isset($data['ok']) && $data['ok']);
-    }
-
-    /**
-     * @return int
-     */
-    public function getStatus()
-    {
-        return $this->_status;
-    }
-
-    /**
-     * Response data array.
-     *
-     * @return array Response data array
-     */
-    public function getData()
-    {
-        if ($this->_response == null) {
-            $response = $this->_responseString;
-            if ($response === false) {
-                $this->_error = true;
-            } else {
-                try {
-                    $response = JSON::parse($response);
-                } catch (JSONParseException $e) {
-                    // leave response as is if parse fails
+                foreach ($data['items'] as $item) {
+                    if (isset($item['index']['ok']) && false == $item['index']['ok']) {
+                        return false;
+                    } elseif (isset($item['index']['status']) && ($item['index']['status'] < 200 || $item['index']['status'] >= 300)) {
+                        return false;
+                    }
                 }
+
+                return true;
             }
 
-            if (empty($response)) {
-                $response = array();
+            if ($this->_status >= 200 && $this->_status <= 300) {
+                // http status is ok
+                return true;
             }
 
-            if (is_string($response)) {
-                $response = array('message' => $response);
+            return (isset($data['ok']) && $data['ok']);
+        }
+
+        /**
+         * @return int
+         */
+        public function getStatus()
+        {
+            return $this->_status;
+        }
+
+        /**
+         * Response data array.
+         *
+         * @return array Response data array
+         */
+        public function getData()
+        {
+            if ($this->_response == null) {
+                $response = $this->_responseString;
+                if ($response === false) {
+                    $this->_error = true;
+                } else {
+                    try {
+                        $response = JSON::parse($response);
+                    } catch (JSONParseException $e) {
+                        // leave response as is if parse fails
+                    }
+                }
+
+                if (empty($response)) {
+                    $response = array();
+                }
+
+                if (is_string($response)) {
+                    $response = array('message' => $response);
+                }
+
+                $this->_response = $response;
             }
 
-            $this->_response = $response;
+            return $this->_response;
         }
 
-        return $this->_response;
-    }
-
-    /**
-     * Gets the transfer information.
-     *
-     * @return array Information about the curl request.
-     */
-    public function getTransferInfo()
-    {
-        return $this->_transferInfo;
-    }
-
-    /**
-     * Sets the transfer info of the curl request. This function is called
-     * from the \Elastica\Client::_callService .
-     *
-     * @param array $transferInfo The curl transfer information.
-     *
-     * @return $this
-     */
-    public function setTransferInfo(array $transferInfo)
-    {
-        $this->_transferInfo = $transferInfo;
-
-        return $this;
-    }
-
-    /**
-     * Returns query execution time.
-     *
-     * @return float Query time
-     */
-    public function getQueryTime()
-    {
-        return $this->_queryTime;
-    }
-
-    /**
-     * Sets the query time.
-     *
-     * @param float $queryTime Query time
-     *
-     * @return $this
-     */
-    public function setQueryTime($queryTime)
-    {
-        $this->_queryTime = $queryTime;
-
-        return $this;
-    }
-
-    /**
-     * Time request took.
-     *
-     * @throws \Elastica\Exception\NotFoundException
-     *
-     * @return int Time request took
-     */
-    public function getEngineTime()
-    {
-        $data = $this->getData();
-
-        if (!isset($data['took'])) {
-            throw new NotFoundException('Unable to find the field [took]from the response');
+        /**
+         * Gets the transfer information.
+         *
+         * @return array Information about the curl request.
+         */
+        public function getTransferInfo()
+        {
+            return $this->_transferInfo;
         }
 
-        return $data['took'];
-    }
+        /**
+         * Sets the transfer info of the curl request. This function is called
+         * from the \Elastica\Client::_callService .
+         *
+         * @param array $transferInfo The curl transfer information.
+         *
+         * @return $this
+         */
+        public function setTransferInfo(array $transferInfo)
+        {
+            $this->_transferInfo = $transferInfo;
 
-    /**
-     * Get the _shard statistics for the response.
-     *
-     * @throws \Elastica\Exception\NotFoundException
-     *
-     * @return array
-     */
-    public function getShardsStatistics()
-    {
-        $data = $this->getData();
-
-        if (!isset($data['_shards'])) {
-            throw new NotFoundException('Unable to find the field [_shards] from the response');
+            return $this;
         }
 
-        return $data['_shards'];
-    }
-
-    /**
-     * Get the _scroll value for the response.
-     *
-     * @throws \Elastica\Exception\NotFoundException
-     *
-     * @return string
-     */
-    public function getScrollId()
-    {
-        $data = $this->getData();
-
-        if (!isset($data['_scroll_id'])) {
-            throw new NotFoundException('Unable to find the field [_scroll_id] from the response');
+        /**
+         * Returns query execution time.
+         *
+         * @return float Query time
+         */
+        public function getQueryTime()
+        {
+            return $this->_queryTime;
         }
 
-        return $data['_scroll_id'];
+        /**
+         * Sets the query time.
+         *
+         * @param float $queryTime Query time
+         *
+         * @return $this
+         */
+        public function setQueryTime($queryTime)
+        {
+            $this->_queryTime = $queryTime;
+
+            return $this;
+        }
+
+        /**
+         * Time request took.
+         *
+         * @throws \Elastica\Exception\NotFoundException
+         *
+         * @return int Time request took
+         */
+        public function getEngineTime()
+        {
+            $data = $this->getData();
+
+            if (!isset($data['took'])) {
+                throw new NotFoundException('Unable to find the field [took]from the response');
+            }
+
+            return $data['took'];
+        }
+
+        /**
+         * Get the _shard statistics for the response.
+         *
+         * @throws \Elastica\Exception\NotFoundException
+         *
+         * @return array
+         */
+        public function getShardsStatistics()
+        {
+            $data = $this->getData();
+
+            if (!isset($data['_shards'])) {
+                throw new NotFoundException('Unable to find the field [_shards] from the response');
+            }
+
+            return $data['_shards'];
+        }
+
+        /**
+         * Get the _scroll value for the response.
+         *
+         * @throws \Elastica\Exception\NotFoundException
+         *
+         * @return string
+         */
+        public function getScrollId()
+        {
+            $data = $this->getData();
+
+            if (!isset($data['_scroll_id'])) {
+                throw new NotFoundException('Unable to find the field [_scroll_id] from the response');
+            }
+
+            return $data['_scroll_id'];
+        }
     }
-}


### PR DESCRIPTION
Hi there. I have a PHP 5.3 + ES 2.3.2 requirement. I'm doing good so far with Elastica 2.3.1, and  as long as my tests pass, I'm ok to use it. I've hit some incompatibilities and already have workarounds (outside Elastica) for those. However, your change to support non-string errors in ES 2.3.2 responses appears not to be breaking ES 1.x compatibility, so I've applied what appears to be minimum change on this branch. Could you please consider merging it, so there is one less fork to manage for anyone concerned. Thanks.
