### PR TITLE
Enable travis on the 5.1-php55 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 branches:
   only:
     - master
+    - 5.1-php55
 
 env:
   - TARGET="56"


### PR DESCRIPTION
The .travis.yml file currently limits travis to only
running on the master branch. Update to include the
new branch supporting php 5.5 as well.