### PR TITLE
QueryBuilder fix #1266

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file based on the
 
 - Fix reading bool index settings like `\Elastica\Index\Settings::getBlocksWrite`. Elasticsearch returns all settings as strings and does not normalize bool values.
   The getters now return the right bool value for whichever string representation is used like 'true', '1', 'on', 'yes'.
+- Fix for QueryBuilder version check `\Elastica\QueryBuilder\Version\Version240.php` added all new query types to queries array.
 
 ### Added
 

--- a/lib/Elastica/QueryBuilder/Version/Version240.php
+++ b/lib/Elastica/QueryBuilder/Version/Version240.php
@@ -44,6 +44,9 @@ class Version240 extends Version
         'terms',
         'wildcard',
         'geo_distance',
+        'exists',
+        'type',
+        'percolate',
     ];
 
     protected $aggregations = [


### PR DESCRIPTION
Fix for QueryBuilder version check `\Elastica\QueryBuilder\Version\Version240.php` added all new query types to queries array. #1266