### PR TITLE
Send scroll_id inside a json rather that text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 
+- Send the `scroll_id` inside a json body instead of plain text [#1325](https://github.com/ruflin/Elastica/pull/1325)
+
 ### Added
 
 ### Improvements

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -451,7 +451,7 @@ class Search
 
         // Send scroll_id via raw HTTP body to handle cases of very large (> 4kb) ids.
         if ('_search/scroll' == $path) {
-            $data = $params[self::OPTION_SCROLL_ID];
+            $data = [ self::OPTION_SCROLL_ID => $params[self::OPTION_SCROLL_ID] ];
             unset($params[self::OPTION_SCROLL_ID]);
         } else {
             $data = $query->toArray();

--- a/test/Elastica/SearchTest.php
+++ b/test/Elastica/SearchTest.php
@@ -283,7 +283,7 @@ class SearchTest extends BaseTest
         $this->assertFalse($result->getResponse()->hasError());
         $this->assertEquals(5, count($result->getResults()));
         $this->assertArrayNotHasKey(Search::OPTION_SCROLL_ID, $search->getClient()->getLastRequest()->getQuery());
-        $this->assertEquals($scrollId, $search->getClient()->getLastRequest()->getData());
+        $this->assertEquals( [ Search::OPTION_SCROLL_ID => $scrollId ], $search->getClient()->getLastRequest()->getData());
 
         $result = $search->search([], [
             Search::OPTION_SCROLL => '5m',
@@ -292,7 +292,7 @@ class SearchTest extends BaseTest
         $this->assertFalse($result->getResponse()->hasError());
         $this->assertEquals(0, count($result->getResults()));
         $this->assertArrayNotHasKey(Search::OPTION_SCROLL_ID, $search->getClient()->getLastRequest()->getQuery());
-        $this->assertEquals($scrollId, $search->getClient()->getLastRequest()->getData());
+        $this->assertEquals( [ Search::OPTION_SCROLL_ID => $scrollId ], $search->getClient()->getLastRequest()->getData());
     }
 
     /**


### PR DESCRIPTION
It's likely to cause issues with elastic 5.3 as Content-Type handling becomes
more and more strict.

eg.:
curl -H"Content-Type: application/json"  -XGET localhost:9200/_search/scroll?scroll=1m -d 'DXF...'
now fails with Failed to parse request body on 5.3.x.
Elastic 5.1 was lenient and accepted this body and content-type.
Since we default Content-Type to application/json this is likely cause issues
in Elastica as well.
Using an array instead of plain string should force the use of a JSON body which is coherent
with the content-type we set.