### PR TITLE
Drop php5.x support, and remove old support classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ branches:
     - master
 
 env:
-  - TARGET="56"
   - TARGET="70"
   - TARGET="71"
 

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": "^7.0",
         "psr/log": "~1.0",
-        "elasticsearch/elasticsearch": "5.3.0"
+        "elasticsearch/elasticsearch": "dev-master"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.0",
         "psr/log": "~1.0",
-        "elasticsearch/elasticsearch": "dev-master"
+        "elasticsearch/elasticsearch": "6.0.0-beta1"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",


### PR DESCRIPTION
- Dropped support for **php5**
- update .travis.yml to execute tests only on 7.x php platforms
- update docker elastica configuration : removed Docker56 file
- remove Bool & Null classes (they worked only on 5.x php versions)
- set **dev-master** for elasticsearch-php until they released a stable version