### PR TITLE
Create transport from class which don't has prefix name Elastica\Transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file based on the
 - Elastica\Aggregation\SerialDiff
 
 ### Improvements
+- Elastica\Client constructor now accepts a transport of fully qualified name. [#1169](https://github.com/ruflin/Elastica/pull/1169)
 
 ## Deprecated
 

--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -99,14 +99,13 @@ abstract class AbstractTransport extends Param
             } else {
                 $transport = ucfirst($transport);
             }
-
-            $className = 'Elastica\\Transport\\'.$transport;
-
-            if (!class_exists($className)) {
-                throw new InvalidException('Invalid transport');
+            $classNames = ["Elastica\\Transport\\$transport", $transport];
+            foreach ($classNames as $className) {
+                if (class_exists($className)) {
+                    $transport = new $className();
+                    break;
+                }
             }
-
-            $transport = new $className();
         }
 
         if ($transport instanceof self) {

--- a/test/lib/Elastica/Test/Transport/AbstractTransportTest.php
+++ b/test/lib/Elastica/Test/Transport/AbstractTransportTest.php
@@ -21,6 +21,7 @@ class AbstractTransportTest extends \PHPUnit_Framework_TestCase
             [['type' => 'Http']],
             [['type' => new Http()]],
             [new Http()],
+            ['Elastica\Test\Transport\DummyTransport'],
         ];
     }
 

--- a/test/lib/Elastica/Test/Transport/DummyTransport.php
+++ b/test/lib/Elastica/Test/Transport/DummyTransport.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Elastica\Test\Transport;
+
+use Elastica\Transport\AbstractTransport;
+use Elastica\Request;
+
+class DummyTransport extends AbstractTransport
+{
+    public function exec(Request $request, array $params)
+    {
+        // empty
+    }
+}


### PR DESCRIPTION
Allow we store configuration in JSON format, and simply restore to in-memory array and pass to Elastica\Client.