### PR TITLE
Remove fielddata fields and fix Fix Set fielddata=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ All notable changes to this project will be documented in this file based on the
 - removed search_type=count is removed in Elasticsearch 5.0
 - removed logging.yml as now ES 5.0 uses log4j2.properties (leaving defaults)
 - removed fielddata_fields has been deprecated in ES5, use parameter docvalue_fields instead
+- Fielddata is disabled on text fields by default in this ES release, enabled on tests Elastica\Test\Query\InnerHitsTest.php::testInnerHitsWithSort and Elastica\Test\Query\InnerHitsTest.php::testInnerHitsWithFieldData 
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ All notable changes to this project will be documented in this file based on the
 - implemented painless as default scripting language in tests
 - removed search_type=count is removed in Elasticsearch 5.0
 - removed logging.yml as now ES 5.0 uses log4j2.properties (leaving defaults)
+- removed fielddata_fields has been deprecated in ES5, use parameter docvalue_fields instead
 
 ### Bugfixes
 

--- a/lib/Elastica/Aggregation/TopHits.php
+++ b/lib/Elastica/Aggregation/TopHits.php
@@ -155,6 +155,6 @@ class TopHits extends AbstractAggregation
      */
     public function setFieldDataFields(array $fields)
     {
-        return $this->setParam('fielddata_fields', $fields);
+        return $this->setParam('docvalue_fields', $fields);
     }
 }

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -267,7 +267,7 @@ class Query extends Param
      */
     public function setFieldDataFields(array $fieldDataFields)
     {
-        return $this->setParam('fielddata_fields', $fieldDataFields);
+        return $this->setParam('docvalue_fields', $fieldDataFields);
     }
 
     /**

--- a/lib/Elastica/Query/InnerHits.php
+++ b/lib/Elastica/Query/InnerHits.php
@@ -166,6 +166,6 @@ class InnerHits extends AbstractQuery
      */
     public function setFieldDataFields(array $fields)
     {
-        return $this->setParam('fielddata_fields', $fields);
+        return $this->setParam('docvalue_fields', $fields);
     }
 }

--- a/test/lib/Elastica/Test/Aggregation/TopHitsTest.php
+++ b/test/lib/Elastica/Test/Aggregation/TopHitsTest.php
@@ -154,7 +154,7 @@ class TopHitsTest extends BaseAggregationTest
         $fields = ['title', 'tags'];
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setFieldDataFields($fields);
-        $this->assertEquals($fields, $agg->getParam('fielddata_fields'));
+        $this->assertEquals($fields, $agg->getParam('docvalue_fields'));
         $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
     }
 

--- a/test/lib/Elastica/Test/Query/InnerHitsTest.php
+++ b/test/lib/Elastica/Test/Query/InnerHitsTest.php
@@ -262,7 +262,7 @@ class InnerHitsTest extends BaseTest
         $fields = ['title', 'tags'];
         $innerHits = new InnerHits();
         $returnValue = $innerHits->setFieldDataFields($fields);
-        $this->assertEquals($fields, $innerHits->getParam('fielddata_fields'));
+        $this->assertEquals($fields, $innerHits->getParam('docvalue_fields'));
         $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
     }
 

--- a/test/lib/Elastica/Test/Query/InnerHitsTest.php
+++ b/test/lib/Elastica/Test/Query/InnerHitsTest.php
@@ -27,7 +27,7 @@ class InnerHitsTest extends BaseTest
             'users' => [
                 'type' => 'nested',
                 'properties' => [
-                    'name' => ['type' => 'string'],
+                    'name' => ['type' => 'string', 'fielddata' => 'true'],
                 ],
             ],
             'title' => ['type' => 'string'],
@@ -110,7 +110,7 @@ class InnerHitsTest extends BaseTest
 
         // Set mapping
         $mappingResponse->setProperties([
-            'answer' => ['type' => 'string'],
+            'answer' => ['type' => 'string', 'fielddata' => 'true'],
             'last_activity_date' => ['type' => 'date'],
         ]);
         $mappingResponse->send();
@@ -406,7 +406,6 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $innerHits->setSort(['answer' => 'asc']);
 
-        $this->_markSkipped50('Set fielddata=true on [answer] in order to load fielddata in memory');
         $results = $this->getParentChildQuery($queryString, $innerHits);
         $firstResult = current($results->getResults());
 
@@ -513,7 +512,6 @@ class InnerHitsTest extends BaseTest
         $queryString = new SimpleQueryString('question simon', ['title', 'users.name']);
         $innerHits = new InnerHits();
 
-        $this->_markSkipped50('Set fielddata=true on [answer] in order to load fielddata in memory');
         $innerHits->setFieldDataFields(['users.name']);
 
         $results = $this->getNestedQuery($queryString, $innerHits);


### PR DESCRIPTION
Remove fielddata fields and fix Fix Set fielddata=true on [answer] in order to load fielddata in memory tests: 

- [fieldsdata_field has been deprecated use docvalue_fields instead](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_search_changes.html#_literal_fielddata_fields_literal_parameter)
- [Fielddata is disabled on text fields by default. in tests Fix Set fielddata=true on [answer] in order to load fielddata in memory tests. ](https://www.elastic.co/guide/en/elasticsearch/reference/current/fielddata.html#_fielddata_is_disabled_on_literal_text_literal_fields_by_default)