### PR TITLE
Don't distribute tests, build files etc. for composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@
 /.gitignore export-ignore
 /.php_cs export-ignore
 /.travis.yml export-ignore
-/CHANGELOG.md export-ignore merge=union
+/CHANGELOG.md merge=union
 /CONTRIBUTING.md export-ignore
 /Dockerfile export-ignore
 /docker-compose.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,15 @@
-CHANGELOG.md  merge=union
+/.coveralls.yml export-ignore
+/.dockerignore export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs export-ignore
+/.travis.yml export-ignore
+/CHANGELOG.md export-ignore merge=union
+/CONTRIBUTING.md export-ignore
+/Dockerfile export-ignore
+/docker-compose.yml export-ignore
+/docker-entrypoint.sh export-ignore
+/env export-ignore
+/phpdoc.dist.xml export-ignore
+/test export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/3.2.3...HEAD)
 
 ### Backward Compatibility Fixes
+- Composer installations will no longer include tests and other development files. 
 
 ### Bugfixes
 
@@ -11,7 +12,6 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 - Add a constant for the expression language.
-- Composer installations will no longer include tests and other development files. 
 
 ## Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 - Add a constant for the expression language.
+- Composer installations will no longer include tests and other development files. 
 
 ## Deprecated
 


### PR DESCRIPTION
Don't distribute tests, build files etc. when installing with Composer with `--prefer-dist` (the default). This saves lots of bandwith and file extraction when installing dependencies with default settings.