### PR TITLE
Resolve deprecation warning in Type::exists()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file based on the
 - `\Elastica\Query\MatchPhrase` and `\Elastica\Query\MatchPhrasePrefix` do not extend `\Elastica\Query\Match` anymore because they do not share exactly the same options
 - Removed the `routing` option in `\Elastica\Index::create` because there is no routing param when creating an index. So that option was doing nothing so far but fails in Elasticearch 5.0 because the non-existing query param is validated.
 - Fix `relation` property of `\Elastica\Query\GeoShapeProvided`
+- repoint `\Elastica\Type::exists` from the deprecated /{index}/{type} endpoint to /{index}/_mapping/{type}
 
 ### Added
 

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -521,7 +521,8 @@ class Type implements SearchableInterface
      */
     public function exists()
     {
-        $response = $this->getIndex()->request($this->getName(), Request::HEAD);
+        $path = '_mapping/' . $this->getName();
+        $response = $this->getIndex()->request($path, Request::HEAD);
 
         return $response->getStatus() === 200;
     }


### PR DESCRIPTION
Elasticsearch 5 logs a deprecation warning when using the exists method:

[org.elasticsearch.deprecation.rest.action.admin.indices.RestTypesExistsAction]
[HEAD /{index}/{type}] is deprecated! Use [HEAD /{index}/_mapping/{type}] instead

Adjust the call to use the appropriate REST url.