### PR TITLE
[DX] Added $indexName as key to result of Health::getIndices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 - Add a constant for the expression language.
+- `Health::getIndices` returns key=>value result, where key === $indexName.
+```
+$cluster->getHealth()->getIndices()[$indexName]
+// or
+$indices = $cluster->getHealth()->getIndices();
+$indices[$indexName]
+```
 
 ## Deprecated
 

--- a/lib/Elastica/Cluster/Health.php
+++ b/lib/Elastica/Cluster/Health.php
@@ -177,7 +177,7 @@ class Health
     {
         $indices = [];
         foreach ($this->_data['indices'] as $indexName => $index) {
-            $indices[] = new Index($indexName, $index);
+            $indices[$indexName] = new Index($indexName, $index);
         }
 
         return $indices;

--- a/test/lib/Elastica/Test/Cluster/HealthTest.php
+++ b/test/lib/Elastica/Test/Cluster/HealthTest.php
@@ -139,6 +139,8 @@ class HealthTest extends BaseTest
 
         $this->assertInternalType('array', $indices);
         $this->assertEquals(2, count($indices));
+        $this->assertArrayHasKey('index_one', $indices);
+        $this->assertArrayHasKey('index_two', $indices);
 
         foreach ($indices as $index) {
             $this->assertInstanceOf('Elastica\Cluster\Health\Index', $index);


### PR DESCRIPTION
Instead of iterating all indices, it's easier to get it by key.
Now result of `getIndices` is index by $indexName

```
$cluster->getHealth()->getIndices()[$indexName]
// or
$indices = $cluster->getHealth()->getIndices();
$indices[$indexName]
```