### PR TITLE
Fix a problem with Travis build, installing libpcre to avoid failing …

### DIFF
--- a/env/elastica/Docker56
+++ b/env/elastica/Docker56
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
 	graphviz \
 	nano \
 	php5-xsl \
+	libpcre3-dev \
 	zlib1g-dev
 	# XSL and Graphviz for PhpDocumentor
 


### PR DESCRIPTION
It looks like that from yesterday evening the build is failing due to a lack of ***libpcre3-dev*** in the docker container with php 5.6. I'm still investigating what happened, I suspect something changed in the *debian:jessie* container. But I'm still inspecting, in the mean time this problem should be fixed installing the lib in the container.