### PR TITLE
In QueryString cannot use [fields] parameter in conjunction with [default_field]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this project will be documented in this file based on the
 - Replace IndexAlreadyExistsException with [ResourceAlreadyExistsException](https://github.com/elastic/elasticsearch/pull/21494) [#1350](https://github.com/ruflin/Elastica/pull/1350)
 - in order to delete an index you should not delete by its alias now you should delete using the [concrete index name](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java#L445) [#1348](https://github.com/ruflin/Elastica/pull/1348) 
 - Removed ```optimize``` from Index class as it has been deprecated in ES 2.1 and removed in [ES 5.x+](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-optimize.html) use forcemerge [#1351](https://github.com/ruflin/Elastica/pull/1350)
-
+- In QueryString is not allowed to use fields parameters in conjunction with default_field parameter. This is not well documented, it's possibile to understand from [Elasticsearch tests :  QueryStringQueryBuilderTests.java](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java#L917) [#1352](https://github.com/ruflin/Elastica/pull/1352)
+   
 ### Bugfixes
 - Enforce [Content-Type requirement on the layer Rest](https://github.com/elastic/elasticsearch/pull/23146), a [PR on Elastica #1301](https://github.com/ruflin/Elastica/issues/1301) solved it (it has been implemented only in the HTTP Transport), but it was not implemented in the Guzzle Transport. [#1349](https://github.com/ruflin/Elastica/pull/1349)
   

--- a/lib/Elastica/Query/QueryString.php
+++ b/lib/Elastica/Query/QueryString.php
@@ -49,6 +49,7 @@ class QueryString extends AbstractQuery
 
     /**
      * Sets the default field.
+     * You cannot set fields and default_field
      *
      * If no field is set, _all is chosen
      *
@@ -202,6 +203,7 @@ class QueryString extends AbstractQuery
 
     /**
      * Sets the fields. If no fields are set, _all is chosen.
+     * You cannot set fields and default_field
      *
      * @param array $fields Fields
      *


### PR DESCRIPTION
In QueryString cannot use anymore [fields] parameter in conjunction with [default_field]. There was a test failing because of an exception : **QueryValidationException**

After having a look a the docs on Es6 Breaking changes I did not find anything reporting this BC, the only way to check it is having a look at Elasticsearch 6.0+ source code.

Inside [QueryStringQueryBuilderTests.java](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java) there a new test [testDefaultFieldsWithFields](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java#L917) which checks exactly if both parameters are set and in case raise a QueryValidationException. 

I also implement a test to check for that Exception.