### PR TITLE
Fix typo in deprecated warning for Index::optimize

### DIFF
--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -199,7 +199,7 @@ class Index implements SearchableInterface
      */
     public function optimize($args = [])
     {
-        trigger_error('Deprecated: Elastica\Index::optimize() is deprecated and will be removed in further Elastica releases. Use Elastica\Query::forcemerge() instead.', E_USER_DEPRECATED);
+        trigger_error('Deprecated: Elastica\Index::optimize() is deprecated and will be removed in further Elastica releases. Use Elastica\Index::forcemerge() instead.', E_USER_DEPRECATED);
 
         return $this->forcemerge($args);
     }


### PR DESCRIPTION
The warning points to Query::forcemerge but should be Index::forcemerge.