### PR TITLE
Search: add support for terminate_after option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file based on the
 - Elastica\Aggregation\GeoCentroid [#1150](https://github.com/ruflin/Elastica/pull/1150)
 - [Multi value field](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_multi_values_fields) param for decay function.
 - Elastica\Client::getVersion [#1152](https://github.com/ruflin/Elastica/pull/1152)
+- Added support for terminate_after parameter in search queries [#1168](https://github.com/ruflin/Elastica/pull/1168)
 
 ### Improvements
 - Set PHP 7.0 as default development version

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -26,6 +26,7 @@ class Search
     const OPTION_SCROLL = 'scroll';
     const OPTION_SCROLL_ID = 'scroll_id';
     const OPTION_QUERY_CACHE = 'query_cache';
+    const OPTION_TERMINATE_AFTER = 'terminate_after';
 
     /*
      * Search types
@@ -296,6 +297,7 @@ class Search
             case self::OPTION_SEARCH_TYPE_SUGGEST:
             case self::OPTION_SEARCH_IGNORE_UNAVAILABLE:
             case self::OPTION_QUERY_CACHE:
+            case self::OPTION_TERMINATE_AFTER:
                 return true;
         }
 

--- a/test/lib/Elastica/Test/SearchTest.php
+++ b/test/lib/Elastica/Test/SearchTest.php
@@ -369,7 +369,6 @@ class SearchTest extends BaseTest
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testArrayConfigSearch()
     {
@@ -418,6 +417,10 @@ class SearchTest extends BaseTest
         $resultSet = $search->search('test', ['limit' => 5, 'routing' => 'r1,r2']);
         $this->assertEquals(5, $resultSet->count());
 
+        //Array with terminate_after
+        $resultSet = $search->search('test', array('terminate_after' => 100));
+        $this->assertEquals(10, $resultSet->count());
+
         //Search types
         $resultSet = $search->search('test', ['limit' => 5, 'search_type' => 'count']);
         $this->assertTrue(($resultSet->count() === 0) && $resultSet->getTotalHits() === 11);
@@ -435,7 +438,16 @@ class SearchTest extends BaseTest
         $query->addScriptScoreFunction($script);
         $resultSet = $search->search($query, ['timeout' => 50]);
         $this->assertTrue($resultSet->hasTimedOut());
+		}
 
+    /**
+     * @group functional
+     * @expectedException \Elastica\Exception\InvalidException
+     */
+    public function testInvalidConfigSearch()
+    {
+        $client = $this->_getClient();
+        $search = new Search($client);
         // Throws InvalidException
         $resultSet = $search->search('test', ['invalid_option' => 'invalid_option_value']);
     }


### PR DESCRIPTION
- Also adds simple test for the option
- Breaks out invalid option test into a separate test so that if the other options become invalid their exceptions will be detected. As previously written the exception is ignored everywhere in the test.

Fixes #1137 
