### PR TITLE
Numeric to and from in aggregation date_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/5.3.0...master)
 
 ### Backward Compatibility Breaks
- 
+- Numeric to and from parameters in [date_range aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_aggregations_changes.html#_numeric_literal_to_literal_and_literal_from_literal_parameters_in_literal_date_range_literal_aggregation_are_interpreted_according_to_literal_format_literal_now) are interpreted according to format of the target field 
 ### Bugfixes
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,7 @@ tests:
 	make elastica-image
 	make start
 	mkdir -p build
-	#docker run --name=nginx -e "ES_HOST=elasticsearch" --network=elastica_esnet elastica_nginx nginx
-	#Elasticsearch 6.0.0-beta1
+
 	docker run -e "ES_HOST=elasticsearch" --network=elastica_esnet elastica_elastica  make phpunit
 	docker cp elastica:/elastica/build/coverage/ $(shell pwd)/build/coverage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     volumes:
       - esdata1:/usr/share/elasticsearch/data
     ports:
-      - 19200:19200
+      - 9200:9200
     networks:
       esnet:
         ipv4_address: 172.18.0.15


### PR DESCRIPTION
Numeric to and from parameters in date_range aggs are interpreted according to the format of the target field.

you can find more info [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_aggregations_changes.html#_numeric_literal_to_literal_and_literal_from_literal_parameters_in_literal_date_range_literal_aggregation_are_interpreted_according_to_literal_format_literal_now)