### PR TITLE
Index mapping field of type 'string' has been removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ All notable changes to this project will be documented in this file based on the
 - Replace IndexAlreadyExistsException with [ResourceAlreadyExistsException](https://github.com/elastic/elasticsearch/pull/21494) [#1350](https://github.com/ruflin/Elastica/pull/1350)
 - in order to delete an index you should not delete by its alias now you should delete using the [concrete index name](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/aliases/IndexAliasesIT.java#L445) [#1348](https://github.com/ruflin/Elastica/pull/1348) 
 - Removed ```optimize``` from Index class as it has been deprecated in ES 2.1 and removed in [ES 5.x+](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-optimize.html) use forcemerge [#1351](https://github.com/ruflin/Elastica/pull/1350)
-- In QueryString is not allowed to use fields parameters in conjunction with default_field parameter. This is not well documented, it's possibile to understand from [Elasticsearch tests :  QueryStringQueryBuilderTests.java](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java#L917) [#1352](https://github.com/ruflin/Elastica/pull/1352)
-   
+- In QueryString is not allowed to use fields parameters in conjunction with default_field parameter. This is not well documented, it's possibile to understand from [Elasticsearch tests :  QueryStringQueryBuilderTests.java](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java#L917) [#1352](https://github.com/ruflin/Elastica/pull/1352)   
+- Index mapping field of type [*'string'*](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/string.html) has been removed from Elasticsearch 6.0 codebase [#1353](https://github.com/ruflin/Elastica/pull/1353)
+
 ### Bugfixes
 - Enforce [Content-Type requirement on the layer Rest](https://github.com/elastic/elasticsearch/pull/23146), a [PR on Elastica #1301](https://github.com/ruflin/Elastica/issues/1301) solved it (it has been implemented only in the HTTP Transport), but it was not implemented in the Guzzle Transport. [#1349](https://github.com/ruflin/Elastica/pull/1349)
   
@@ -24,6 +25,7 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 
 ### Deprecated
+
 
 ## [5.3.0](https://github.com/ruflin/Elastica/compare/5.2.1...5.3.0)
 

--- a/test/Elastica/TypeTest.php
+++ b/test/Elastica/TypeTest.php
@@ -509,21 +509,19 @@ class TypeTest extends BaseTest
      */
     public function testGetDocumentWithFieldsSelection()
     {
-        $this->markTestSkipped('ES6 update: No handler for type [string] declared on field [name]');
-
         $index = $this->_createIndex();
 
         $type = new Type($index, 'test');
         $mapping = new Mapping();
         $mapping->setProperties([
             'name' => [
-                'type' => 'string',
-                'store' => 'yes', ],
+                'type' => 'text',
+                'store' => true, ],
             'email' => [
-                'type' => 'string',
-                'store' => 'yes', ],
+                'type' => 'text',
+                'store' => true, ],
             'country' => [
-                'type' => 'string',
+                'type' => 'text',
             ],
         ]);
 


### PR DESCRIPTION
Index mapping field of type 'string' has been removed in Elasticsearch 6. It was deprecated in 5.0.
In order to make tests pass, I changed the value yes to boolean, due to strict boolean type implemented in 6.0

https://www.elastic.co/guide/en/elasticsearch/reference/5.5/string.html