### PR TITLE
Bugfix array push to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/3.2.1...HEAD)
 
 ### Backward Compatibility Fixes
-- Use short array [] - so PHP 5.3 deprecated
+- Use short array syntax `[]` instead of long `array()` - so break compatibility with PHP 5.3
 
 ### Bugfixes
 - Set HTTP headers on each request preventing server error if persistent connection is enabled and compression enabled and later disabled for the same connection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/3.2.1...HEAD)
 
 ### Backward Compatibility Fixes
+- Use short array [] - so PHP 5.3 deprecated
 
 ### Bugfixes
 - Set HTTP headers on each request preventing server error if persistent connection is enabled and compression enabled and later disabled for the same connection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/3.2.1...HEAD)
 
 ### Backward Compatibility Fixes
-- Use short array syntax `[]` instead of long `array()` - so break compatibility with PHP 5.3
+- Use short array syntax `[]` instead of long `array()`
 
 ### Bugfixes
 - Set HTTP headers on each request preventing server error if persistent connection is enabled and compression enabled and later disabled for the same connection.

--- a/lib/Elastica/Query/Fuzzy.php
+++ b/lib/Elastica/Query/Fuzzy.php
@@ -57,7 +57,7 @@ class Fuzzy extends AbstractQuery
     {
         //Retrieve the single existing field for alteration.
         $params = $this->getParams();
-        if (count($params) < 1) {
+        if (empty($params)) {
             throw new InvalidException('No field has been set');
         }
         $keyArray = array_keys($params);

--- a/lib/Elastica/Query/Ids.php
+++ b/lib/Elastica/Query/Ids.php
@@ -64,7 +64,7 @@ class Ids extends AbstractQuery
     /**
      * Set type.
      *
-     * @param string|\Elastica\Type $type Type name or object
+     * @param array|string|\Elastica\Type $type Type name or object
      *
      * @return $this
      */
@@ -77,7 +77,7 @@ class Ids extends AbstractQuery
             return $this;
         }
 
-        $this->_params['type'] = $type;
+        $this->_params['type'] = is_array($type) ? $type : [$type];
 
         return $this;
     }

--- a/lib/Elastica/Query/Ids.php
+++ b/lib/Elastica/Query/Ids.php
@@ -77,7 +77,7 @@ class Ids extends AbstractQuery
             return $this;
         }
 
-        $this->_params['type'] = is_array($type) ? $type : [$type];
+        $this->_params['type'] = (array)$type;
 
         return $this;
     }
@@ -91,7 +91,7 @@ class Ids extends AbstractQuery
      */
     public function setIds($ids)
     {
-        $this->_params['values'] = is_array($ids) ? $ids : [$ids];
+        $this->_params['values'] = (array)$ids;
 
         return $this;
     }

--- a/lib/Elastica/Query/Ids.php
+++ b/lib/Elastica/Query/Ids.php
@@ -91,11 +91,7 @@ class Ids extends AbstractQuery
      */
     public function setIds($ids)
     {
-        if (is_array($ids)) {
-            $this->_params['values'] = $ids;
-        } else {
-            $this->_params['values'] = array($ids);
-        }
+        $this->_params['values'] = is_array($ids) ? $ids : [$ids];
 
         return $this;
     }


### PR DESCRIPTION
Answer for possible future questions
1. First time use short array syntax in https://github.com/ruflin/Elastica/blob/e77bf54cf714b92828106a8d3863f1503c8e7d05/lib/Elastica/Transport/Http.php#L106
2. Fatal error on push as `array` to string http://sandbox.onlinephpfunctions.com/code/dbc5b51d01771f258fb814b12b7a5843052df15d