### PR TITLE
update Travis to new Ubuntu Trusty images 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
-group: deprecated-2017Q2
+dist: trusty
+
+group: edge
 
 
 services:
@@ -19,7 +21,7 @@ before_install:
   #- apt-cache madison docker-engine
 
   # update docker engine to the desired version
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=1.13.1-0~ubuntu-trusty
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=17.03.1~ce-0~ubuntu-trusty
 
   - sudo rm /usr/local/bin/docker-compose
   - curl -L https://github.com/docker/compose/releases/download/1.13.0/docker-compose-`uname -s`-`uname -m` > docker-compose

--- a/env/elastica/Docker70
+++ b/env/elastica/Docker70
@@ -24,7 +24,6 @@ RUN pecl install xdebug-2.4.0
 
 RUN echo "memory_limit=1024M" >> /usr/local/etc/php/conf.d/memory-limit.ini
 RUN echo "date.timezone=UTC" >> /usr/local/etc/php/conf.d/timezone.ini
-RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install and setup composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/env/elastica/Docker71
+++ b/env/elastica/Docker71
@@ -24,7 +24,6 @@ RUN pecl install xdebug-2.4.0
 
 RUN echo "memory_limit=1024M" >> /usr/local/etc/php/conf.d/memory-limit.ini
 RUN echo "date.timezone=UTC" >> /usr/local/etc/php/conf.d/timezone.ini
-RUN echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install and setup composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer


### PR DESCRIPTION
Hi All, after making a review on the problem we had yesterday on Travis I found that the solution look easier than what I thought :) so @ruflin this way we will start implementing new docker Ubuntu Images (trusty 14.04). I fix a minor error on php71 with the xdebug extension which looks updated on the base image.