### PR TITLE
use `::class` constant to reference class names

### DIFF
--- a/test/lib/Elastica/Test/Aggregation/AbstractSimpleAggregationTest.php
+++ b/test/lib/Elastica/Test/Aggregation/AbstractSimpleAggregationTest.php
@@ -6,7 +6,7 @@ use Elastica\Exception\InvalidException;
 
 class AbstractSimpleAggregationTest extends BaseAggregationTest
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->aggregation = $this->getMockForAbstractClass(
             AbstractSimpleAggregation::class,

--- a/test/lib/Elastica/Test/Aggregation/AbstractSimpleAggregationTest.php
+++ b/test/lib/Elastica/Test/Aggregation/AbstractSimpleAggregationTest.php
@@ -1,22 +1,23 @@
 <?php
 namespace Elastica\Test\Aggregation;
 
+use Elastica\Aggregation\AbstractSimpleAggregation;
+use Elastica\Exception\InvalidException;
+
 class AbstractSimpleAggregationTest extends BaseAggregationTest
 {
     public function setUp()
     {
         $this->aggregation = $this->getMockForAbstractClass(
-            'Elastica\Aggregation\AbstractSimpleAggregation',
+            AbstractSimpleAggregation::class,
             ['whatever']
         );
     }
 
     public function testToArrayThrowsExceptionOnUnsetParams()
     {
-        $this->setExpectedException(
-            'Elastica\Exception\InvalidException',
-            'Either the field param or the script param should be set'
-        );
+        $this->expectException(InvalidException::class);
+        $this->expectExceptionMessage('Either the field param or the script param should be set');
 
         $this->aggregation->toArray();
     }

--- a/test/lib/Elastica/Test/Aggregation/DateHistogramTest.php
+++ b/test/lib/Elastica/Test/Aggregation/DateHistogramTest.php
@@ -73,7 +73,7 @@ class DateHistogramTest extends BaseAggregationTest
 
         $this->assertEquals($expected, $agg->toArray());
 
-        $this->assertInstanceOf('Elastica\Aggregation\DateHistogram', $agg->setOffset('3m'));
+        $this->assertInstanceOf(DateHistogram::class, $agg->setOffset('3m'));
     }
 
     /**
@@ -112,6 +112,6 @@ class DateHistogramTest extends BaseAggregationTest
 
         $this->assertEquals($expected, $agg->toArray());
 
-        $this->assertInstanceOf('Elastica\Aggregation\DateHistogram', $agg->setTimezone('-02:30'));
+        $this->assertInstanceOf(DateHistogram::class, $agg->setTimezone('-02:30'));
     }
 }

--- a/test/lib/Elastica/Test/Aggregation/PercentilesTest.php
+++ b/test/lib/Elastica/Test/Aggregation/PercentilesTest.php
@@ -28,7 +28,7 @@ class PercentilesTest extends BaseAggregationTest
         $aggr->setField('price');
 
         $this->assertEquals('price', $aggr->getParam('field'));
-        $this->assertInstanceOf('Elastica\Aggregation\Percentiles', $aggr->setField('price'));
+        $this->assertInstanceOf(Percentiles::class, $aggr->setField('price'));
     }
 
     /**
@@ -39,7 +39,7 @@ class PercentilesTest extends BaseAggregationTest
         $aggr = new Percentiles('price_percentile');
         $aggr->setCompression(200);
         $this->assertEquals(200, $aggr->getParam('compression'));
-        $this->assertInstanceOf('Elastica\Aggregation\Percentiles', $aggr->setCompression(200));
+        $this->assertInstanceOf(Percentiles::class, $aggr->setCompression(200));
     }
 
     /**
@@ -51,7 +51,7 @@ class PercentilesTest extends BaseAggregationTest
         $aggr = new Percentiles('price_percentile');
         $aggr->setPercents($percents);
         $this->assertEquals($percents, $aggr->getParam('percents'));
-        $this->assertInstanceOf('Elastica\Aggregation\Percentiles', $aggr->setPercents($percents));
+        $this->assertInstanceOf(Percentiles::class, $aggr->setPercents($percents));
     }
 
     /**
@@ -66,7 +66,7 @@ class PercentilesTest extends BaseAggregationTest
         $aggr->addPercent(4);
         $percents[] = 4;
         $this->assertEquals($percents, $aggr->getParam('percents'));
-        $this->assertInstanceOf('Elastica\Aggregation\Percentiles', $aggr->addPercent(4));
+        $this->assertInstanceOf(Percentiles::class, $aggr->addPercent(4));
     }
 
     /**
@@ -78,7 +78,7 @@ class PercentilesTest extends BaseAggregationTest
         $aggr = new Percentiles('price_percentile');
         $aggr->setScript($script);
         $this->assertEquals($script, $aggr->getParam('script'));
-        $this->assertInstanceOf('Elastica\Aggregation\Percentiles', $aggr->setScript($script));
+        $this->assertInstanceOf(Percentiles::class, $aggr->setScript($script));
     }
 
     /**

--- a/test/lib/Elastica/Test/Aggregation/TopHitsTest.php
+++ b/test/lib/Elastica/Test/Aggregation/TopHitsTest.php
@@ -64,7 +64,7 @@ class TopHitsTest extends BaseAggregationTest
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setSize(12);
         $this->assertEquals(12, $agg->getParam('size'));
-        $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
+        $this->assertInstanceOf(TopHits::class, $returnValue);
     }
 
     /**
@@ -75,7 +75,7 @@ class TopHitsTest extends BaseAggregationTest
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setFrom(12);
         $this->assertEquals(12, $agg->getParam('from'));
-        $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
+        $this->assertInstanceOf(TopHits::class, $returnValue);
     }
 
     /**
@@ -87,7 +87,7 @@ class TopHitsTest extends BaseAggregationTest
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setSort($sort);
         $this->assertEquals($sort, $agg->getParam('sort'));
-        $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
+        $this->assertInstanceOf(TopHits::class, $returnValue);
     }
 
     /**
@@ -99,7 +99,7 @@ class TopHitsTest extends BaseAggregationTest
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setSource($fields);
         $this->assertEquals($fields, $agg->getParam('_source'));
-        $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
+        $this->assertInstanceOf(TopHits::class, $returnValue);
     }
 
     /**
@@ -110,7 +110,7 @@ class TopHitsTest extends BaseAggregationTest
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setVersion(true);
         $this->assertTrue($agg->getParam('version'));
-        $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
+        $this->assertInstanceOf(TopHits::class, $returnValue);
 
         $agg->setVersion(false);
         $this->assertFalse($agg->getParam('version'));
@@ -124,7 +124,7 @@ class TopHitsTest extends BaseAggregationTest
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setExplain(true);
         $this->assertTrue($agg->getParam('explain'));
-        $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
+        $this->assertInstanceOf(TopHits::class, $returnValue);
 
         $agg->setExplain(false);
         $this->assertFalse($agg->getParam('explain'));
@@ -143,7 +143,7 @@ class TopHitsTest extends BaseAggregationTest
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setHighlight($highlight);
         $this->assertEquals($highlight, $agg->getParam('highlight'));
-        $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
+        $this->assertInstanceOf(TopHits::class, $returnValue);
     }
 
     /**
@@ -155,7 +155,7 @@ class TopHitsTest extends BaseAggregationTest
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setFieldDataFields($fields);
         $this->assertEquals($fields, $agg->getParam('docvalue_fields'));
-        $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
+        $this->assertInstanceOf(TopHits::class, $returnValue);
     }
 
     /**
@@ -169,7 +169,7 @@ class TopHitsTest extends BaseAggregationTest
         $agg = new TopHits('agg_name');
         $returnValue = $agg->setScriptFields($scriptFields);
         $this->assertEquals($scriptFields->toArray(), $agg->getParam('script_fields')->toArray());
-        $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
+        $this->assertInstanceOf(TopHits::class, $returnValue);
     }
 
     /**
@@ -181,7 +181,7 @@ class TopHitsTest extends BaseAggregationTest
         $agg = new TopHits('agg_name');
         $returnValue = $agg->addScriptField('five', $script);
         $this->assertEquals(['five' => $script->toArray()], $agg->getParam('script_fields')->toArray());
-        $this->assertInstanceOf('Elastica\Aggregation\TopHits', $returnValue);
+        $this->assertInstanceOf(TopHits::class, $returnValue);
     }
 
     protected function getOuterAggregationResult($innerAggr)

--- a/test/lib/Elastica/Test/Base.php
+++ b/test/lib/Elastica/Test/Base.php
@@ -113,7 +113,7 @@ class Base extends \PHPUnit_Framework_TestCase
      * @param bool   $delete Delete index if it exists
      * @param int    $shards Number of shards to create
      *
-     * @return \Elastica\Index
+     * @return Index
      */
     protected function _createIndex($name = null, $delete = true, $shards = 1)
     {

--- a/test/lib/Elastica/Test/Bulk/ResponseSetTest.php
+++ b/test/lib/Elastica/Test/Bulk/ResponseSetTest.php
@@ -3,6 +3,9 @@ namespace Elastica\Test\Bulk;
 
 use Elastica\Bulk;
 use Elastica\Bulk\Action;
+use Elastica\Bulk\ResponseSet;
+use Elastica\Client;
+use Elastica\Exception\Bulk\Response\ActionException;
 use Elastica\Exception\Bulk\ResponseException;
 use Elastica\Response;
 use Elastica\Test\Base as BaseTest;
@@ -36,7 +39,7 @@ class ResponseSetTest extends BaseTest
         } catch (ResponseException $e) {
             $responseSet = $e->getResponseSet();
 
-            $this->assertInstanceOf('Elastica\\Bulk\\ResponseSet', $responseSet);
+            $this->assertInstanceOf(ResponseSet::class, $responseSet);
 
             $this->assertTrue($responseSet->hasError());
             $this->assertEquals('SomeExceptionMessage', $responseSet->getError());
@@ -45,12 +48,12 @@ class ResponseSetTest extends BaseTest
             $actionExceptions = $e->getActionExceptions();
             $this->assertEquals(2, count($actionExceptions));
 
-            $this->assertInstanceOf('Elastica\Exception\Bulk\Response\ActionException', $actionExceptions[0]);
+            $this->assertInstanceOf(ActionException::class, $actionExceptions[0]);
             $this->assertSame($actions[1], $actionExceptions[0]->getAction());
             $this->assertContains('SomeExceptionMessage', $actionExceptions[0]->getMessage());
             $this->assertTrue($actionExceptions[0]->getResponse()->hasError());
 
-            $this->assertInstanceOf('Elastica\Exception\Bulk\Response\ActionException', $actionExceptions[1]);
+            $this->assertInstanceOf(ActionException::class, $actionExceptions[1]);
             $this->assertSame($actions[2], $actionExceptions[1]->getAction());
             $this->assertContains('AnotherExceptionMessage', $actionExceptions[1]->getMessage());
             $this->assertTrue($actionExceptions[1]->getResponse()->hasError());
@@ -71,7 +74,7 @@ class ResponseSetTest extends BaseTest
         $this->assertEquals(3, count($bulkResponses));
 
         foreach ($bulkResponses as $i => $bulkResponse) {
-            $this->assertInstanceOf('Elastica\\Bulk\\Response', $bulkResponse);
+            $this->assertInstanceOf(Bulk\Response::class, $bulkResponse);
             $bulkResponseData = $bulkResponse->getData();
             $this->assertInternalType('array', $bulkResponseData);
             $this->assertArrayHasKey('_id', $bulkResponseData);
@@ -93,7 +96,7 @@ class ResponseSetTest extends BaseTest
         $this->assertEquals(3, count($responseSet));
 
         foreach ($responseSet as $i => $bulkResponse) {
-            $this->assertInstanceOf('Elastica\Bulk\Response', $bulkResponse);
+            $this->assertInstanceOf(Bulk\Response::class, $bulkResponse);
             $bulkResponseData = $bulkResponse->getData();
             $this->assertInternalType('array', $bulkResponseData);
             $this->assertArrayHasKey('_id', $bulkResponseData);
@@ -103,20 +106,20 @@ class ResponseSetTest extends BaseTest
         }
 
         $this->assertFalse($responseSet->valid());
-        $this->assertNotInstanceOf('Elastica\Bulk\Response', $responseSet->current());
+        $this->assertNotInstanceOf(Bulk\Response::class, $responseSet->current());
         $this->assertFalse($responseSet->current());
 
         $responseSet->next();
 
         $this->assertFalse($responseSet->valid());
-        $this->assertNotInstanceOf('Elastica\Bulk\Response', $responseSet->current());
+        $this->assertNotInstanceOf(Bulk\Response::class, $responseSet->current());
         $this->assertFalse($responseSet->current());
 
         $responseSet->rewind();
 
         $this->assertEquals(0, $responseSet->key());
         $this->assertTrue($responseSet->valid());
-        $this->assertInstanceOf('Elastica\Bulk\Response', $responseSet->current());
+        $this->assertInstanceOf(Bulk\Response::class, $responseSet->current());
     }
 
     public function isOkDataProvider()
@@ -135,11 +138,11 @@ class ResponseSetTest extends BaseTest
      * @param array $responseData
      * @param array $actions
      *
-     * @return \Elastica\Bulk\ResponseSet
+     * @return ResponseSet
      */
     protected function _createResponseSet(array $responseData, array $actions)
     {
-        $client = $this->createMock('Elastica\\Client');
+        $client = $this->createMock(Client::class);
 
         $client->expects($this->once())
             ->method('request')

--- a/test/lib/Elastica/Test/BulkTest.php
+++ b/test/lib/Elastica/Test/BulkTest.php
@@ -4,7 +4,11 @@ namespace Elastica\Test;
 use Elastica\Bulk;
 use Elastica\Bulk\Action;
 use Elastica\Bulk\Action\AbstractDocument;
+use Elastica\Bulk\Action\CreateDocument;
+use Elastica\Bulk\Action\IndexDocument;
 use Elastica\Bulk\Action\UpdateDocument;
+use Elastica\Bulk\Response;
+use Elastica\Bulk\ResponseSet;
 use Elastica\Document;
 use Elastica\Exception\Bulk\ResponseException;
 use Elastica\Exception\NotFoundException;
@@ -44,19 +48,19 @@ class BulkTest extends BaseTest
 
         $actions = $bulk->getActions();
 
-        $this->assertInstanceOf('Elastica\Bulk\Action\IndexDocument', $actions[0]);
+        $this->assertInstanceOf(IndexDocument::class, $actions[0]);
         $this->assertEquals('index', $actions[0]->getOpType());
         $this->assertSame($newDocument1, $actions[0]->getDocument());
 
-        $this->assertInstanceOf('Elastica\Bulk\Action\IndexDocument', $actions[1]);
+        $this->assertInstanceOf(IndexDocument::class, $actions[1]);
         $this->assertEquals('index', $actions[1]->getOpType());
         $this->assertSame($newDocument2, $actions[1]->getDocument());
 
-        $this->assertInstanceOf('Elastica\Bulk\Action\CreateDocument', $actions[2]);
+        $this->assertInstanceOf(CreateDocument::class, $actions[2]);
         $this->assertEquals('create', $actions[2]->getOpType());
         $this->assertSame($newDocument3, $actions[2]->getDocument());
 
-        $this->assertInstanceOf('Elastica\Bulk\Action\IndexDocument', $actions[3]);
+        $this->assertInstanceOf(IndexDocument::class, $actions[3]);
         $this->assertEquals('index', $actions[3]->getOpType());
         $this->assertSame($newDocument4, $actions[3]->getDocument());
 
@@ -89,13 +93,13 @@ class BulkTest extends BaseTest
 
         $response = $bulk->send();
 
-        $this->assertInstanceOf('Elastica\Bulk\ResponseSet', $response);
+        $this->assertInstanceOf(ResponseSet::class, $response);
 
         $this->assertTrue($response->isOk());
         $this->assertFalse($response->hasError());
 
         foreach ($response as $i => $bulkResponse) {
-            $this->assertInstanceOf('Elastica\Bulk\Response', $bulkResponse);
+            $this->assertInstanceOf(Response::class, $bulkResponse);
             $this->assertTrue($bulkResponse->isOk());
             $this->assertFalse($bulkResponse->hasError());
             $this->assertSame($actions[$i], $bulkResponse->getAction());
@@ -259,29 +263,29 @@ class BulkTest extends BaseTest
         $this->assertInternalType('array', $actions);
         $this->assertEquals(5, count($actions));
 
-        $this->assertInstanceOf('Elastica\Bulk\Action', $actions[0]);
+        $this->assertInstanceOf(Action::class, $actions[0]);
         $this->assertEquals('index', $actions[0]->getOpType());
         $this->assertEquals($rawData[0]['index'], $actions[0]->getMetadata());
         $this->assertTrue($actions[0]->hasSource());
         $this->assertEquals($rawData[1], $actions[0]->getSource());
 
-        $this->assertInstanceOf('Elastica\Bulk\Action', $actions[1]);
+        $this->assertInstanceOf(Action::class, $actions[1]);
         $this->assertEquals('delete', $actions[1]->getOpType());
         $this->assertEquals($rawData[2]['delete'], $actions[1]->getMetadata());
         $this->assertFalse($actions[1]->hasSource());
 
-        $this->assertInstanceOf('Elastica\Bulk\Action', $actions[2]);
+        $this->assertInstanceOf(Action::class, $actions[2]);
         $this->assertEquals('delete', $actions[2]->getOpType());
         $this->assertEquals($rawData[3]['delete'], $actions[2]->getMetadata());
         $this->assertFalse($actions[2]->hasSource());
 
-        $this->assertInstanceOf('Elastica\Bulk\Action', $actions[3]);
+        $this->assertInstanceOf(Action::class, $actions[3]);
         $this->assertEquals('create', $actions[3]->getOpType());
         $this->assertEquals($rawData[4]['create'], $actions[3]->getMetadata());
         $this->assertTrue($actions[3]->hasSource());
         $this->assertEquals($rawData[5], $actions[3]->getSource());
 
-        $this->assertInstanceOf('Elastica\Bulk\Action', $actions[4]);
+        $this->assertInstanceOf(Action::class, $actions[4]);
         $this->assertEquals('delete', $actions[4]->getOpType());
         $this->assertEquals($rawData[6]['delete'], $actions[4]->getMetadata());
         $this->assertFalse($actions[4]->hasSource());
@@ -609,7 +613,7 @@ class BulkTest extends BaseTest
     public function testSetShardTimeout()
     {
         $bulk = new Bulk($this->_getClient());
-        $this->assertInstanceOf('Elastica\Bulk', $bulk->setShardTimeout(10));
+        $this->assertInstanceOf(Bulk::class, $bulk->setShardTimeout(10));
     }
 
     /**
@@ -618,7 +622,7 @@ class BulkTest extends BaseTest
     public function testSetRequestParam()
     {
         $bulk = new Bulk($this->_getClient());
-        $this->assertInstanceOf('Elastica\Bulk', $bulk->setRequestParam('key', 'value'));
+        $this->assertInstanceOf(Bulk::class, $bulk->setRequestParam('key', 'value'));
     }
 
     /**

--- a/test/lib/Elastica/Test/ClientTest.php
+++ b/test/lib/Elastica/Test/ClientTest.php
@@ -2,13 +2,17 @@
 namespace Elastica\Test;
 
 use Elastica\Bulk;
+use Elastica\Bulk\ResponseSet;
 use Elastica\Client;
 use Elastica\Connection;
 use Elastica\Document;
 use Elastica\Exception\Connection\HttpException;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\NotFoundException;
 use Elastica\Index;
 use Elastica\Request;
+use Elastica\Response;
 use Elastica\Script\Script;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Type;
@@ -207,7 +211,7 @@ class ClientTest extends BaseTest
         $ixCoin->setIndex(null);  // Make sure the index gets set properly if missing
         $index->deleteDocuments([$anonCoin, $ixCoin]);
 
-        $this->setExpectedException('Elastica\Exception\NotFoundException');
+        $this->expectException(NotFoundException::class);
         $index->getType('altcoin')->getDocument(1);
         $index->getType('altcoin')->getDocument(2);
     }
@@ -240,7 +244,7 @@ class ClientTest extends BaseTest
         $nameCoin->setType(null);  // Make sure the type gets set properly if missing
         $type->deleteDocuments([$liteCoin, $nameCoin]);
 
-        $this->setExpectedException('Elastica\Exception\NotFoundException');
+        $this->expectException(NotFoundException::class);
         $type->getDocument(1);
         $type->getDocument(2);
     }
@@ -412,7 +416,7 @@ class ClientTest extends BaseTest
         // deleteIds are the type we are testing for
         $idxString = $index->getName();
         $this->assertTrue(is_string($idxString));
-        $this->assertInstanceOf('Elastica\Type', $type);
+        $this->assertInstanceOf(Type::class, $type);
 
         // Using the existing $index and $type variables which
         // are \Elastica\Index and \Elastica\Type objects respectively
@@ -475,7 +479,7 @@ class ClientTest extends BaseTest
         // And verify that the variables we are doing to send to
         // deleteIds are the type we are testing for
         $typeString = $type->getName();
-        $this->assertInstanceOf('Elastica\Index', $index);
+        $this->assertInstanceOf(Index::class, $index);
         $this->assertTrue(is_string($typeString));
 
         // Using the existing $index and $type variables which
@@ -538,8 +542,8 @@ class ClientTest extends BaseTest
 
         // And verify that the variables we are doing to send to
         // deleteIds are the type we are testing for
-        $this->assertInstanceOf('Elastica\Index', $index);
-        $this->assertInstanceOf('Elastica\Type', $type);
+        $this->assertInstanceOf(Index::class, $index);
+        $this->assertInstanceOf(Type::class, $type);
 
         // Using the existing $index and $type variables which
         // are \Elastica\Index and \Elastica\Type objects respectively
@@ -618,9 +622,9 @@ class ClientTest extends BaseTest
 
         // Callback function which verifies that disabled connection objects are returned
         $callback = function ($connection, $exception, $client) use (&$object, &$count) {
-            $object->assertInstanceOf('Elastica\Connection', $connection);
-            $object->assertInstanceOf('Elastica\Exception\ConnectionException', $exception);
-            $object->assertInstanceOf('Elastica\Client', $client);
+            $object->assertInstanceOf(Connection::class, $connection);
+            $object->assertInstanceOf(ConnectionException::class, $exception);
+            $object->assertInstanceOf(Client::class, $client);
             $object->assertFalse($connection->isEnabled());
             ++$count;
         };
@@ -657,7 +661,7 @@ class ClientTest extends BaseTest
         $client = $this->_getClient(['url' => $url, 'port' => '9101', 'timeout' => 2]);
 
         $response = $client->request('_stats');
-        $this->assertInstanceOf('Elastica\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
     }
 
     /**
@@ -677,7 +681,7 @@ class ClientTest extends BaseTest
 
         $document = $type->getDocument(1);
 
-        $this->assertInstanceOf('Elastica\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $data = $document->getData();
         $this->assertArrayHasKey('field1', $data);
         $this->assertEquals('value1', $data['field1']);
@@ -705,7 +709,7 @@ class ClientTest extends BaseTest
 
         $document = $type->getDocument(1);
 
-        $this->assertInstanceOf('Elastica\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $data = $document->getData();
         $this->assertArrayHasKey('field1', $data);
         $this->assertEquals('value1', $data['field1']);
@@ -735,7 +739,7 @@ class ClientTest extends BaseTest
 
         $document = $type->getDocument(1);
 
-        $this->assertInstanceOf('Elastica\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $data = $document->getData();
         $this->assertArrayHasKey('field1', $data);
         $this->assertEquals('value1', $data['field1']);
@@ -751,7 +755,7 @@ class ClientTest extends BaseTest
 
         $document = $type->getDocument(1);
 
-        $this->assertInstanceOf('Elastica\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $data = $document->getData();
         $this->assertArrayHasKey('field1', $data);
         $this->assertEquals('value1', $data['field1']);
@@ -785,7 +789,7 @@ class ClientTest extends BaseTest
 
         $document = $type->getDocument(1);
 
-        $this->assertInstanceOf('Elastica\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $data = $document->getData();
         $this->assertArrayHasKey('field1', $data);
         $this->assertEquals('value1', $data['field1']);
@@ -808,7 +812,7 @@ class ClientTest extends BaseTest
         $client->updateDocument(1, $newDocument, $index->getName(), $type->getName(), ['fields' => '_source']);
 
         $document = $type->getDocument(1);
-        $this->assertInstanceOf('Elastica\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $data = $document->getData();
         $this->assertArrayHasKey('field1', $data);
         $this->assertEquals('value1', $data['field1']);
@@ -819,7 +823,7 @@ class ClientTest extends BaseTest
         $client->updateDocument(1, $newDocument, $index->getName(), $type->getName(), ['fields' => '_source']);
 
         $document = $type->getDocument(1);
-        $this->assertInstanceOf('Elastica\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $data = $document->getData();
         $this->assertArrayHasKey('field1', $data);
         $this->assertEquals('value1updated', $data['field1']);
@@ -849,7 +853,7 @@ class ClientTest extends BaseTest
         $client->updateDocument(1, $newDocument, $index->getName(), $type->getName(), ['fields' => '_source']);
 
         $document = $type->getDocument(1);
-        $this->assertInstanceOf('Elastica\Document', $document);
+        $this->assertInstanceOf(Document::class, $document);
         $data = $document->getData();
         $this->assertArrayHasKey('field1', $data);
         $this->assertEquals('value1', $data['field1']);
@@ -894,7 +898,7 @@ class ClientTest extends BaseTest
 
         $response = $client->addDocuments($docs);
 
-        $this->assertInstanceOf('Elastica\Bulk\ResponseSet', $response);
+        $this->assertInstanceOf(ResponseSet::class, $response);
         $this->assertEquals(3, count($response));
         $this->assertTrue($response->isOk());
         $this->assertFalse($response->hasError());
@@ -911,7 +915,7 @@ class ClientTest extends BaseTest
 
         $response = $client->deleteDocuments($deleteDocs);
 
-        $this->assertInstanceOf('Elastica\Bulk\ResponseSet', $response);
+        $this->assertInstanceOf(ResponseSet::class, $response);
         $this->assertEquals(2, count($response));
         $this->assertTrue($response->isOk());
         $this->assertFalse($response->hasError());
@@ -930,15 +934,15 @@ class ClientTest extends BaseTest
         $client = $this->_getClient();
         $response = $client->request('_stats');
 
-        $this->assertInstanceOf('Elastica\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
 
         $lastRequest = $client->getLastRequest();
 
-        $this->assertInstanceOf('Elastica\Request', $lastRequest);
+        $this->assertInstanceOf(Request::class, $lastRequest);
         $this->assertEquals('_stats', $lastRequest->getPath());
 
         $lastResponse = $client->getLastResponse();
-        $this->assertInstanceOf('Elastica\Response', $lastResponse);
+        $this->assertInstanceOf(Response::class, $lastResponse);
         $this->assertSame($response, $lastResponse);
     }
 
@@ -1124,7 +1128,7 @@ class ClientTest extends BaseTest
         $this->assertEquals(['foo' => 'bar'], $client->getConfigValue('headers'));
 
         // check class
-        $this->assertInstanceOf('Elastica\Client', $client->addHeader('foo', 'bar'));
+        $this->assertInstanceOf(Client::class, $client->addHeader('foo', 'bar'));
 
         // check invalid parameters
         try {
@@ -1163,7 +1167,7 @@ class ClientTest extends BaseTest
         $this->assertEquals($headers, $client->getConfigValue('headers'));
 
         // check class
-        $this->assertInstanceOf('Elastica\Client', $client->removeHeader('second'));
+        $this->assertInstanceOf(Client::class, $client->removeHeader('second'));
 
         // check invalid parameter
         try {
@@ -1196,7 +1200,7 @@ class ClientTest extends BaseTest
         $this->assertTrue($client->hasConnection());
 
         $connection = $client->getConnection();
-        $this->assertInstanceOf('\Elastica\Connection', $connection);
+        $this->assertInstanceOf(Connection::class, $connection);
         $this->assertEquals($this->_getHost(), $connection->getHost());
         $this->assertEquals($this->_getPort(), $connection->getPort());
     }

--- a/test/lib/Elastica/Test/Cluster/Health/IndexTest.php
+++ b/test/lib/Elastica/Test/Cluster/Health/IndexTest.php
@@ -1,13 +1,14 @@
 <?php
 namespace Elastica\Test\Cluster\Health;
 
-use Elastica\Cluster\Health\Index as HealthIndex;
+use Elastica\Cluster\Health\Index;
+use Elastica\Cluster\Health\Shard;
 use Elastica\Test\Base as BaseTest;
 
 class IndexTest extends BaseTest
 {
     /**
-     * @var \Elastica\Cluster\Health\Index
+     * @var Index
      */
     protected $_index;
 
@@ -52,7 +53,7 @@ class IndexTest extends BaseTest
             ],
         ];
 
-        $this->_index = new HealthIndex('test', $data);
+        $this->_index = new Index('test', $data);
     }
 
     /**
@@ -138,7 +139,7 @@ class IndexTest extends BaseTest
         $this->assertEquals(3, count($shards));
 
         foreach ($shards as $shard) {
-            $this->assertInstanceOf('Elastica\Cluster\Health\Shard', $shard);
+            $this->assertInstanceOf(Shard::class, $shard);
         }
     }
 }

--- a/test/lib/Elastica/Test/Cluster/Health/IndexTest.php
+++ b/test/lib/Elastica/Test/Cluster/Health/IndexTest.php
@@ -12,7 +12,7 @@ class IndexTest extends BaseTest
      */
     protected $_index;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/test/lib/Elastica/Test/Cluster/Health/ShardTest.php
+++ b/test/lib/Elastica/Test/Cluster/Health/ShardTest.php
@@ -1,13 +1,13 @@
 <?php
 namespace Elastica\Test\Cluster\Health;
 
-use Elastica\Cluster\Health\Shard as HealthShard;
+use Elastica\Cluster\Health\Shard;
 use Elastica\Test\Base as BaseTest;
 
 class ShardTest extends BaseTest
 {
     /**
-     * @var \Elastica\Cluster\Health\Shard
+     * @var Shard
      */
     protected $_shard;
 
@@ -24,7 +24,7 @@ class ShardTest extends BaseTest
             'unassigned_shards' => 1,
         ];
 
-        $this->_shard = new HealthShard(2, $shardData);
+        $this->_shard = new Shard(2, $shardData);
     }
 
     /**

--- a/test/lib/Elastica/Test/Cluster/Health/ShardTest.php
+++ b/test/lib/Elastica/Test/Cluster/Health/ShardTest.php
@@ -11,7 +11,7 @@ class ShardTest extends BaseTest
      */
     protected $_shard;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/test/lib/Elastica/Test/Cluster/HealthTest.php
+++ b/test/lib/Elastica/Test/Cluster/HealthTest.php
@@ -1,12 +1,14 @@
 <?php
 namespace Elastica\Test\Cluster;
 
+use Elastica\Cluster\Health;
+use Elastica\Cluster\Health\Index;
 use Elastica\Test\Base as BaseTest;
 
 class HealthTest extends BaseTest
 {
     /**
-     * @var \Elastica\Cluster\Health
+     * @var Health
      */
     protected $_health;
 
@@ -34,7 +36,7 @@ class HealthTest extends BaseTest
         ];
 
         $health = $this
-            ->getMockBuilder('Elastica\Cluster\Health')
+            ->getMockBuilder(Health::class)
             ->setConstructorArgs([$this->_getClient()])
             ->setMethods(['_retrieveHealthData'])
             ->getMock();
@@ -143,7 +145,7 @@ class HealthTest extends BaseTest
         $this->assertArrayHasKey('index_two', $indices);
 
         foreach ($indices as $index) {
-            $this->assertInstanceOf('Elastica\Cluster\Health\Index', $index);
+            $this->assertInstanceOf(Index::class, $index);
         }
     }
 }

--- a/test/lib/Elastica/Test/ClusterTest.php
+++ b/test/lib/Elastica/Test/ClusterTest.php
@@ -2,6 +2,8 @@
 namespace Elastica\Test;
 
 use Elastica\Cluster;
+use Elastica\Cluster\Health;
+use Elastica\Node;
 use Elastica\Test\Base as BaseTest;
 
 class ClusterTest extends BaseTest
@@ -39,7 +41,7 @@ class ClusterTest extends BaseTest
         $nodes = $cluster->getNodes();
 
         foreach ($nodes as $node) {
-            $this->assertInstanceOf('Elastica\Node', $node);
+            $this->assertInstanceOf(Node::class, $node);
         }
 
         $this->assertGreaterThan(0, count($nodes));
@@ -86,6 +88,6 @@ class ClusterTest extends BaseTest
     public function testGetHealth()
     {
         $client = $this->_getClient();
-        $this->assertInstanceOf('Elastica\Cluster\Health', $client->getCluster()->getHealth());
+        $this->assertInstanceOf(Health::class, $client->getCluster()->getHealth());
     }
 }

--- a/test/lib/Elastica/Test/Connection/ConnectionPoolTest.php
+++ b/test/lib/Elastica/Test/Connection/ConnectionPoolTest.php
@@ -34,7 +34,7 @@ class ConnectionPoolTest extends BaseTest
 
         $this->assertEquals($connections, $pool->getConnections());
 
-        $this->assertInstanceOf('Elastica\Connection\ConnectionPool', $pool->setConnections($connections));
+        $this->assertInstanceOf(ConnectionPool::class, $pool->setConnections($connections));
     }
 
     /**
@@ -53,7 +53,7 @@ class ConnectionPoolTest extends BaseTest
 
         $this->assertEquals($connections, $pool->getConnections());
 
-        $this->assertInstanceOf('Elastica\Connection\ConnectionPool', $pool->addConnection($connections[0]));
+        $this->assertInstanceOf(ConnectionPool::class, $pool->addConnection($connections[0]));
     }
 
     /**
@@ -85,7 +85,7 @@ class ConnectionPoolTest extends BaseTest
     {
         $pool = $this->createPool();
 
-        $this->assertInstanceOf('Elastica\Connection', $pool->getConnection());
+        $this->assertInstanceOf(Connection::class, $pool->getConnection());
     }
 
     protected function getConnections($quantity = 1)

--- a/test/lib/Elastica/Test/Connection/Strategy/CallbackStrategyTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/CallbackStrategyTest.php
@@ -42,11 +42,11 @@ class CallbackStrategyTest extends Base
         $this->assertTrue($isValid);
 
         // static method as string
-        $isValid = CallbackStrategy::isValid('Elastica\Test\Connection\Strategy\CallbackStrategyTestHelper::getFirstConnectionStatic');
+        $isValid = CallbackStrategy::isValid(CallbackStrategyTestHelper::class.'::getFirstConnectionStatic');
         $this->assertTrue($isValid);
 
         // static method as array
-        $isValid = CallbackStrategy::isValid(['Elastica\Test\Connection\Strategy\CallbackStrategyTestHelper', 'getFirstConnectionStatic']);
+        $isValid = CallbackStrategy::isValid([CallbackStrategyTestHelper::class, 'getFirstConnectionStatic']);
         $this->assertTrue($isValid);
 
         // object method
@@ -92,6 +92,6 @@ class CallbackStrategyTest extends Base
 
         $strategy = $client->getConnectionStrategy();
 
-        $this->assertInstanceOf('Elastica\Connection\Strategy\CallbackStrategy', $strategy);
+        $this->assertInstanceOf(CallbackStrategy::class, $strategy);
     }
 }

--- a/test/lib/Elastica/Test/Connection/Strategy/RoundRobinTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/RoundRobinTest.php
@@ -118,7 +118,7 @@ class RoundRobinTest extends Base
     {
         $strategy = $client->getConnectionStrategy();
 
-        $this->assertInstanceOf('Elastica\Connection\Strategy\RoundRobin', $strategy);
+        $this->assertInstanceOf(RoundRobin::class, $strategy);
     }
 
     protected function _checkResponse($response)

--- a/test/lib/Elastica/Test/Connection/Strategy/SimpleTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/SimpleTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection;
+use Elastica\Connection\Strategy\Simple;
 use Elastica\Exception\ConnectionException;
 use Elastica\Test\Base;
 
@@ -24,7 +25,6 @@ class SimpleTest extends Base
     {
         $client = $this->_getClient();
         $response = $client->request('/_aliases');
-        /* @var $response \Elastica\Response */
 
         $this->_checkResponse($response);
 
@@ -103,7 +103,7 @@ class SimpleTest extends Base
     {
         $strategy = $client->getConnectionStrategy();
 
-        $this->assertInstanceOf('Elastica\Connection\Strategy\Simple', $strategy);
+        $this->assertInstanceOf(Simple::class, $strategy);
     }
 
     protected function _checkResponse($response)

--- a/test/lib/Elastica/Test/Connection/Strategy/StrategyFactoryTest.php
+++ b/test/lib/Elastica/Test/Connection/Strategy/StrategyFactoryTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Elastica\Test\Connection\Strategy;
 
+use Elastica\Connection\Strategy\CallbackStrategy;
+use Elastica\Connection\Strategy\Simple;
 use Elastica\Connection\Strategy\StrategyFactory;
 use Elastica\Test\Base;
 
@@ -21,7 +23,7 @@ class StrategyFactoryTest extends Base
 
         $strategy = StrategyFactory::create($callback);
 
-        $this->assertInstanceOf('Elastica\Connection\Strategy\CallbackStrategy', $strategy);
+        $this->assertInstanceOf(CallbackStrategy::class, $strategy);
     }
 
     /**
@@ -33,7 +35,7 @@ class StrategyFactoryTest extends Base
 
         $strategy = StrategyFactory::create($strategyName);
 
-        $this->assertInstanceOf('Elastica\Connection\Strategy\Simple', $strategy);
+        $this->assertInstanceOf(Simple::class, $strategy);
     }
 
     /**
@@ -51,11 +53,9 @@ class StrategyFactoryTest extends Base
      */
     public function testCreateByClassName()
     {
-        $strategyName = '\\Elastica\Test\Connection\Strategy\\EmptyStrategy';
+        $strategy = StrategyFactory::create(EmptyStrategy::class);
 
-        $strategy = StrategyFactory::create($strategyName);
-
-        $this->assertInstanceOf($strategyName, $strategy);
+        $this->assertInstanceOf(EmptyStrategy::class, $strategy);
     }
 
     /**
@@ -79,6 +79,6 @@ class StrategyFactoryTest extends Base
             class_alias('Elastica\Util', 'Simple');
         }
         $strategy = StrategyFactory::create('Simple');
-        $this->assertInstanceOf('Elastica\Connection\Strategy\Simple', $strategy);
+        $this->assertInstanceOf(Simple::class, $strategy);
     }
 }

--- a/test/lib/Elastica/Test/ConnectionTest.php
+++ b/test/lib/Elastica/Test/ConnectionTest.php
@@ -5,6 +5,8 @@ use Elastica\Client;
 use Elastica\Connection;
 use Elastica\Request;
 use Elastica\Test\Base as BaseTest;
+use Elastica\Transport\AbstractTransport;
+use Elastica\Transport\Http;
 
 class ConnectionTest extends BaseTest
 {
@@ -17,7 +19,7 @@ class ConnectionTest extends BaseTest
         $this->assertEquals(Connection::DEFAULT_HOST, $connection->getHost());
         $this->assertEquals(Connection::DEFAULT_PORT, $connection->getPort());
         $this->assertEquals(Connection::DEFAULT_TRANSPORT, $connection->getTransport());
-        $this->assertInstanceOf('Elastica\Transport\AbstractTransport', $connection->getTransportObject());
+        $this->assertInstanceOf(AbstractTransport::class, $connection->getTransportObject());
         $this->assertEquals(Connection::TIMEOUT, $connection->getTimeout());
         $this->assertEquals(Connection::CONNECT_TIMEOUT, $connection->getConnectTimeout());
         $this->assertEquals([], $connection->getConfig());
@@ -58,14 +60,14 @@ class ConnectionTest extends BaseTest
     public function testCreate()
     {
         $connection = Connection::create();
-        $this->assertInstanceOf('Elastica\Connection', $connection);
+        $this->assertInstanceOf(Connection::class, $connection);
 
         $connection = Connection::create([]);
-        $this->assertInstanceOf('Elastica\Connection', $connection);
+        $this->assertInstanceOf(Connection::class, $connection);
 
         $port = 9999;
         $connection = Connection::create(['port' => $port]);
-        $this->assertInstanceOf('Elastica\Connection', $connection);
+        $this->assertInstanceOf(Connection::class, $connection);
         $this->assertEquals($port, $connection->getPort());
     }
 
@@ -96,12 +98,12 @@ class ConnectionTest extends BaseTest
     public function testGetConfigWithArrayUsedForTransport()
     {
         $connection = new Connection(['transport' => ['type' => 'Http']]);
-        $this->assertInstanceOf('Elastica\Transport\Http', $connection->getTransportObject());
+        $this->assertInstanceOf(Http::class, $connection->getTransportObject());
     }
 
     /**
      * @group unit
-     * @expectedException Elastica\Exception\InvalidException
+     * @expectedException \Elastica\Exception\InvalidException
      * @expectedExceptionMessage Invalid transport
      */
     public function testGetInvalidConfigWithArrayUsedForTransport()

--- a/test/lib/Elastica/Test/DocumentTest.php
+++ b/test/lib/Elastica/Test/DocumentTest.php
@@ -20,7 +20,7 @@ class DocumentTest extends BaseTest
         }
         $doc = new Document();
         $returnValue = $doc->addFile('key', $fileName);
-        $this->assertInstanceOf('Elastica\Document', $returnValue);
+        $this->assertInstanceOf(Document::class, $returnValue);
     }
 
     /**
@@ -30,7 +30,7 @@ class DocumentTest extends BaseTest
     {
         $doc = new Document();
         $returnValue = $doc->addGeoPoint('point', 38.89859, -77.035971);
-        $this->assertInstanceOf('Elastica\Document', $returnValue);
+        $this->assertInstanceOf(Document::class, $returnValue);
     }
 
     /**
@@ -40,7 +40,7 @@ class DocumentTest extends BaseTest
     {
         $doc = new Document();
         $returnValue = $doc->setData(['data']);
-        $this->assertInstanceOf('Elastica\Document', $returnValue);
+        $this->assertInstanceOf(Document::class, $returnValue);
     }
 
     /**
@@ -192,9 +192,9 @@ class DocumentTest extends BaseTest
         $this->assertNull($data['field4']);
 
         $returnValue = $document->set('field1', 'changed1');
-        $this->assertInstanceOf('Elastica\Document', $returnValue);
+        $this->assertInstanceOf(Document::class, $returnValue);
         $returnValue = $document->remove('field3');
-        $this->assertInstanceOf('Elastica\Document', $returnValue);
+        $this->assertInstanceOf(Document::class, $returnValue);
         try {
             $document->remove('field5');
             $this->fail('Undefined field unset should throw exception');

--- a/test/lib/Elastica/Test/Exception/AbstractExceptionTest.php
+++ b/test/lib/Elastica/Test/Exception/AbstractExceptionTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Test\Exception;
 
+use Elastica\Exception\ExceptionInterface;
 use Elastica\Test\Base as BaseTest;
 
 abstract class AbstractExceptionTest extends BaseTest
@@ -25,7 +26,7 @@ abstract class AbstractExceptionTest extends BaseTest
     {
         $className = $this->_getExceptionClass();
         $reflection = new \ReflectionClass($className);
-        $this->assertTrue($reflection->isSubclassOf('Exception'));
-        $this->assertTrue($reflection->implementsInterface('Elastica\Exception\ExceptionInterface'));
+        $this->assertTrue($reflection->isSubclassOf(\Exception::class));
+        $this->assertTrue($reflection->implementsInterface(ExceptionInterface::class));
     }
 }

--- a/test/lib/Elastica/Test/Index/SettingsTest.php
+++ b/test/lib/Elastica/Test/Index/SettingsTest.php
@@ -5,6 +5,7 @@ use Elastica\Document;
 use Elastica\Exception\ResponseException;
 use Elastica\Index;
 use Elastica\Index\Settings as IndexSettings;
+use Elastica\Response;
 use Elastica\Test\Base as BaseTest;
 
 class SettingsTest extends BaseTest
@@ -168,7 +169,7 @@ class SettingsTest extends BaseTest
 
         $response = $settings->setMergePolicy('max_merge_at_once', 15);
         $this->assertEquals(15, $settings->getMergePolicy('max_merge_at_once'));
-        $this->assertInstanceOf('Elastica\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertTrue($response->isOk());
 
         $settings->setMergePolicy('max_merge_at_once', 10);

--- a/test/lib/Elastica/Test/Index/StatsTest.php
+++ b/test/lib/Elastica/Test/Index/StatsTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Test\Index;
 
+use Elastica\Index\Stats;
 use Elastica\Test\Base as BaseTest;
 
 class StatsTest extends BaseTest
@@ -16,7 +17,7 @@ class StatsTest extends BaseTest
         $index = $client->getIndex($indexName);
         $index->create([], true);
         $stats = $index->getStats();
-        $this->assertInstanceOf('Elastica\Index\Stats', $stats);
+        $this->assertInstanceOf(Stats::class, $stats);
 
         $this->assertTrue($stats->getResponse()->isOk());
         $this->assertEquals(0, $stats->get('_all', 'indices', 'test', 'primaries', 'docs', 'count'));

--- a/test/lib/Elastica/Test/IndexTemplateTest.php
+++ b/test/lib/Elastica/Test/IndexTemplateTest.php
@@ -45,7 +45,7 @@ class IndexTemplateTest extends BaseTest
         $name = 'index_template1';
         $response = new Response('');
         /** @var \PHPUnit_Framework_MockObject_MockObject|Client $clientMock */
-        $clientMock = $this->createMock('\Elastica\Client');
+        $clientMock = $this->createMock(Client::class);
         $clientMock->expects($this->once())
             ->method('request')
             ->with('_template/'.$name, Request::DELETE, [], [])
@@ -63,7 +63,7 @@ class IndexTemplateTest extends BaseTest
         $response = new Response('');
         $name = 'index_template1';
         /** @var \PHPUnit_Framework_MockObject_MockObject|Client $clientMock */
-        $clientMock = $this->createMock('\Elastica\Client');
+        $clientMock = $this->createMock(Client::class);
         $clientMock->expects($this->once())
             ->method('request')
             ->with('_template/'.$name, Request::PUT, $args, [])
@@ -80,7 +80,7 @@ class IndexTemplateTest extends BaseTest
         $name = 'index_template1';
         $response = new Response('', 200);
         /** @var \PHPUnit_Framework_MockObject_MockObject|Client $clientMock */
-        $clientMock = $this->createMock('\Elastica\Client');
+        $clientMock = $this->createMock(Client::class);
         $clientMock->expects($this->once())
             ->method('request')
             ->with('_template/'.$name, Request::HEAD, [], [])

--- a/test/lib/Elastica/Test/IndexTest.php
+++ b/test/lib/Elastica/Test/IndexTest.php
@@ -8,6 +8,7 @@ use Elastica\Query\HasChild;
 use Elastica\Query\QueryString;
 use Elastica\Query\SimpleQueryString;
 use Elastica\Query\Term;
+use Elastica\Request;
 use Elastica\Status;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Type;
@@ -678,7 +679,7 @@ class IndexTest extends BaseTest
             $response = $error->getResponse();
             $this->assertTrue($response->hasError());
             $request = $error->getRequest();
-            $this->assertInstanceOf('Elastica\Request', $request);
+            $this->assertInstanceOf(Request::class, $request);
         }
     }
 

--- a/test/lib/Elastica/Test/Multi/MultiBuilderTest.php
+++ b/test/lib/Elastica/Test/Multi/MultiBuilderTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Test\Multi;
 
 use Elastica\Multi\MultiBuilder;
+use Elastica\Multi\ResultSet as MultiResultSet;
 use Elastica\Response;
 use Elastica\ResultSet;
 use Elastica\ResultSet\BuilderInterface;
@@ -27,7 +28,7 @@ class MultiBuilderTest extends BaseTest
     {
         parent::setUp();
 
-        $this->builder = $this->createMock('Elastica\\ResultSet\\BuilderInterface');
+        $this->builder = $this->createMock(BuilderInterface::class);
         $this->multiBuilder = new MultiBuilder($this->builder);
     }
 
@@ -41,7 +42,7 @@ class MultiBuilderTest extends BaseTest
 
         $result = $this->multiBuilder->buildMultiResultSet($response, $searches);
 
-        $this->assertInstanceOf('Elastica\\Multi\\ResultSet', $result);
+        $this->assertInstanceOf(MultiResultSet::class, $result);
     }
 
     public function testBuildMultiResultSet()
@@ -62,14 +63,14 @@ class MultiBuilderTest extends BaseTest
         $this->builder->expects($this->exactly(2))
             ->method('buildResultSet')
             ->withConsecutive(
-                [$this->isInstanceOf('Elastica\\Response'), $s1->getQuery()],
-                [$this->isInstanceOf('Elastica\\Response'), $s2->getQuery()]
+                [$this->isInstanceOf(Response::class), $s1->getQuery()],
+                [$this->isInstanceOf(Response::class), $s2->getQuery()]
             )
             ->willReturnOnConsecutiveCalls($resultSet1, $resultSet2);
 
         $result = $this->multiBuilder->buildMultiResultSet($response, $searches);
 
-        $this->assertInstanceOf('Elastica\\Multi\\ResultSet', $result);
+        $this->assertInstanceOf(MultiResultSet::class, $result);
         $this->assertSame($resultSet1, $result[0]);
         $this->assertSame($resultSet2, $result[1]);
     }

--- a/test/lib/Elastica/Test/Multi/SearchTest.php
+++ b/test/lib/Elastica/Test/Multi/SearchTest.php
@@ -2,9 +2,12 @@
 namespace Elastica\Test\Multi;
 
 use Elastica\Document;
+use Elastica\Multi\ResultSet as MultiResultSet;
 use Elastica\Multi\Search as MultiSearch;
 use Elastica\Query;
 use Elastica\Query\Term;
+use Elastica\Response;
+use Elastica\ResultSet;
 use Elastica\Search;
 use Elastica\Test\Base as BaseTest;
 
@@ -47,7 +50,6 @@ class SearchTest extends BaseTest
         $client = $this->_getClient();
         $multiSearch = new MultiSearch($client);
 
-        $this->assertInstanceOf('Elastica\Multi\Search', $multiSearch);
         $this->assertSame($client, $multiSearch->getClient());
     }
 
@@ -158,12 +160,12 @@ class SearchTest extends BaseTest
 
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
+        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf('Elastica\Response', $multiResultSet->getResponse());
+        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         foreach ($multiResultSet as $resultSet) {
-            $this->assertInstanceOf('Elastica\ResultSet', $resultSet);
+            $this->assertInstanceOf(ResultSet::class, $resultSet);
         }
 
         $resultSets = $multiResultSet->getResultSets();
@@ -171,13 +173,13 @@ class SearchTest extends BaseTest
         $this->assertInternalType('array', $resultSets);
 
         $this->assertArrayHasKey(0, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[0]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[0]);
         $this->assertCount(2, $resultSets[0]);
         $this->assertSame($query1, $resultSets[0]->getQuery());
         $this->assertEquals(3, $resultSets[0]->getTotalHits());
 
         $this->assertArrayHasKey(1, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[1]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[1]);
         $this->assertCount(3, $resultSets[1]);
         $this->assertSame($query2, $resultSets[1]->getQuery());
         $this->assertEquals(6, $resultSets[1]->getTotalHits());
@@ -188,22 +190,22 @@ class SearchTest extends BaseTest
         $search2->getQuery()->setSize(0);
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
+        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf('Elastica\Response', $multiResultSet->getResponse());
+        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
         $this->assertInternalType('array', $resultSets);
 
         $this->assertArrayHasKey(0, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[0]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[0]);
         $this->assertCount(0, $resultSets[0]);
         $this->assertSame($query1, $resultSets[0]->getQuery());
         $this->assertEquals(3, $resultSets[0]->getTotalHits());
 
         $this->assertArrayHasKey(1, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[1]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[1]);
         $this->assertCount(0, $resultSets[1]);
         $this->assertSame($query2, $resultSets[1]->getQuery());
         $this->assertEquals(6, $resultSets[1]->getTotalHits());
@@ -252,29 +254,29 @@ class SearchTest extends BaseTest
 
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
+        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf('Elastica\Response', $multiResultSet->getResponse());
+        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         foreach ($multiResultSet as $resultSet) {
-            $this->assertInstanceOf('Elastica\ResultSet', $resultSet);
+            $this->assertInstanceOf(ResultSet::class, $resultSet);
         }
 
-        $this->assertInstanceOf('Elastica\ResultSet', $multiResultSet['search1']);
-        $this->assertInstanceOf('Elastica\ResultSet', $multiResultSet['search2']);
+        $this->assertInstanceOf(ResultSet::class, $multiResultSet['search1']);
+        $this->assertInstanceOf(ResultSet::class, $multiResultSet['search2']);
 
         $resultSets = $multiResultSet->getResultSets();
 
         $this->assertInternalType('array', $resultSets);
 
         $this->assertArrayHasKey('search1', $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets['search1']);
+        $this->assertInstanceOf(ResultSet::class, $resultSets['search1']);
         $this->assertCount(2, $resultSets['search1']);
         $this->assertSame($query1, $resultSets['search1']->getQuery());
         $this->assertEquals(3, $resultSets['search1']->getTotalHits());
 
         $this->assertArrayHasKey('search2', $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets['search2']);
+        $this->assertInstanceOf(ResultSet::class, $resultSets['search2']);
         $this->assertCount(3, $resultSets['search2']);
         $this->assertSame($query2, $resultSets['search2']->getQuery());
         $this->assertEquals(6, $resultSets['search2']->getTotalHits());
@@ -285,22 +287,22 @@ class SearchTest extends BaseTest
         $search2->getQuery()->setSize(0);
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
+        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf('Elastica\Response', $multiResultSet->getResponse());
+        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
         $this->assertInternalType('array', $resultSets);
 
         $this->assertArrayHasKey('search1', $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets['search1']);
+        $this->assertInstanceOf(ResultSet::class, $resultSets['search1']);
         $this->assertCount(0, $resultSets['search1']);
         $this->assertSame($query1, $resultSets['search1']->getQuery());
         $this->assertEquals(3, $resultSets['search1']->getTotalHits());
 
         $this->assertArrayHasKey('search2', $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets['search2']);
+        $this->assertInstanceOf(ResultSet::class, $resultSets['search2']);
         $this->assertCount(0, $resultSets['search2']);
         $this->assertSame($query2, $resultSets['search2']->getQuery());
         $this->assertEquals(6, $resultSets['search2']->getTotalHits());
@@ -331,18 +333,18 @@ class SearchTest extends BaseTest
 
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
+        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $resultSets = $multiResultSet->getResultSets();
         $this->assertInternalType('array', $resultSets);
 
         $this->assertArrayHasKey(0, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[0]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[0]);
         $this->assertSame($searchGood->getQuery(), $resultSets[0]->getQuery());
         $this->assertSame(6, $resultSets[0]->getTotalHits());
         $this->assertCount(6, $resultSets[0]);
 
         $this->assertArrayHasKey(1, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[1]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[1]);
         $this->assertSame($searchBad->getQuery(), $resultSets[1]->getQuery());
         $this->assertSame(0, $resultSets[1]->getTotalHits());
         $this->assertCount(0, $resultSets[1]);
@@ -377,18 +379,18 @@ class SearchTest extends BaseTest
 
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
+        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $resultSets = $multiResultSet->getResultSets();
         $this->assertInternalType('array', $resultSets);
 
         $this->assertArrayHasKey('search1', $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets['search1']);
+        $this->assertInstanceOf(ResultSet::class, $resultSets['search1']);
         $this->assertSame($searchGood->getQuery(), $resultSets['search1']->getQuery());
         $this->assertSame(6, $resultSets['search1']->getTotalHits());
         $this->assertCount(6, $resultSets['search1']);
 
         $this->assertArrayHasKey(0, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[0]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[0]);
         $this->assertSame($searchBad->getQuery(), $resultSets[0]->getQuery());
         $this->assertSame(0, $resultSets[0]->getTotalHits());
         $this->assertCount(0, $resultSets[0]);
@@ -437,22 +439,22 @@ class SearchTest extends BaseTest
         $search2->getQuery()->setSize(0);
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
+        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf('Elastica\Response', $multiResultSet->getResponse());
+        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
         $this->assertInternalType('array', $resultSets);
 
         $this->assertArrayHasKey(0, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[0]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[0]);
         $this->assertCount(0, $resultSets[0]);
         $this->assertSame($query1, $resultSets[0]->getQuery());
         $this->assertEquals(3, $resultSets[0]->getTotalHits());
 
         $this->assertArrayHasKey(1, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[1]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[1]);
         $this->assertCount(0, $resultSets[1]);
         $this->assertSame($query2, $resultSets[1]->getQuery());
         $this->assertEquals(6, $resultSets[1]->getTotalHits());
@@ -461,22 +463,22 @@ class SearchTest extends BaseTest
 
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
+        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf('Elastica\Response', $multiResultSet->getResponse());
+        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
         $this->assertInternalType('array', $resultSets);
 
         $this->assertArrayHasKey(0, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[0]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[0]);
         $this->assertCount(0, $resultSets[0]);
         $this->assertSame($query1, $resultSets[0]->getQuery());
         $this->assertEquals(3, $resultSets[0]->getTotalHits());
 
         $this->assertArrayHasKey(1, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[1]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[1]);
         $this->assertCount(0, $resultSets[1]);
         $this->assertSame($query2, $resultSets[1]->getQuery());
         $this->assertEquals(6, $resultSets[1]->getTotalHits());
@@ -522,22 +524,22 @@ class SearchTest extends BaseTest
 
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
+        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf('Elastica\Response', $multiResultSet->getResponse());
+        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
         $this->assertInternalType('array', $resultSets);
 
         $this->assertArrayHasKey(0, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[0]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[0]);
         $this->assertCount(0, $resultSets[0]);
         $this->assertSame($query1, $resultSets[0]->getQuery());
         $this->assertEquals(3, $resultSets[0]->getTotalHits());
 
         $this->assertArrayHasKey(1, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[1]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[1]);
         $this->assertCount(0, $resultSets[1]);
         $this->assertSame($query2, $resultSets[1]->getQuery());
         $this->assertEquals(6, $resultSets[1]->getTotalHits());
@@ -546,22 +548,22 @@ class SearchTest extends BaseTest
 
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf('Elastica\Multi\ResultSet', $multiResultSet);
+        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf('Elastica\Response', $multiResultSet->getResponse());
+        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
         $this->assertInternalType('array', $resultSets);
 
         $this->assertArrayHasKey(0, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[0]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[0]);
         $this->assertCount(0, $resultSets[0]);
         $this->assertSame($query1, $resultSets[0]->getQuery());
         $this->assertEquals(3, $resultSets[0]->getTotalHits());
 
         $this->assertArrayHasKey(1, $resultSets);
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSets[1]);
+        $this->assertInstanceOf(ResultSet::class, $resultSets[1]);
         $this->assertCount(0, $resultSets[1]);
         $this->assertSame($query2, $resultSets[1]->getQuery());
         $this->assertEquals(6, $resultSets[1]->getTotalHits());

--- a/test/lib/Elastica/Test/NodeTest.php
+++ b/test/lib/Elastica/Test/NodeTest.php
@@ -2,6 +2,8 @@
 namespace Elastica\Test;
 
 use Elastica\Node;
+use Elastica\Node\Info;
+use Elastica\Node\Stats;
 use Elastica\Test\Base as BaseTest;
 
 class NodeTest extends BaseTest
@@ -16,7 +18,7 @@ class NodeTest extends BaseTest
         $name = reset($names);
 
         $node = new Node($name, $client);
-        $this->assertInstanceOf('Elastica\Node', $node);
+        $this->assertInstanceOf(Node::class, $node);
     }
 
     /**
@@ -32,7 +34,7 @@ class NodeTest extends BaseTest
 
         $info = $node->getInfo();
 
-        $this->assertInstanceOf('Elastica\Node\Info', $info);
+        $this->assertInstanceOf(Info::class, $info);
     }
 
     /**
@@ -48,7 +50,7 @@ class NodeTest extends BaseTest
 
         $stats = $node->getStats();
 
-        $this->assertInstanceOf('Elastica\Node\Stats', $stats);
+        $this->assertInstanceOf(Stats::class, $stats);
     }
 
     /**

--- a/test/lib/Elastica/Test/ParamTest.php
+++ b/test/lib/Elastica/Test/ParamTest.php
@@ -13,7 +13,7 @@ class ParamTest extends BaseTest
     public function testToArrayEmpty()
     {
         $param = new Param();
-        $this->assertInstanceOf('Elastica\Param', $param);
+        $this->assertInstanceOf(Param::class, $param);
         $this->assertEquals([$this->_getFilterName($param) => []], $param->toArray());
     }
 
@@ -26,7 +26,7 @@ class ParamTest extends BaseTest
         $params = ['hello' => 'word', 'nicolas' => 'ruflin'];
         $param->setParams($params);
 
-        $this->assertInstanceOf('Elastica\Param', $param);
+        $this->assertInstanceOf(Param::class, $param);
         $this->assertEquals([$this->_getFilterName($param) => $params], $param->toArray());
     }
 

--- a/test/lib/Elastica/Test/Query/ExistsTest.php
+++ b/test/lib/Elastica/Test/Query/ExistsTest.php
@@ -29,7 +29,7 @@ class ExistsTest extends BaseTest
         $this->assertEquals($field, $query->getParam('field'));
 
         $newField = 'hello world';
-        $this->assertInstanceOf('Elastica\Query\Exists', $query->setField($newField));
+        $this->assertInstanceOf(Exists::class, $query->setField($newField));
 
         $this->assertEquals($newField, $query->getParam('field'));
     }

--- a/test/lib/Elastica/Test/Query/FunctionScoreTest.php
+++ b/test/lib/Elastica/Test/Query/FunctionScoreTest.php
@@ -497,7 +497,7 @@ class FunctionScoreTest extends BaseTest
         $returnedValue = $query->setMinScore(0.8);
 
         $this->assertEquals($expected, $query->toArray());
-        $this->assertInstanceOf('Elastica\Query\FunctionScore', $returnedValue);
+        $this->assertInstanceOf(FunctionScore::class, $returnedValue);
 
         $response = $this->_getIndexForTest()->search($query);
         $results = $response->getResults();

--- a/test/lib/Elastica/Test/Query/FuzzyTest.php
+++ b/test/lib/Elastica/Test/Query/FuzzyTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Query\Fuzzy;
 use Elastica\Test\Base as BaseTest;
 
@@ -72,7 +73,8 @@ class FuzzyTest extends BaseTest
     public function testNeedSetFieldBeforeOption()
     {
         $fuzzy = new Fuzzy();
-        $this->setExpectedException('Elastica\Exception\InvalidException', 'No field has been set');
+        $this->expectException(InvalidException::class);
+        $this->expectExceptionMessage('No field has been set');
         $fuzzy->setFieldOption('boost', 1.0);
     }
 
@@ -130,7 +132,8 @@ class FuzzyTest extends BaseTest
     {
         $fuzzy = new Fuzzy();
         $fuzzy->setField('name', 'value');
-        $this->setExpectedException('Elastica\Exception\InvalidException', 'Fuzzy query can only support a single field.');
+        $this->expectException(InvalidException::class);
+        $this->expectExceptionMessage('Fuzzy query can only support a single field.');
         $fuzzy->setField('name1', 'value1');
     }
 
@@ -140,7 +143,8 @@ class FuzzyTest extends BaseTest
     public function testFieldNameMustBeString()
     {
         $fuzzy = new Fuzzy();
-        $this->setExpectedException('Elastica\Exception\InvalidException', 'The field and value arguments must be of type string.');
+        $this->expectException(InvalidException::class);
+        $this->expectExceptionMessage('The field and value arguments must be of type string.');
         $fuzzy->setField(['name'], 'value');
     }
 
@@ -150,7 +154,8 @@ class FuzzyTest extends BaseTest
     public function testValueMustBeString()
     {
         $fuzzy = new Fuzzy();
-        $this->setExpectedException('Elastica\Exception\InvalidException', 'The field and value arguments must be of type string.');
+        $this->expectException(InvalidException::class);
+        $this->expectExceptionMessage('The field and value arguments must be of type string.');
         $fuzzy->setField('name', ['value']);
     }
 }

--- a/test/lib/Elastica/Test/Query/GeoBoundingBoxTest.php
+++ b/test/lib/Elastica/Test/Query/GeoBoundingBoxTest.php
@@ -20,7 +20,7 @@ class GeoBoundingBoxTest extends BaseTest
         $this->assertEquals($expectedArray, $query->getParam($key));
 
         $returnValue = $query->addCoordinates($key, $coords);
-        $this->assertInstanceOf('Elastica\Query\GeoBoundingBox', $returnValue);
+        $this->assertInstanceOf(GeoBoundingBox::class, $returnValue);
     }
 
     /**

--- a/test/lib/Elastica/Test/Query/IndicesTest.php
+++ b/test/lib/Elastica/Test/Query/IndicesTest.php
@@ -104,7 +104,7 @@ class IndicesTest extends DeprecatedClassBase
         $this->assertEquals($expected, $query->getParam('indices'));
 
         $returnValue = $query->setIndices($indices);
-        $this->assertInstanceOf('Elastica\Query\Indices', $returnValue);
+        $this->assertInstanceOf(Indices::class, $returnValue);
     }
 
     /**
@@ -126,6 +126,6 @@ class IndicesTest extends DeprecatedClassBase
         $this->assertEquals($expected, $query->getParam('indices'));
 
         $returnValue = $query->addIndex('bar');
-        $this->assertInstanceOf('Elastica\Query\Indices', $returnValue);
+        $this->assertInstanceOf(Indices::class, $returnValue);
     }
 }

--- a/test/lib/Elastica/Test/Query/InnerHitsTest.php
+++ b/test/lib/Elastica/Test/Query/InnerHitsTest.php
@@ -173,7 +173,7 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $returnValue = $innerHits->setSize(12);
         $this->assertEquals(12, $innerHits->getParam('size'));
-        $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $returnValue);
     }
 
     /**
@@ -184,7 +184,7 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $returnValue = $innerHits->setFrom(12);
         $this->assertEquals(12, $innerHits->getParam('from'));
-        $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $returnValue);
     }
 
     /**
@@ -196,7 +196,7 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $returnValue = $innerHits->setSort($sort);
         $this->assertEquals($sort, $innerHits->getParam('sort'));
-        $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $returnValue);
     }
 
     /**
@@ -208,7 +208,7 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $returnValue = $innerHits->setSource($fields);
         $this->assertEquals($fields, $innerHits->getParam('_source'));
-        $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $returnValue);
     }
 
     /**
@@ -219,7 +219,7 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $returnValue = $innerHits->setVersion(true);
         $this->assertTrue($innerHits->getParam('version'));
-        $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $returnValue);
 
         $innerHits->setVersion(false);
         $this->assertFalse($innerHits->getParam('version'));
@@ -233,7 +233,7 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $returnValue = $innerHits->setExplain(true);
         $this->assertTrue($innerHits->getParam('explain'));
-        $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $returnValue);
 
         $innerHits->setExplain(false);
         $this->assertFalse($innerHits->getParam('explain'));
@@ -252,7 +252,7 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $returnValue = $innerHits->setHighlight($highlight);
         $this->assertEquals($highlight, $innerHits->getParam('highlight'));
-        $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $returnValue);
     }
 
     /**
@@ -264,7 +264,7 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $returnValue = $innerHits->setFieldDataFields($fields);
         $this->assertEquals($fields, $innerHits->getParam('docvalue_fields'));
-        $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $returnValue);
     }
 
     /**
@@ -278,7 +278,7 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $returnValue = $innerHits->setScriptFields($scriptFields);
         $this->assertEquals($scriptFields->toArray(), $innerHits->getParam('script_fields')->toArray());
-        $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $returnValue);
     }
 
     /**
@@ -290,7 +290,7 @@ class InnerHitsTest extends BaseTest
         $innerHits = new InnerHits();
         $returnValue = $innerHits->addScriptField('five', $script);
         $this->assertEquals(['five' => $script->toArray()], $innerHits->getParam('script_fields')->toArray());
-        $this->assertInstanceOf('Elastica\Query\InnerHits', $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $returnValue);
     }
 
     private function getNestedQuery(AbstractQuery $query, InnerHits $innerHits)

--- a/test/lib/Elastica/Test/Query/LimitTest.php
+++ b/test/lib/Elastica/Test/Query/LimitTest.php
@@ -14,7 +14,7 @@ class LimitTest extends BaseTest
         $query = new Limit(10);
         $this->assertEquals(10, $query->getParam('value'));
 
-        $this->assertInstanceOf('Elastica\Query\Limit', $query->setLimit(20));
+        $this->assertInstanceOf(Limit::class, $query->setLimit(20));
         $this->assertEquals(20, $query->getParam('value'));
     }
 

--- a/test/lib/Elastica/Test/Query/NestedTest.php
+++ b/test/lib/Elastica/Test/Query/NestedTest.php
@@ -16,8 +16,8 @@ class NestedTest extends BaseTest
         $path = 'test1';
 
         $queryString = new QueryString('test');
-        $this->assertInstanceOf('Elastica\Query\Nested', $nested->setQuery($queryString));
-        $this->assertInstanceOf('Elastica\Query\Nested', $nested->setPath($path));
+        $this->assertInstanceOf(Nested::class, $nested->setQuery($queryString));
+        $this->assertInstanceOf(Nested::class, $nested->setPath($path));
         $expected = [
             'nested' => [
                 'query' => $queryString->toArray(),

--- a/test/lib/Elastica/Test/Query/NumericRangeTest.php
+++ b/test/lib/Elastica/Test/Query/NumericRangeTest.php
@@ -13,7 +13,7 @@ class NumericRangeTest extends BaseTest
     {
         $rangeQuery = new NumericRange();
         $returnValue = $rangeQuery->addField('fieldName', ['to' => 'value']);
-        $this->assertInstanceOf('Elastica\Query\NumericRange', $returnValue);
+        $this->assertInstanceOf(NumericRange::class, $returnValue);
     }
 
     /**

--- a/test/lib/Elastica/Test/Query/QueryStringTest.php
+++ b/test/lib/Elastica/Test/Query/QueryStringTest.php
@@ -152,7 +152,7 @@ class QueryStringTest extends BaseTest
         ];
 
         $this->assertEquals($expected, $query->toArray());
-        $this->assertInstanceOf('Elastica\Query\QueryString', $query->setTimezone($timezone));
+        $this->assertInstanceOf(QueryString::class, $query->setTimezone($timezone));
     }
 
     /**

--- a/test/lib/Elastica/Test/Query/SimpleQueryStringTest.php
+++ b/test/lib/Elastica/Test/Query/SimpleQueryStringTest.php
@@ -74,7 +74,7 @@ class SimpleQueryStringTest extends Base
         $query->setMinimumShouldMatch($expected['simple_query_string']['minimum_should_match']);
 
         $this->assertEquals($expected, $query->toArray());
-        $this->assertInstanceOf('Elastica\Query\SimpleQueryString', $query->setMinimumShouldMatch('75%'));
+        $this->assertInstanceOf(SimpleQueryString::class, $query->setMinimumShouldMatch('75%'));
     }
 
     /**

--- a/test/lib/Elastica/Test/Query/TypeTest.php
+++ b/test/lib/Elastica/Test/Query/TypeTest.php
@@ -13,7 +13,7 @@ class TypeTest extends BaseTest
     {
         $typeQuery = new Type();
         $returnValue = $typeQuery->setType('type_name');
-        $this->assertInstanceOf('Elastica\Query\Type', $returnValue);
+        $this->assertInstanceOf(Type::class, $returnValue);
     }
 
     /**

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/AggregationTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/AggregationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Test\QueryBuilder\DSL;
 
+use Elastica\Aggregation;
 use Elastica\Query\Exists;
 use Elastica\QueryBuilder\DSL;
 
@@ -13,7 +14,7 @@ class AggregationTest extends AbstractDSLTest
     {
         $aggregationDSL = new DSL\Aggregation();
 
-        $this->assertInstanceOf('Elastica\QueryBuilder\DSL', $aggregationDSL);
+        $this->assertInstanceOf(DSL::class, $aggregationDSL);
         $this->assertEquals(DSL::TYPE_AGGREGATION, $aggregationDSL->getType());
     }
 
@@ -24,34 +25,34 @@ class AggregationTest extends AbstractDSLTest
     {
         $aggregationDSL = new DSL\Aggregation();
 
-        $this->_assertImplemented($aggregationDSL, 'avg', 'Elastica\Aggregation\Avg', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'cardinality', 'Elastica\Aggregation\Cardinality', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'date_histogram', 'Elastica\Aggregation\DateHistogram', ['name', 'field', 1]);
-        $this->_assertImplemented($aggregationDSL, 'date_range', 'Elastica\Aggregation\DateRange', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'extended_stats', 'Elastica\Aggregation\ExtendedStats', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'filter', 'Elastica\Aggregation\Filter', ['name', new Exists('field')]);
-        $this->_assertImplemented($aggregationDSL, 'filters', 'Elastica\Aggregation\Filters', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'geo_distance', 'Elastica\Aggregation\GeoDistance', ['name', 'field', 'origin']);
-        $this->_assertImplemented($aggregationDSL, 'geohash_grid', 'Elastica\Aggregation\GeohashGrid', ['name', 'field']);
-        $this->_assertImplemented($aggregationDSL, 'global_agg', 'Elastica\Aggregation\GlobalAggregation', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'histogram', 'Elastica\Aggregation\Histogram', ['name', 'field', 1]);
-        $this->_assertImplemented($aggregationDSL, 'ipv4_range', 'Elastica\Aggregation\IpRange', ['name', 'field']);
-        $this->_assertImplemented($aggregationDSL, 'max', 'Elastica\Aggregation\Max', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'min', 'Elastica\Aggregation\Min', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'missing', 'Elastica\Aggregation\Missing', ['name', 'field']);
-        $this->_assertImplemented($aggregationDSL, 'nested', 'Elastica\Aggregation\Nested', ['name', 'path']);
-        $this->_assertImplemented($aggregationDSL, 'percentiles', 'Elastica\Aggregation\Percentiles', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'range', 'Elastica\Aggregation\Range', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'reverse_nested', 'Elastica\Aggregation\ReverseNested', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'scripted_metric', 'Elastica\Aggregation\ScriptedMetric', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'significant_terms', 'Elastica\Aggregation\SignificantTerms', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'stats', 'Elastica\Aggregation\Stats', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'sum', 'Elastica\Aggregation\Sum', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'terms', 'Elastica\Aggregation\Terms', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'top_hits', 'Elastica\Aggregation\TopHits', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'value_count', 'Elastica\Aggregation\ValueCount', ['name', 'field']);
-        $this->_assertImplemented($aggregationDSL, 'bucket_script', 'Elastica\Aggregation\BucketScript', ['name']);
-        $this->_assertImplemented($aggregationDSL, 'serial_diff', 'Elastica\Aggregation\SerialDiff', ['name']);
+        $this->_assertImplemented($aggregationDSL, 'avg', Aggregation\Avg::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'cardinality', Aggregation\Cardinality::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'date_histogram', Aggregation\DateHistogram::class, ['name', 'field', 1]);
+        $this->_assertImplemented($aggregationDSL, 'date_range', Aggregation\DateRange::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'extended_stats', Aggregation\ExtendedStats::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'filter', Aggregation\Filter::class, ['name', new Exists('field')]);
+        $this->_assertImplemented($aggregationDSL, 'filters', Aggregation\Filters::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'geo_distance', Aggregation\GeoDistance::class, ['name', 'field', 'origin']);
+        $this->_assertImplemented($aggregationDSL, 'geohash_grid', Aggregation\GeohashGrid::class, ['name', 'field']);
+        $this->_assertImplemented($aggregationDSL, 'global_agg', Aggregation\GlobalAggregation::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'histogram', Aggregation\Histogram::class, ['name', 'field', 1]);
+        $this->_assertImplemented($aggregationDSL, 'ipv4_range', Aggregation\IpRange::class, ['name', 'field']);
+        $this->_assertImplemented($aggregationDSL, 'max', Aggregation\Max::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'min', Aggregation\Min::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'missing', Aggregation\Missing::class, ['name', 'field']);
+        $this->_assertImplemented($aggregationDSL, 'nested', Aggregation\Nested::class, ['name', 'path']);
+        $this->_assertImplemented($aggregationDSL, 'percentiles', Aggregation\Percentiles::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'range', Aggregation\Range::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'reverse_nested', Aggregation\ReverseNested::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'scripted_metric', Aggregation\ScriptedMetric::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'significant_terms', Aggregation\SignificantTerms::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'stats', Aggregation\Stats::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'sum', Aggregation\Sum::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'terms', Aggregation\Terms::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'top_hits', Aggregation\TopHits::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'value_count', Aggregation\ValueCount::class, ['name', 'field']);
+        $this->_assertImplemented($aggregationDSL, 'bucket_script', Aggregation\BucketScript::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'serial_diff', Aggregation\SerialDiff::class, ['name']);
 
         $this->_assertNotImplemented($aggregationDSL, 'children', ['name']);
         $this->_assertNotImplemented($aggregationDSL, 'geo_bounds', ['name']);

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/QueryTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Test\QueryBuilder\DSL;
 
+use Elastica\Query;
 use Elastica\Query\Match;
 use Elastica\QueryBuilder\DSL;
 
@@ -13,7 +14,7 @@ class QueryTest extends AbstractDSLTest
     {
         $queryDSL = new DSL\Query();
 
-        $this->assertInstanceOf('Elastica\QueryBuilder\DSL', $queryDSL);
+        $this->assertInstanceOf(DSL::class, $queryDSL);
         $this->assertEquals(DSL::TYPE_QUERY, $queryDSL->getType());
     }
 
@@ -26,7 +27,7 @@ class QueryTest extends AbstractDSLTest
 
         $match = $queryDSL->match('field', 'match');
         $this->assertEquals('match', $match->getParam('field'));
-        $this->assertInstanceOf('Elastica\Query\Match', $match);
+        $this->assertInstanceOf(Match::class, $match);
     }
 
     /**
@@ -36,37 +37,37 @@ class QueryTest extends AbstractDSLTest
     {
         $queryDSL = new DSL\Query();
 
-        $this->_assertImplemented($queryDSL, 'bool', 'Elastica\Query\BoolQuery', []);
-        $this->_assertImplemented($queryDSL, 'boosting', 'Elastica\Query\Boosting', []);
-        $this->_assertImplemented($queryDSL, 'common_terms', 'Elastica\Query\Common', ['field', 'query', 0.001]);
-        $this->_assertImplemented($queryDSL, 'dis_max', 'Elastica\Query\DisMax', []);
-        $this->_assertImplemented($queryDSL, 'function_score', 'Elastica\Query\FunctionScore', []);
-        $this->_assertImplemented($queryDSL, 'fuzzy', 'Elastica\Query\Fuzzy', ['field', 'type']);
-        $this->_assertImplemented($queryDSL, 'has_child', 'Elastica\Query\HasChild', [new Match()]);
-        $this->_assertImplemented($queryDSL, 'has_parent', 'Elastica\Query\HasParent', [new Match(), 'type']);
-        $this->_assertImplemented($queryDSL, 'ids', 'Elastica\Query\Ids', ['type', []]);
-        $this->_assertImplemented($queryDSL, 'match', 'Elastica\Query\Match', ['field', 'values']);
-        $this->_assertImplemented($queryDSL, 'match_all', 'Elastica\Query\MatchAll', []);
-        $this->_assertImplemented($queryDSL, 'more_like_this', 'Elastica\Query\MoreLikeThis', []);
-        $this->_assertImplemented($queryDSL, 'multi_match', 'Elastica\Query\MultiMatch', []);
-        $this->_assertImplemented($queryDSL, 'nested', 'Elastica\Query\Nested', []);
-        $this->_assertImplemented($queryDSL, 'prefix', 'Elastica\Query\Prefix', []);
-        $this->_assertImplemented($queryDSL, 'query_string', 'Elastica\Query\QueryString', []);
-        $this->_assertImplemented($queryDSL, 'range', 'Elastica\Query\Range', ['field', []]);
-        $this->_assertImplemented($queryDSL, 'regexp', 'Elastica\Query\Regexp', ['field', 'value', 1.0]);
-        $this->_assertImplemented($queryDSL, 'simple_query_string', 'Elastica\Query\SimpleQueryString', ['query']);
-        $this->_assertImplemented($queryDSL, 'term', 'Elastica\Query\Term', []);
-        $this->_assertImplemented($queryDSL, 'terms', 'Elastica\Query\Terms', ['field', []]);
-        $this->_assertImplemented($queryDSL, 'wildcard', 'Elastica\Query\Wildcard', []);
+        $this->_assertImplemented($queryDSL, 'bool', Query\BoolQuery::class, []);
+        $this->_assertImplemented($queryDSL, 'boosting', Query\Boosting::class, []);
+        $this->_assertImplemented($queryDSL, 'common_terms', Query\Common::class, ['field', 'query', 0.001]);
+        $this->_assertImplemented($queryDSL, 'dis_max', Query\DisMax::class, []);
+        $this->_assertImplemented($queryDSL, 'function_score', Query\FunctionScore::class, []);
+        $this->_assertImplemented($queryDSL, 'fuzzy', Query\Fuzzy::class, ['field', 'type']);
+        $this->_assertImplemented($queryDSL, 'has_child', Query\HasChild::class, [new Match()]);
+        $this->_assertImplemented($queryDSL, 'has_parent', Query\HasParent::class, [new Match(), 'type']);
+        $this->_assertImplemented($queryDSL, 'ids', Query\Ids::class, ['type', []]);
+        $this->_assertImplemented($queryDSL, 'match', Match::class, ['field', 'values']);
+        $this->_assertImplemented($queryDSL, 'match_all', Query\MatchAll::class, []);
+        $this->_assertImplemented($queryDSL, 'more_like_this', Query\MoreLikeThis::class, []);
+        $this->_assertImplemented($queryDSL, 'multi_match', Query\MultiMatch::class, []);
+        $this->_assertImplemented($queryDSL, 'nested', Query\Nested::class, []);
+        $this->_assertImplemented($queryDSL, 'prefix', Query\Prefix::class, []);
+        $this->_assertImplemented($queryDSL, 'query_string', Query\QueryString::class, []);
+        $this->_assertImplemented($queryDSL, 'range', Query\Range::class, ['field', []]);
+        $this->_assertImplemented($queryDSL, 'regexp', Query\Regexp::class, ['field', 'value', 1.0]);
+        $this->_assertImplemented($queryDSL, 'simple_query_string', Query\SimpleQueryString::class, ['query']);
+        $this->_assertImplemented($queryDSL, 'term', Query\Term::class, []);
+        $this->_assertImplemented($queryDSL, 'terms', Query\Terms::class, ['field', []]);
+        $this->_assertImplemented($queryDSL, 'wildcard', Query\Wildcard::class, []);
         $this->_assertImplemented(
             $queryDSL,
             'geo_distance',
-            'Elastica\Query\GeoDistance',
+            Query\GeoDistance::class,
             ['key', ['lat' => 1, 'lon' => 0], 'distance']
         );
-        $this->_assertImplemented($queryDSL, 'exists', 'Elastica\Query\Exists', ['field']);
-        $this->_assertImplemented($queryDSL, 'type', 'Elastica\Query\Type', []);
-        $this->_assertImplemented($queryDSL, 'type', 'Elastica\Query\Type', ['type']);
+        $this->_assertImplemented($queryDSL, 'exists', Query\Exists::class, ['field']);
+        $this->_assertImplemented($queryDSL, 'type', Query\Type::class, []);
+        $this->_assertImplemented($queryDSL, 'type', Query\Type::class, ['type']);
 
         $this->_assertNotImplemented($queryDSL, 'geo_shape', []);
         $this->_assertNotImplemented($queryDSL, 'span_first', []);

--- a/test/lib/Elastica/Test/QueryBuilder/DSL/SuggestTest.php
+++ b/test/lib/Elastica/Test/QueryBuilder/DSL/SuggestTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\QueryBuilder\DSL;
+use Elastica\Suggest;
 
 class SuggestTest extends AbstractDSLTest
 {
@@ -12,7 +13,7 @@ class SuggestTest extends AbstractDSLTest
     {
         $suggestDSL = new DSL\Suggest();
 
-        $this->assertInstanceOf('Elastica\QueryBuilder\DSL', $suggestDSL);
+        $this->assertInstanceOf(DSL::class, $suggestDSL);
         $this->assertEquals(DSL::TYPE_SUGGEST, $suggestDSL->getType());
     }
 
@@ -23,9 +24,9 @@ class SuggestTest extends AbstractDSLTest
     {
         $suggestDSL = new DSL\Suggest();
 
-        $this->_assertImplemented($suggestDSL, 'completion', 'Elastica\Suggest\Completion', ['name', 'field']);
-        $this->_assertImplemented($suggestDSL, 'phrase', 'Elastica\Suggest\Phrase', ['name', 'field']);
-        $this->_assertImplemented($suggestDSL, 'term', 'Elastica\Suggest\Term', ['name', 'field']);
+        $this->_assertImplemented($suggestDSL, 'completion', Suggest\Completion::class, ['name', 'field']);
+        $this->_assertImplemented($suggestDSL, 'phrase', Suggest\Phrase::class, ['name', 'field']);
+        $this->_assertImplemented($suggestDSL, 'term', Suggest\Term::class, ['name', 'field']);
 
         $this->_assertNotImplemented($suggestDSL, 'context', []);
     }

--- a/test/lib/Elastica/Test/QueryBuilderTest.php
+++ b/test/lib/Elastica/Test/QueryBuilderTest.php
@@ -1,10 +1,11 @@
 <?php
 namespace Elastica\Test;
 
+use Elastica\Aggregation\AbstractAggregation;
 use Elastica\Exception\QueryBuilderException;
-use Elastica\Query;
+use Elastica\Query\AbstractQuery;
 use Elastica\QueryBuilder;
-use Elastica\Suggest;
+use Elastica\Suggest\AbstractSuggest;
 
 class QueryBuilderTest extends Base
 {
@@ -39,9 +40,9 @@ class QueryBuilderTest extends Base
         $qb = new QueryBuilder();
 
         // test one example QueryBuilder flow for each default DSL type
-        $this->assertInstanceOf('Elastica\Query\AbstractQuery', $qb->query()->match());
-        $this->assertInstanceOf('Elastica\Aggregation\AbstractAggregation', $qb->aggregation()->avg('name'));
-        $this->assertInstanceOf('Elastica\Suggest\AbstractSuggest', $qb->suggest()->term('name', 'field'));
+        $this->assertInstanceOf(AbstractQuery::class, $qb->query()->match());
+        $this->assertInstanceOf(AbstractAggregation::class, $qb->aggregation()->avg('name'));
+        $this->assertInstanceOf(AbstractSuggest::class, $qb->suggest()->term('name', 'field'));
     }
 }
 

--- a/test/lib/Elastica/Test/QueryTest.php
+++ b/test/lib/Elastica/Test/QueryTest.php
@@ -1,11 +1,14 @@
 <?php
 namespace Elastica\Test;
 
+use Elastica\Aggregation\Terms as TermsAggregation;
 use Elastica\Document;
 use Elastica\Exception\InvalidException;
 use Elastica\Query;
 use Elastica\Query\Term;
+use Elastica\Query\Terms;
 use Elastica\Query\Text;
+use Elastica\Rescore\Query as RescoreQuery;
 use Elastica\Script\Script;
 use Elastica\Script\ScriptFields;
 use Elastica\Suggest;
@@ -57,7 +60,7 @@ class QueryTest extends BaseTest
     {
         $query = new Query();
         $suggest = new Suggest();
-        $this->assertInstanceOf('Elastica\Query', $query->setSuggest($suggest));
+        $this->assertInstanceOf(Query::class, $query->setSuggest($suggest));
     }
 
     /**
@@ -330,7 +333,7 @@ class QueryTest extends BaseTest
     public function testAddAggregationToArrayCast()
     {
         $query = new Query();
-        $aggregation = new \Elastica\Aggregation\Terms('text');
+        $aggregation = new TermsAggregation('text');
         $aggregation->setField('field');
 
         $query->addAggregation($aggregation);
@@ -368,7 +371,7 @@ class QueryTest extends BaseTest
     public function testSetRescoreToArrayCast()
     {
         $query = new Query();
-        $rescore = new \Elastica\Rescore\Query();
+        $rescore = new RescoreQuery();
         $rescore->setQueryWeight(1);
 
         $query->setRescore($rescore);
@@ -387,7 +390,7 @@ class QueryTest extends BaseTest
     public function testSetPostFilterToArrayCast()
     {
         $query = new Query();
-        $postFilter = new \Elastica\Query\Terms();
+        $postFilter = new Terms();
         $postFilter->setTerms('key', ['term']);
         $query->setPostFilter($postFilter);
 

--- a/test/lib/Elastica/Test/RequestTest.php
+++ b/test/lib/Elastica/Test/RequestTest.php
@@ -3,6 +3,7 @@ namespace Elastica\Test;
 
 use Elastica\Connection;
 use Elastica\Request;
+use Elastica\Response;
 use Elastica\Test\Base as BaseTest;
 
 class RequestTest extends BaseTest
@@ -48,7 +49,7 @@ class RequestTest extends BaseTest
 
         $response = $request->send();
 
-        $this->assertInstanceOf('Elastica\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
     }
 
     /**

--- a/test/lib/Elastica/Test/ResultSet/ChainProcessorTest.php
+++ b/test/lib/Elastica/Test/ResultSet/ChainProcessorTest.php
@@ -5,6 +5,7 @@ use Elastica\Query;
 use Elastica\Response;
 use Elastica\ResultSet;
 use Elastica\ResultSet\ChainProcessor;
+use Elastica\ResultSet\ProcessorInterface;
 use Elastica\Test\Base as BaseTest;
 
 /**
@@ -15,8 +16,8 @@ class ChainProcessorTest extends BaseTest
     public function testProcessor()
     {
         $processor = new ChainProcessor([
-            $processor1 = $this->createMock('Elastica\\ResultSet\\ProcessorInterface'),
-            $processor2 = $this->createMock('Elastica\\ResultSet\\ProcessorInterface'),
+            $processor1 = $this->createMock(ProcessorInterface::class),
+            $processor2 = $this->createMock(ProcessorInterface::class),
         ]);
         $resultSet = new ResultSet(new Response(''), new Query(), []);
 

--- a/test/lib/Elastica/Test/ResultSet/ProcessingBuilderTest.php
+++ b/test/lib/Elastica/Test/ResultSet/ProcessingBuilderTest.php
@@ -6,6 +6,7 @@ use Elastica\Response;
 use Elastica\ResultSet;
 use Elastica\ResultSet\BuilderInterface;
 use Elastica\ResultSet\ProcessingBuilder;
+use Elastica\ResultSet\ProcessorInterface;
 use Elastica\Test\Base as BaseTest;
 
 /**
@@ -19,12 +20,12 @@ class ProcessingBuilderTest extends BaseTest
     private $builder;
 
     /**
-     * @var BuilderInterface
+     * @var BuilderInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $innerBuilder;
 
     /**
-     * @var ResultSet\ProcessorInterface
+     * @var ProcessorInterface|PHPUnit_Framework_MockObject_MockObject
      */
     private $processor;
 
@@ -32,8 +33,8 @@ class ProcessingBuilderTest extends BaseTest
     {
         parent::setUp();
 
-        $this->innerBuilder = $this->createMock('Elastica\\ResultSet\\BuilderInterface');
-        $this->processor = $this->createMock('Elastica\\ResultSet\\ProcessorInterface');
+        $this->innerBuilder = $this->createMock(BuilderInterface::class);
+        $this->processor = $this->createMock(ProcessorInterface::class);
 
         $this->builder = new ProcessingBuilder($this->innerBuilder, $this->processor);
     }

--- a/test/lib/Elastica/Test/ResultSetTest.php
+++ b/test/lib/Elastica/Test/ResultSetTest.php
@@ -3,6 +3,7 @@ namespace Elastica\Test;
 
 use Elastica\Document;
 use Elastica\Result;
+use Elastica\ResultSet;
 use Elastica\Test\Base as BaseTest;
 
 class ResultSetTest extends BaseTest
@@ -24,7 +25,7 @@ class ResultSetTest extends BaseTest
 
         $resultSet = $type->search('elastica search');
 
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSet);
+        $this->assertInstanceOf(ResultSet::class, $resultSet);
         $this->assertEquals(3, $resultSet->getTotalHits());
         $this->assertGreaterThan(0, $resultSet->getMaxScore());
         $this->assertNotTrue($resultSet->hasTimedOut());
@@ -51,10 +52,10 @@ class ResultSetTest extends BaseTest
 
         $resultSet = $type->search('elastica search');
 
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSet);
-        $this->assertInstanceOf('Elastica\Result', $resultSet[0]);
-        $this->assertInstanceOf('Elastica\Result', $resultSet[1]);
-        $this->assertInstanceOf('Elastica\Result', $resultSet[2]);
+        $this->assertInstanceOf(ResultSet::class, $resultSet);
+        $this->assertInstanceOf(Result::class, $resultSet[0]);
+        $this->assertInstanceOf(Result::class, $resultSet[1]);
+        $this->assertInstanceOf(Result::class, $resultSet[2]);
 
         $this->assertFalse(isset($resultSet[3]));
     }
@@ -76,15 +77,15 @@ class ResultSetTest extends BaseTest
 
         $resultSet = $type->search('elastica search');
 
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSet);
+        $this->assertInstanceOf(ResultSet::class, $resultSet);
 
         $documents = $resultSet->getDocuments();
 
         $this->assertInternalType('array', $documents);
         $this->assertEquals(3, count($documents));
-        $this->assertInstanceOf('Elastica\Document', $documents[0]);
-        $this->assertInstanceOf('Elastica\Document', $documents[1]);
-        $this->assertInstanceOf('Elastica\Document', $documents[2]);
+        $this->assertInstanceOf(Document::class, $documents[0]);
+        $this->assertInstanceOf(Document::class, $documents[1]);
+        $this->assertInstanceOf(Document::class, $documents[2]);
         $this->assertFalse(isset($documents[3]));
         $this->assertEquals('elastica search', $documents[0]->get('name'));
     }

--- a/test/lib/Elastica/Test/ResultTest.php
+++ b/test/lib/Elastica/Test/ResultTest.php
@@ -33,8 +33,8 @@ class ResultTest extends BaseTest
 
         $result = $resultSet->current();
 
-        $this->assertInstanceOf('Elastica\Result', $result);
-        $this->assertInstanceOf('Elastica\Document', $result->getDocument());
+        $this->assertInstanceOf(Result::class, $result);
+        $this->assertInstanceOf(Document::class, $result->getDocument());
         $this->assertEquals($index->getName(), $result->getIndex());
         $this->assertEquals($typeName, $result->getType());
         $this->assertEquals($docId, $result->getId());
@@ -77,7 +77,7 @@ class ResultTest extends BaseTest
         $result = $resultSet->current();
 
         $this->assertEquals([], $result->getSource());
-        $this->assertInstanceOf('Elastica\Result', $result);
+        $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals($indexName, $result->getIndex());
         $this->assertEquals($typeName, $result->getType());
         $this->assertEquals($docId, $result->getId());

--- a/test/lib/Elastica/Test/Script/ScriptFileTest.php
+++ b/test/lib/Elastica/Test/Script/ScriptFileTest.php
@@ -95,7 +95,7 @@ class ScriptFileTest extends BaseTest
     {
         $scriptFile = ScriptFile::create(self::SCRIPT_FILE);
 
-        $this->assertInstanceOf('Elastica\Script\ScriptFile', $scriptFile);
+        $this->assertInstanceOf(ScriptFile::class, $scriptFile);
 
         $this->assertEquals(self::SCRIPT_FILE, $scriptFile->getScriptFile());
 
@@ -116,7 +116,7 @@ class ScriptFileTest extends BaseTest
 
         $scriptFile = ScriptFile::create($data);
 
-        $this->assertInstanceOf('Elastica\Script\ScriptFile', $scriptFile);
+        $this->assertInstanceOf(ScriptFile::class, $scriptFile);
         $this->assertSame($data, $scriptFile);
     }
 
@@ -138,7 +138,7 @@ class ScriptFileTest extends BaseTest
 
         $scriptFile = ScriptFile::create($array);
 
-        $this->assertInstanceOf('Elastica\Script\ScriptFile', $scriptFile);
+        $this->assertInstanceOf(ScriptFile::class, $scriptFile);
         $this->assertEquals($array, $scriptFile->toArray());
 
         $this->assertEquals(self::SCRIPT_FILE, $scriptFile->getScriptFile());

--- a/test/lib/Elastica/Test/Script/ScriptIdTest.php
+++ b/test/lib/Elastica/Test/Script/ScriptIdTest.php
@@ -58,7 +58,7 @@ class ScriptIdTest extends BaseTest
     {
         $script = ScriptId::create(self::SCRIPT_ID);
 
-        $this->assertInstanceOf('Elastica\Script\ScriptId', $script);
+        $this->assertInstanceOf(ScriptId::class, $script);
 
         $this->assertEquals(self::SCRIPT_ID, $script->getScriptId());
 
@@ -77,7 +77,7 @@ class ScriptIdTest extends BaseTest
 
         $script = ScriptId::create($data);
 
-        $this->assertInstanceOf('Elastica\Script\ScriptId', $script);
+        $this->assertInstanceOf(ScriptId::class, $script);
         $this->assertSame($data, $script);
     }
 
@@ -100,7 +100,7 @@ class ScriptIdTest extends BaseTest
 
         $script = ScriptId::create($array);
 
-        $this->assertInstanceOf('Elastica\Script\ScriptId', $script);
+        $this->assertInstanceOf(ScriptId::class, $script);
         $this->assertEquals($array, $script->toArray());
 
         $this->assertEquals(self::SCRIPT_ID, $script->getScriptId());

--- a/test/lib/Elastica/Test/Script/ScriptTest.php
+++ b/test/lib/Elastica/Test/Script/ScriptTest.php
@@ -57,7 +57,7 @@ class ScriptTest extends BaseTest
     {
         $script = Script::create(self::SCRIPT);
 
-        $this->assertInstanceOf('Elastica\Script\Script', $script);
+        $this->assertInstanceOf(Script::class, $script);
 
         $this->assertEquals(self::SCRIPT, $script->getScript());
 
@@ -76,7 +76,7 @@ class ScriptTest extends BaseTest
 
         $script = Script::create($data);
 
-        $this->assertInstanceOf('Elastica\Script\Script', $script);
+        $this->assertInstanceOf(Script::class, $script);
         $this->assertSame($data, $script);
     }
 
@@ -99,7 +99,7 @@ class ScriptTest extends BaseTest
 
         $script = Script::create($array);
 
-        $this->assertInstanceOf('Elastica\Script\Script', $script);
+        $this->assertInstanceOf(Script::class, $script);
         $this->assertEquals($array, $script->toArray());
 
         $this->assertEquals(self::SCRIPT, $script->getScript());

--- a/test/lib/Elastica/Test/SearchTest.php
+++ b/test/lib/Elastica/Test/SearchTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Test;
 
+use Elastica\Client;
 use Elastica\Document;
 use Elastica\Exception\ResponseException;
 use Elastica\Index;
@@ -9,6 +10,7 @@ use Elastica\Query\FunctionScore;
 use Elastica\Query\MatchAll;
 use Elastica\Query\QueryString;
 use Elastica\Response;
+use Elastica\ResultSet;
 use Elastica\Script\Script;
 use Elastica\Search;
 use Elastica\Test\Base as BaseTest;
@@ -24,7 +26,6 @@ class SearchTest extends BaseTest
         $client = $this->_getClient();
         $search = new Search($client);
 
-        $this->assertInstanceOf('Elastica\Search', $search);
         $this->assertSame($client, $search->getClient());
     }
 
@@ -393,9 +394,7 @@ class SearchTest extends BaseTest
 
         //Timeout - this one is a bit more tricky to test
         $mockResponse = new Response(json_encode(['timed_out' => true]));
-        $client = $this->getMockBuilder('Elastica\\Client')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $client = $this->createMock(Client::class);
         $client->method('request')
             ->will($this->returnValue($mockResponse));
         $search = new Search($client);
@@ -515,7 +514,7 @@ class SearchTest extends BaseTest
 
         $search->addIndex($index)->addType($type);
         $resultSet = $search->search();
-        $this->assertInstanceOf('Elastica\ResultSet', $resultSet);
+        $this->assertInstanceOf(ResultSet::class, $resultSet);
         $this->assertCount(10, $resultSet);
         $this->assertEquals(11, $resultSet->getTotalHits());
 
@@ -551,7 +550,7 @@ class SearchTest extends BaseTest
         $this->assertEquals(1, $result1);
 
         $result2 = $search->count(new MatchAll(), true);
-        $this->assertInstanceOf('\Elastica\ResultSet', $result2);
+        $this->assertInstanceOf(ResultSet::class, $result2);
         $this->assertEquals(1, $result2->getTotalHits());
     }
 
@@ -577,6 +576,6 @@ class SearchTest extends BaseTest
         $this->assertEquals('index_not_found_exception', $error['type']);
 
         $results = $search->search($query, [Search::OPTION_SEARCH_IGNORE_UNAVAILABLE => true]);
-        $this->assertInstanceOf('\Elastica\ResultSet', $results);
+        $this->assertInstanceOf(ResultSet::class, $results);
     }
 }

--- a/test/lib/Elastica/Test/SnapshotTest.php
+++ b/test/lib/Elastica/Test/SnapshotTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Test;
 
 use Elastica\Document;
+use Elastica\Exception\NotFoundException;
 use Elastica\Index;
 use Elastica\Snapshot;
 
@@ -55,7 +56,7 @@ class SnapshotTest extends Base
         $this->assertEquals($location, $response['settings']['location']);
 
         // attempt to retrieve a repository which does not exist
-        $this->setExpectedException('Elastica\Exception\NotFoundException');
+        $this->expectException(NotFoundException::class);
         $this->_snapshot->getRepository('foobar');
     }
 
@@ -106,7 +107,7 @@ class SnapshotTest extends Base
         $this->assertTrue($response->isOk());
 
         // ensure that the snapshot has been deleted
-        $this->setExpectedException('Elastica\Exception\NotFoundException');
+        $this->expectException(NotFoundException::class);
         $this->_snapshot->getSnapshot($repositoryName, $snapshotName);
     }
 }

--- a/test/lib/Elastica/Test/StatusTest.php
+++ b/test/lib/Elastica/Test/StatusTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Test;
 
 use Elastica\Exception\ResponseException;
+use Elastica\Response;
 use Elastica\Status;
 use Elastica\Test\Base as BaseTest;
 
@@ -14,7 +15,7 @@ class StatusTest extends BaseTest
     {
         $index = $this->_createIndex();
         $status = new Status($index->getClient());
-        $this->assertInstanceOf('Elastica\Response', $status->getResponse());
+        $this->assertInstanceOf(Response::class, $status->getResponse());
     }
 
     /**

--- a/test/lib/Elastica/Test/Suggest/CompletionTest.php
+++ b/test/lib/Elastica/Test/Suggest/CompletionTest.php
@@ -124,7 +124,7 @@ class CompletionTest extends BaseTest
 
         $this->assertEquals($fuzzy, $suggest->getParam('fuzzy'));
 
-        $this->assertInstanceOf('Elastica\\Suggest\\Completion', $suggest->setFuzzy($fuzzy));
+        $this->assertInstanceOf(Completion::class, $suggest->setFuzzy($fuzzy));
     }
 
     /**

--- a/test/lib/Elastica/Test/Tool/CrossIndexTest.php
+++ b/test/lib/Elastica/Test/Tool/CrossIndexTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Test\Tool;
 
 use Elastica\Document;
+use Elastica\Index;
 use Elastica\Test\Base;
 use Elastica\Tool\CrossIndex;
 use Elastica\Type;
@@ -21,7 +22,7 @@ class CrossIndexTest extends Base
         $newIndex = $this->_createIndex(null, true, 2);
 
         $this->assertInstanceOf(
-            'Elastica\Index',
+            Index::class,
             CrossIndex::reindex($oldIndex, $newIndex)
         );
 
@@ -104,7 +105,7 @@ class CrossIndexTest extends Base
 
         // mapping
         $this->assertInstanceOf(
-            'Elastica\Index',
+            Index::class,
             CrossIndex::copy($oldIndex, $newIndex)
         );
 

--- a/test/lib/Elastica/Test/Transport/AbstractTransportTest.php
+++ b/test/lib/Elastica/Test/Transport/AbstractTransportTest.php
@@ -21,7 +21,7 @@ class AbstractTransportTest extends \PHPUnit_Framework_TestCase
             [['type' => 'Http']],
             [['type' => new Http()]],
             [new Http()],
-            ['Elastica\Test\Transport\DummyTransport'],
+            [DummyTransport::class],
         ];
     }
 
@@ -34,7 +34,7 @@ class AbstractTransportTest extends \PHPUnit_Framework_TestCase
         $connection = new Connection();
         $params = [];
         $transport = AbstractTransport::create($transport, $connection, $params);
-        $this->assertInstanceOf('Elastica\Transport\AbstractTransport', $transport);
+        $this->assertInstanceOf(AbstractTransport::class, $transport);
         $this->assertSame($connection, $transport->getConnection());
     }
 
@@ -49,7 +49,7 @@ class AbstractTransportTest extends \PHPUnit_Framework_TestCase
     /**
      * @group unit
      * @dataProvider getInvalidDefinitions
-     * @expectedException Elastica\Exception\InvalidException
+     * @expectedException \Elastica\Exception\InvalidException
      * @expectedExceptionMessage Invalid transport
      */
     public function testThrowsExecptionOnInvalidTransportDefinition($transport)

--- a/test/lib/Elastica/Test/Transport/GuzzleTest.php
+++ b/test/lib/Elastica/Test/Transport/GuzzleTest.php
@@ -168,7 +168,7 @@ class GuzzleTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException Elastica\Exception\Connection\GuzzleException
+     * @expectedException \Elastica\Exception\Connection\GuzzleException
      */
     public function testInvalidConnection()
     {

--- a/test/lib/Elastica/Test/Transport/NullTransportTest.php
+++ b/test/lib/Elastica/Test/Transport/NullTransportTest.php
@@ -4,6 +4,7 @@ namespace Elastica\Test\Transport;
 use Elastica\Connection;
 use Elastica\Query;
 use Elastica\Request;
+use Elastica\Response;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Transport\NullTransport;
 
@@ -68,7 +69,7 @@ class NullTransportTest extends BaseTest
         $transport = new NullTransport();
         $response = $transport->exec($request, $params);
 
-        $this->assertInstanceOf('\Elastica\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
 
         $data = $response->getData();
         $this->assertEquals($params, $data['params']);
@@ -90,7 +91,7 @@ class NullTransportTest extends BaseTest
         $this->showDeprecated();
         $response = $transport->exec($request, $params);
 
-        $this->assertInstanceOf('\Elastica\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
 
         $data = $response->getData();
         $this->assertEquals($params, $data['params']);

--- a/test/lib/Elastica/Test/TypeTest.php
+++ b/test/lib/Elastica/Test/TypeTest.php
@@ -5,7 +5,6 @@ use Elastica\Document;
 use Elastica\Exception\NotFoundException;
 use Elastica\Exception\ResponseException;
 use Elastica\Index;
-use Elastica\Query;
 use Elastica\Query\MatchAll;
 use Elastica\Query\QueryString;
 use Elastica\Query\SimpleQueryString;
@@ -834,7 +833,7 @@ class TypeTest extends BaseTest
         $this->assertTrue($document->hasId());
 
         $foundDoc = $type->getDocument($document->getId());
-        $this->assertInstanceOf('Elastica\Document', $foundDoc);
+        $this->assertInstanceOf(Document::class, $foundDoc);
         $this->assertEquals($document->getId(), $foundDoc->getId());
         $data = $foundDoc->getData();
         $this->assertArrayHasKey('name', $data);
@@ -890,7 +889,7 @@ class TypeTest extends BaseTest
         $index = $this->_getClient()->getIndex('foo');
         $type = $index->getType('user');
         $ret = $type->setSerializer('get_object_vars');
-        $this->assertInstanceOf('Elastica\Type', $ret);
+        $this->assertInstanceOf(Type::class, $ret);
     }
 
     /**

--- a/test/phpunit.xml.dist
+++ b/test/phpunit.xml.dist
@@ -1,22 +1,19 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="./bootstrap.php"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnError="false"
-    stopOnFailure="false"
-    stopOnIncomplete="false"
-    stopOnSkipped="false"
-    syntaxCheck="false"
-    verbose="true"
-    >
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
+  backupGlobals                           = "false"
+  colors                                  = "true"
+  beStrictAboutTestsThatDoNotTestAnything = "true"
+  beStrictAboutOutputDuringTests          = "true"
+  verbose                                 = "true"
+  bootstrap                               = "bootstrap.php"
+>
   <filter>
     <whitelist>
-      <directory suffix=".php">../lib/</directory>
+      <directory>../lib/</directory>
     </whitelist>
   </filter>
   <testsuites>


### PR DESCRIPTION
Based on #1251 and will be rebased once merged.