### PR TITLE
WIP: Expose getNumberOfReplicas() from index settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 
 ### Added
+ - Added getNumberOfReplicas() for index settings [PR#1324](https://github.com/ruflin/Elastica/pull/1324)
 
 ### Improvements
 

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -22,6 +22,8 @@ class Settings
 {
     const DEFAULT_REFRESH_INTERVAL = '1s';
 
+    const DEFAULT_NUMBER_OF_REPLICAS = 1;
+
     /**
      * Response.
      *
@@ -131,6 +133,24 @@ class Settings
     public function setNumberOfReplicas($replicas)
     {
         return $this->set(['number_of_replicas' => (int) $replicas]);
+    }
+
+    /**
+     * Returns the number of replicas.
+     *
+     * If no number of replicas is set, the default number is returned
+     *
+     * @return int The number of replicas
+     */
+    public function getNumberOfReplicas()
+    {
+        $replicas = $this->get('number_of_replicas');
+
+        if (empty($replicas)) {
+            $replicas = self::DEFAULT_NUMBER_OF_REPLICAS;
+        }
+
+        return $replicas;
     }
 
     /**

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -146,7 +146,7 @@ class Settings
     {
         $replicas = $this->get('number_of_replicas');
 
-        if (empty($replicas)) {
+        if (null === $replicas) {
             $replicas = self::DEFAULT_NUMBER_OF_REPLICAS;
         }
 

--- a/test/Elastica/Index/SettingsTest.php
+++ b/test/Elastica/Index/SettingsTest.php
@@ -59,7 +59,7 @@ class SettingsTest extends BaseTest
     /**
      * @group functional
      */
-    public function testSetNumberOfReplicas()
+    public function testSetGetNumberOfReplicas()
     {
         $indexName = 'test';
 
@@ -68,13 +68,17 @@ class SettingsTest extends BaseTest
         $index->create([], true);
         $settings = $index->getSettings();
 
-        $settings->setNumberOfReplicas(2);
+        // Check for zero replicas
+        $settings->setNumberOfReplicas(0);
         $index->refresh();
-        $this->assertEquals(2, $settings->get('number_of_replicas'));
+        $this->assertEquals(0, $settings->get('number_of_replicas'));
+        $this->assertEquals(0, $settings->getNumberOfReplicas());
 
+        // Check with 3 replicas
         $settings->setNumberOfReplicas(3);
         $index->refresh();
         $this->assertEquals(3, $settings->get('number_of_replicas'));
+        $this->assertEquals(3, $settings->getNumberOfReplicas());
 
         $index->delete();
     }
@@ -82,7 +86,7 @@ class SettingsTest extends BaseTest
     /**
      * @group functional
      */
-    public function testGetNumberOfShards()
+    public function testGetNumberOfReplicas()
     {
         $indexName = 'test';
 
@@ -92,13 +96,9 @@ class SettingsTest extends BaseTest
 
         $settings = $index->getSettings();
 
+        // Test with default number of replicas
+        $this->assertEquals(IndexSettings::DEFAULT_NUMBER_OF_REPLICAS, $settings->get('number_of_replicas'));
         $this->assertEquals(IndexSettings::DEFAULT_NUMBER_OF_REPLICAS, $settings->getNumberOfReplicas());
-
-        $replicas = '2';
-        $settings->setNumberOfReplicas($replicas);
-        $index->refresh();
-        $this->assertEquals($replicas, $settings->getNumberOfReplicas());
-        $this->assertEquals($replicas, $settings->get('number_of_replicas'));
 
         $index->delete();
     }

--- a/test/Elastica/Index/SettingsTest.php
+++ b/test/Elastica/Index/SettingsTest.php
@@ -82,6 +82,30 @@ class SettingsTest extends BaseTest
     /**
      * @group functional
      */
+    public function testGetNumberOfShards()
+    {
+        $indexName = 'test';
+
+        $client = $this->_getClient();
+        $index = $client->getIndex($indexName);
+        $index->create([], true);
+
+        $settings = $index->getSettings();
+
+        $this->assertEquals(IndexSettings::DEFAULT_NUMBER_OF_REPLICAS, $settings->getNumberOfReplicas());
+
+        $replicas = '2';
+        $settings->setNumberOfReplicas($replicas);
+        $index->refresh();
+        $this->assertEquals($replicas, $settings->getNumberOfReplicas());
+        $this->assertEquals($replicas, $settings->get('number_of_replicas'));
+
+        $index->delete();
+    }
+
+    /**
+     * @group functional
+     */
     public function testSetRefreshInterval()
     {
         $indexName = 'test';


### PR DESCRIPTION
The index settings exposes most of the available settings, while for the numberOfReplicas the "get" method is missing