### PR TITLE
Fix AnalyzeAPI with 'explain' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 
+- added support for the "explain" flag of AnalyzeAPI [PR-1254](https://github.com/ruflin/Elastica/pull/1254)
+
 ### Deprecated
 
 

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -537,6 +537,12 @@ class Index implements SearchableInterface
     {
         $data = $this->request('_analyze', Request::POST, $text, $args)->getData();
 
+        // Support for "Explain" parameter, that returns a different response structure from Elastic
+        // @see: https://www.elastic.co/guide/en/elasticsearch/reference/current/_explain_analyze.html
+        if (isset($args['explain']) && $args['explain']) {
+            return $data['detail'];
+        }
+
         return $data['tokens'];
     }
 }

--- a/test/lib/Elastica/Test/IndexTest.php
+++ b/test/lib/Elastica/Test/IndexTest.php
@@ -914,6 +914,18 @@ class IndexTest extends BaseTest
     }
 
     /**
+     * @group functional
+     */
+    public function testAnalyzeExplain()
+    {
+        $index = $this->_createIndex();
+        $index->refresh();
+        $data = $index->analyze('foo', ['explain' => true]);
+
+        $this->assertArrayHasKey('custom_analyzer', $data);
+    }
+
+    /**
      * @group unit
      * @expectedException \Elastica\Exception\InvalidException
      */


### PR DESCRIPTION
The ElasticSearch AnalyzeAPI has an "explain" parameter to gather further details about the performed analysis on a text content.
Unfortunately the ElasticSearch response is different when such parameter is set or not set.
See https://www.elastic.co/guide/en/elasticsearch/reference/5.2/_explain_analyze.html
and https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html.

The format "explain = true" is consistent in the 5.x major release.

