### PR TITLE
Fix direct generators deprecation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this project will be documented in this file based on the
 
 - Deprecated `\Elastica\Exception\ElasticsearchException` which is irrelevant since Elasticsearch now exposes the errors as a structured array instead of a single string.
   Use `\Elastica\Exception\ResponseException::getResponse::getFullError` instead.
+- Deprecated both `prefix_len` & `min_word_len` fields in `Elastica\Suggest\CandidateGenerator\DirectGenerator` as these now return errors when using the phrase suggester to querying terms.
+  Use `prefix_length` & `min_word_length` instead [#1282](https://github.com/ruflin/Elastica/pull/1282)
 
 ## [5.1.0](https://github.com/ruflin/Elastica/compare/5.0.0...5.1.0)
 

--- a/lib/Elastica/Suggest/CandidateGenerator/DirectGenerator.php
+++ b/lib/Elastica/Suggest/CandidateGenerator/DirectGenerator.php
@@ -71,7 +71,7 @@ class DirectGenerator extends AbstractCandidateGenerator
      */
     public function setPrefixLength($length)
     {
-        return $this->setParam('prefix_len', $length);
+        return $this->setParam('prefix_length', $length);
     }
 
     /**
@@ -81,7 +81,7 @@ class DirectGenerator extends AbstractCandidateGenerator
      */
     public function setMinWordLength($min)
     {
-        return $this->setParam('min_word_len', $min);
+        return $this->setParam('min_word_length', $min);
     }
 
     /**


### PR DESCRIPTION
Deprecation of the below is now enforced in 5.3

- "prefix_len" becomes "prefix_length"
- "min_word_len" becomes "min_word_length"

Docs: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html#_direct_generators