### PR TITLE
Add a constant for the expression language.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 ### Improvements
+- Add a constant for the expression language.
 
 ## Deprecated
 

--- a/lib/Elastica/Script/Script.php
+++ b/lib/Elastica/Script/Script.php
@@ -17,6 +17,7 @@ class Script extends AbstractScript
     const LANG_GROOVY = 'groovy';
     const LANG_PYTHON = 'python';
     const LANG_NATIVE = 'native';
+    const LANG_EXPRESSION = 'expression';
 
     /**
      * @var string


### PR DESCRIPTION
Just add a constant for the _expression_ language. It exists since ES 1.3 (maybe before) : https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html