### PR TITLE
store_fields don'textract values from the _source, use mapping 'store' (#1184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Backward Compatibility Fixes
 - Updated Elastica\Test\Suggest\CompletionTest now payload and output are removed
+- Updated Elastica\Test\TypeTest::testGetDocumentWithFieldsSelection The stored_fields parameter will only return stored fields — it will no longer extract values from the _source
 
 ### Bugfixes
 

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -507,9 +507,25 @@ class TypeTest extends BaseTest
      */
     public function testGetDocumentWithFieldsSelection()
     {
-        $this->_markSkipped50('Currently seems like stored_fields does not work as expected -> requires mapping?');
         $index = $this->_createIndex();
+
         $type = new Type($index, 'test');
+        $mapping = new Mapping();
+        $mapping->setProperties([
+            'name' => [
+                'type' => 'string',
+                'store' => 'yes', ],
+            'email' => [
+                'type' => 'string',
+                'store' => 'yes', ],
+            'country' => [
+                'type' => 'string'
+            ]
+        ]);
+
+        $mapping->disableSource();
+        $type->setMapping($mapping);
+
         $type->addDocument(new Document(1, ['name' => 'loris', 'country' => 'FR', 'email' => 'test@test.com']));
         $index->refresh();
 


### PR DESCRIPTION
The stored_fields parameter will only return stored fields — it will no longer extract values from the _source.

I've updated the test in \Elastica\Test\TypeTest.php::testGetDocumentWithFieldsSelection, there was the need to have "stored" ('store' => 'yes') the fields extracted from the Docuement.

https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_search_changes.html#_literal_fields_literal_parameter