### PR TITLE
ES6 use strict type on boolean  (true|false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/5.3.0...master)
-
+ 
 ### Backward Compatibility Breaks
-- Numeric to and from parameters in [date_range aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_aggregations_changes.html#_numeric_literal_to_literal_and_literal_from_literal_parameters_in_literal_date_range_literal_aggregation_are_interpreted_according_to_literal_format_literal_now) are interpreted according to format of the target field 
+
+- Numeric to and from parameters in [date_range aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_aggregations_changes.html#_numeric_literal_to_literal_and_literal_from_literal_parameters_in_literal_date_range_literal_aggregation_are_interpreted_according_to_literal_format_literal_now) are interpreted according to format of the target field
+- In ES6 only [strict type boolean](https://github.com/elastic/elasticsearch/pull/22200) are accepted. [On ES6 docs](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/boolean.html)
+- removed analyzed/not_analyzed on [indices mapping](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-index.html)
+- [store](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-store.html) field only accepts boolean
+ 
 ### Bugfixes
 
 ### Added

--- a/test/Elastica/Query/BoostingTest.php
+++ b/test/Elastica/Query/BoostingTest.php
@@ -16,7 +16,7 @@ class BoostingTest extends BaseTest
         ['name' => 'Vital Match', 'price' => 2.1],
         ['name' => 'Mercury Vital', 'price' => 7.5],
         ['name' => 'Fist Mercury', 'price' => 3.8],
-        ['name' => 'Lama Vital 2nd', 'price' => 3.2],
+        ['name' => 'Lama Vital 2nd', 'price' => 1.2],
     ];
 
     protected function _getTestIndex()
@@ -24,7 +24,7 @@ class BoostingTest extends BaseTest
         $index = $this->_createIndex();
         $type = $index->getType('test');
         $type->setMapping([
-            'name' => ['type' => 'text', 'index' => 'analyzed'],
+            'name' => ['type' => 'text', 'index' => 'true'],
             'price' => ['type' => 'float'],
         ]);
         $docs = [];
@@ -68,7 +68,7 @@ class BoostingTest extends BaseTest
      */
     public function testNegativeBoost()
     {
-        $this->markTestSkipped('ES6 update: in mapping index accepts only strict boolean values (true|false) : https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-index.html');
+        $this->markTestSkipped('ES6 update: it looks like that boosting changes in ES6.0. did not find at the moment some docs on it. Results in 5.0 and 6.0 are differents.');
 
         $keyword = 'vital';
         $negativeKeyword = 'mercury';

--- a/test/Elastica/Query/FunctionScoreTest.php
+++ b/test/Elastica/Query/FunctionScoreTest.php
@@ -14,13 +14,11 @@ class FunctionScoreTest extends BaseTest
 
     protected function _getIndexForTest()
     {
-        $this->markTestSkipped('ES6 update: in mapping index accepts only strict boolean values (true|false) : https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-index.html');
-
         $index = $this->_createIndex();
         $type = $index->getType('test');
 
         $type->setMapping([
-            'name' => ['type' => 'text', 'index' => 'not_analyzed'],
+            'name' => ['type' => 'text', 'index' => 'false'],
             'location' => ['type' => 'geo_point'],
             'price' => ['type' => 'float'],
             'popularity' => ['type' => 'integer'],

--- a/test/Elastica/Query/MoreLikeThisTest.php
+++ b/test/Elastica/Query/MoreLikeThisTest.php
@@ -18,8 +18,6 @@ class MoreLikeThisTest extends BaseTest
      */
     public function testSearch()
     {
-        $this->markTestSkipped('ES6 update: in mapping index accepts only strict boolean values (true|false) : https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-index.html');
-
         $client = $this->_getClient();
         $index = new Index($client, 'test');
         $index->create([], true);
@@ -28,8 +26,8 @@ class MoreLikeThisTest extends BaseTest
 
         $type = new Type($index, 'helloworldmlt');
         $mapping = new Mapping($type, [
-            'email' => ['store' => 'true', 'type' => 'text', 'index' => 'analyzed'],
-            'content' => ['store' => 'true', 'type' => 'text',  'index' => 'analyzed'],
+            'email' => ['store' => 'true', 'type' => 'text', 'index' => 'true'],
+            'content' => ['store' => 'true', 'type' => 'text',  'index' => 'true'],
         ]);
 
         $mapping->setSource(['enabled' => false]);

--- a/test/Elastica/TypeTest.php
+++ b/test/Elastica/TypeTest.php
@@ -146,13 +146,11 @@ class TypeTest extends BaseTest
      */
     public function testNoSource()
     {
-        $this->markTestSkipped('ES6 update: in mapping store accepts only strict boolean values (true|false) : https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-store.html');
-
         $index = $this->_createIndex();
 
         $type = new Type($index, 'user');
         $mapping = new Mapping($type, [
-            'id' => ['type' => 'integer', 'store' => 'yes'],
+            'id' => ['type' => 'integer', 'store' => 'true'],
             'username' => ['type' => 'text'],
         ]);
         $mapping->setSource(['enabled' => false]);


### PR DESCRIPTION
Updated failing tests failing on boolean type or on legacy values

- Removed the use of values different from TRUE or FALSE as [strict boolean type](https://github.com/elastic/elasticsearch/pull/22200) implemented in ES6.

- Removed 'analyzed' and not analyzed as index mapping now accepts only TRUE|FALSE

- Updated the use of store mapping with BOOLEAN