### PR TITLE
Added BucketScript and SerialDiff aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 
 ### Added
+- Elastica\Aggregation\BucketScript
+- Elastica\Aggregation\SerialDiff
 
 ### Improvements
 

--- a/lib/Elastica/Aggregation/BucketScript.php
+++ b/lib/Elastica/Aggregation/BucketScript.php
@@ -1,0 +1,93 @@
+<?php
+namespace Elastica\Aggregation;
+
+use Elastica\Exception\InvalidException;
+
+/**
+ * Class BucketScript.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-script-aggregation.html
+ */
+class BucketScript extends AbstractAggregation
+{
+    /**
+     * @param string $name
+     * @param array|null $bucketsPath
+     * @param string|null $script
+     */
+    public function __construct($name, $bucketsPath = null, $script = null)
+    {
+        parent::__construct($name);
+
+        if ($bucketsPath !== null) {
+            $this->setBucketsPath($bucketsPath);
+        }
+
+        if ($script !== null) {
+            $this->setScript($script);
+        }
+    }
+
+    /**
+     * Set the buckets_path for this aggregation.
+     *
+     * @param array $bucketsPath
+     *
+     * @return $this
+     */
+    public function setBucketsPath($bucketsPath)
+    {
+        return $this->setParam('buckets_path', $bucketsPath);
+    }
+
+    /**
+     * Set the script for this aggregation.
+     *
+     * @param string $script
+     *
+     * @return $this
+     */
+    public function setScript($script)
+    {
+        return $this->setParam('script', $script);
+    }
+
+    /**
+     * Set the gap policy for this aggregation.
+     *
+     * @param string $gapPolicy
+     *
+     * @return $this
+     */
+    public function setGapPolicy($gapPolicy)
+    {
+        return $this->setParam('gap_policy', $gapPolicy);
+    }
+
+    /**
+     * Set the format for this aggregation.
+     *
+     * @param string $format
+     *
+     * @return $this
+     */
+    public function setFormat($format)
+    {
+        return $this->setParam('format', $format);
+    }
+
+    /**
+     * @return array
+     * @throws InvalidException If buckets path or script is not set
+     */
+    public function toArray()
+    {
+        if (!$this->hasParam('buckets_path')) {
+            throw new InvalidException('Buckets path is required');
+        } elseif (!$this->hasParam('script')) {
+            throw new InvalidException('Script parameter is required');
+        }
+
+        return parent::toArray();
+    }
+}

--- a/lib/Elastica/Aggregation/SerialDiff.php
+++ b/lib/Elastica/Aggregation/SerialDiff.php
@@ -1,0 +1,86 @@
+<?php
+namespace Elastica\Aggregation;
+
+use Elastica\Exception\InvalidException;
+
+/**
+ * Class SerialDiff.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-serialdiff-aggregation.html
+ */
+class SerialDiff extends AbstractAggregation
+{
+    /**
+     * @param string $name
+     * @param string|null $bucketsPath
+     */
+    public function __construct($name, $bucketsPath = null)
+    {
+        parent::__construct($name);
+
+        if ($bucketsPath !== null) {
+            $this->setBucketsPath($bucketsPath);
+        }
+    }
+
+    /**
+     * Set the buckets_path for this aggregation.
+     *
+     * @param string $bucketsPath
+     *
+     * @return $this
+     */
+    public function setBucketsPath($bucketsPath)
+    {
+        return $this->setParam('buckets_path', $bucketsPath);
+    }
+
+    /**
+     * Set the lag for this aggregation.
+     *
+     * @param int $lag
+     *
+     * @return $this
+     */
+    public function setLag($lag)
+    {
+        return $this->setParam('lag', $lag);
+    }
+
+    /**
+     * Set the gap policy for this aggregation.
+     *
+     * @param string $gapPolicy
+     *
+     * @return $this
+     */
+    public function setGapPolicy($gapPolicy)
+    {
+        return $this->setParam('gap_policy', $gapPolicy);
+    }
+
+    /**
+     * Set the format for this aggregation.
+     *
+     * @param string $format
+     *
+     * @return $this
+     */
+    public function setFormat($format)
+    {
+        return $this->setParam('format', $format);
+    }
+
+    /**
+     * @return array
+     * @throws InvalidException If buckets path is not set
+     */
+    public function toArray()
+    {
+        if (!$this->hasParam('buckets_path')) {
+            throw new InvalidException('Buckets path is required');
+        }
+
+        return parent::toArray();
+    }
+}

--- a/lib/Elastica/QueryBuilder/DSL/Aggregation.php
+++ b/lib/Elastica/QueryBuilder/DSL/Aggregation.php
@@ -27,6 +27,8 @@ use Elastica\Aggregation\Sum;
 use Elastica\Aggregation\Terms;
 use Elastica\Aggregation\TopHits;
 use Elastica\Aggregation\ValueCount;
+use Elastica\Aggregation\BucketScript;
+use Elastica\Aggregation\SerialDiff;
 use Elastica\Exception\NotImplementedException;
 use Elastica\Filter\AbstractFilter;
 use Elastica\QueryBuilder\DSL;
@@ -466,5 +468,36 @@ class Aggregation implements DSL
     public function geohash_grid($name, $field)
     {
         return new GeohashGrid($name, $field);
+    }
+
+    /**
+     * bucket script aggregation.
+     *
+     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-script-aggregation.html
+     *
+     * @param string $name
+     * @param array|null $bucketsPath
+     * @param string|null $script
+     *
+     * @return BucketScript
+     */
+    public function bucket_script($name, $bucketsPath = null, $script = null)
+    {
+        return new BucketScript($name, $bucketsPath, $script);
+    }
+
+    /**
+     * serial diff aggregation.
+     *
+     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-serialdiff-aggregation.html
+     *
+     * @param string $name
+     * @param string|null $bucketsPath
+     *
+     * @return SerialDiff
+     */
+    public function serial_diff($name, $bucketsPath = null)
+    {
+        return new SerialDiff($name, $bucketsPath);
     }
 }

--- a/test/lib/Elastica/Test/Aggregation/BucketScriptTest.php
+++ b/test/lib/Elastica/Test/Aggregation/BucketScriptTest.php
@@ -55,4 +55,57 @@ class BucketScriptTest extends BaseAggregationTest
         $this->assertEquals(2.4, $results['buckets'][1]['result']['value']);
         $this->assertEquals(3.1, $results['buckets'][2]['result']['value']);
     }
+
+    /**
+     * @group unit
+     */
+    public function testConstructThroughSetters()
+    {
+        $serialDiffAgg = new BucketScript('bucket_scripted');
+
+        $serialDiffAgg
+            ->setScript('x / y * z')
+            ->setBucketsPath([
+                'x' => 'agg_max',
+                'y' => 'agg_sum',
+                'z' => 'agg_min',
+            ])
+            ->setFormat('test_format')
+            ->setGapPolicy(10);
+
+        $expected = [
+            'bucket_script' => [
+                'script' => 'x / y * z',
+                'buckets_path' => [
+                    'x' => 'agg_max',
+                    'y' => 'agg_sum',
+                    'z' => 'agg_min',
+                ],
+                'format' => 'test_format',
+                'gap_policy' => 10,
+            ],
+        ];
+
+        $this->assertEquals($expected, $serialDiffAgg->toArray());
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testToArrayInvalidBucketsPath()
+    {
+        $serialDiffAgg = new BucketScript('bucket_scripted');
+        $serialDiffAgg->toArray();
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testToArrayInvalidScript()
+    {
+        $serialDiffAgg = new BucketScript('bucket_scripted', ['path' => 'agg']);
+        $serialDiffAgg->toArray();
+    }
 }

--- a/test/lib/Elastica/Test/Aggregation/BucketScriptTest.php
+++ b/test/lib/Elastica/Test/Aggregation/BucketScriptTest.php
@@ -1,0 +1,58 @@
+<?php
+namespace Elastica\Test\Aggregation;
+
+use Elastica\Aggregation\BucketScript;
+use Elastica\Aggregation\Max;
+use Elastica\Aggregation\Histogram;
+use Elastica\Document;
+use Elastica\Query;
+
+class BucketScriptTest extends BaseAggregationTest
+{
+    protected function _getIndexForTest()
+    {
+        $index = $this->_createIndex();
+
+        $index->getType('test')->addDocuments([
+            Document::create(['weight' => 60, 'height' => 180, 'age' => 25]),
+            Document::create(['weight' => 65, 'height' => 156, 'age' => 32]),
+            Document::create(['weight' => 50, 'height' => 155, 'age' => 45]),
+        ]);
+
+        $index->refresh();
+
+        return $index;
+    }
+
+    /**
+     * @group functional
+     */
+    public function testBucketScriptAggregation()
+    {
+        $this->_checkScriptInlineSetting();
+
+        $bucketScriptAggregation = new BucketScript(
+            'result',
+            [
+                'divisor' => 'max_weight',
+                'dividend' => 'max_height',
+            ],
+            'dividend / divisor'
+        );
+
+        $histogramAggregation = new Histogram('age_groups', 'age', 10);
+
+        $histogramAggregation
+            ->addAggregation((new Max('max_weight'))->setField('weight'))
+            ->addAggregation((new Max('max_height'))->setField('height'))
+            ->addAggregation($bucketScriptAggregation);
+
+        $query = Query::create([])->addAggregation($histogramAggregation);
+
+        $results = $this->_getIndexForTest()->search($query)->getAggregation('age_groups');
+
+        $this->assertEquals(3, $results['buckets'][0]['result']['value']);
+        $this->assertEquals(2.4, $results['buckets'][1]['result']['value']);
+        $this->assertEquals(3.1, $results['buckets'][2]['result']['value']);
+    }
+}

--- a/test/lib/Elastica/Test/Aggregation/SerialDiffTest.php
+++ b/test/lib/Elastica/Test/Aggregation/SerialDiffTest.php
@@ -52,4 +52,39 @@ class SerialDiffTest extends BaseAggregationTest
         $this->assertEquals(84, $results['buckets'][2]['result']['value']);
         $this->assertEquals(121, $results['buckets'][3]['result']['value']);
     }
+
+    /**
+     * @group unit
+     */
+    public function testConstructThroughSetters()
+    {
+        $serialDiffAgg = new SerialDiff('difference');
+
+        $serialDiffAgg
+            ->setBucketsPath('nested_agg')
+            ->setFormat('test_format')
+            ->setGapPolicy(10)
+            ->setLag(5);
+
+        $expected = [
+            'serial_diff' => [
+                'buckets_path' => 'nested_agg',
+                'format' => 'test_format',
+                'gap_policy' => 10,
+                'lag' => 5,
+            ],
+        ];
+
+        $this->assertEquals($expected, $serialDiffAgg->toArray());
+    }
+
+    /**
+     * @group unit
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testToArrayInvalidBucketsPath()
+    {
+        $serialDiffAgg = new SerialDiff('difference');
+        $serialDiffAgg->toArray();
+    }
 }

--- a/test/lib/Elastica/Test/Aggregation/SerialDiffTest.php
+++ b/test/lib/Elastica/Test/Aggregation/SerialDiffTest.php
@@ -1,0 +1,55 @@
+<?php
+namespace Elastica\Test\Aggregation;
+
+use Elastica\Aggregation\SerialDiff;
+use Elastica\Aggregation\DateHistogram;
+use Elastica\Aggregation\Max;
+use Elastica\Document;
+use Elastica\Query;
+use Elastica\Type\Mapping;
+
+class SerialDiffTest extends BaseAggregationTest
+{
+    protected function _getIndexForTest()
+    {
+        $index = $this->_createIndex();
+        $type = $index->getType('test');
+
+        $type->setMapping(Mapping::create([
+            'value' => ['type' => 'long'],
+            'measured_at' => ['type' => 'date'],
+        ]));
+
+        $type->addDocuments([
+            Document::create(['value' => 100, 'measured_at' => '2016-08-23T15:00:00+0200']),
+            Document::create(['value' => 266, 'measured_at' => '2016-08-23T16:00:00+0200']),
+            Document::create(['value' => 350, 'measured_at' => '2016-08-23T17:00:00+0200']),
+            Document::create(['value' => 471, 'measured_at' => '2016-08-23T18:00:00+0200']),
+        ]);
+
+        $index->refresh();
+
+        return $index;
+    }
+
+    /**
+     * @group functional
+     */
+    public function testSerialDiffAggregation()
+    {
+        $dateHistogramAggregation = new DateHistogram('measurements', 'measured_at', 'hour');
+
+        $dateHistogramAggregation
+            ->addAggregation((new Max('max_value'))->setField('value'))
+            ->addAggregation(new SerialDiff('result', 'max_value'));
+
+        $query = Query::create([])->addAggregation($dateHistogramAggregation);
+
+        $results = $this->_getIndexForTest()->search($query)->getAggregation('measurements');
+
+        $this->assertEquals(false, isset($results['buckets'][0]['result']['value']));
+        $this->assertEquals(166, $results['buckets'][1]['result']['value']);
+        $this->assertEquals(84, $results['buckets'][2]['result']['value']);
+        $this->assertEquals(121, $results['buckets'][3]['result']['value']);
+    }
+}

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/AggregationTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/AggregationTest.php
@@ -66,6 +66,8 @@ class AggregationTest extends AbstractDSLTest
         $this->_assertImplemented($aggregationDSL, 'terms', 'Elastica\Aggregation\Terms', ['name']);
         $this->_assertImplemented($aggregationDSL, 'top_hits', 'Elastica\Aggregation\TopHits', ['name']);
         $this->_assertImplemented($aggregationDSL, 'value_count', 'Elastica\Aggregation\ValueCount', ['name', 'field']);
+        $this->_assertImplemented($aggregationDSL, 'bucket_script', 'Elastica\Aggregation\BucketScript', ['name']);
+        $this->_assertImplemented($aggregationDSL, 'serial_diff', 'Elastica\Aggregation\SerialDiff', ['name']);
 
         $this->_assertNotImplemented($aggregationDSL, 'children', ['name']);
         $this->_assertNotImplemented($aggregationDSL, 'geo_bounds', ['name']);


### PR DESCRIPTION
These are more complex aggregations that require to be nested inside:
- any bucket aggregation for `BucketScript`
- any histogram aggregation for `SerialDiff`

that's why integration tests are using other aggregations in order to work.