### PR TITLE
Get the root reason from elasticsearch's json when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 - Set PHP 7.0 as default development version
+- Get the root reason from Elasticsearch's error JSON, when available [#1111](https://github.com/ruflin/Elastica/pull/1111)
 
 ## [3.2.1](https://github.com/ruflin/Elastica/compare/3.2.0...3.2.1)
 

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -95,13 +95,18 @@ class Response
             return $error;
         }
 
+        $rootError = $error;
         if (isset($error['root_cause'][0])) {
-            $error = $error['root_cause'][0];
+            $rootError = $error['root_cause'][0];
         }
 
-        $message = $error['reason'];
-        if (isset($error['index'])) {
-            $message .= ' [index: '.$error['index'].']';
+        $message = $rootError['reason'];
+        if (isset($rootError['index'])) {
+            $message .= ' [index: '.$rootError['index'].']';
+        }
+
+        if (isset($error['reason']) && $rootError['reason'] != $error['reason']) {
+            $message .= ' [reason: '.$error['reason'].']';
         }
 
         return $message;


### PR DESCRIPTION
Sometimes elasticsearch (i'm using 2.3.3) returns an error with two reasons:

```json
{
  "error": {
    "root_cause": [
      {
        "type": "index_creation_exception",
        "reason": "failed to create index"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "synonym requires either `synonyms` or `synonyms_path` to be configured"
  },
  "status": 400
}
```

But the current code uses only the "root_cause" reason, leaving me with an exception that says "failed to create index" and not much else. This change uses the "root" reason key if it exists.