### PR TITLE
Fix relation property in geo_shape query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ All notable changes to this project will be documented in this file based on the
   - `\Elastica\Query\TopChildren`
 - `\Elastica\Query\MatchPhrase` and `\Elastica\Query\MatchPhrasePrefix` do not extend `\Elastica\Query\Match` anymore because they do not share exactly the same options
 - Removed the `routing` option in `\Elastica\Index::create` because there is no routing param when creating an index. So that option was doing nothing so far but fails in Elasticearch 5.0 because the non-existing query param is validated.
+- Fix `relation` property of `\Elastica\Query\GeoShapeProvided`
 
 ### Added
 
 - added `\Elastica\Script\ScriptId` to reference stored scripts by ID
+- added `\Elastica\Query\AbstractGeoShape::RELATION_WITHIN`
 
 ### Improvements
 

--- a/lib/Elastica/Query/AbstractGeoShape.php
+++ b/lib/Elastica/Query/AbstractGeoShape.php
@@ -4,33 +4,41 @@ namespace Elastica\Query;
 /**
  * geo_shape query.
  *
- * Query pre-indexed shape definitions
- *
  * @author Bennie Krijger <benniekrijger@gmail.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
  */
 abstract class AbstractGeoShape extends AbstractQuery
 {
+    /** Return all documents whose geo_shape field intersects the query geometry. (default behavior) */
     const RELATION_INTERSECT = 'intersects';
+
+    /** Return all documents whose geo_shape field has nothing in common with the query geometry. */
     const RELATION_DISJOINT = 'disjoint';
-    const RELATION_CONTAINS = 'within';
+
+    /** Return all documents whose geo_shape field is within the query geometry. */
+    const RELATION_WITHIN = 'within';
+
+    /** Return all documents whose geo_shape field contains the query geometry. */
+    const RELATION_CONTAINS = 'contains';
 
     /**
-     * @var string
+     * Elasticsearch path of the geo_shape field
      *
-     * elasticsearch path of the pre-indexed shape
+     * @var string
      */
     protected $_path;
 
     /**
      * @var string
-     *
-     * the relation of the 2 shaped: intersects, disjoint, within
      */
     protected $_relation = self::RELATION_INTERSECT;
 
     /**
+     * Sets the relation of the geo_shape field and the query geometry.
+     *
+     * Possible values: intersects, disjoint, within, contains (see constants).
+     *
      * @param string $relation
      *
      * @return $this
@@ -43,6 +51,8 @@ abstract class AbstractGeoShape extends AbstractQuery
     }
 
     /**
+     * Gets the relation of the geo_shape field and the query geometry.
+     *
      * @return string
      */
     public function getRelation()

--- a/lib/Elastica/Query/GeoShapeProvided.php
+++ b/lib/Elastica/Query/GeoShapeProvided.php
@@ -2,7 +2,7 @@
 namespace Elastica\Query;
 
 /**
- * geo_shape query or provided shapes.
+ * geo_shape query for provided shapes.
  *
  * Query provided shape definitions
  *
@@ -64,8 +64,8 @@ class GeoShapeProvided extends AbstractGeoShape
                     'shape' => [
                         'type' => $this->_shapeType,
                         'coordinates' => $this->_coordinates,
-                        'relation' => $this->_relation,
                     ],
+                    'relation' => $this->_relation,
                 ],
             ],
         ];


### PR DESCRIPTION
- The `relation` property in `GeoShapeProvided` was serialized in the wrong place making it useless.
- Add `contains` relation which has been introduced in ES 2.2

Todo
- [x] add changelog once #1242 is merged