### PR TITLE
Fixed bad parameter value to refresh document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file based on the
 
 - Fix elastic 5.3.x deprecation warning related to Content-Type not being set.
 - Fix updating settings of an index. [#1296](https://github.com/ruflin/Elastica/pull/1296)
+- Fix bad parameter value to refresh document [#1318](https://github.com/rufli/Elastica/pull/1318)
 
 ### Added
 

--- a/lib/Elastica/AbstractUpdateAction.php
+++ b/lib/Elastica/AbstractUpdateAction.php
@@ -327,7 +327,7 @@ class AbstractUpdateAction extends Param
      */
     public function setRefresh($refresh = true)
     {
-        return $this->setParam('_refresh', (bool) $refresh);
+        return $this->setParam('_refresh', (bool) $refresh ? 'true' : 'false');
     }
 
     /**
@@ -335,7 +335,7 @@ class AbstractUpdateAction extends Param
      */
     public function getRefresh()
     {
-        return $this->getParam('_refresh');
+        return 'true' === $this->getParam('_refresh');
     }
 
     /**

--- a/test/Elastica/DocumentTest.php
+++ b/test/Elastica/DocumentTest.php
@@ -119,6 +119,30 @@ class DocumentTest extends BaseTest
     /**
      * @group unit
      */
+    public function testGetSetHasRefresh()
+    {
+        $document = new Document();
+        $this->assertFalse($document->hasRefresh());
+
+        try {
+            $document->getRefresh();
+            $this->fail('Undefined refresh option should throw exception');
+        } catch (InvalidException $e) {
+            $this->assertTrue(true);
+        }
+
+        $document->setRefresh(false);
+        $this->assertTrue($document->hasRefresh());
+        $this->assertFalse($document->getRefresh());
+
+        $document->setRefresh(true);
+        $this->assertTrue($document->hasRefresh());
+        $this->assertTrue($document->getRefresh());
+    }
+
+    /**
+     * @group unit
+     */
     public function testGetOptions()
     {
         $document = new Document();


### PR DESCRIPTION
Since Elasticsearch 5.0 adds more strict parameter checking, for example 1/0 are not accepted for true/false anymore.

The function http_build_query() transform php constant true and false to 1 or 0. Theses value are not accepted by Elasticsearch 5.0+.

This PR avoid this error:

```json
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Unknown value for refresh: [1]."}],"type":"illegal_argument_exception","reason":"Unknown value for refresh: [1]."},"status":400}
```