### PR TITLE
add query to setMapping in Type Class (see #1216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file based on the
 
  - Parameter `filter_path` for response filtering (e.g. `$index->search($query, ['filter_path' => 'hits.hits._source'])`)
  - Add support for Health parameters for Cluster\Health endpoint (new prop : delayed_unassigned_shards, number_of_pending_tasks, number_of_in_flight_fetch, task_max_waiting_in_queue_millis, active_shards_percent_as_number)
+ - Add support for querystring in Type. this allow to use `update_all_types` in type mapping in order to resolve conflicts between fields in different types. [Conflicts between fields in different types](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html#merging-conflicts) 
 
 ### Improvements
 

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -292,15 +292,16 @@ class Type implements SearchableInterface
      * Sets value type mapping for this type.
      *
      * @param \Elastica\Type\Mapping|array $mapping Elastica\Type\MappingType object or property array with all mappings
+     * @param array $query querystring when put mapping (for example update_all_types)
      *
      * @return \Elastica\Response
      */
-    public function setMapping($mapping)
+    public function setMapping($mapping, array $query = [])
     {
         $mapping = Mapping::create($mapping);
         $mapping->setType($this);
 
-        return $mapping->send();
+        return $mapping->send($query);
     }
 
     /**

--- a/test/Elastica/TypeTest.php
+++ b/test/Elastica/TypeTest.php
@@ -990,4 +990,50 @@ class TypeTest extends BaseTest
             $mapping['mappings']
         );
     }
+
+    /**
+     * @group functional
+     *
+     * @expectedException \Elastica\Exception\ResponseException
+     */
+    public function testExceptionMappingOnFieldsWithSameName()
+    {
+        $index = $this->_createIndex();
+        $type1 = new Type($index, 'foo');
+        $type2 = new Type($index, 'bar');
+
+        $mapping = new Mapping(null, $expect = [
+            'text' => ['type' => 'text', 'analyzer' => 'standard'],
+        ]);
+        $type1->setMapping($mapping);
+        $type2->setMapping($mapping);
+
+        $mapping2 = new Mapping($type1, $expect = [
+            'text' => ['type' => 'text', 'analyzer' => 'standard', 'search_analyzer' => 'whitespace'],
+        ]);
+        $type1->setMapping($mapping2);
+    }
+
+    /**
+     * @group functional
+     *
+     */
+    public function testMappingOnFieldsWithSameName()
+    {
+        $index = $this->_createIndex();
+        $type1 = new Type($index, 'foo');
+        $type2 = new Type($index, 'bar');
+
+        $mapping = new Mapping(null, $expect = [
+            'text' => ['type' => 'text', 'analyzer' => 'standard'],
+        ]);
+        $type1->setMapping($mapping);
+        $type2->setMapping($mapping);
+
+        $mapping2 = new Mapping($type1, $expect = [
+            'text' => ['type' => 'text', 'analyzer' => 'standard', 'search_analyzer' => 'whitespace'],
+        ]);
+        $type1->setMapping($mapping2, ['update_all_types' => 'update_all_types']);
+        $this->assertTrue(true);
+    }
 }


### PR DESCRIPTION
Add support for querystring in Type: this allow to use `update_all_types` in type mapping in order to resolve conflicts between fields in different typesedit Fields. [Conflicts between fields in different typesedit Fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html#merging-conflicts)