### PR TITLE
Fixed gzip encoding enable/disable on persistent connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Fixes
 
 ### Bugfixes
+- Set HTTP headers on each request preventing server error if persistent connection is enabled and compression enabled and later disabled for the same connection.
 
 ### Added
 

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -103,13 +103,13 @@ class Http extends AbstractTransport
 
         $headersConfig = $connection->hasConfig('headers') ? $connection->getConfig('headers') : array();
 
+        $headers = [];
+
         if (!empty($headersConfig)) {
             $headers = array();
             while (list($header, $headerValue) = each($headersConfig)) {
                 array_push($headers, $header.': '.$headerValue);
             }
-
-            curl_setopt($conn, CURLOPT_HTTPHEADER, $headers);
         }
 
         // TODO: REFACTOR
@@ -135,13 +135,15 @@ class Http extends AbstractTransport
                 curl_setopt($conn, CURLOPT_POSTFIELDS, gzencode($content));
 
                 // ... and tell ES that it is compressed
-                curl_setopt($conn, CURLOPT_HTTPHEADER, array('Content-Encoding: gzip'));
+                array_push($headers, 'Content-Encoding: gzip');
             } else {
                 curl_setopt($conn, CURLOPT_POSTFIELDS, $content);
             }
         } else {
             curl_setopt($conn, CURLOPT_POSTFIELDS, '');
         }
+
+        curl_setopt($conn, CURLOPT_HTTPHEADER, $headers);
 
         curl_setopt($conn, CURLOPT_NOBODY, $httpMethod == 'HEAD');
 


### PR DESCRIPTION
When using a persistent connection and you enable compression with setCompression, make a request and then disable the compression, the next requests are sent without encoding as gzip (because compression is disabled) but the headers are persisted with the Content-Encoding: gzip, because we are reusing the same curl client and no headers are sent, so $headerConfig is empty and the CURLOPT_HTTPHEADER is never reached.