### PR TITLE
Fix incorred AbstractUpdateAction::setVersionType annotation

### DIFF
--- a/lib/Elastica/AbstractUpdateAction.php
+++ b/lib/Elastica/AbstractUpdateAction.php
@@ -168,7 +168,7 @@ class AbstractUpdateAction extends Param
      * Sets the version_type of a document
      * Default in ES is internal, but you can set to external to use custom versioning.
      *
-     * @param int $versionType Document version type
+     * @param string $versionType Document version type
      *
      * @return $this
      */


### PR DESCRIPTION
This function should take a string, specifically 'external', so
annotate as taking a string rather than an integer.