### PR TITLE
Fix reading bool index setting & deprecate ElasticsearchException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 
+- Fix reading bool index settings like `\Elastica\Index\Settings::getBlocksWrite`. Elasticsearch returns all settings as strings and does not normalize bool values.
+  The getters now return the right bool value for whichever string representation is used like 'true', '1', 'on', 'yes'.
+
 ### Added
 
 ### Improvements
 
 ### Deprecated
 
+- Deprecated `\Elastica\Exception\ElasticsearchException` which is irrelevant since Elasticsearch now exposes the errors as a structured array instead of a single string.
+  Use `\Elastica\Exception\ResponseException::getResponse::getFullError` instead.
 
 ## [5.1.0](https://github.com/ruflin/Elastica/compare/5.0.0...5.1.0)
 

--- a/lib/Elastica/Exception/ElasticsearchException.php
+++ b/lib/Elastica/Exception/ElasticsearchException.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elastica\Exception;
 
+trigger_error('Elastica\Exception\ElasticsearchException is deprecated. Use Elastica\Exception\ResponseException::getResponse::getFullError instead.', E_USER_DEPRECATED);
+
 /**
  * Elasticsearch exception.
  *
@@ -28,15 +30,13 @@ class ElasticsearchException extends \Exception implements ExceptionInterface
     /**
      * Constructs elasticsearch exception.
      *
-     * @param int   $code  Error code
-     * @param array $error Error object from elasticsearch
+     * @param int    $code  Error code
+     * @param string $error Error message from elasticsearch
      */
     public function __construct($code, $error)
     {
-        $this->_error = $error;
-        // TODO: es2 improve as now an array
-        $this->_parseError(json_encode($error));
-        parent::__construct(json_encode($error), $code);
+        $this->_parseError($error);
+        parent::__construct($error, $code);
     }
 
     /**

--- a/lib/Elastica/Exception/ResponseException.php
+++ b/lib/Elastica/Exception/ResponseException.php
@@ -62,9 +62,7 @@ class ResponseException extends \RuntimeException implements ExceptionInterface
     public function getElasticsearchException()
     {
         $response = $this->getResponse();
-        $transfer = $response->getTransferInfo();
-        $code = array_key_exists('http_code', $transfer) ? $transfer['http_code'] : 0;
 
-        return new ElasticsearchException($code, $response->getErrorMessage());
+        return new ElasticsearchException($response->getStatus(), $response->getErrorMessage());
     }
 }

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -283,9 +283,8 @@ class Index implements SearchableInterface
     public function exists()
     {
         $response = $this->getClient()->request($this->getName(), Request::HEAD);
-        $info = $response->getTransferInfo();
 
-        return (bool) ($info['http_code'] == 200);
+        return $response->getStatus() === 200;
     }
 
     /**

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -103,6 +103,25 @@ class Settings
     }
 
     /**
+     * Returns a setting interpreted as a bool.
+     *
+     * One can use a real bool, int(0), int(1) to set bool settings.
+     * But Elasticsearch stores and returns all settings as strings and does
+     * not normalize bool values. This method ensures a bool is returned
+     * for whichever bool string is used: 'true', '1', 'on', 'yes'
+     *
+     * @param string $setting Setting name to return
+     *
+     * @return bool
+     */
+    public function getBool($setting)
+    {
+        $data = $this->get($setting);
+
+        return 'true' === $data | '1' === $data | 'on' === $data | 'yes' === $data;
+    }
+
+    /**
      * Sets the number of replicas.
      *
      * @param int $replicas Number of replicas
@@ -111,11 +130,7 @@ class Settings
      */
     public function setNumberOfReplicas($replicas)
     {
-        $replicas = (int) $replicas;
-
-        $data = ['number_of_replicas' => $replicas];
-
-        return $this->set($data);
+        return $this->set(['number_of_replicas' => (int) $replicas]);
     }
 
     /**
@@ -127,17 +142,15 @@ class Settings
      */
     public function setReadOnly($readOnly = true)
     {
-        return $this->set(['blocks.write' => $readOnly]);
+        return $this->set(['blocks.read_only' => $readOnly]);
     }
 
     /**
-     * getReadOnly.
-     *
      * @return bool
      */
     public function getReadOnly()
     {
-        return $this->get('blocks.write') === 'true'; // ES returns a string for this setting
+        return $this->getBool('blocks.read_only');
     }
 
     /**
@@ -145,7 +158,7 @@ class Settings
      */
     public function getBlocksRead()
     {
-        return (bool) $this->get('blocks.read');
+        return $this->getBool('blocks.read');
     }
 
     /**
@@ -155,8 +168,6 @@ class Settings
      */
     public function setBlocksRead($state = true)
     {
-        $state = $state ? 1 : 0;
-
         return $this->set(['blocks.read' => $state]);
     }
 
@@ -165,7 +176,7 @@ class Settings
      */
     public function getBlocksWrite()
     {
-        return (bool) $this->get('blocks.write');
+        return $this->getBool('blocks.write');
     }
 
     /**
@@ -175,8 +186,6 @@ class Settings
      */
     public function setBlocksWrite($state = true)
     {
-        $state = $state ? 1 : 0;
-
         return $this->set(['blocks.write' => $state]);
     }
 
@@ -185,13 +194,12 @@ class Settings
      */
     public function getBlocksMetadata()
     {
-        // TODO will have to be replace by block.metadata.write once https://github.com/elasticsearch/elasticsearch/pull/9203 has been fixed
-        // the try/catch will have to be remove too
+        // When blocks.metadata is enabled, reading the settings is not possible anymore.
+        // So when a cluster_block_exception happened it must be enabled.
         try {
-            return (bool) $this->get('blocks.write');
+            return $this->getBool('blocks.metadata');
         } catch (ResponseException $e) {
-            if (strpos($e->getMessage(), 'ClusterBlockException') !== false) {
-                // hacky way to test if the metadata is blocked since bug 9203 is not fixed
+            if ($e->getResponse()->getFullError()['type'] === 'cluster_block_exception') {
                 return true;
             }
 
@@ -200,15 +208,15 @@ class Settings
     }
 
     /**
+     * Set to true to disable index metadata reads and writes.
+     *
      * @param bool $state OPTIONAL (default = true)
      *
      * @return \Elastica\Response
      */
     public function setBlocksMetadata($state = true)
     {
-        $state = $state ? 1 : 0;
-
-        return $this->set(['blocks.write' => $state]);
+        return $this->set(['blocks.metadata' => $state]);
     }
 
     /**

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -118,7 +118,7 @@ class Settings
     {
         $data = $this->get($setting);
 
-        return 'true' === $data | '1' === $data | 'on' === $data | 'yes' === $data;
+        return 'true' === $data || '1' === $data || 'on' === $data || 'yes' === $data;
     }
 
     /**

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -107,8 +107,8 @@ class Settings
      *
      * One can use a real bool, int(0), int(1) to set bool settings.
      * But Elasticsearch stores and returns all settings as strings and does
-     * not normalize bool values. This method ensures a bool is returned
-     * for whichever bool string is used: 'true', '1', 'on', 'yes'
+     * not normalize bool values. This method ensures a bool is returned for
+     * whichever string representation is used like 'true', '1', 'on', 'yes'.
      *
      * @param string $setting Setting name to return
      *

--- a/lib/Elastica/IndexTemplate.php
+++ b/lib/Elastica/IndexTemplate.php
@@ -78,9 +78,8 @@ class IndexTemplate
     public function exists()
     {
         $response = $this->request(Request::HEAD);
-        $info = $response->getTransferInfo();
 
-        return (bool) ($info['http_code'] == 200);
+        return $response->getStatus() === 200;
     }
 
     /**

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -46,13 +46,13 @@ class Query extends Param
     }
 
     /**
-     * Transforms a string or an array to a query object.
+     * Transforms the argument to a query object.
      *
-     * If query is empty,
+     * For example, an empty argument will return a \Elastica\Query with a \Elastica\Query\MatchAll.
      *
      * @param mixed $query
      *
-     * @throws \Elastica\Exception\NotImplementedException
+     * @throws InvalidException For an invalid argument
      *
      * @return self
      */
@@ -77,8 +77,7 @@ class Query extends Param
 
         }
 
-        // TODO: Implement queries without
-        throw new NotImplementedException();
+        throw new InvalidException('Unexpected argument to create a query for.');
     }
 
     /**

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -28,13 +28,6 @@ class Response
     protected $_responseString = '';
 
     /**
-     * Error.
-     *
-     * @var bool Error
-     */
-    protected $_error = false;
-
-    /**
      * Transfer info.
      *
      * @var array transfer info
@@ -113,11 +106,11 @@ class Response
     }
 
     /**
-     * A keyed array representing any errors that occured.
+     * A keyed array representing any errors that occurred.
      *
      * In case of http://localhost:9200/_alias/test the error is a string
      *
-     * @return array|string Error data
+     * @return array|string|null Error data or null if there is no error
      */
     public function getFullError()
     {
@@ -133,13 +126,7 @@ class Response
      */
     public function getErrorMessage()
     {
-        $error = $this->getError();
-
-        if (!is_string($error)) {
-            $error = json_encode($error);
-        }
-
-        return $error;
+        return $this->getError();
     }
 
     /**
@@ -227,18 +214,15 @@ class Response
     {
         if ($this->_response == null) {
             $response = $this->_responseString;
-            if ($response === false) {
-                $this->_error = true;
-            } else {
-                try {
-                    if ($this->getJsonBigintConversion()) {
-                        $response = JSON::parse($response, true, 512, JSON_BIGINT_AS_STRING);
-                    } else {
-                        $response = JSON::parse($response);
-                    }
-                } catch (JSONParseException $e) {
-                    // leave response as is if parse fails
+
+            try {
+                if ($this->getJsonBigintConversion()) {
+                    $response = JSON::parse($response, true, 512, JSON_BIGINT_AS_STRING);
+                } else {
+                    $response = JSON::parse($response);
                 }
+            } catch (JSONParseException $e) {
+                // leave response as is if parse fails
             }
 
             if (empty($response)) {

--- a/lib/Elastica/Status.php
+++ b/lib/Elastica/Status.php
@@ -106,9 +106,8 @@ class Status
         try {
             $response = $this->_client->request('/_alias/'.$alias);
         } catch (ResponseException $e) {
-            $transferInfo = $e->getResponse()->getTransferInfo();
             // 404 means the index alias doesn't exist which means no indexes have it.
-            if ($transferInfo['http_code'] === 404) {
+            if ($e->getResponse()->getStatus() === 404) {
                 return [];
             }
             // If we don't have a 404 then this is still unexpected so rethrow the exception.

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -522,8 +522,7 @@ class Type implements SearchableInterface
     public function exists()
     {
         $response = $this->getIndex()->request($this->getName(), Request::HEAD);
-        $info = $response->getTransferInfo();
 
-        return $info['http_code'] == 200;
+        return $response->getStatus() === 200;
     }
 }

--- a/test/lib/Elastica/Test/Bulk/ResponseSetTest.php
+++ b/test/lib/Elastica/Test/Bulk/ResponseSetTest.php
@@ -139,7 +139,7 @@ class ResponseSetTest extends BaseTest
      */
     protected function _createResponseSet(array $responseData, array $actions)
     {
-        $client = $this->createMock('Elastica\\Client', ['request']);
+        $client = $this->createMock('Elastica\\Client');
 
         $client->expects($this->once())
             ->method('request')

--- a/test/lib/Elastica/Test/Exception/ElasticsearchExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ElasticsearchExceptionTest.php
@@ -1,6 +1,0 @@
-<?php
-namespace Elastica\Test\Exception;
-
-class ElasticsearchExceptionTest extends AbstractExceptionTest
-{
-}

--- a/test/lib/Elastica/Test/Exception/ResponseExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/ResponseExceptionTest.php
@@ -19,7 +19,7 @@ class ResponseExceptionTest extends AbstractExceptionTest
         } catch (ResponseException $ex) {
             $error = $ex->getResponse()->getFullError();
             $this->assertEquals('index_already_exists_exception', $error['type']);
-            $this->assertEquals(400, $ex->getElasticsearchException()->getCode());
+            $this->assertEquals(400, $ex->getResponse()->getStatus());
         }
     }
 
@@ -45,7 +45,7 @@ class ResponseExceptionTest extends AbstractExceptionTest
         } catch (ResponseException $ex) {
             $error = $ex->getResponse()->getFullError();
             $this->assertEquals('mapper_parsing_exception', $error['type']);
-            $this->assertEquals(400, $ex->getElasticsearchException()->getCode());
+            $this->assertEquals(400, $ex->getResponse()->getStatus());
         }
     }
 
@@ -62,7 +62,7 @@ class ResponseExceptionTest extends AbstractExceptionTest
         } catch (ResponseException $ex) {
             $error = $ex->getResponse()->getFullError();
             $this->assertEquals('index_not_found_exception', $error['type']);
-            $this->assertEquals(404, $ex->getElasticsearchException()->getCode());
+            $this->assertEquals(404, $ex->getResponse()->getStatus());
         }
     }
 }

--- a/test/lib/Elastica/Test/Index/SettingsTest.php
+++ b/test/lib/Elastica/Test/Index/SettingsTest.php
@@ -199,6 +199,7 @@ class SettingsTest extends BaseTest
         // Try to add doc to read only index
         $index->getSettings()->setReadOnly(true);
         $this->assertTrue($index->getSettings()->getReadOnly());
+        $this->assertTrue($index->exists());
 
         try {
             $type->addDocument($doc2);
@@ -207,7 +208,7 @@ class SettingsTest extends BaseTest
             $error = $e->getResponse()->getFullError();
 
             $this->assertContains('cluster_block_exception', $error['type']);
-            $this->assertContains('index write', $error['reason']);
+            $this->assertContains('read-only', $error['reason']);
         }
 
         // Remove read only, add document

--- a/test/lib/Elastica/Test/IndexTemplateTest.php
+++ b/test/lib/Elastica/Test/IndexTemplateTest.php
@@ -45,7 +45,7 @@ class IndexTemplateTest extends BaseTest
         $name = 'index_template1';
         $response = new Response('');
         /** @var \PHPUnit_Framework_MockObject_MockObject|Client $clientMock */
-        $clientMock = $this->createMock('\Elastica\Client', ['request']);
+        $clientMock = $this->createMock('\Elastica\Client');
         $clientMock->expects($this->once())
             ->method('request')
             ->with('_template/'.$name, Request::DELETE, [], [])
@@ -63,7 +63,7 @@ class IndexTemplateTest extends BaseTest
         $response = new Response('');
         $name = 'index_template1';
         /** @var \PHPUnit_Framework_MockObject_MockObject|Client $clientMock */
-        $clientMock = $this->createMock('\Elastica\Client', ['request']);
+        $clientMock = $this->createMock('\Elastica\Client');
         $clientMock->expects($this->once())
             ->method('request')
             ->with('_template/'.$name, Request::PUT, $args, [])
@@ -78,10 +78,9 @@ class IndexTemplateTest extends BaseTest
     public function testExists()
     {
         $name = 'index_template1';
-        $response = new Response('');
-        $response->setTransferInfo(['http_code' => 200]);
+        $response = new Response('', 200);
         /** @var \PHPUnit_Framework_MockObject_MockObject|Client $clientMock */
-        $clientMock = $this->createMock('\Elastica\Client', ['request']);
+        $clientMock = $this->createMock('\Elastica\Client');
         $clientMock->expects($this->once())
             ->method('request')
             ->with('_template/'.$name, Request::HEAD, [], [])


### PR DESCRIPTION
- Use the explicit getter Response::getStatus instead of the curl transfer info
- Fix reading bool index setting, e.g. when it uses `'off'` instead of `'0'` (where just casting to bool doesn't work)
- Deprecate ElasticsearchException which is irrelevant since elasticsearch now exposes the errors as a structured array instead of a single string. So the whole purpose of the class is gone.
- Add test to show #457 is solved by now