### PR TITLE
Resolve deprecated use of type in has_parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 
+- `\Elastica\Query\HasParent` to use `parent_type` instead of `type`. Fixes warning due to field being deprecated.
+
 ### Deprecated
 
 ## [5.0.0](https://github.com/ruflin/Elastica/compare/5.0.0-beta1...5.0.0)

--- a/lib/Elastica/Query/HasParent.php
+++ b/lib/Elastica/Query/HasParent.php
@@ -43,7 +43,7 @@ class HasParent extends AbstractQuery
      */
     public function setType($type)
     {
-        return $this->setParam('type', $type);
+        return $this->setParam('parent_type', $type);
     }
 
     /**

--- a/test/lib/Elastica/Test/Query/HasParentTest.php
+++ b/test/lib/Elastica/Test/Query/HasParentTest.php
@@ -25,7 +25,7 @@ class HasParentTest extends BaseTest
         $expectedArray = [
             'has_parent' => [
                 'query' => $q->toArray(),
-                'type' => $type,
+                'parent_type' => $type,
             ],
         ];
 
@@ -49,7 +49,7 @@ class HasParentTest extends BaseTest
         $expectedArray = [
             'has_parent' => [
                 'query' => $q->toArray(),
-                'type' => $type,
+                'parent_type' => $type,
                 '_scope' => $scope,
             ],
         ];


### PR DESCRIPTION
`[2016-12-20T21:55:44,882][WARN ][o.e.d.c.ParseField       ] Deprecated field [type] used, expected [parent_type] instead`

Was seeing a lot these warnings in my logs. As it says this is due to use of `type` instead of `parent_type` when using a `has_child` query. Have simply changed this and updated the tests to reflect the change. 
