### PR TITLE
 payload and output are removed from completion suggester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/5.0.0-beta1...master)
 
 ### Backward Compatibility Fixes
+- Updated Elastica\Test\Suggest\CompletionTest now payload and output are removed
 
 ### Bugfixes
 
@@ -89,7 +90,7 @@ $indices[$indexName]
     - Elastica\Test\TypeTest::testUpdateDocumentWithIdForwardSlashes
     - Elastica\Test\TypeTest::testUpdateDocumentWithParameter
     - Elastica\Test\TypeTest::testUpdateDocumentWithFieldsSource
-  - Composer installations will no longer include tests and other development files.
+- Composer installations will no longer include tests and other development files.
 
 
 ## [3.2.3](https://github.com/ruflin/Elastica/compare/3.2.2...3.2.3)

--- a/test/lib/Elastica/Test/Suggest/CompletionTest.php
+++ b/test/lib/Elastica/Test/Suggest/CompletionTest.php
@@ -17,40 +17,29 @@ class CompletionTest extends BaseTest
         $index = $this->_createIndex();
         $type = $index->getType('song');
 
-        $this->_markSkipped50('Mapping definition for [fieldName] has unsupported parameters:  [payloads : true]');
         $type->setMapping([
             'fieldName' => [
                 'type' => 'completion',
-                'payloads' => true,
             ],
         ]);
 
         $type->addDocuments([
             new Document(1, [
-                'fieldName' => [
-                    'input' => ['Nevermind', 'Nirvana'],
-                    'output' => 'Nevermind - Nirvana',
-                    'payload' => [
-                        'year' => 1991,
-                    ],
+                'fieldName'  => [
+                    'input'  => ['Nevermind', 'Nirvana'],
+                    'weight' => 5
                 ],
             ]),
             new Document(2, [
-                'fieldName' => [
-                    'input' => ['Bleach', 'Nirvana'],
-                    'output' => 'Bleach - Nirvana',
-                    'payload' => [
-                        'year' => 1989,
-                    ],
+                'fieldName'  => [
+                    'input'  => ['Bleach', 'Nirvana'],
+                    'weight' => 2
                 ],
             ]),
             new Document(3, [
-                'fieldName' => [
-                    'input' => ['Incesticide', 'Nirvana'],
-                    'output' => 'Incesticide - Nirvana',
-                    'payload' => [
-                        'year' => 1992,
-                    ],
+                'fieldName'  => [
+                    'input'  => ['Incesticide', 'Nirvana'],
+                    'weight' => 7
                 ],
             ]),
         ]);
@@ -95,8 +84,7 @@ class CompletionTest extends BaseTest
         $options = $suggests['suggestName'][0]['options'];
 
         $this->assertCount(1, $options);
-        $this->assertEquals('Nevermind - Nirvana', $options[0]['text']);
-        $this->assertEquals(1991, $options[0]['payload']['year']);
+        $this->assertEquals('Nevermind', $options[0]['text']);
     }
 
     /**
@@ -117,7 +105,7 @@ class CompletionTest extends BaseTest
         $options = $suggests['suggestName'][0]['options'];
 
         $this->assertCount(1, $options);
-        $this->assertEquals('Nevermind - Nirvana', $options[0]['text']);
+        $this->assertEquals('Nevermind', $options[0]['text']);
     }
 
     /**


### PR DESCRIPTION
Updated  Elastica\Test\Suggest\CompletionTest.php
- [ES 5.0 completion suggester output removed](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_suggester.html#_simpler_completion_indexing)

- [payloads removed in ES 5.0](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_suggester.html#_completion_suggester_is_document_oriented)