### PR TITLE
Querystring bool values should be a string

### DIFF
--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -61,6 +61,23 @@ abstract class AbstractTransport extends Param
     abstract public function exec(Request $request, array $params);
 
     /**
+     * BOOL values true|false should be sanityzed and passed to Elasticsearch
+     * as string.
+     *
+     * @param string $query
+     * @return mixed
+     */
+    public function sanityzeQueryStringBool($query)
+    {
+        foreach ($query as $key => $value) {
+            if (is_bool($value)) {
+                $query[$key] = ($value) ? 'true' : 'false';
+            }
+        }
+        return $query;
+    }
+
+    /**
      * Create a transport.
      *
      * The $transport parameter can be one of the following values:

--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -215,7 +215,9 @@ class Guzzle extends AbstractTransport
         $query = $request->getQuery();
 
         if (!empty($query)) {
-            $action .= '?'.http_build_query($query);
+            $action .= '?'.http_build_query(
+                $this->sanityzeQueryStringBool($query)
+                );
         }
 
         return $action;

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -69,8 +69,12 @@ class Http extends AbstractTransport
         $query = $request->getQuery();
 
         if (!empty($query)) {
-            $baseUri .= '?'.http_build_query($query);
+
+            $baseUri .= '?'.http_build_query(
+                $this->sanityzeQueryStringBool($query)
+                );
         }
+
 
         curl_setopt($conn, CURLOPT_URL, $baseUri);
         curl_setopt($conn, CURLOPT_TIMEOUT, $connection->getTimeout());

--- a/test/Elastica/SearchTest.php
+++ b/test/Elastica/SearchTest.php
@@ -428,8 +428,6 @@ class SearchTest extends BaseTest
      */
     public function testSearchWithVersionOption()
     {
-        $this->markTestSkipped('ES6 update: Failed to parse value [1] as only [true] or [false] are allowed.');
-
         $index = $this->_createIndex();
         $doc = new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'ruflin']);
         $index->getType('test')->addDocument($doc);

--- a/test/Elastica/SnapshotTest.php
+++ b/test/Elastica/SnapshotTest.php
@@ -64,8 +64,6 @@ class SnapshotTest extends Base
      */
     public function testSnapshotAndRestore()
     {
-        $this->markTestSkipped('ES6 update: Failed to parse value [1] as only [true] or [false] are allowed.');
-
         $repositoryName = 'testrepo';
         $location = $this->_snapshotPath.'backup2';
 

--- a/test/Elastica/Transport/AbstractTransportTest.php
+++ b/test/Elastica/Transport/AbstractTransportTest.php
@@ -2,11 +2,32 @@
 namespace Elastica\Test\Transport;
 
 use Elastica\Connection;
+use Elastica\Document;
+use Elastica\Exception\ResponseException;
+use Elastica\Search;
 use Elastica\Transport\AbstractTransport;
 use Elastica\Transport\Http;
+use Elastica\Test\Base as BaseTest;
 
-class AbstractTransportTest extends \PHPUnit_Framework_TestCase
+class AbstractTransportTest extends BaseTest
 {
+    /**
+     * Return transport configuration and the expected HTTP method.
+     *
+     * @return array[]
+     */
+    public function getTransport()
+    {
+        return [
+            [
+                ['transport' => 'Http', 'curl' => [CURLINFO_HEADER_OUT => true]]
+            ],
+            [
+                ['transport' => 'Guzzle', 'curl' => [CURLINFO_HEADER_OUT => true]]
+            ]
+        ];
+    }
+
     /**
      * Return transport configuration and the expected HTTP method.
      *
@@ -77,5 +98,41 @@ class AbstractTransportTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('value1', $transport->getParam('param1'));
         $this->assertSame('value2', $transport->getParam('param2'));
         $this->assertSame('value3', $transport->getParam('param3'));
+    }
+
+    /**
+     * This test check that boolean values in the querystring
+     * are passed as string (true|false) and not with other values
+     * due to boolean strict type in ES
+     *
+     * @group functional
+     * @dataProvider getTransport
+     */
+    public function testBooleanStringValues($transport)
+    {
+        $client = $this->_getClient($transport);
+        $index = $client->getIndex('elastica_testbooleanstringvalues');
+
+        $doc = new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'ruflin']);
+        $index->getType('test')->addDocument($doc);
+        $index->refresh();
+
+        $search = new Search($index->getClient());
+        $search->addIndex($index);
+
+        // Added version param to result
+        try {
+            $results = $search->search([], ['version' => true]);
+            $this->assertTrue(true);
+        } catch (ResponseException $e) {
+            $this->fail('Failed to parse value [1] as only [true] or [false] are allowed.');
+        }
+
+
+        if ($transport['transport'] == 'Http') {
+            $info = $results->getResponse()->getTransferInfo();
+            $url = $info['url'];
+            $this->assertStringEndsWith('version=true', $url);
+        }
     }
 }

--- a/test/Elastica/TypeTest.php
+++ b/test/Elastica/TypeTest.php
@@ -671,7 +671,7 @@ class TypeTest extends BaseTest
             $this->assertContains('can\'t provide both upsert request and a version', $error['reason']);
         }
         $updatedDoc = $type->getDocument($id)->getData();
-        var_dump($updatedDoc);
+
         $this->assertNotEquals($newName, $updatedDoc['name'], 'Name was updated');
         $this->assertNotEquals(3, $updatedDoc['counter'], 'Counter was incremented');
     }


### PR DESCRIPTION
Due to ES 6.0 bool strict type, boolean values in as url parameters (querystring) should be passed as string (true|false). Http & Guzzle Transport use to pass bool as php do so **true** was converted to **1**. 

Due to strict type hint only "true" and "false" are allowed I updated AbtractTransport and implemented a simple sanityzer that convert boolean values to String, and implemented a functional test to check it.