### PR TITLE
add support for old travis images until a solution could be found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: required
+group: deprecated-2017Q2
+
 
 services:
   - docker


### PR DESCRIPTION
@ruflin  Due to Travis update of their base docker images 
we need to fix some of our docker tests. While trying to find a solution, this patch will allow other PRs to execute successfully the TESTS.

[https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch](https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch)