### PR TITLE
Type.php: Removed Exception thrown in deleteById()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 
- - Added support for `other_bucket` and `other_bucket_key` paramters on `Elastica\Aggregation\Filters`
+ - Added support for `other_bucket` and `other_bucket_key` parameters on `Elastica\Aggregation\Filters`
+ - Removed NotFoundException thrown in `\Elastica\Type::deleteById` [#565](https://github.com/ruflin/Elastica/issues/565)
 
 ### Deprecated
  - Deprecated `Tool\CrossIndex` use `\Elastica\Reindex` instead [#1311](https://github.com/ruflin/Elastica/issues/1311)

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -450,10 +450,6 @@ class Type implements SearchableInterface
 
         $responseData = $response->getData();
 
-        if (isset($responseData['found']) && false == $responseData['found']) {
-            throw new NotFoundException('Doc id '.$id.' not found and can not be deleted');
-        }
-
         return $response;
     }
 

--- a/test/Elastica/TypeTest.php
+++ b/test/Elastica/TypeTest.php
@@ -266,27 +266,6 @@ class TypeTest extends BaseTest
             $this->assertTrue(true);
         }
 
-        try {
-            $type->deleteById('*');
-            $this->fail('Delete request should fail because of invalid id: *');
-        } catch (NotFoundException $e) {
-            $this->assertTrue(true);
-        }
-
-        try {
-            $type->deleteById('*:*');
-            $this->fail('Delete request should fail because document with id *.* does not exist');
-        } catch (NotFoundException $e) {
-            $this->assertTrue(true);
-        }
-
-        try {
-            $type->deleteById('!');
-            $this->fail('Delete request should fail because document with id ! does not exist');
-        } catch (NotFoundException $e) {
-            $this->assertTrue(true);
-        }
-
         $index->refresh();
 
         // rolf should no longer be there


### PR DESCRIPTION
An exception was thrown if no data set corresponding to param $id was found (and hence was not deleted). Removed this behavior because it is a very harsh reaction to a more or less uncritical situation because the result is the same: The data requested to be deleted no longer exists. The information wether or not a record set was deleted is supposed to be part of the returned $response.