### PR TITLE
update Docker images to support ES6.0 alpha, removed groovy scripting

### DIFF
--- a/env/elasticsearch/Dockerfile
+++ b/env/elasticsearch/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0-alpha2
 MAINTAINER Nicolas Ruflin <spam@ruflin.com>
 
-RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-attachments
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install ingest-attachment
 
 # Copy config files
 COPY elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml

--- a/env/elasticsearch/elasticsearch.yml
+++ b/env/elasticsearch/elasticsearch.yml
@@ -1,14 +1,6 @@
 #Set Cluster name
 cluster.name: "docker-cluster-elastica"
 
-# Required plugins
-plugin.mandatory: mapper-attachments
-
-# For script tests
-script.inline: true
-
-script.engine.groovy.file: on
-
 # Limit threadpool by set number of available processors to 1
 # Without this, travis builds will be failed with OutOfMemory error
 processors: 1


### PR DESCRIPTION
these amends will allow to start ES 6.0 properly (mapper-attachments plugin, scripts.inline, groovy scripts has been removed)