### PR TITLE
Remove Index Optimize as removed in 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to this project will be documented in this file based on the
 - removed analyzed/not_analyzed on [indices mapping](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-index.html)
 - [store](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/mapping-store.html) field only accepts boolean
 - Replace IndexAlreadyExistsException with [ResourceAlreadyExistsException](https://github.com/elastic/elasticsearch/pull/21494) [#1350](https://github.com/ruflin/Elastica/pull/1350)
-- in order to delete an index you should not delete by its alias now you should delete using the [concrete index name](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java#L445) [#1348](https://github.com/ruflin/Elastica/pull/1348)
- 
+- in order to delete an index you should not delete by its alias now you should delete using the [concrete index name](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java#L445) [#1348](https://github.com/ruflin/Elastica/pull/1348) 
+- Removed ```optimize``` from Index class as it has been deprecated in ES 2.1 and removed in [ES 5.x+](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-optimize.html) use forcemerge [#1351](https://github.com/ruflin/Elastica/pull/1350)
+
 ### Bugfixes
 - Enforce [Content-Type requirement on the layer Rest](https://github.com/elastic/elasticsearch/pull/23146), a [PR on Elastica #1301](https://github.com/ruflin/Elastica/issues/1301) solved it (it has been implemented only in the HTTP Transport), but it was not implemented in the Guzzle Transport. [#1349](https://github.com/ruflin/Elastica/pull/1349)
   

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -201,25 +201,6 @@ class Index implements SearchableInterface
     }
 
     /**
-     * Optimizes search index.
-     *
-     * Detailed arguments can be found here in the link
-     *
-     * @param array $args OPTIONAL Additional arguments
-     *
-     * @return array Server response
-     *
-     * @deprecated Replaced by forcemerge
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-optimize.html
-     */
-    public function optimize($args = [])
-    {
-        trigger_error('Deprecated: Elastica\Index::optimize() is deprecated and will be removed in further Elastica releases. Use Elastica\Index::forcemerge() instead.', E_USER_DEPRECATED);
-
-        return $this->forcemerge($args);
-    }
-
-    /**
      * Force merges index.
      *
      * Detailed arguments can be found here in the link


### PR DESCRIPTION
Index Optimize has been deprecated in Elasticsearch 2.1 and removed in ES 5.x, so I suggest to remove it as it is recommended to use force_merge instead.

[Index Optimize Deprecation](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-optimize.html)