### PR TITLE
Optimize memory usage for Http Adapter

### DIFF
--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -122,13 +122,13 @@ class Http extends AbstractTransport
             }
 
             if (is_array($data)) {
-                $content = JSON::stringify($data, 'JSON_ELASTICSEARCH');
+                $content = JSON::stringify($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
             } else {
                 $content = $data;
-            }
 
-            // Escaping of / not necessary. Causes problems in base64 encoding of files
-            $content = str_replace('\/', '/', $content);
+                // Escaping of / not necessary. Causes problems in base64 encoding of files
+                $content = str_replace('\/', '/', $content);
+            }
 
             if ($connection->hasCompression()) {
                 // Compress the body of the request ...


### PR DESCRIPTION
`$content = str_replace('\/', '/', $content);` consumes a lot of memory, especially with large payloads.

In my import loop, it was consuming 40MB per bulk.

This improves memory consumption