### PR TITLE
Fix ExceptionAction - Array to string conversion

### DIFF
--- a/lib/Elastica/Exception/Bulk/Response/ActionException.php
+++ b/lib/Elastica/Exception/Bulk/Response/ActionException.php
@@ -58,7 +58,7 @@ class ActionException extends BulkException
         if (isset($data['_id'])) {
             $path .= '/'.$data['_id'];
         }
-        $message = "$opType: $path caused $error";
+        $message = "$opType: $path caused $error['reason']";
 
         return $message;
     }


### PR DESCRIPTION
Fix Array to string conversion error in ExceptionAction. When an error is thrown, we have a Array to string conversion on line 61 in this file. 
`$error` is an Array and not a string, here is an example of `$error` :
```
Array
        (
            [type] => illegal_argument_exception
            [reason] => mapper [currentPrice] of different type, current_type [double], merged_type [long]
        )
```