### PR TITLE
JSON_FORCE_OBJECT to prevent malformed requests

### DIFF
--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -122,7 +122,7 @@ class Http extends AbstractTransport
             }
 
             if (is_array($data)) {
-                $content = JSON::stringify($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                $content = JSON::stringify($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_FORCE_OBJECT);
             } else {
                 $content = $data;
 


### PR DESCRIPTION
Sending data with an empty array causes an ES error, since it's stringified like so:
`{"query":{"match_all":[]}}` instead of `{"query":{"match_all":{}}}`. 
Using JSON_FORCE_OBJECT fixes that.