### PR TITLE
Prepare for elasticsearch 6.0

### DIFF
--- a/env/elasticsearch/Dockerfile
+++ b/env/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0-alpha2
 MAINTAINER Nicolas Ruflin <spam@ruflin.com>
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-attachments


### PR DESCRIPTION
This PR is a first step to see the things which will break with 6.0. The major change is the removal of Types.