### PR TITLE
[DX] Version method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file based on the
 - Elastica\QueryBuilder\DSL\Query::geo_distance
 - Elastica\Aggregation\GeoCentroid [#1150](https://github.com/ruflin/Elastica/pull/1150)
 - [Multi value field](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_multi_values_fields) param for decay function.
+- Elastica\Client::getVersion [#1152](https://github.com/ruflin/Elastica/pull/1152)
 
 ### Improvements
 - Set PHP 7.0 as default development version

--- a/env/elasticsearch/Dockerfile
+++ b/env/elasticsearch/Dockerfile
@@ -2,6 +2,7 @@ FROM elasticsearch:2.3.2
 MAINTAINER Nicolas Ruflin <spam@ruflin.com>
 
 # Dependencies
+ENV ELASTICSEARCH_VERSION 2.3.2
 ENV ES_IMAGE_PLUGIN_VER 1.7.1
 ENV ES_PLUGIN_BIN /usr/share/elasticsearch/bin/plugin
 

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -68,6 +68,11 @@ class Client
     protected $_logger;
 
     /**
+     * @var string
+     */
+    protected $_version;
+
+    /**
      * Creates a new Elastica client.
      *
      * @param array           $config   OPTIONAL Additional config options
@@ -85,6 +90,21 @@ class Client
 
         $this->setConfig($config);
         $this->_initConnections();
+    }
+
+    /**
+     * Get current version
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        if ($this->_version) {
+            return $this->_version;
+        }
+
+        $data = $this->request('/')->getData();
+        return $this->_version = $data['version']['number'];
     }
 
     /**

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -29,8 +29,8 @@ class ClientTest extends BaseTest
     public function testGetVersion()
     {
         $client = $this->_getClient();
-        $this->assertNotEmpty($version = $client->getVersion());
-        $this->assertSame($version, $client->getVersion());
+        $this->assertNotEmpty($client->getVersion());
+        $this->assertTrue(version_compare($client->getVersion(), $_SERVER['ELASTICSEARCH_VERSION'], '>='));
     }
 
     /**

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -26,6 +26,16 @@ class ClientTest extends BaseTest
     /**
      * @group functional
      */
+    public function testGetVersion()
+    {
+        $client = $this->_getClient();
+        $this->assertNotEmpty($version = $client->getVersion());
+        $this->assertSame($version, $client->getVersion());
+    }
+
+    /**
+     * @group functional
+     */
     public function testConnectionsArray()
     {
         // Creates a new index 'xodoa' and a type 'user' inside this index


### PR DESCRIPTION
adding `getVersion` method to Client.

**Case:** For large platforms it's critical to upgrade incrementally/step-by-step, for this purpose we need to know current version on ES 