### PR TITLE
remove addParam with null key

### DIFF
--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -136,11 +136,7 @@ class Param implements ArrayableInterface
      */
     public function addParam($key, $value)
     {
-        if ($key != null) {
-            $this->_params[$key][] = $value;
-        } else {
-            $this->_params = $value;
-        }
+        $this->_params[$key][] = $value;
 
         return $this;
     }


### PR DESCRIPTION
Fixes #1130

This strange thing was added in #460 but a null key is not used in Elastica at all anymore. Also it doesn't make sense (the value can be mixed but _params property must be an array, is not documented, nor tested.