### PR TITLE
Always set Content-Type with Http Transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 
+- Fix elastic 5.3.x deprecation warning related to Content-Type not being set.
 - Fix updating settings of an index. [#1296](https://github.com/ruflin/Elastica/pull/1296)
 
 ### Added

--- a/lib/Elastica/Bulk.php
+++ b/lib/Elastica/Bulk.php
@@ -354,7 +354,7 @@ class Bulk
         $path = $this->getPath();
         $data = $this->toString();
 
-        $response = $this->_client->request($path, Request::POST, $data, $this->_requestParams);
+        $response = $this->_client->request($path, Request::POST, $data, $this->_requestParams, Request::NDJSON_CONTENT_TYPE);
 
         return $this->_processResponse($response);
     }

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -658,15 +658,16 @@ class Client
      * @param string       $method Rest method to use (GET, POST, DELETE, PUT)
      * @param array|string $data   OPTIONAL Arguments as array or pre-encoded string
      * @param array        $query  OPTIONAL Query params
+     * @param string       $contentType Content-Type sent with this request
      *
      * @throws Exception\ConnectionException|\Exception
      *
      * @return Response Response object
      */
-    public function request($path, $method = Request::GET, $data = [], array $query = [])
+    public function request($path, $method = Request::GET, $data = [], array $query = [], $contentType = Request::DEFAULT_CONTENT_TYPE)
     {
         $connection = $this->getConnection();
-        $request = $this->_lastRequest = new Request($path, $method, $data, $query, $connection);
+        $request = $this->_lastRequest = new Request($path, $method, $data, $query, $connection, $contentType);
         $this->_lastResponse = null;
 
         try {

--- a/lib/Elastica/Multi/Search.php
+++ b/lib/Elastica/Multi/Search.php
@@ -145,7 +145,8 @@ class Search
             '_msearch',
             Request::POST,
             $data,
-            $this->_options
+            $this->_options,
+	    Request::NDJSON_CONTENT_TYPE
         );
 
         return $this->_builder->buildMultiResultSet($response, $this->getSearches());

--- a/lib/Elastica/Request.php
+++ b/lib/Elastica/Request.php
@@ -15,6 +15,8 @@ class Request extends Param
     const PUT = 'PUT';
     const GET = 'GET';
     const DELETE = 'DELETE';
+    const DEFAULT_CONTENT_TYPE = 'application/json';
+    const NDJSON_CONTENT_TYPE = 'application/x-ndjson';
 
     /**
      * @var \Elastica\Connection
@@ -29,10 +31,11 @@ class Request extends Param
      * @param array      $data       OPTIONAL Data array
      * @param array      $query      OPTIONAL Query params
      * @param Connection $connection
+     * @param string     $contentType Content-Type sent with this request
      *
      * @return \Elastica\Request OPTIONAL Connection object
      */
-    public function __construct($path, $method = self::GET, $data = [], array $query = [], Connection $connection = null)
+    public function __construct($path, $method = self::GET, $data = [], array $query = [], Connection $connection = null, $contentType = self::DEFAULT_CONTENT_TYPE )
     {
         $this->setPath($path);
         $this->setMethod($method);
@@ -42,6 +45,7 @@ class Request extends Param
         if ($connection) {
             $this->setConnection($connection);
         }
+        $this->setContentType($contentType);
     }
 
     /**
@@ -156,6 +160,23 @@ class Request extends Param
         }
 
         return $this->_connection;
+    }
+
+    /**
+     * Set the Content-Type of this request
+     * @param string $contentType
+     */
+    public function setContentType($contentType)
+    {
+        return $this->setParam('contentType', $contentType);
+    }
+
+    /**
+     * Get the Content-Type of this request
+     */
+    public function getContentType()
+    {
+        return $this->getParam('contentType');
     }
 
     /**

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -136,6 +136,7 @@ class Http extends AbstractTransport
                 $content = str_replace('\/', '/', $content);
             }
 
+            array_push($headers, $request->getContentType());
             if ($connection->hasCompression()) {
                 // Compress the body of the request ...
                 curl_setopt($conn, CURLOPT_POSTFIELDS, gzencode($content));


### PR DESCRIPTION
Added a new param to Client::request and Request::_construct to allow
setting the content-type of the data being sent.
This defaults to "application/json" and is only overidden by Bulk and MultiSearch
where it should be application/x-ndjson.

Sadly I'm not sure how to test this properly.
I'm not a big a big fan of adding a new param like that. Ideally we should refactor
the $data param of Request::_construct to accept a array (defaults to application/json)
or a new RequestBody object where the client could set the content-type alongside the
the string.

closes #1301