### PR TITLE
update Cluster\Health properties and its own test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
  - Parameter `filter_path` for response filtering (e.g. `$index->search($query, ['filter_path' => 'hits.hits._source'])`)
+ - Add support for Health parameters for Cluster\Health endpoint (new prop : delayed_unassigned_shards, number_of_pending_tasks, number_of_in_flight_fetch, task_max_waiting_in_queue_millis, active_shards_percent_as_number)
 
 ### Improvements
 

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ build:
 
 .PHONY: start
 start:
-	docker-compose up -d
+	docker-compose up -d --build
 
 .PHONY: stop
 stop:

--- a/lib/Elastica/Cluster/Health.php
+++ b/lib/Elastica/Cluster/Health.php
@@ -170,6 +170,48 @@ class Health
     }
 
     /**
+     * get the number of delayed unassined shards
+     *
+     * @return int
+     */
+    public function getDelayedUnassignedShards()
+    {
+        return $this->_data['delayed_unassigned_shards'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getNumberOfPendingTasks()
+    {
+        return $this->_data['number_of_pending_tasks'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getNumberOfInFlightFetch()
+    {
+        return $this->_data['number_of_in_flight_fetch'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getTaskMaxWaitingInQueueMillis()
+    {
+        return $this->_data['task_max_waiting_in_queue_millis'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getActiveShardsPercentAsNumber()
+    {
+        return $this->_data['active_shards_percent_as_number'];
+    }
+
+    /**
      * Gets the status of the indices.
      *
      * @return \Elastica\Cluster\Health\Index[]

--- a/test/Elastica/Cluster/HealthTest.php
+++ b/test/Elastica/Cluster/HealthTest.php
@@ -27,6 +27,12 @@ class HealthTest extends BaseTest
             'relocating_shards' => 2,
             'initializing_shards' => 7,
             'unassigned_shards' => 5,
+            'delayed_unassigned_shards' => 4,
+            'number_of_pending_tasks' => 1,
+            'number_of_in_flight_fetch' =>  2,
+            'task_max_waiting_in_queue_millis' => 634,
+            'active_shards_percent_as_number' => 50.0,
+
             'indices' => [
                 'index_one' => [
                 ],
@@ -130,6 +136,46 @@ class HealthTest extends BaseTest
     public function testGetUnassignedShards()
     {
         $this->assertEquals(5, $this->_health->getUnassignedShards());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testGetDelayedUnassignedShards()
+    {
+        $this->assertEquals(4, $this->_health->getDelayedUnassignedShards());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testNumberOfPendingTasks()
+    {
+        $this->assertEquals(1, $this->_health->getNumberOfPendingTasks());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testNumberOfInFlightFetch()
+    {
+        $this->assertEquals(2, $this->_health->getNumberOfInFlightFetch());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testTaskMaxWaitingInQueueMillis()
+    {
+        $this->assertEquals(634, $this->_health->getTaskMaxWaitingInQueueMillis());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testActiveShardsPercentAsNumber()
+    {
+        $this->assertEquals(50, $this->_health->getActiveShardsPercentAsNumber());
     }
 
     /**


### PR DESCRIPTION
since ES 2.0 Cluster Health returns 5 new properties

- delayed_unassigned_shards
- number_of_pending_tasks
- number_of_in_flight_fetch
- task_max_waiting_in_queue_millis
- active_shards_percent_as_number

I've implemented the Cluster\Health object coherently to these new properties.

[https://www.elastic.co/guide/en/elasticsearch/reference/1.7/cluster-health.html](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/cluster-health.html)
[https://www.elastic.co/guide/en/elasticsearch/reference/2.0/cluster-health.html](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/cluster-health.html)