### PR TITLE
Fixing bad syntax on parent call for ResponseException

### DIFF
--- a/lib/Elastica/Exception/ResponseException.php
+++ b/lib/Elastica/Exception/ResponseException.php
@@ -31,7 +31,7 @@ class ResponseException extends \RuntimeException implements ExceptionInterface
     {
         $this->_request = $request;
         $this->_response = $response;
-        parent::__construct($response->getErrorMessage()['reason'], 500);
+        parent::__construct($response->getErrorMessage(), 500);
     }
 
     /**

--- a/lib/Elastica/Exception/ResponseException.php
+++ b/lib/Elastica/Exception/ResponseException.php
@@ -31,7 +31,7 @@ class ResponseException extends \RuntimeException implements ExceptionInterface
     {
         $this->_request = $request;
         $this->_response = $response;
-        parent::__construct($response->getErrorMessage());
+        parent::__construct($response->getErrorMessage()['reason'], 500);
     }
 
     /**


### PR DESCRIPTION
Without this, mapping errors throw this:

```
  Wrong parameters for Elastica\Exception\ResponseException([string $message [, long $code [, Throwable $previous = NULL]]])
```