### PR TITLE
Fix PHP 5.4 build

### DIFF
--- a/env/elastica/Docker54
+++ b/env/elastica/Docker54
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y \
 	graphviz \
 	libxslt-dev \
 	nano \
-	php5-xsl
+	php5-xsl \
+	wget
 	# XSL and Graphviz for PhpDocumentor
 
 RUN docker-php-ext-install sockets xsl
@@ -24,10 +25,13 @@ RUN pecl install xdebug-2.3.2
 RUN echo "memory_limit=1024M" >> /usr/local/etc/php/conf.d/memory-limit.ini
 RUN echo "date.timezone=UTC" >> /usr/local/etc/php/conf.d/timezone.ini
 #RUN echo "extension=/usr/lib/php5/20131226/xsl.so" >> /usr/local/etc/php/conf.d/xsl.ini # TODO: Debian is putting the xsl extension in a different directory, should be in: /usr/local/lib/php/extensions/no-debug-non-zts-20131226
-RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20131226/xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini
+RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20100525/xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install and setup composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN wget https://getcomposer.org/download/1.0.3/composer.phar
+RUN mv composer.phar /usr/local/bin/composer
+RUN chmod a+x /usr/local/bin/composer
+
 ENV COMPOSER_HOME /root/composer
 
 # Add composer bin to the environment


### PR DESCRIPTION
Since composer 1.1 if no lock file exists, require-dev dependencies are checked. This leads to a problem during our tests for PHP 5.4 as some dependencies are not compatible. For PHP 5.4 builds composer 1.0.3 is used to have the old behaviour. For more details see: composer/composer#5308 (comment)