### PR TITLE
Remove tests on index.merge.policy.merge_factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file based on the
 - Remove deprecated Elastica\Script*.php classes. Use Elastica\Script\* instead.
 - Remove Elastica/Query/Image.php and test/Elastica/Query/ImageTest.php, no more support for image-plugin.
 - Remove Elastica/Query/Filtered.php and test/Elastica/Query/FilteredTest.php and all uses from code.
+- Remove index.merge.policy.merge_factor, and set/get MergePolicy as it looks deprecated from ES 1.6
 
 ### Bugfixes
 

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -245,34 +245,6 @@ class Settings
     }
 
     /**
-     * Return merge policy.
-     *
-     * @return string Merge policy type
-     */
-    public function getMergePolicyType()
-    {
-        return $this->get('merge.policy.type');
-    }
-
-    /**
-     * Sets merge policy.
-     *
-     * @param string $type Merge policy type
-     *
-     * @return \Elastica\Response Response object
-     *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-merge.html
-     */
-    public function setMergePolicyType($type)
-    {
-        $this->getIndex()->close();
-        $response = $this->set(['merge.policy.type' => $type]);
-        $this->getIndex()->open();
-
-        return $response;
-    }
-
-    /**
      * Sets the specific merge policies.
      *
      * To have this changes made the index has to be closed and reopened

--- a/test/lib/Elastica/Test/Index/SettingsTest.php
+++ b/test/lib/Elastica/Test/Index/SettingsTest.php
@@ -153,7 +153,7 @@ class SettingsTest extends BaseTest
     /**
      * @group functional
      */
-    public function testSetMergeFactor()
+    public function testSetMaxMergeAtOnce()
     {
         $indexName = 'test';
 
@@ -166,42 +166,13 @@ class SettingsTest extends BaseTest
 
         $settings = $index->getSettings();
 
-        $this->_markSkipped50('unknown setting [index.merge.policy.merge_factor] did you mean [index.merge.policy.max_merge_at_once]');
-        $response = $settings->setMergePolicy('merge_factor', 15);
-        $this->assertEquals(15, $settings->getMergePolicy('merge_factor'));
+        $response = $settings->setMergePolicy('max_merge_at_once', 15);
+        $this->assertEquals(15, $settings->getMergePolicy('max_merge_at_once'));
         $this->assertInstanceOf('Elastica\Response', $response);
         $this->assertTrue($response->isOk());
 
-        $settings->setMergePolicy('merge_factor', 10);
-        $this->assertEquals(10, $settings->getMergePolicy('merge_factor'));
-
-        $index->delete();
-    }
-
-    /**
-     * @group functional
-     */
-    public function testSetMergePolicyType()
-    {
-        $indexName = 'test';
-
-        $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
-        $index->create([], true);
-
-        //wait for the shards to be allocated
-        $this->_waitForAllocation($index);
-
-        $settings = $index->getSettings();
-
-        $this->_markSkipped50('unknown setting [index.merge.policy.type] please check that any required plugins are installed,');
-        $settings->setMergePolicyType('log_byte_size');
-        $this->assertEquals('log_byte_size', $settings->getMergePolicyType());
-
-        $response = $settings->setMergePolicy('merge_factor', 15);
-        $this->assertEquals(15, $settings->getMergePolicy('merge_factor'));
-        $this->assertInstanceOf('Elastica\Response', $response);
-        $this->assertTrue($response->isOk());
+        $settings->setMergePolicy('max_merge_at_once', 10);
+        $this->assertEquals(10, $settings->getMergePolicy('max_merge_at_once'));
 
         $index->delete();
     }


### PR DESCRIPTION
index.merge.policy.merge_factor has been removed from ES 1.7
https://www.elastic.co/guide/en/elasticsearch/reference/1.7/index-modules-merge.html

I have removed also setMergePolicyType and the getter as it seems (from the above link) that policy type has been deprecated from 1.6.0
