### PR TITLE
implemented Painless as the new default scripting language (#1184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ All notable changes to this project will be documented in this file based on the
     - Elastica\Test\Query\PercolateTest.php
 - removed Elastica\ScanAndScroll and test, Scan search type is removed from ElasticSearch 5.0.
 
+- removed groovy as default scripting language
+- implemented painless as default scripting language in tests
 
 ### Bugfixes
 

--- a/env/elasticsearch/scripts/calculate-distance.groovy
+++ b/env/elasticsearch/scripts/calculate-distance.groovy
@@ -1,1 +1,0 @@
-doc['location'].arcDistanceInKm(lat,lon)

--- a/env/elasticsearch/scripts/calculate-distance.painless
+++ b/env/elasticsearch/scripts/calculate-distance.painless
@@ -1,0 +1,1 @@
+doc['location'].arcDistance(params.lat,params.lon)

--- a/lib/Elastica/Script/Script.php
+++ b/lib/Elastica/Script/Script.php
@@ -18,6 +18,7 @@ class Script extends AbstractScript
     const LANG_PYTHON = 'python';
     const LANG_NATIVE = 'native';
     const LANG_EXPRESSION = 'expression';
+    const LANG_PAINLESS = 'painless';
 
     /**
      * @var string

--- a/lib/Elastica/Script/ScriptFile.php
+++ b/lib/Elastica/Script/ScriptFile.php
@@ -83,17 +83,17 @@ class ScriptFile extends Script
      */
     protected static function _createFromArray(array $data)
     {
-        if (!isset($data['script_file'])) {
-            throw new InvalidException("\$data['script_file'] is required");
+        if (!isset($data['script']['file'])) {
+            throw new InvalidException("\$data['script']['file'] is required");
         }
 
-        $scriptFile = new self($data['script_file']);
+        $scriptFile = new self($data['script']['file']);
 
-        if (isset($data['params'])) {
-            if (!is_array($data['params'])) {
-                throw new InvalidException("\$data['params'] should be array");
+        if (isset($data['script']['params'])) {
+            if (!is_array($data['script']['params'])) {
+                throw new InvalidException("\$data['script']['params'] should be array");
             }
-            $scriptFile->setParams($data['params']);
+            $scriptFile->setParams($data['script']['params']);
         }
 
         return $scriptFile;
@@ -105,11 +105,13 @@ class ScriptFile extends Script
     public function toArray()
     {
         $array = [
-            'script_file' => $this->_scriptFile,
+            'script' => [
+                'file' => $this->_scriptFile,
+            ],
         ];
 
         if (!empty($this->_params)) {
-            $array['params'] = $this->_params;
+            $array['script']['params'] = $this->_params;
         }
 
         return $array;

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Tool/CrossIndex.php
+++ b/lib/Elastica/Tool/CrossIndex.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Tool;
 
 use Elastica\Bulk;

--- a/test/lib/Elastica/Test/Aggregation/ScriptTest.php
+++ b/test/lib/Elastica/Test/Aggregation/ScriptTest.php
@@ -31,8 +31,7 @@ class ScriptTest extends BaseAggregationTest
     {
         $this->_checkScriptInlineSetting();
         $agg = new Sum('sum');
-        // x = (0..1) is groovy-specific syntax, to see if lang is recognized
-        $script = new Script("x = (0..1); return doc['price'].value", null, Script::LANG_GROOVY);
+        $script = new Script("return doc['price'].value", null, Script::LANG_PAINLESS);
         $agg->setScript($script);
 
         $query = new Query();
@@ -49,7 +48,7 @@ class ScriptTest extends BaseAggregationTest
     {
         $this->_checkScriptInlineSetting();
         $agg = new Sum('sum');
-        $agg->setScript(new Script("doc['price'].value", null, Script::LANG_GROOVY));
+        $agg->setScript(new Script("doc['price'].value", null, Script::LANG_PAINLESS));
 
         $query = new Query();
         $query->addAggregation($agg);
@@ -69,7 +68,7 @@ class ScriptTest extends BaseAggregationTest
             'param1' => 'one',
             'param2' => 1,
         ];
-        $lang = 'groovy';
+        $lang = Script::LANG_PAINLESS;
 
         $agg = new Sum($aggregation);
         $script = new Script($string, $params, $lang);

--- a/test/lib/Elastica/Test/BulkTest.php
+++ b/test/lib/Elastica/Test/BulkTest.php
@@ -484,7 +484,7 @@ class BulkTest extends BaseTest
         $this->assertEquals('The Walrus', $docData['name']);
 
         //test updating via script
-        $script = new \Elastica\Script\Script('ctx._source.name += param1;', ['param1' => ' was Paul'], null, \Elastica\Script\Script::LANG_GROOVY);
+        $script = new \Elastica\Script\Script('ctx._source.name += params.param1;', ['param1' => ' was Paul'], null, \Elastica\Script\Script::LANG_PAINLESS);
         $doc2 = new Document();
         $script->setUpsert($doc2);
         $updateAction = Action\AbstractDocument::create($script, Action::OP_TYPE_UPDATE);
@@ -503,7 +503,7 @@ class BulkTest extends BaseTest
         $this->assertEquals('The Walrus was Paul', $doc2->name);
 
         //test upsert
-        $script = new \Elastica\Script\Script('ctx._scource.counter += count', ['count' => 1], null, \Elastica\Script\Script::LANG_GROOVY);
+        $script = new \Elastica\Script\Script('ctx._scource.counter += params.count', ['count' => 1], null, \Elastica\Script\Script::LANG_PAINLESS);
         $doc = new Document('', ['counter' => 1]);
         $script->setUpsert($doc);
         $updateAction = Action\AbstractDocument::create($script, Action::OP_TYPE_UPDATE);

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -699,7 +699,7 @@ class ClientTest extends BaseTest
         $newDocument = new Document(1, ['field1' => 'value1', 'field2' => 10, 'field3' => 'should be removed', 'field4' => 'should be changed']);
         $type->addDocument($newDocument);
 
-        $script = new Script('ctx._source.field2 += 5; ctx._source.remove("field3"); ctx._source.field4 = "changed"', null, Script::LANG_GROOVY);
+        $script = new Script('ctx._source.field2 += 5; ctx._source.remove("field3"); ctx._source.field4 = "changed"', null, Script::LANG_PAINLESS);
         $client->updateDocument(1, $script, $index->getName(), $type->getName());
 
         $document = $type->getDocument(1);
@@ -725,7 +725,7 @@ class ClientTest extends BaseTest
         $type = $index->getType('test');
         $client = $index->getClient();
 
-        $script = new Script('ctx._source.field2 += 5; ctx._source.remove("field3"); ctx._source.field4 = "changed"');
+        $script = new Script('ctx._source.field2 += params.count; ctx._source.remove("field3"); ctx._source.field4 = "changed"', null, Script::LANG_PAINLESS);
         $script->setParam('count', 5);
         $script->setUpsert(['field1' => 'value1', 'field2' => 10, 'field3' => 'should be removed', 'field4' => 'value4']);
 
@@ -955,7 +955,7 @@ class ClientTest extends BaseTest
         $newDocument->setAutoPopulate();
         $type->addDocument($newDocument);
 
-        $script = new Script('ctx._source.field2 += count; ctx._source.remove("field3"); ctx._source.field4 = "changed"', null, Script::LANG_GROOVY);
+        $script = new Script('ctx._source.field2 += params.count; ctx._source.remove("field3"); ctx._source.field4 = "changed"', null, Script::LANG_PAINLESS);
         $script->setParam('count', 5);
         $script->setUpsert($newDocument);
 
@@ -976,7 +976,7 @@ class ClientTest extends BaseTest
         $this->assertEquals('changed', $data['field4']);
         $this->assertArrayNotHasKey('field3', $data);
 
-        $script = new Script('ctx._source.field2 += count; ctx._source.remove("field4"); ctx._source.field1 = field1;', null, Script::LANG_GROOVY);
+        $script = new Script('ctx._source.field2 += params.count; ctx._source.remove("field4"); ctx._source.field1 = params.field1;', null, Script::LANG_PAINLESS);
         $script->setParam('count', 5);
         $script->setParam('field1', 'updated');
         $script->setUpsert($newDocument);
@@ -986,7 +986,7 @@ class ClientTest extends BaseTest
             $script,
             $index->getName(),
             $type->getName(),
-            ['fields' => 'field2,field4']
+            ['fields' => 'field2, field4']
         );
 
         $document = $type->getDocument(1);

--- a/test/lib/Elastica/Test/Query/FunctionScoreTest.php
+++ b/test/lib/Elastica/Test/Query/FunctionScoreTest.php
@@ -453,7 +453,7 @@ class FunctionScoreTest extends BaseTest
     {
         $this->_checkScriptInlineSetting();
         $scriptString = "_score * doc['price'].value";
-        $script = new Script($scriptString, null, Script::LANG_GROOVY);
+        $script = new Script($scriptString, null, Script::LANG_PAINLESS);
         $query = new FunctionScore();
         $query->addScriptScoreFunction($script);
         $expected = [
@@ -463,7 +463,7 @@ class FunctionScoreTest extends BaseTest
                         'script_score' => [
                             'script' => [
                                 'inline' => $scriptString,
-                                'lang' => Script::LANG_GROOVY,
+                                'lang' => Script::LANG_PAINLESS,
                             ],
                         ],
                     ],

--- a/test/lib/Elastica/Test/Script/ScriptFileTest.php
+++ b/test/lib/Elastica/Test/Script/ScriptFileTest.php
@@ -35,7 +35,6 @@ class ScriptFileTest extends BaseTest
         $query = new Query();
         $query->addScriptField('distance', $scriptFile);
 
-        $this->_markSkipped50('Unknown key for a VALUE_STRING in [script_file].');
         try {
             $resultSet = $type->search($query);
         } catch (ResponseException $e) {
@@ -49,8 +48,8 @@ class ScriptFileTest extends BaseTest
         $results = $resultSet->getResults();
 
         $this->assertEquals(2, $resultSet->count());
-        $this->assertEquals([3.149406767298327], $results[0]->__get('distance'));
-        $this->assertEquals([7.4639790751755726], $results[1]->__get('distance'));
+        $this->assertEquals([3151.855706373115], $results[0]->__get('distance'));
+        $this->assertEquals([7469.7862256855769], $results[1]->__get('distance'));
     }
 
     /**
@@ -58,11 +57,13 @@ class ScriptFileTest extends BaseTest
      */
     public function testConstructor()
     {
-        $value = 'calculate-distance.groovy';
+        $value = 'calculate-distance.painless';
         $scriptFile = new ScriptFile($value);
 
         $expected = [
-            'script_file' => $value,
+            'script' => [
+                'file' => $value,
+            ],
         ];
         $this->assertEquals($value, $scriptFile->getScriptFile());
         $this->assertEquals($expected, $scriptFile->toArray());
@@ -75,8 +76,10 @@ class ScriptFileTest extends BaseTest
         $scriptFile = new ScriptFile($value, $params);
 
         $expected = [
-            'script_file' => $value,
-            'params' => $params,
+            'script' => [
+                'file' => $value,
+                'params' => $params,
+            ],
         ];
 
         $this->assertEquals($value, $scriptFile->getScriptFile());
@@ -89,7 +92,7 @@ class ScriptFileTest extends BaseTest
      */
     public function testCreateString()
     {
-        $string = 'calculate-distance.groovy';
+        $string = 'calculate-distance.painless';
         $scriptFile = ScriptFile::create($string);
 
         $this->assertInstanceOf('Elastica\Script\ScriptFile', $scriptFile);
@@ -97,7 +100,9 @@ class ScriptFileTest extends BaseTest
         $this->assertEquals($string, $scriptFile->getScriptFile());
 
         $expected = [
-            'script_file' => $string,
+            'script' => [
+                'file' => $string,
+            ],
         ];
         $this->assertEquals($expected, $scriptFile->toArray());
     }
@@ -107,7 +112,7 @@ class ScriptFileTest extends BaseTest
      */
     public function testCreateScriptFile()
     {
-        $data = new ScriptFile('calculate-distance.groovy');
+        $data = new ScriptFile('calculate-distance.painless');
 
         $scriptFile = ScriptFile::create($data);
 
@@ -120,14 +125,16 @@ class ScriptFileTest extends BaseTest
      */
     public function testCreateArray()
     {
-        $string = 'calculate-distance.groovy';
+        $string = 'calculate-distance.painless';
         $params = [
             'param1' => 'one',
             'param2' => 1,
         ];
         $array = [
-            'script_file' => $string,
-            'params' => $params,
+            'script' => [
+                'file' => $string,
+                'params' => $params,
+            ],
         ];
 
         $scriptFile = ScriptFile::create($array);
@@ -163,7 +170,7 @@ class ScriptFileTest extends BaseTest
                 ['params' => ['param1' => 'one']],
             ],
             [
-                ['script' => 'calculate-distance.groovy', 'params' => 'param'],
+                ['script' => 'calculate-distance.painless', 'params' => 'param'],
             ],
         ];
     }

--- a/test/lib/Elastica/Test/Script/ScriptTest.php
+++ b/test/lib/Elastica/Test/Script/ScriptTest.php
@@ -143,13 +143,13 @@ class ScriptTest extends BaseTest
      */
     public function testSetLang()
     {
-        $script = new Script('foo', [], Script::LANG_GROOVY);
+        $script = new Script('foo', [], Script::LANG_PAINLESS);
+        $this->assertEquals(Script::LANG_PAINLESS, $script->getLang());
+
+        $script->setLang(Script::LANG_GROOVY);
         $this->assertEquals(Script::LANG_GROOVY, $script->getLang());
 
-        $script->setLang(Script::LANG_PYTHON);
-        $this->assertEquals(Script::LANG_PYTHON, $script->getLang());
-
-        $this->assertInstanceOf('Elastica\Script\Script', $script->setLang(Script::LANG_PYTHON));
+        $this->assertInstanceOf('Elastica\Script\Script', $script->setLang(Script::LANG_GROOVY));
     }
 
     /**

--- a/test/lib/Elastica/Test/SearchTest.php
+++ b/test/lib/Elastica/Test/SearchTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -573,12 +573,12 @@ class TypeTest extends BaseTest
 
         $document = new Document();
         $script = new Script(
-            'ctx._source.name = name; ctx._source.counter += count',
+            'ctx._source.name = params.name; ctx._source.counter += params.count',
             [
                 'name' => $newName,
                 'count' => 2,
             ],
-            Script::LANG_GROOVY,
+            Script::LANG_PAINLESS,
             $id
         );
         $script->setUpsert($document);
@@ -604,12 +604,12 @@ class TypeTest extends BaseTest
 
         $document = new Document();
         $script = new Script(
-            'ctx._source.name = name; ctx._source.counter += count',
+            'ctx._source.name = params.name; ctx._source.counter += params.count',
             [
                 'name' => $newName,
                 'count' => 2,
             ],
-            Script::LANG_GROOVY,
+            Script::LANG_PAINLESS,
             $id
         );
         $script->setUpsert($document);
@@ -634,12 +634,12 @@ class TypeTest extends BaseTest
 
         $document = new Document();
         $script = new Script(
-            'ctx._source.name = name; ctx._source.counter += count',
+            'ctx._source.name = params.name; ctx._source.counter += params.count',
             [
                 'name' => $newName,
                 'count' => 2,
             ],
-            Script::LANG_GROOVY,
+            Script::LANG_PAINLESS,
             $id
         );
         $script->setUpsert($document);
@@ -681,7 +681,7 @@ class TypeTest extends BaseTest
 
         $this->assertTrue($newDocument->hasId());
 
-        $script = new Script('ctx._source.counter += count; ctx._source.realName = realName', null, Script::LANG_GROOVY);
+        $script = new Script('ctx._source.counter += params.count; ctx._source.realName = params.realName', null, Script::LANG_PAINLESS);
         $script->setId($newDocument->getId());
         $script->setParam('count', 7);
         $script->setParam('realName', 'Bruce Wayne');


### PR DESCRIPTION
Painless is the new scripting language in Elasticsearch:
https://github.com/elastic/elasticsearch/commit/9d56c1b76637e5f64f43edf0a14ca4081be85e14

groovy has been deprecated:
https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-groovy.html

