### PR TITLE
Replace IndexAlreadyExistsException with ResourceAlreadyExistsException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file based on the
 - In ES6 only [strict type boolean](https://github.com/elastic/elasticsearch/pull/22200) are accepted. [On ES6 docs](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/boolean.html)
 - removed analyzed/not_analyzed on [indices mapping](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-index.html)
 - [store](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-store.html) field only accepts boolean
- 
+- Replace IndexAlreadyExistsException with [ResourceAlreadyExistsException](https://github.com/elastic/elasticsearch/pull/21494) [#1350](https://github.com/ruflin/Elastica/pull/1350)
+   
 ### Bugfixes
 
 ### Added

--- a/test/Elastica/Exception/ResponseExceptionTest.php
+++ b/test/Elastica/Exception/ResponseExceptionTest.php
@@ -11,8 +11,6 @@ class ResponseExceptionTest extends AbstractExceptionTest
      */
     public function testCreateExistingIndex()
     {
-        $this->markTestSkipped('ES6 update: looks like now ES6 returns a different exception --> resource_already_exists_exception ');
-
         $this->_createIndex('woo', true);
 
         try {
@@ -20,7 +18,9 @@ class ResponseExceptionTest extends AbstractExceptionTest
             $this->fail('Index created when it should fail');
         } catch (ResponseException $ex) {
             $error = $ex->getResponse()->getFullError();
-            $this->assertEquals('index_already_exists_exception', $error['type']);
+
+            $this->assertNotEquals('index_already_exists_exception', $error['type']);
+            $this->assertEquals('resource_already_exists_exception', $error['type']);
             $this->assertEquals(400, $ex->getResponse()->getStatus());
         }
     }


### PR DESCRIPTION
In **Elasticsearch 6.0-alpha1** :

- IndexAlreadyExistsException
- IndexTemplateAlreadyExistsException
- IndexShardAlreadyExistsException

have been removed and replaced by *[ResourceAlreadyExistsException](https://github.com/elastic/elasticsearch/pull/21494)*
