### PR TITLE
Escape date math in request path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file based on the
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/5.0.0...master)
 
+- Date math in index names is now escaped in URI
+- Added a check for paths that already have date math escaped
+
 ### Backward Compatibility Fixes
 
 ### Bugfixes

--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -8,6 +8,7 @@ use Elastica\Exception\ResponseException;
 use Elastica\JSON;
 use Elastica\Request;
 use Elastica\Response;
+use Elastica\Util;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7;
@@ -200,6 +201,11 @@ class Guzzle extends AbstractTransport
         if ($action) {
             $action = '/'.ltrim($action, '/');
         }
+
+        if (!Util::isDateMathEscaped($action)) {
+            $action = Util::escapeDateMath($action);
+        }
+
         $query = $request->getQuery();
 
         if (!empty($query)) {

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -7,6 +7,7 @@ use Elastica\Exception\ResponseException;
 use Elastica\JSON;
 use Elastica\Request;
 use Elastica\Response;
+use Elastica\Util;
 
 /**
  * Elastica Http Transport object.
@@ -58,7 +59,12 @@ class Http extends AbstractTransport
             $baseUri = $this->_scheme.'://'.$connection->getHost().':'.$connection->getPort().'/'.$connection->getPath();
         }
 
-        $baseUri .= $request->getPath();
+        $requestPath = $request->getPath();
+        if (!Util::isDateMathEscaped($requestPath)) {
+            $requestPath = Util::escapeDateMath($requestPath);
+        }
+
+        $baseUri .= $requestPath;
 
         $query = $request->getQuery();
 

--- a/lib/Elastica/Transport/HttpAdapter.php
+++ b/lib/Elastica/Transport/HttpAdapter.php
@@ -7,6 +7,7 @@ use Elastica\Exception\ResponseException;
 use Elastica\JSON;
 use Elastica\Request as ElasticaRequest;
 use Elastica\Response as ElasticaResponse;
+use Elastica\Util;
 use Ivory\HttpAdapter\HttpAdapterInterface;
 use Ivory\HttpAdapter\Message\Request as HttpAdapterRequest;
 use Ivory\HttpAdapter\Message\Response as HttpAdapterResponse;
@@ -146,7 +147,12 @@ class HttpAdapter extends AbstractTransport
             $baseUri = $this->_scheme.'://'.$connection->getHost().':'.$connection->getPort().'/'.$connection->getPath();
         }
 
-        $baseUri .= $request->getPath();
+        $requestPath = $request->getPath();
+        if (!Util::isDateMathEscaped($requestPath)) {
+            $requestPath = Util::escapeDateMath($requestPath);
+        }
+
+        $baseUri .= $requestPath;
 
         $query = $request->getQuery();
 

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -11,6 +11,72 @@ namespace Elastica;
  */
 class Util
 {
+    /** @var array */
+    protected static $dateMathSymbols = ['<', '>', '/', '{', '}', '|', '+', ':', ','];
+
+    /** @var array */
+    protected static $escapedDateMathSymbols = ['%3C', '%3E', '%2F', '%7B', '%7D', '%7C', '%2B', '%3A', '%2C'];
+
+    /**
+     * Checks if date math is already escaped within request URI.
+     *
+     * @param string $requestUri
+     *
+     * @return bool
+     */
+    public static function isDateMathEscaped($requestUri)
+    {
+        // In practice, the only symbol that really needs to be escaped in URI is '/' => '%2F'
+        return false !== strpos($requestUri, '%2F');
+    }
+
+    /**
+     * Escapes date math symbols within request URI.
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/date-math-index-names.html
+     *
+     * @param string $requestUri
+     *
+     * @return string
+     */
+    public static function escapeDateMath($requestUri)
+    {
+        if (empty($requestUri)) {
+            return $requestUri;
+        }
+
+        // Check if date math if used at all. Find last '>'. E.g. /<log-{now/d}>,log-2011.12.01/log/_refresh
+        $pos1 = strrpos($requestUri, '>');
+        if (false === $pos1) {
+            return $requestUri;
+        }
+
+        // Trim leading slash if present
+        if ($startsWithSlash = '/' === $requestUri[0]) {
+            $requestUri = ltrim($requestUri, '/');
+        }
+
+        // Find the position up to which we should escape.
+        // Should be next slash '/' after last '>' E.g. <log-{now/d}>,log-2011.12.01/log/_refresh
+        $pos2 = strpos($requestUri, '/', $pos1);
+        $pos2 = false !== $pos2 ? $pos2 : strlen($requestUri);
+
+        // Cut out the bit we need to escape: <log-{now/d}>,log-2011.12.01
+        $uriSegment = substr($requestUri, 0, $pos2);
+
+        // Escape using character map
+        $escapedUriSegment = str_replace(static::$dateMathSymbols, static::$escapedDateMathSymbols, $uriSegment);
+
+        // '\\{' and '\\}' should not be escaped
+        if (false !== strpos($uriSegment, '\\\\')) {
+            $escapedUriSegment = str_replace(['\\\\%7B', '\\\\%7D'], ['\\\\{', '\\\\}'], $escapedUriSegment);
+        }
+
+        // Replace part of the string. E.g. /%3Clog-%7Bnow%2Fd%7D%3E%2Clog-2011.12.01/log/_refresh
+        $requestUri = substr_replace($requestUri, $escapedUriSegment, 0, $pos2);
+
+        return ($startsWithSlash ? '/' : '').$requestUri;
+    }
+
     /**
      * Replace the following reserved words: AND OR NOT
      * and

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -40,7 +40,8 @@ class Util
      */
     public static function escapeDateMath($requestUri)
     {
-        if (empty($requestUri)) {
+        // No need to escape if a second slash is not present
+        if (empty($requestUri) || false === strpos($requestUri, '/', 1)) {
             return $requestUri;
         }
 

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -51,11 +51,11 @@ class Util
         }
 
         // Find the position up to which we should escape.
-        // Should be next slash '/' after last '>' E.g. <log-{now/d}>,log-2011.12.01/log/_refresh
+        // Should be next slash '/' after last '>' E.g. /<log-{now/d}>,log-2011.12.01/log/_refresh
         $pos2 = strpos($requestUri, '/', $pos1);
         $pos2 = false !== $pos2 ? $pos2 : strlen($requestUri);
 
-        // Cut out the bit we need to escape: <log-{now/d}>,log-2011.12.01
+        // Cut out the bit we need to escape: /<log-{now/d}>,log-2011.12.01
         $uriSegment = substr($requestUri, 1, $pos2 - 1);
 
         // Escape using character map

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -56,7 +56,7 @@ class Util
         $pos2 = false !== $pos2 ? $pos2 : strlen($requestUri);
 
         // Cut out the bit we need to escape: /<log-{now/d}>,log-2011.12.01
-        $uriSegment = substr($requestUri, 1, $pos2 - 1);
+        $uriSegment = substr($requestUri, 0, $pos2);
 
         // Escape using character map
         $escapedUriSegment = str_replace(static::$dateMathSymbols, static::$escapedDateMathSymbols, $uriSegment);
@@ -67,7 +67,7 @@ class Util
         }
 
         // Replace part of the string. E.g. /%3Clog-%7Bnow%2Fd%7D%3E%2Clog-2011.12.01/log/_refresh
-        return substr_replace($requestUri, $escapedUriSegment, 1, $pos2 - 1);
+        return substr_replace($requestUri, $escapedUriSegment, 0, $pos2);
     }
 
     /**

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -27,7 +27,7 @@ class Util
     public static function isDateMathEscaped($requestUri)
     {
         // In practice, the only symbol that really needs to be escaped in URI is '/' => '%2F'
-        return false !== strpos($requestUri, '%2F');
+        return false !== strpos(strtoupper($requestUri), '%2F');
     }
 
     /**

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -40,8 +40,7 @@ class Util
      */
     public static function escapeDateMath($requestUri)
     {
-        // No need to escape if a second slash is not present
-        if (empty($requestUri) || false === strpos($requestUri, '/', 1)) {
+        if (empty($requestUri)) {
             return $requestUri;
         }
 
@@ -51,18 +50,13 @@ class Util
             return $requestUri;
         }
 
-        // Trim leading slash if present
-        if ($startsWithSlash = '/' === $requestUri[0]) {
-            $requestUri = ltrim($requestUri, '/');
-        }
-
         // Find the position up to which we should escape.
         // Should be next slash '/' after last '>' E.g. <log-{now/d}>,log-2011.12.01/log/_refresh
         $pos2 = strpos($requestUri, '/', $pos1);
         $pos2 = false !== $pos2 ? $pos2 : strlen($requestUri);
 
         // Cut out the bit we need to escape: <log-{now/d}>,log-2011.12.01
-        $uriSegment = substr($requestUri, 0, $pos2);
+        $uriSegment = substr($requestUri, 1, $pos2 - 1);
 
         // Escape using character map
         $escapedUriSegment = str_replace(static::$dateMathSymbols, static::$escapedDateMathSymbols, $uriSegment);
@@ -73,9 +67,7 @@ class Util
         }
 
         // Replace part of the string. E.g. /%3Clog-%7Bnow%2Fd%7D%3E%2Clog-2011.12.01/log/_refresh
-        $requestUri = substr_replace($requestUri, $escapedUriSegment, 0, $pos2);
-
-        return ($startsWithSlash ? '/' : '').$requestUri;
+        return substr_replace($requestUri, $escapedUriSegment, 1, $pos2 - 1);
     }
 
     /**

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -1252,7 +1252,7 @@ class ClientTest extends BaseTest
     /**
      * @group functional
      */
-    public function testDateMathEscaping()
+    public function testDateMathEscapingWithMixedRequestTypes()
     {
         $client = $this->_getClient();
 
@@ -1278,5 +1278,22 @@ class ClientTest extends BaseTest
         $bulk->addDocuments([$doc1, $doc2]);
         // Should be sent successfully without exceptions
         $bulk->send();
+    }
+
+    /**
+     * @group functional
+     */
+    public function testDateMathEscapingWithEscapedPath()
+    {
+        $client = $this->_getClient();
+
+        $now = new \DateTime();
+
+        // e.g. test-2018.01.01
+        $staticIndex = $client->getIndex('test-'.$now->format('Y.m.d'));
+        $staticIndex->create();
+
+        // It should not double escape the index name, since it came already escaped.
+        $client->request('<test-{now%2Fd}>/_refresh');
     }
 }

--- a/test/lib/Elastica/Test/UtilTest.php
+++ b/test/lib/Elastica/Test/UtilTest.php
@@ -10,6 +10,59 @@ class UtilTest extends BaseTest
 {
     /**
      * @group unit
+     * @dataProvider getIsDateMathEscapedPairs
+     */
+    public function testIsDateMathEscaped($requestUri, $expectedIsEscaped)
+    {
+        $this->assertEquals($expectedIsEscaped, Util::isDateMathEscaped($requestUri));
+    }
+
+    public function getIsDateMathEscapedPairs()
+    {
+        return [
+            ['', false],
+            ['/', false],
+            ['/<log-{now/d}>/type/_search', false],
+            ['/<log-{now%2Fd}>/type/_search', true],
+            ['/<logstash-{now/d-2d}>,<logstash-{now/d-1d}>,<logstash-{now/d}>/_search', false],
+            ['/%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2Fd%7D%3E/_search', true]
+        ];
+    }
+
+    /**
+     * @group unit
+     * @dataProvider getEscapeDateMathPairs
+     */
+    public function testEscapeDateMath($requestUri, $expectedEscapedRequestUri)
+    {
+        $this->assertEquals($expectedEscapedRequestUri, Util::escapeDateMath($requestUri));
+    }
+
+    public function getEscapeDateMathPairs()
+    {
+        return [
+            ['', ''],
+            ['/', '/'],
+            ['/_bulk', '/_bulk'],
+            ['/bulk', '/bulk'],
+            ['/index/type/id/_create', '/index/type/id/_create'],
+            ['/index/_warmer', '/index/_warmer'],
+            ['/index/type/id/_percolate/count', '/index/type/id/_percolate/count'],
+            ['/<logstash-{now/d}>/_search', '/%3Clogstash-%7Bnow%2Fd%7D%3E/_search'],
+            ['/<log-{now/d}>,log-2011.12.01/log/_refresh', '/%3Clog-%7Bnow%2Fd%7D%3E%2Clog-2011.12.01/log/_refresh'],
+            [
+                '/<logstash-{now/d-2d}>,<logstash-{now/d-1d}>,<logstash-{now/d}>/_search',
+                '/%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2Fd%7D%3E/_search'
+            ],
+            [
+                '/<elastic\\\\{ON\\\\}-{now/M}>', // <elastic\\{ON\\}-{now/M}>
+                '/%3Celastic\\\\{ON\\\\}-%7Bnow%2FM%7D%3E',
+            ],
+        ];
+    }
+
+    /**
+     * @group unit
      * @dataProvider getEscapeTermPairs
      */
     public function testEscapeTerm($unescaped, $escaped)

--- a/test/lib/Elastica/Test/UtilTest.php
+++ b/test/lib/Elastica/Test/UtilTest.php
@@ -25,7 +25,8 @@ class UtilTest extends BaseTest
             ['/<log-{now/d}>/type/_search', false],
             ['/<log-{now%2Fd}>/type/_search', true],
             ['/<logstash-{now/d-2d}>,<logstash-{now/d-1d}>,<logstash-{now/d}>/_search', false],
-            ['/%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2Fd%7D%3E/_search', true]
+            ['/%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2fd%7D%3E/_search', true],
+            ['/%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2Fd%7D%3E/_search', true],
         ];
     }
 

--- a/test/lib/Elastica/Test/UtilTest.php
+++ b/test/lib/Elastica/Test/UtilTest.php
@@ -21,12 +21,12 @@ class UtilTest extends BaseTest
     {
         return [
             ['', false],
-            ['/', false],
-            ['/<log-{now/d}>/type/_search', false],
-            ['/<log-{now%2Fd}>/type/_search', true],
-            ['/<logstash-{now/d-2d}>,<logstash-{now/d-1d}>,<logstash-{now/d}>/_search', false],
-            ['/%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2fd%7D%3E/_search', true],
-            ['/%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2Fd%7D%3E/_search', true],
+            ['', false],
+            ['<log-{now/d}>/type/_search', false],
+            ['<log-{now%2Fd}>/type/_search', true],
+            ['<logstash-{now/d-2d}>,<logstash-{now/d-1d}>,<logstash-{now/d}>/_search', false],
+            ['%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2fd%7D%3E/_search', true],
+            ['%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2Fd%7D%3E/_search', true],
         ];
     }
 
@@ -43,21 +43,20 @@ class UtilTest extends BaseTest
     {
         return [
             ['', ''],
-            ['/', '/'],
-            ['/_bulk', '/_bulk'],
-            ['/bulk', '/bulk'],
-            ['/index/type/id/_create', '/index/type/id/_create'],
-            ['/index/_warmer', '/index/_warmer'],
-            ['/index/type/id/_percolate/count', '/index/type/id/_percolate/count'],
-            ['/<logstash-{now/d}>/_search', '/%3Clogstash-%7Bnow%2Fd%7D%3E/_search'],
-            ['/<log-{now/d}>,log-2011.12.01/log/_refresh', '/%3Clog-%7Bnow%2Fd%7D%3E%2Clog-2011.12.01/log/_refresh'],
+            ['_bulk', '_bulk'],
+            ['bulk', 'bulk'],
+            ['index/type/id/_create', 'index/type/id/_create'],
+            ['index/_warmer', 'index/_warmer'],
+            ['index/type/id/_percolate/count', 'index/type/id/_percolate/count'],
+            ['<logstash-{now/d}>/_search', '%3Clogstash-%7Bnow%2Fd%7D%3E/_search'],
+            ['<log-{now/d}>,log-2011.12.01/log/_refresh', '%3Clog-%7Bnow%2Fd%7D%3E%2Clog-2011.12.01/log/_refresh'],
             [
-                '/<logstash-{now/d-2d}>,<logstash-{now/d-1d}>,<logstash-{now/d}>/_search',
-                '/%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2Fd%7D%3E/_search'
+                '<logstash-{now/d-2d}>,<logstash-{now/d-1d}>,<logstash-{now/d}>/_search',
+                '%3Clogstash-%7Bnow%2Fd-2d%7D%3E%2C%3Clogstash-%7Bnow%2Fd-1d%7D%3E%2C%3Clogstash-%7Bnow%2Fd%7D%3E/_search'
             ],
             [
-                '/<elastic\\\\{ON\\\\}-{now/M}>', // <elastic\\{ON\\}-{now/M}>
-                '/%3Celastic\\\\{ON\\\\}-%7Bnow%2FM%7D%3E',
+                '<elastic\\\\{ON\\\\}-{now/M}>', // <elastic\\{ON\\}-{now/M}>
+                '%3Celastic\\\\{ON\\\\}-%7Bnow%2FM%7D%3E',
             ],
         ];
     }


### PR DESCRIPTION
Resolves #1228

I couldn't run the full test suite on Windows (Docker problems), so I pushed my solution + unit test (to get things moving). If someone could run this on Docker, that wouldd great. I'll try to run Docker suite at work.

Integration test for this would be declaring an index name with date math, then using it for both writing `_bulk` (index name ends up in JSON body, needs to be unescaped) and reading/doing something, e.g. `_refresh`, where index name is in URI (needs to be escaped).