### PR TITLE
removed search_type=count is removed in Elasticsearch 5.0 (#1184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,11 +64,10 @@ All notable changes to this project will be documented in this file based on the
     - Elastica\Test\Node\InfoTest.php
     - Elastica\Test\Query\PercolateTest.php
 - removed Elastica\ScanAndScroll and test, Scan search type is removed from ElasticSearch 5.0.
-- Remove upport for PHP 5.4 and 5.5. Require at least PHP 5.6 #1202
-
-
+- Remove support for PHP 5.4 and 5.5. Require at least PHP 5.6 #1202
 - removed groovy as default scripting language
 - implemented painless as default scripting language in tests
+- removed search_type=count is removed in Elasticsearch 5.0
 
 ### Bugfixes
 

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -30,7 +30,7 @@ class Search
     /*
      * Search types
      */
-    const OPTION_SEARCH_TYPE_COUNT = 'count';
+
     const OPTION_SEARCH_TYPE_DFS_QUERY_THEN_FETCH = 'dfs_query_then_fetch';
     const OPTION_SEARCH_TYPE_DFS_QUERY_AND_FETCH = 'dfs_query_and_fetch';
     const OPTION_SEARCH_TYPE_QUERY_THEN_FETCH = 'query_then_fetch';

--- a/test/lib/Elastica/Test/Multi/SearchTest.php
+++ b/test/lib/Elastica/Test/Multi/SearchTest.php
@@ -185,11 +185,8 @@ class SearchTest extends BaseTest
 
         $this->assertFalse($multiResultSet->hasError());
 
-        $this->_markSkipped50('No search type for [count]');
-
-        $search1->setOption(Search::OPTION_SEARCH_TYPE, Search::OPTION_SEARCH_TYPE_COUNT);
-        $search2->setOption(Search::OPTION_SEARCH_TYPE, Search::OPTION_SEARCH_TYPE_COUNT);
-
+        $search1->getQuery()->setSize(0);
+        $search2->getQuery()->setSize(0);
         $multiResultSet = $multiSearch->search();
 
         $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
@@ -285,11 +282,8 @@ class SearchTest extends BaseTest
 
         $this->assertFalse($multiResultSet->hasError());
 
-        $this->_markSkipped50('No search type for [count]');
-
-        $search1->setOption(Search::OPTION_SEARCH_TYPE, Search::OPTION_SEARCH_TYPE_COUNT);
-        $search2->setOption(Search::OPTION_SEARCH_TYPE, Search::OPTION_SEARCH_TYPE_COUNT);
-
+        $search1->getQuery()->setSize(0);
+        $search2->getQuery()->setSize(0);
         $multiResultSet = $multiSearch->search();
 
         $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
@@ -448,9 +442,8 @@ class SearchTest extends BaseTest
 
         $multiSearch->addSearch($search2);
 
-        $this->_markSkipped50('No search type for [count]');
-        $multiSearch->setSearchType(Search::OPTION_SEARCH_TYPE_COUNT);
-
+        $search1->getQuery()->setSize(0);
+        $search2->getQuery()->setSize(0);
         $multiResultSet = $multiSearch->search();
 
         $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
@@ -487,7 +480,7 @@ class SearchTest extends BaseTest
 
         $this->assertArrayHasKey(0, $resultSets);
         $this->assertInstanceOf('Elastica\ResultSet', $resultSets[0]);
-        $this->assertCount(2, $resultSets[0]);
+        $this->assertCount(0, $resultSets[0]);
         $this->assertSame($query1, $resultSets[0]->getQuery());
         $this->assertEquals(3, $resultSets[0]->getTotalHits());
 
@@ -533,8 +526,8 @@ class SearchTest extends BaseTest
 
         $multiSearch->addSearch($search2);
 
-        $this->_markSkipped50('No search type for [count]');
-        $multiSearch->setSearchType(Search::OPTION_SEARCH_TYPE_COUNT);
+        $search1->getQuery()->setSize(0);
+        $search2->getQuery()->setSize(0);
 
         $multiResultSet = $multiSearch->search();
 
@@ -572,7 +565,7 @@ class SearchTest extends BaseTest
 
         $this->assertArrayHasKey(0, $resultSets);
         $this->assertInstanceOf('Elastica\ResultSet', $resultSets[0]);
-        $this->assertCount(2, $resultSets[0]);
+        $this->assertCount(0, $resultSets[0]);
         $this->assertSame($query1, $resultSets[0]->getQuery());
         $this->assertEquals(3, $resultSets[0]->getTotalHits());
 

--- a/test/lib/Elastica/Test/SearchTest.php
+++ b/test/lib/Elastica/Test/SearchTest.php
@@ -259,6 +259,7 @@ class SearchTest extends BaseTest
 
         $search = new Search($client);
         $search->addIndex($index)->addType($type);
+        $search->setOption('size', 0);
         $result = $search->search([], [
             Search::OPTION_SCROLL => '5m',
             Search::OPTION_SIZE => 5,
@@ -386,9 +387,7 @@ class SearchTest extends BaseTest
         $resultSet = $search->search('test', ['terminate_after' => 100]);
         $this->assertEquals(10, $resultSet->count());
 
-        //Search types
-        $this->_markSkipped50('No search type for [count]');
-        $resultSet = $search->search('test', ['limit' => 5, 'search_type' => 'count']);
+        $resultSet = $search->search('test', ['limit' => 0]);
         $this->assertTrue(($resultSet->count() === 0) && $resultSet->getTotalHits() === 11);
 
         //Timeout - this one is a bit more tricky to test


### PR DESCRIPTION
removed search_type=count 
https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_search_changes.html#_literal_search_type_count_literal_removed