### PR TITLE
Adding the missing Content-Type key in the headers for ES 5.3+

### DIFF
--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -136,7 +136,7 @@ class Http extends AbstractTransport
                 $content = str_replace('\/', '/', $content);
             }
 
-            array_push($headers, $request->getContentType());
+            array_push($headers, sprintf('Content-Type: %s', $request->getContentType()));
             if ($connection->hasCompression()) {
                 // Compress the body of the request ...
                 curl_setopt($conn, CURLOPT_POSTFIELDS, gzencode($content));


### PR DESCRIPTION
Refactor on the Transport/Http.php would be better, this is a quick fix for https://github.com/nomoa/Elastica/commit/c8896cec23d23d92fdeb0c5fcf1b03ee0d7c4cb7