### PR TITLE
Delete indices only by concrete name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file based on the
 - removed analyzed/not_analyzed on [indices mapping](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-index.html)
 - [store](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-store.html) field only accepts boolean
 - Replace IndexAlreadyExistsException with [ResourceAlreadyExistsException](https://github.com/elastic/elasticsearch/pull/21494) [#1350](https://github.com/ruflin/Elastica/pull/1350)
-   
+- in order to delete an index you should not delete by its alias now you should delete using the [concrete index name](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java#L445) [#1348](https://github.com/ruflin/Elastica/pull/1348)
+ 
 ### Bugfixes
 - Enforce [Content-Type requirement on the layer Rest](https://github.com/elastic/elasticsearch/pull/23146), a [PR on Elastica #1301](https://github.com/ruflin/Elastica/issues/1301) solved it (it has been implemented only in the HTTP Transport), but it was not implemented in the Guzzle Transport. [#1349](https://github.com/ruflin/Elastica/pull/1349)
   

--- a/test/Elastica/Query/BoostingTest.php
+++ b/test/Elastica/Query/BoostingTest.php
@@ -16,7 +16,7 @@ class BoostingTest extends BaseTest
         ['name' => 'Vital Match', 'price' => 2.1],
         ['name' => 'Mercury Vital', 'price' => 7.5],
         ['name' => 'Fist Mercury', 'price' => 3.8],
-        ['name' => 'Lama Vital 2nd', 'price' => 1.2],
+        ['name' => 'Lama Vital 2nd', 'price' => 3.2],
     ];
 
     protected function _getTestIndex()

--- a/test/Elastica/Query/MoreLikeThisTest.php
+++ b/test/Elastica/Query/MoreLikeThisTest.php
@@ -26,8 +26,8 @@ class MoreLikeThisTest extends BaseTest
 
         $type = new Type($index, 'helloworldmlt');
         $mapping = new Mapping($type, [
-            'email' => ['store' => 'true', 'type' => 'text', 'index' => 'true'],
-            'content' => ['store' => 'true', 'type' => 'text',  'index' => 'true'],
+            'email' => ['store' => true, 'type' => 'text', 'index' => true],
+            'content' => ['store' => true, 'type' => 'text',  'index' => true],
         ]);
 
         $mapping->setSource(['enabled' => false]);


### PR DESCRIPTION
It has been introduced a BC into ES 6 which force to delete an index *only* with [**concrete Index name**](https://github.com/elastic/elasticsearch/pull/25268). I've update a test, and created a new one to test the exception in case of index deletion by alias.