### PR TITLE
Throw an exception if the setExecution method is called on RangerFilter.

### DIFF
--- a/lib/Elastica/Filter/Range.php
+++ b/lib/Elastica/Filter/Range.php
@@ -3,6 +3,8 @@ namespace Elastica\Filter;
 
 trigger_error('Deprecated: Filters are deprecated. Use queries in filter context. See https://www.elastic.co/guide/en/elasticsearch/reference/2.0/query-dsl-filters.html', E_USER_DEPRECATED);
 
+use Elastica\Exception\InvalidException;
+
 /**
  * Range Filter.
  *
@@ -53,11 +55,11 @@ class Range extends AbstractFilter
      *
      * @param string $execution Options: "index" or "fielddata"
      *
-     * @return $this
+     * @throws \Elastica\Exception\InvalidException If you call this method.
      */
     public function setExecution($execution)
     {
-        return $this->setParam('execution', (string) $execution);
+        throw new InvalidException('The "execution" option for "range filter" was removed since Elasticsearch 2.0.');
     }
 
     /**

--- a/test/lib/Elastica/Test/Filter/RangeTest.php
+++ b/test/lib/Elastica/Test/Filter/RangeTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Test\Filter;
 
+use Elastica\Exception\InvalidException;
 use Elastica\Filter\Range;
 use Elastica\Test\DeprecatedClassBase as BaseTest;
 
@@ -44,15 +45,13 @@ class RangeTest extends BaseTest
      */
     public function testSetExecution()
     {
+        $this->setExpectedException(InvalidException::class);
+
         $field = 'field_name';
         $range = ['gte' => 10, 'lte' => 99];
         $filter = new Range('field_name', $range);
 
         $filter->setExecution('fielddata');
-        $this->assertEquals('fielddata', $filter->getParam('execution'));
-
-        $returnValue = $filter->setExecution('index');
-        $this->assertInstanceOf('Elastica\Filter\Range', $returnValue);
     }
 
     /**


### PR DESCRIPTION
The ```execution``` option for ```range filter``` was removed since Elasticsearch 2.0.

I try to find a changelog to confirm but in the [1.7 documentation](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/query-dsl-range-filter.html#_execution), the execution option is mentioned but in the [2.x documentation](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-range-query.html), the execution option isn't mentioned in Range Query.

For this query, elasticsearch throws ```"reason": "[range] query does not support [execution]"``` : 
```json
GET index/type/_search
{
  "query": {
     "bool": {
       "filter": {
         "range": {
           "year": {
             "from": 1950,
             "to": 2000,
             "execution": "fielddata"
           }
         }
       }
     }
  }
}
```

Note : The Elastica\Filter\Range class is deprecated so I don't know if my change is relevant.