### PR TITLE
Docker config improvements, properly create an Elasticsearch cluster and share the FS to be able to test SNAPSHOTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,23 @@ env:
   - TARGET="71"
 
 before_install:
-  # Docker-compose installation
-  - curl -L https://github.com/docker/compose/releases/download/1.8.1/docker-compose-`uname -s`-`uname -m` > docker-compose
+  # list docker-engine versions, usefull to update the docker engine on travis and trusty
+  #- apt-cache madison docker-engine
+
+  # update docker engine to the desired version
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=1.13.1-0~ubuntu-trusty
+
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.13.0/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+
+  # check running "docker engine" and "docker-compose" version on travis
+  - docker --version
+  - docker-compose --version
+
+before_script:
+  - sudo sysctl -w vm.max_map_count=262144
 
 script:
   - make tests TARGET=$TARGET

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ endif
 
 .PHONY: clean
 clean:
+	docker-compose down -v
 	rm -r -f ./build
 	rm -r -f ./vendor
 	rm -r -f ./composer.lock
@@ -57,16 +58,16 @@ phpunit:
 tests:
 	# Rebuild image to copy changes files to the image
 	make elastica-image
-	make setup
+	make start
 	mkdir -p build
-	docker-compose run elastica make phpunit
-	docker cp elastica_elastica_run_1:/elastica/build/coverage/ $(shell pwd)/build/coverage
+	docker run --network=elastica_esnet elastica_elastica  make phpunit
+	docker cp elastica:/elastica/build/coverage/ $(shell pwd)/build/coverage
 
 # Makes it easy to run a single test file. Example to run IndexTest.php: make test TEST="IndexTest.php"
 .PHONY: test
 test:
 	make elastica-image
-	make setup
+	make start
 	mkdir -p build
 	docker-compose run elastica phpunit -c test/ ${TEST}
 
@@ -93,15 +94,9 @@ phploc:
 build:
 	docker-compose build
 
-.PHONY: setup
-setup: build
-	#docker-compose scale elasticsearch=3
-	# TODO: Makes the snapshot directory writable for all instances. Nicer solution needed.
-	#docker-compose run elasticsearch chmod -R 777 /tmp/backups/
-
 .PHONY: start
 start:
-	docker-compose up
+	docker-compose up -d
 
 .PHONY: stop
 stop:
@@ -155,7 +150,6 @@ build-images:
 	docker build -t ruflin/elastica-dev-base -f env/elastica/Docker${TARGET} env/elastica/
 	docker build -t ruflin/elasticsearch-elastica env/elasticsearch/
 	docker build -t ruflin/nginx-elastica env/nginx/
-	docker build -t ruflin/elastica-data env/data/
 	make elastica-image
 
 # Removes all local images
@@ -165,7 +159,6 @@ clean-images:
 	-docker rmi ruflin/elasticsearch-elastica
 	-docker rmi ruflin/nginx-elastica
 	-docker rmi ruflin/elastica
-	-docker rmi ruflin/elastica-data
 
 # Pushs images as latest to the docker registry. This is normally not needed as they are directly fetched and built from Github
 .PHONY: push-images

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,82 @@
-elastica:
-  build: .
-  #image: ruflin/elastica
-  ports:
-    - "9200:9200"
-  links:
-    - nginx
-    - elasticsearch
-  environment:
-    - ES_HOST=elasticsearch
-    - PROXY_HOST=nginx
+version: '2.0'
 
-elasticsearch:
-  build: ./env/elasticsearch/
-  #image: ruflin/elasticsearch-elastica
-  volumes_from:
-    - data
-  environment:
-    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    - "network.host="
-    - "transport.host=127.0.0.1"
-    - "http.host=0.0.0.0"
-    - "xpack.security.enabled=false"
+services:
+  elastica:
+    build: .
+    container_name: elastica
+    environment:
+      - ES_HOST=elasticsearch
+      - PROXY_HOST=nginx
+    networks:
+      - esnet
 
-nginx:
-  build: ./env/nginx/
-  #image: ruflin/nginx-elastica
-  links:
-    - elasticsearch
-# data container to share data between elasticsearch nodes for snapshot testing
-data:
-  image: ruflin/elastica-data
-  volumes:
-    - "/tmp/backups/backup1"
-    - "/tmp/backups/backup2"
+  elasticsearch1:
+    build: ./env/elasticsearch/
+    container_name: elasticsearch
+    privileged: true
+    environment:
+      - bootstrap.memory_lock=true
+      - network.host=172.18.0.4
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    mem_limit: 1g
+    cap_add:
+      - ALL
+      - IPC_LOCK
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      esnet:
+        ipv4_address: 172.18.0.4
+  elasticsearch2:
+    build: ./env/elasticsearch/
+    privileged: true
+    environment:
+      - bootstrap.memory_lock=true
+      - network.host=172.18.0.3
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    mem_limit: 1g
+    cap_add:
+      - ALL
+      - IPC_LOCK
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    networks:
+      esnet:
+        ipv4_address: 172.18.0.3
+
+  nginx:
+    build: ./env/nginx/
+    networks:
+      esnet:
+        ipv4_address: 172.18.0.5
+
+
+volumes:
+  esdata1:
+    driver: local
+
+networks:
+  esnet:
+    driver: bridge
+    ipam:
+     config:
+       - subnet: 172.18.0.0/16
+         gateway: 172.18.0.1

--- a/env/data/Dockerfile
+++ b/env/data/Dockerfile
@@ -1,9 +1,0 @@
-# Data image for elasticsearch instances
-FROM debian:jessie
-MAINTAINER Nicolas Ruflin <spam@ruflin.com>
-
-RUN mkdir -p /tmp/backups/backup1
-RUN mkdir -p /tmp/backups/backup2
-
-VOLUME /tmp/backups/backup1
-VOLUME /tmp/backups/backup2

--- a/env/data/README.md
+++ b/env/data/README.md
@@ -1,3 +1,0 @@
-PHP base image for the development of Elastica.
-
-This image containts the basic setup for the development of Elastica. Part of this image are all parts which do not change often and do not need access to the source code of Elastica. The only file needed to build this image is the composer.json file in the folder `env/elastica/`. It contains a list of the global packages which are needed for the development environment like phpunit.

--- a/env/elasticsearch/Dockerfile
+++ b/env/elasticsearch/Dockerfile
@@ -6,7 +6,3 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-attachments
 # Copy config files
 COPY elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
 COPY scripts/* /usr/share/elasticsearch/config/scripts/
-
-
-RUN mkdir -p /tmp/backups/backup1
-RUN mkdir -p /tmp/backups/backup2

--- a/env/elasticsearch/elasticsearch.yml
+++ b/env/elasticsearch/elasticsearch.yml
@@ -1,32 +1,30 @@
-
-#index.number_of_shards: 2
-#index.number_of_replicas: 0
+#Set Cluster name
+cluster.name: "docker-cluster-elastica"
 
 # Required plugins
 plugin.mandatory: mapper-attachments
 
 # For script tests
 script.inline: true
-#script.indexed: on
 
 script.engine.groovy.file: on
-
-# Accept any connection - disable checks
-http.host: 0.0.0.0
 
 # Limit threadpool by set number of available processors to 1
 # Without this, travis builds will be failed with OutOfMemory error
 processors: 1
 
-# All nodes will be called Elastica
-node.name: Elastica
+network.host: 0.0.0.0
 
-# Ports config
-http.port: 9200
-transport.tcp.port: 9300
+# minimum_master_nodes need to be explicitly set when bound on a public IP
+# set to 1 to allow single node clusters
+# Details: https://github.com/elastic/elasticsearch/pull/17288
+discovery.zen.minimum_master_nodes: 2
+discovery.zen.ping.unicast.hosts: ["elasticsearch"]
+
+xpack.security.enabled: false
 
 # Added for snapshot tests
-path.repo: ["/tmp/backups"]
+path.repo: ["/usr/share/elasticsearch/data"]
+node.max_local_storage_nodes: 2
 
-#discovery.zen.ping.unicast.enabled: true
-#discovery.zen.ping.multicast.enabled: true
+

--- a/lib/Elastica/Snapshot.php
+++ b/lib/Elastica/Snapshot.php
@@ -178,6 +178,6 @@ class Snapshot
      */
     public function request($path, $method = Request::GET, $data = [], array $query = [])
     {
-        return $this->_client->request('/_snapshot/'.$path, $method, $data, $query);
+        return $this->_client->request('_snapshot/'.$path, $method, $data, $query);
     }
 }

--- a/test/Elastica/Base.php
+++ b/test/Elastica/Base.php
@@ -123,7 +123,7 @@ class Base extends \PHPUnit_Framework_TestCase
 
         $client = $this->_getClient();
         $index = $client->getIndex('elastica_'.$name);
-        $index->create(['index' => ['number_of_shards' => $shards, 'number_of_replicas' => 0]], $delete);
+        $index->create(['index' => ['number_of_shards' => $shards, 'number_of_replicas' => 1]], $delete);
 
         return $index;
     }

--- a/test/Elastica/SnapshotTest.php
+++ b/test/Elastica/SnapshotTest.php
@@ -18,7 +18,7 @@ class SnapshotTest extends Base
      */
     protected $_index;
 
-    protected $_snapshotPath = '/tmp/backups/';
+    protected $_snapshotPath = '/usr/share/elasticsearch/data/';
 
     /**
      * @var Document[]
@@ -27,7 +27,6 @@ class SnapshotTest extends Base
 
     protected function setUp()
     {
-        $this->markTestSkipped('Snapshot tests currently skipped because not working on Travis');
         parent::setUp();
         $this->_snapshot = new Snapshot($this->_getClient());
 
@@ -48,6 +47,7 @@ class SnapshotTest extends Base
     {
         $repositoryName = 'testrepo';
         $location = $this->_snapshotPath.'backup1';
+
 
         $response = $this->_snapshot->registerRepository($repositoryName, 'fs', ['location' => $location]);
         $this->assertTrue($response->isOk());


### PR DESCRIPTION
This PR solves many problems : 

- now Docker is configured to properly create an Elasticsearch Cluster
- I've tweak some ES configuration to make ES create a cluster properly
- I've removed a container used just only the filesystem sharing, as it is possibile
to share a volume from the docker-compose file
- now the 2 Elasticsearch nodes shares a filesystem on which we can test snapshot generation.