### PR TITLE
Properly pass query options with Multi\Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file based on the
 - remove _shutdown for Node and Cluster as deprecated
 
 ### Bugfixes
+- Query options such as "timeout" or "terminate_after" should not be ignored when using Multi\Search
 
 ### Added
 - Added regex option form suggest completions https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html#regex

--- a/lib/Elastica/Multi/Search.php
+++ b/lib/Elastica/Multi/Search.php
@@ -16,6 +16,11 @@ use Elastica\Search as BaseSearch;
 class Search
 {
     /**
+     * @const string[] valid header options
+     */
+    private static $HEADER_OPTIONS = ['index', 'types', 'search_type',
+                                      'routing', 'preference', ];
+    /**
      * @var MultiBuilderInterface
      */
     private $_builder;
@@ -167,11 +172,15 @@ class Search
     protected function _getSearchData(BaseSearch $search)
     {
         $header = $this->_getSearchDataHeader($search);
+
         $header = (empty($header)) ? new \stdClass() : $header;
         $query = $search->getQuery();
 
+        // Keep other query options as part of the search body
+        $queryOptions = array_diff_key($search->getOptions(), array_flip(self::$HEADER_OPTIONS));
+
         $data = JSON::stringify($header)."\n";
-        $data .= JSON::stringify($query->toArray())."\n";
+        $data .= JSON::stringify($query->toArray() + $queryOptions)."\n";
 
         return $data;
     }
@@ -193,6 +202,7 @@ class Search
             $header['types'] = $search->getTypes();
         }
 
-        return $header;
+        // Filter options accepted in the "header"
+        return array_intersect_key($header, array_flip(self::$HEADER_OPTIONS));
     }
 }

--- a/test/lib/Elastica/Test/Multi/SearchTest.php
+++ b/test/lib/Elastica/Test/Multi/SearchTest.php
@@ -575,4 +575,45 @@ class SearchTest extends BaseTest
         $this->assertSame($query2, $resultSets[1]->getQuery());
         $this->assertEquals(6, $resultSets[1]->getTotalHits());
     }
+
+    /**
+     * @group functional
+     */
+    public function testSearchWithSearchOptions()
+    {
+        $type = $this->_createType();
+        $index = $type->getIndex();
+        $client = $index->getClient();
+
+        $multiSearch = new MultiSearch($client);
+
+        $search1 = new Search($client);
+        $search1->addIndex($index)->addType($type);
+        $search1->setOption('terminate_after', '1');
+        $query1 = new Query();
+        $termQuery1 = new Term();
+        $termQuery1->setTerm('username', 'bunny');
+        $query1->setQuery($termQuery1);
+        $query1->setSize(1);
+        $search1->setQuery($query1);
+
+        $multiSearch->addSearch($search1);
+
+        $this->assertCount(1, $multiSearch->getSearches());
+
+        $search2 = new Search($client);
+        $search2->addIndex($index)->addType($type);
+        $query2 = new Query();
+        $termQuery2 = new Term();
+        $termQuery2->setTerm('username', 'bunny');
+        $query2->setQuery($termQuery2);
+        $query2->setSize(3);
+        $search2->setQuery($query2);
+
+        $multiSearch->addSearch($search2);
+        $multiResultSet = $multiSearch->search();
+        $resultSets = $multiResultSet->getResultSets();
+        $this->assertEquals(1, $resultSets[0]->getTotalHits());
+        $this->assertEquals(6, $resultSets[1]->getTotalHits());
+    }
 }


### PR DESCRIPTION
According to the doc only few options need to be passed in the header of a
MultiSearch. Unfortunately the current behavior is to sent all query options
into the header. For instance terminate_after or timeout are ignored by elastic
if the search is sent via a MultiSearch.
This patch adds an explicit filter of query options to pass in the header and
write remaining ones in the search request body.