### PR TITLE
Remove unused extra parameter to _createElasticaResponse

### DIFF
--- a/lib/Elastica/Transport/HttpAdapter.php
+++ b/lib/Elastica/Transport/HttpAdapter.php
@@ -64,7 +64,7 @@ class HttpAdapter extends AbstractTransport
         $httpAdapterResponse = $this->httpAdapter->sendRequest($httpAdapterRequest);
         $end = microtime(true);
 
-        $elasticaResponse = $this->_createElasticaResponse($httpAdapterResponse, $connection);
+        $elasticaResponse = $this->_createElasticaResponse($httpAdapterResponse);
         $elasticaResponse->setQueryTime($end - $start);
 
         $elasticaResponse->setTransferInfo(


### PR DESCRIPTION
This method does not have a second argument, as such remove it from the
caller.