### PR TITLE
Enforce Content-Type requirement on the rest layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file based on the
 - [store](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-store.html) field only accepts boolean
  
 ### Bugfixes
-
+- Enforce [Content-Type requirement on the layer Rest](https://github.com/elastic/elasticsearch/pull/23146), a [PR on Elastica #1301](https://github.com/ruflin/Elastica/issues/1301) solved it (it has been implemented only in the HTTP Transport), but it was not implemented in the Guzzle Transport. [#1349](https://github.com/ruflin/Elastica/pull/1349)
+  
 ### Added
 
 - Added `Query\SpanContaining`, `Query\SpanWithin` and `Query\SpanNot` [#1319](https://github.com/ruflin/Elastica/pull/1319)

--- a/lib/Elastica/Transport/AwsAuthV4.php
+++ b/lib/Elastica/Transport/AwsAuthV4.php
@@ -5,6 +5,7 @@ use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\Signature\SignatureV4;
 use Elastica\Connection;
+use Elastica\Request;
 use GuzzleHttp;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
@@ -13,7 +14,7 @@ use Psr\Http\Message\RequestInterface;
 
 class AwsAuthV4 extends Guzzle
 {
-    protected function _getGuzzleClient($baseUrl, $persistent = true)
+    protected function _getGuzzleClient($baseUrl, $persistent = true, Request $request)
     {
         if (!$persistent || !self::$_guzzleClientConnection) {
             $stack = HandlerStack::create(GuzzleHttp\choose_handler());
@@ -22,6 +23,9 @@ class AwsAuthV4 extends Guzzle
             self::$_guzzleClientConnection = new Client([
                 'base_uri' => $baseUrl,
                 'handler' => $stack,
+                'headers' => [
+                    'Content-Type' => $request->getContentType()
+                ]
             ]);
         }
 

--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -53,7 +53,7 @@ class Guzzle extends AbstractTransport
     {
         $connection = $this->getConnection();
 
-        $client = $this->_getGuzzleClient($this->_getBaseUrl($connection), $connection->isPersistent());
+        $client = $this->_getGuzzleClient($this->_getBaseUrl($connection), $connection->isPersistent(), $request);
 
         $options = [
             'exceptions' => false, // 4xx and 5xx is expected and NOT an exceptions in this context
@@ -150,13 +150,19 @@ class Guzzle extends AbstractTransport
      *
      * @param string $baseUrl
      * @param bool   $persistent False if not persistent connection
+     * @param Request $request Elastica Request Object
      *
      * @return Client
      */
-    protected function _getGuzzleClient($baseUrl, $persistent = true)
+    protected function _getGuzzleClient($baseUrl, $persistent = true, Request $request)
     {
         if (!$persistent || !self::$_guzzleClientConnection) {
-            self::$_guzzleClientConnection = new Client(['base_uri' => $baseUrl]);
+            self::$_guzzleClientConnection = new Client([
+                'base_uri' => $baseUrl,
+                'headers' => [
+                    'Content-Type' => $request->getContentType()
+                ]
+            ]);
         }
 
         return self::$_guzzleClientConnection;

--- a/test/Elastica/Transport/GuzzleTest.php
+++ b/test/Elastica/Transport/GuzzleTest.php
@@ -44,8 +44,6 @@ class GuzzleTest extends BaseTest
      */
     public function testDynamicHttpMethodBasedOnConfigParameter(array $config, $httpMethod)
     {
-        $this->markTestSkipped('ES6 update: Content-Type header [] is not supported');
-
         $client = $this->_getClient($config);
 
         $index = $client->getIndex('dynamic_http_method_test');
@@ -140,8 +138,6 @@ class GuzzleTest extends BaseTest
      */
     public function testBodyReuse()
     {
-        $this->markTestSkipped('ES6 update: Content-Type header [] is not supported');
-
         $client = $this->_getClient(['transport' => 'Guzzle', 'persistent' => false]);
         $index = $client->getIndex('elastica_body_reuse_test');
         $index->create([], true);


### PR DESCRIPTION
Due to a change on Elastica 5.3 a PR was open #1301, the problem is that the update was done only to HTTP Transport and not to the Guzzle one. This update solve 7/8 skipped tests on **ES6**.

PR #1301 on Elastica
Elasticsearch BC : Enforces Content-Type on the [Rest Layer](https://github.com/elastic/elasticsearch/pull/23146) 