### PR TITLE
using official nginx image and use of php:7.1 instead of php:7.1-rc

### DIFF
--- a/env/elastica/Docker71
+++ b/env/elastica/Docker71
@@ -1,6 +1,6 @@
 # This image is the base image for the Elastica development and includes all parts which rarely change
 # PHP 7 Docker file with Composer installed
-FROM php:7.1-rc
+FROM php:7.1
 MAINTAINER Nicolas Ruflin <spam@ruflin.com>
 
 RUN apt-get update && apt-get install -y \

--- a/env/nginx/Dockerfile
+++ b/env/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.9
+FROM nginx:1.13
 MAINTAINER Nicolas Ruflin <spam@ruflin.com>
 
 # Copy config files


### PR DESCRIPTION
This small PR will correct some configurations on docker images

- remove the use of ruflin/nginx:1.9 with the official version:latest.
- update the docker image for Travis for php:7.1. Updating the php:7.1-rc to php:7.1