### PR TITLE
HTTP Transport already append / between path and host+port

### DIFF
--- a/test/Elastica/Connection/Strategy/CallbackStrategyTest.php
+++ b/test/Elastica/Connection/Strategy/CallbackStrategyTest.php
@@ -75,8 +75,6 @@ class CallbackStrategyTest extends Base
      */
     public function testConnection()
     {
-        $this->markTestSkipped('ES6 update: Incorrect HTTP method for uri [//_aliases] and method [GET], allowed: [PUT]');
-
         $count = 0;
 
         $config = ['connectionStrategy' => function ($connections) use (&$count) {
@@ -86,7 +84,7 @@ class CallbackStrategyTest extends Base
        }];
 
         $client = $this->_getClient($config);
-        $response = $client->request('/_aliases');
+        $response = $client->request('_aliases');
 
         $this->assertEquals(1, $count);
 

--- a/test/Elastica/Connection/Strategy/RoundRobinTest.php
+++ b/test/Elastica/Connection/Strategy/RoundRobinTest.php
@@ -24,11 +24,9 @@ class RoundRobinTest extends Base
      */
     public function testConnection()
     {
-        $this->markTestSkipped('ES6 update: Incorrect HTTP method for uri [//_aliases] and method [GET], allowed: [PUT]');
-
         $config = ['connectionStrategy' => 'RoundRobin'];
         $client = $this->_getClient($config);
-        $response = $client->request('/_aliases');
+        $response = $client->request('_aliases');
         /* @var $response Response */
 
         $this->_checkResponse($response);
@@ -58,7 +56,7 @@ class RoundRobinTest extends Base
 
         $this->_checkStrategy($client);
 
-        $client->request('/_aliases');
+        $client->request('_aliases');
     }
 
     /**
@@ -66,8 +64,6 @@ class RoundRobinTest extends Base
      */
     public function testWithOneFailConnection()
     {
-        $this->markTestSkipped('ES6 update: Incorrect HTTP method for uri [//_aliases] and method [GET], allowed: [PUT]');
-
         $connections = [
             new Connection(['host' => '255.255.255.0', 'timeout' => $this->_timeout]),
             new Connection(['host' => $this->_getHost(), 'timeout' => $this->_timeout]),
@@ -81,7 +77,7 @@ class RoundRobinTest extends Base
         $client = $this->_getClient(['connectionStrategy' => 'RoundRobin'], $callback);
         $client->setConnections($connections);
 
-        $response = $client->request('/_aliases');
+        $response = $client->request('_aliases');
         /* @var $response Response */
 
         $this->_checkResponse($response);
@@ -110,7 +106,7 @@ class RoundRobinTest extends Base
         $client->setConnections($connections);
 
         try {
-            $client->request('/_aliases');
+            $client->request('_aliases');
             $this->fail('Should throw exception as no connection valid');
         } catch (ConnectionException $e) {
             $this->assertEquals(count($connections), $count);

--- a/test/Elastica/Connection/Strategy/SimpleTest.php
+++ b/test/Elastica/Connection/Strategy/SimpleTest.php
@@ -23,10 +23,8 @@ class SimpleTest extends Base
      */
     public function testConnection()
     {
-        $this->markTestSkipped('ES6 update: Incorrect HTTP method for uri [//_aliases] and method [GET], allowed: [PUT]');
-
         $client = $this->_getClient();
-        $response = $client->request('/_aliases');
+        $response = $client->request('_aliases');
 
         $this->_checkResponse($response);
 
@@ -44,7 +42,7 @@ class SimpleTest extends Base
 
         $this->_checkStrategy($client);
 
-        $client->request('/_aliases');
+        $client->request('_aliases');
     }
 
     /**
@@ -52,8 +50,6 @@ class SimpleTest extends Base
      */
     public function testWithOneFailConnection()
     {
-        $this->markTestSkipped('ES6 update: Incorrect HTTP method for uri [//_aliases] and method [GET], allowed: [PUT]');
-
         $connections = [
             new Connection(['host' => '255.255.255.0', 'timeout' => $this->_timeout]),
             new Connection(['host' => $this->_getHost(), 'timeout' => $this->_timeout]),
@@ -67,7 +63,7 @@ class SimpleTest extends Base
         $client = $this->_getClient([], $callback);
         $client->setConnections($connections);
 
-        $response = $client->request('/_aliases');
+        $response = $client->request('_aliases');
         /* @var $response Response */
 
         $this->_checkResponse($response);
@@ -96,7 +92,7 @@ class SimpleTest extends Base
         $client->setConnections($connections);
 
         try {
-            $client->request('/_aliases');
+            $client->request('_aliases');
             $this->fail('Should throw exception as no connection valid');
         } catch (ConnectionException $e) {
             $this->assertEquals(count($connections), $count);


### PR DESCRIPTION
There are many failing tests in Connection\Strategy classes that fails because the *_aliases* enpoint
are called with a slash that is already appened in HTTP Transport. So the final **GET** will be

*curl localhost:9200//_aliases*

This endpoint didn't reaised exception in ES 5.x, now it returns this error : 

```Incorrect HTTP method for uri [//_aliases] and method [GET], allowed: [PUT]","status":405```

With guzzle transport this doesn't happened 'cause guzzle solve this problem. I thought initially to add a test inside HttpTest.php, but I think that this is a responsibility of the developer.

@ruflin  What do you think ?