### PR TITLE
Allow strings for setMinimumMatch in Terms query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 - Set HTTP headers on each request preventing server error if persistent connection is enabled and compression enabled and later disabled for the same connection.
+- Removed `int` type hinting in `setMinimumMatch` (`Terms` Query): it should also allow `string`. [#1151](https://github.com/ruflin/Elastica/pull/1151)  
 
 ### Added
 - Elastica\QueryBuilder\DSL\Query::geo_distance

--- a/lib/Elastica/Query/Terms.php
+++ b/lib/Elastica/Query/Terms.php
@@ -7,6 +7,7 @@ use Elastica\Exception\InvalidException;
  * Terms query.
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
+ * @author Roberto Nygaard <roberto@nygaard.es>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
  */
@@ -70,13 +71,12 @@ class Terms extends AbstractQuery
     /**
      * Sets the minimum matching values.
      *
-     * @param int $minimum Minimum value
-     *
-     * @return $this
+     * @param int|string $minimum Minimum value
+     * @return  $this
      */
     public function setMinimumMatch($minimum)
     {
-        return $this->setParam('minimum_match', (int) $minimum);
+        return $this->setParam('minimum_match', $minimum);
     }
 
     /**

--- a/test/lib/Elastica/Test/Query/TermsTest.php
+++ b/test/lib/Elastica/Test/Query/TermsTest.php
@@ -36,14 +36,38 @@ class TermsTest extends BaseTest
         $this->assertEquals(3, $resultSet->count());
     }
 
+    public function provideMinimumArguments()
+    {
+        return [
+            [
+                3
+            ],
+            [
+                -2
+            ],
+            [
+                '75%'
+            ],
+            [
+                '-25%'
+            ],
+            [
+                '3<90%'
+            ],
+            [
+                '2<-25% 9<-3'
+            ]
+        ];
+    }
+
     /**
      * @group unit
+     * @dataProvider provideMinimumArguments
      */
-    public function testSetMinimum()
+    public function testSetMinimum($minimum)
     {
         $key = 'name';
         $terms = ['nicolas', 'ruflin'];
-        $minimum = 2;
 
         $query = new Terms($key, $terms);
         $query->setMinimumMatch($minimum);


### PR DESCRIPTION
This closes #1149 