### PR TITLE
Error: Wrong parameters for Exception([string $exception [, long $cod…

### DIFF
--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -192,7 +192,7 @@ class Http extends AbstractTransport
     {
         if ($this->getConnection()->hasConfig('curl')) {
             foreach ($this->getConnection()->getConfig('curl') as $key => $param) {
-                curl_setopt($curlConnection, $key, $param);
+                curl_setopt($curlConnection, constant($key), $param);
             }
         }
     }


### PR DESCRIPTION
…e [, Exception $previous = NULL]]])

needed to https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1108