### PR TITLE
Functional test in HasParentTest intermittently fails due to a lack in ES configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - bootstrap.memory_lock=true
       - network.host=172.18.0.4
       - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:
@@ -44,6 +45,7 @@ services:
       - bootstrap.memory_lock=true
       - network.host=172.18.0.3
       - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:

--- a/env/elasticsearch/elasticsearch.yml
+++ b/env/elasticsearch/elasticsearch.yml
@@ -21,7 +21,12 @@ network.host: 0.0.0.0
 discovery.zen.minimum_master_nodes: 2
 discovery.zen.ping.unicast.hosts: ["elasticsearch"]
 
+# at the moment it's not possible to remove the x-pack plugin from the official ES docker image
+# https://github.com/elastic/elasticsearch-docker/issues/36
+# they've solved on 5.4, I will wait that version to remove the plugin correctly
+# and remove the following two lines
 xpack.security.enabled: false
+xpack.monitoring.enabled: false
 
 # Added for snapshot tests
 path.repo: ["/usr/share/elasticsearch/data"]


### PR DESCRIPTION
The problem with the docker image from ES version 5.2.2 is that is shipped with x-pack installed, I disabled security but I forgot to disable monitor which sometimes make this test failing. 

At this time it's not possible to remove completely the xpack plugin (except with a workaround) due
to an issue in the official docker ES image : [https://github.com/elastic/elasticsearch-docker/issues/36](https://github.com/elastic/elasticsearch-docker/issues/36). At the moment I've disabled *security* and *monitoring* from the elasticsearch.yml. The problem has been resolved (maybe) in the 5.4, my suggestion is to completely remove the plugin when we will switch to that version.