### PR TITLE
Update tests with two mapping type and some other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file based on the
 - In QueryString is not allowed to use fields parameters in conjunction with default_field parameter. This is not well documented, it's possibile to understand from [Elasticsearch tests :  QueryStringQueryBuilderTests.java](https://github.com/elastic/elasticsearch/blob/6.0/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java#L917) [#1352](https://github.com/ruflin/Elastica/pull/1352)   
 - Index mapping field of type [*'string'*](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/string.html) has been removed from Elasticsearch 6.0 codebase [#1353](https://github.com/ruflin/Elastica/pull/1353)
 - The [created and found](https://github.com/elastic/elasticsearch/pull/25516) fields in index and delete responses became obsolete after the introduction of the result field in index, update and delete responses [#1354](https://github.com/ruflin/Elastica/pull/1354) 
- 
+
 ### Bugfixes
 - Enforce [Content-Type requirement on the layer Rest](https://github.com/elastic/elasticsearch/pull/23146), a [PR on Elastica #1301](https://github.com/ruflin/Elastica/issues/1301) solved it (it has been implemented only in the HTTP Transport), but it was not implemented in the Guzzle Transport. [#1349](https://github.com/ruflin/Elastica/pull/1349)
 - Scroll no longer does an extra iteration both on an empty result and on searches where the last page has a significantly smaller number of results than the pages before it.

--- a/test/Elastica/Base.php
+++ b/test/Elastica/Base.php
@@ -135,7 +135,7 @@ class Base extends \PHPUnit_Framework_TestCase
         $nodes = $this->_getClient()->getCluster()->getNodes();
         $scriptInline = $nodes[0]->getInfo()->get('settings', 'script', 'inline');
 
-        if ($scriptInline != 'true' && $this->_getVersion() < 6) {
+        if ($this->_getVersion() < 6 && $scriptInline != 'true') {
             $this->markTestSkipped('script.inline is not enabled. This is required for this test');
         }
     }

--- a/test/Elastica/BulkTest.php
+++ b/test/Elastica/BulkTest.php
@@ -22,11 +22,11 @@ class BulkTest extends BaseTest
      */
     public function testSend()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
         $index = $this->_createIndex();
+        $index2 = $this->_createIndex();
         $indexName = $index->getName();
         $type = $index->getType('bulk_test');
-        $type2 = $index->getType('bulk_test2');
+        $type2 = $index2->getType('bulk_test2');
         $client = $index->getClient();
 
         $newDocument1 = $type->createDocument(1, ['name' => 'Mister Fantastic']);
@@ -125,6 +125,7 @@ class BulkTest extends BaseTest
         $bulk->send();
 
         $type->getIndex()->refresh();
+        $type2->getIndex()->refresh();
 
         $this->assertEquals(2, $type->count());
 
@@ -142,8 +143,9 @@ class BulkTest extends BaseTest
     public function testUnicodeBulkSend()
     {
         $index = $this->_createIndex();
+        $index2 = $this->_createIndex();
         $type = $index->getType('bulk_test');
-        $type2 = $index->getType('bulk_test2');
+        $type2 = $index2->getType('bulk_test2');
         $client = $index->getClient();
 
         $newDocument1 = $type->createDocument(1, ['name' => 'Сегодня, я вижу, особенно грустен твой взгляд,']);

--- a/test/Elastica/ClientTest.php
+++ b/test/Elastica/ClientTest.php
@@ -1309,18 +1309,18 @@ class ClientTest extends BaseTest
      */
     public function testEndpointParamsRequest()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
         $index = $this->_createIndex();
+        $index2 = $this->_createIndex();
         $client = $index->getClient();
         $type = $index->getType('test');
         $doc = new Document(null, ['foo' => 'bar']);
         $doc->setRouting('first_routing');
         $type->addDocument($doc);
 
-        $type2 = $index->getType('foobar');
-        $doc = new Document(null, ['foo2' => 'bar2']);
+        $type2 = $index2->getType('foobar');
+        $doc2 = new Document(null, ['foo2' => 'bar2']);
         $doc->setRouting('second_routing');
-        $type2->addDocument($doc);
+        $type2->addDocument($doc2);
 
         $index->refresh();
 

--- a/test/Elastica/Index/SettingsTest.php
+++ b/test/Elastica/Index/SettingsTest.php
@@ -91,10 +91,7 @@ class SettingsTest extends BaseTest
      */
     public function testSetGetNumberOfReplicas()
     {
-        $indexName = 'test';
-
-        $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
+        $index = $this->_createIndex();
         $index->create([], true);
         $settings = $index->getSettings();
 
@@ -118,10 +115,7 @@ class SettingsTest extends BaseTest
      */
     public function testGetNumberOfReplicas()
     {
-        $indexName = 'test';
-
-        $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
+        $index = $this->_createIndex();
         $index->create([], true);
 
         $settings = $index->getSettings();
@@ -138,10 +132,7 @@ class SettingsTest extends BaseTest
      */
     public function testGetNumberOfShards()
     {
-        $indexName = 'test';
-
-        $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
+        $index = $this->_createIndex();
         $index->create(['index' => ['number_of_shards' => 1]], true);
 
         $settings = $index->getSettings();
@@ -158,10 +149,7 @@ class SettingsTest extends BaseTest
      */
     public function testGetDefaultNumberOfShards()
     {
-        $indexName = 'test';
-
-        $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
+        $index = $this->_createIndex();
         $index->create([], true);
 
         $settings = $index->getSettings();
@@ -178,10 +166,7 @@ class SettingsTest extends BaseTest
      */
     public function testSetRefreshInterval()
     {
-        $indexName = 'test';
-
-        $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
+        $index = $this->_createIndex();
         $index->create([], true);
 
         $settings = $index->getSettings();
@@ -202,10 +187,7 @@ class SettingsTest extends BaseTest
      */
     public function testGetRefreshInterval()
     {
-        $indexName = 'test';
-
-        $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
+        $index = $this->_createIndex();
         $index->create([], true);
 
         $settings = $index->getSettings();
@@ -226,10 +208,7 @@ class SettingsTest extends BaseTest
      */
     public function testSetMergePolicy()
     {
-        $indexName = 'test';
-
-        $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
+        $index = $this->_createIndex();
         $index->create([], true);
         //wait for the shards to be allocated
         $this->_waitForAllocation($index);
@@ -250,10 +229,7 @@ class SettingsTest extends BaseTest
      */
     public function testSetMaxMergeAtOnce()
     {
-        $indexName = 'test';
-
-        $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
+        $index = $this->_createIndex();
         $index->create([], true);
 
         //wait for the shards to be allocated
@@ -412,10 +388,7 @@ class SettingsTest extends BaseTest
      */
     public function testSetMultiple()
     {
-        $indexName = 'test';
-
-        $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
+        $index = $this->_createIndex();
         $index->create([], true);
 
         $settings = $index->getSettings();

--- a/test/Elastica/IndexTest.php
+++ b/test/Elastica/IndexTest.php
@@ -356,22 +356,17 @@ class IndexTest extends BaseTest
      */
     public function testDeleteByQueryWithQueryString()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $index = $this->_createIndex();
         $type1 = new Type($index, 'test1');
         $type1->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type1->addDocument(new Document(2, ['name' => 'ruflin']));
-        $type2 = new Type($index, 'test2');
-        $type2->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
-        $type2->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
 
         $response = $index->search('ruflin*');
-        $this->assertEquals(4, $response->count());
+        $this->assertEquals(2, $response->count());
 
         $response = $index->search('nicolas');
-        $this->assertEquals(2, $response->count());
+        $this->assertEquals(1, $response->count());
 
         // Delete first document
         $response = $index->deleteByQuery('nicolas');
@@ -381,7 +376,7 @@ class IndexTest extends BaseTest
 
         // Makes sure, document is deleted
         $response = $index->search('ruflin*');
-        $this->assertEquals(2, $response->count());
+        $this->assertEquals(1, $response->count());
 
         $response = $index->search('nicolas');
         $this->assertEquals(0, $response->count());
@@ -392,22 +387,17 @@ class IndexTest extends BaseTest
      */
     public function testDeleteByQueryWithQuery()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $index = $this->_createIndex();
         $type1 = new Type($index, 'test1');
         $type1->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type1->addDocument(new Document(2, ['name' => 'ruflin']));
-        $type2 = new Type($index, 'test2');
-        $type2->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
-        $type2->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
 
         $response = $index->search('ruflin*');
-        $this->assertEquals(4, $response->count());
+        $this->assertEquals(2, $response->count());
 
         $response = $index->search('nicolas');
-        $this->assertEquals(2, $response->count());
+        $this->assertEquals(1, $response->count());
 
         // Delete first document
         $response = $index->deleteByQuery(new SimpleQueryString('nicolas'));
@@ -417,7 +407,7 @@ class IndexTest extends BaseTest
 
         // Makes sure, document is deleted
         $response = $index->search('ruflin*');
-        $this->assertEquals(2, $response->count());
+        $this->assertEquals(1, $response->count());
 
         $response = $index->search('nicolas');
         $this->assertEquals(0, $response->count());
@@ -428,22 +418,17 @@ class IndexTest extends BaseTest
      */
     public function testDeleteByQueryWithArrayQuery()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $index = $this->_createIndex();
         $type1 = new Type($index, 'test1');
         $type1->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type1->addDocument(new Document(2, ['name' => 'ruflin']));
-        $type2 = new Type($index, 'test2');
-        $type2->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
-        $type2->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
 
         $response = $index->search('ruflin*');
-        $this->assertEquals(4, $response->count());
+        $this->assertEquals(2, $response->count());
 
         $response = $index->search('nicolas');
-        $this->assertEquals(2, $response->count());
+        $this->assertEquals(1, $response->count());
 
         // Delete first document
         $response = $index->deleteByQuery(['query' => ['query_string' => ['query' => 'nicolas']]]);
@@ -453,7 +438,7 @@ class IndexTest extends BaseTest
 
         // Makes sure, document is deleted
         $response = $index->search('ruflin*');
-        $this->assertEquals(2, $response->count());
+        $this->assertEquals(1, $response->count());
 
         $response = $index->search('nicolas');
         $this->assertEquals(0, $response->count());
@@ -464,58 +449,88 @@ class IndexTest extends BaseTest
      */
     public function testDeleteByQueryWithQueryAndOptions()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $index = $this->_createIndex(null, true, 2);
+        $index2 = $this->_createIndex(null, true, 2);
 
         $routing1 = 'first_routing';
         $routing2 = 'second_routing';
 
-        for ($i = 1; $i <= 2; ++$i) {
-            $type = new Type($index, 'test'.$i);
-            $doc = new Document(1, ['name' => 'ruflin nicolas']);
-            $doc->setRouting($routing1);
-            $type->addDocument($doc);
 
-            $doc = new Document(2, ['name' => 'ruflin']);
-            $doc->setRouting($routing1);
-            $type->addDocument($doc);
-        }
+        $type = new Type($index, 'test');
+        $doc = new Document(1, ['name' => 'ruflin nicolas']);
+        $doc->setRouting($routing1);
+        $type->addDocument($doc);
+
+        $doc = new Document(2, ['name' => 'ruflin']);
+        $doc->setRouting($routing1);
+        $type->addDocument($doc);
+
+        $type = new Type($index2, 'test');
+        $doc = new Document(1, ['name' => 'ruflin nicolas']);
+        $doc->setRouting($routing1);
+        $type->addDocument($doc);
+
+        $doc = new Document(2, ['name' => 'ruflin']);
+        $doc->setRouting($routing1);
+        $type->addDocument($doc);
 
         $index->refresh();
+        $index2->refresh();
 
         $response = $index->search('ruflin*');
-        $this->assertEquals(4, $response->count());
+        $this->assertEquals(2, $response->count());
+        $response = $index2->search('ruflin*');
+        $this->assertEquals(2, $response->count());
 
         $response = $index->search('ruflin*', ['routing' => $routing2]);
         $this->assertEquals(0, $response->count());
+        $response = $index2->search('ruflin*', ['routing' => $routing2]);
+        $this->assertEquals(0, $response->count());
 
         $response = $index->search('nicolas');
-        $this->assertEquals(2, $response->count());
+        $this->assertEquals(1, $response->count());
+        $response = $index2->search('nicolas');
+        $this->assertEquals(1, $response->count());
 
         // Route to the wrong document id; should not delete
         $response = $index->deleteByQuery(new SimpleQueryString('nicolas'), ['routing' => $routing2]);
         $this->assertTrue($response->isOk());
 
+        // Route to the wrong document id; should not delete
+        $response = $index2->deleteByQuery(new SimpleQueryString('nicolas'), ['routing' => $routing2]);
+        $this->assertTrue($response->isOk());
+
         $index->refresh();
+        $index2->refresh();
 
         $response = $index->search('ruflin*');
-        $this->assertEquals(4, $response->count());
+        $this->assertEquals(2, $response->count());
+        $response = $index2->search('ruflin*');
+        $this->assertEquals(2, $response->count());
 
         $response = $index->search('nicolas');
-        $this->assertEquals(2, $response->count());
+        $this->assertEquals(1, $response->count());
+        $response = $index2->search('nicolas');
+        $this->assertEquals(1, $response->count());
 
         // Delete first document
         $response = $index->deleteByQuery(new SimpleQueryString('nicolas'), ['routing' => $routing1]);
         $this->assertTrue($response->isOk());
+        $response = $index2->deleteByQuery(new SimpleQueryString('nicolas'), ['routing' => $routing1]);
+        $this->assertTrue($response->isOk());
 
         $index->refresh();
+        $index2->refresh();
 
         // Makes sure, document is deleted
         $response = $index->search('ruflin*');
-        $this->assertEquals(2, $response->count());
+        $this->assertEquals(1, $response->count());
+        $response = $index2->search('ruflin*');
+        $this->assertEquals(1, $response->count());
 
         $response = $index->search('nicolas');
+        $this->assertEquals(0, $response->count());
+        $response = $index2->search('nicolas');
         $this->assertEquals(0, $response->count());
     }
 

--- a/test/Elastica/Query/IdsTest.php
+++ b/test/Elastica/Query/IdsTest.php
@@ -13,13 +13,11 @@ class IdsTest extends BaseTest
 
     protected function setUp()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
         parent::setUp();
 
         $index = $this->_createIndex();
 
         $type1 = $index->getType('helloworld1');
-        $type2 = $index->getType('helloworld2');
 
         $doc = new Document(1, ['name' => 'hello world']);
         $type1->addDocument($doc);
@@ -30,8 +28,6 @@ class IdsTest extends BaseTest
         $doc = new Document(3, ['name' => 'ruflin']);
         $type1->addDocument($doc);
 
-        $doc = new Document(4, ['name' => 'hello world again']);
-        $type2->addDocument($doc);
 
         $index->refresh();
 
@@ -44,8 +40,6 @@ class IdsTest extends BaseTest
      */
     public function testSetIdsSearchSingle()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $query = new Ids();
         $query->setIds('1');
 
@@ -59,8 +53,6 @@ class IdsTest extends BaseTest
      */
     public function testSetIdsSearchArray()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $query = new Ids();
         $query->setIds(['1', '2']);
 
@@ -74,8 +66,6 @@ class IdsTest extends BaseTest
      */
     public function testAddIdsSearchSingle()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $query = new Ids();
         $query->addId('3');
 
@@ -89,8 +79,6 @@ class IdsTest extends BaseTest
      */
     public function testComboIdsSearchArray()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $query = new Ids();
 
         $query->setIds(['1', '2']);
@@ -106,8 +94,6 @@ class IdsTest extends BaseTest
      */
     public function testSetTypeSingleSearchSingle()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $query = new Ids();
 
         $query->setIds('1');
@@ -123,8 +109,6 @@ class IdsTest extends BaseTest
      */
     public function testSetTypeSingleSearchArray()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $query = new Ids();
 
         $query->setIds(['1', '2']);
@@ -140,8 +124,6 @@ class IdsTest extends BaseTest
      */
     public function testSetTypeSingleSearchSingleDocInOtherType()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $query = new Ids();
 
         // Doc 4 is in the second type...
@@ -159,8 +141,6 @@ class IdsTest extends BaseTest
      */
     public function testSetTypeSingleSearchArrayDocInOtherType()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $query = new Ids();
 
         // Doc 4 is in the second type...
@@ -174,63 +154,10 @@ class IdsTest extends BaseTest
     }
 
     /**
-     * @group functional
-     */
-    public function testSetTypeAndAddType()
-    {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
-        $query = new Ids();
-
-        $query->setIds(['1', '4']);
-        $query->setType('helloworld1');
-        $query->addType('helloworld2');
-
-        $resultSet = $this->_index->search($query);
-
-        $this->assertEquals(2, $resultSet->count());
-    }
-
-    /**
-     * @group functional
-     */
-    public function testSetTypeArraySearchArray()
-    {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
-        $query = new Ids();
-
-        $query->setIds(['1', '4']);
-        $query->setType(['helloworld1', 'helloworld2']);
-
-        $resultSet = $this->_index->search($query);
-
-        $this->assertEquals(2, $resultSet->count());
-    }
-
-    /**
-     * @group functional
-     */
-    public function testSetTypeArraySearchSingle()
-    {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
-        $query = new Ids();
-
-        $query->setIds('4');
-        $query->setType(['helloworld1', 'helloworld2']);
-
-        $resultSet = $this->_index->search($query);
-
-        $this->assertEquals(1, $resultSet->count());
-    }
-
-    /**
      * @group unit
      */
     public function testQueryTypeAndTypeCollision()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
         // This test ensures that Elastica\Type and Elastica\Query\Type
         // do not collide when used together, which at one point
         // happened because of a use statement in Elastica\Query\Ids

--- a/test/Elastica/Transport/TransportBenchmarkTest.php
+++ b/test/Elastica/Transport/TransportBenchmarkTest.php
@@ -137,18 +137,19 @@ class TransportBenchmarkTest extends BaseTest
         $mapping = new Mapping();
         $mapping->setParam('_boost', ['name' => '_boost', 'null_value' => 1.0]);
         $mapping->setProperties([
-            'id' => ['type' => 'integer', 'include_in_all' => false],
+            'id' => ['type' => 'integer'],
             'user' => [
                 'type' => 'object',
                 'properties' => [
-                    'name' => ['type' => 'text', 'include_in_all' => true],
-                    'fullName' => ['type' => 'text', 'include_in_all' => true],
+                    'name' => ['type' => 'text', 'copy_to' => 'allincluded'],
+                    'fullName' => ['type' => 'text', 'copy_to' => 'allincluded'],
                 ],
             ],
-            'msg' => ['type' => 'text', 'include_in_all' => true],
-            'tstamp' => ['type' => 'date', 'include_in_all' => false],
-            'location' => ['type' => 'geo_point', 'include_in_all' => false],
-            '_boost' => ['type' => 'float', 'include_in_all' => false],
+            'msg' => ['type' => 'text', 'copy_to' => 'allincluded'],
+            'tstamp' => ['type' => 'date'],
+            'location' => ['type' => 'geo_point'],
+            '_boost' => ['type' => 'float'],
+            'allincluded' => ['type' => 'text'],
         ]);
 
         $type->setMapping($mapping);

--- a/test/Elastica/Type/MappingTest.php
+++ b/test/Elastica/Type/MappingTest.php
@@ -138,7 +138,7 @@ class MappingTest extends BaseTest
      */
     public function testParentMapping()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
+        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type, TEST USING JOIN FIELDS');
 
         $index = $this->_createIndex();
 
@@ -170,8 +170,6 @@ class MappingTest extends BaseTest
      */
     public function testMappingExample()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $index = $this->_createIndex();
         $type = $index->getType('notes');
 
@@ -179,8 +177,9 @@ class MappingTest extends BaseTest
             [
                 'note' => [
                     'properties' => [
-                        'titulo' => ['type' => 'text', 'include_in_all' => true, 'boost' => 1.0],
-                        'contenido' => ['type' => 'text', 'include_in_all' => true, 'boost' => 1.0],
+                        'titulo' => ['type' => 'text', 'copy_to' => 'testall', 'boost' => 1.0],
+                        'contenido' => ['type' => 'text', 'copy_to' => 'testall', 'boost' => 1.0],
+                        'testall' => ['type' => 'text',  'boost' => 1.0],
                     ],
                 ],
             ]


### PR DESCRIPTION
- Updated lot of tests that used two mapping type 
- remove reference to `include_in_all ` in mapping as [removed](https://github.com/elastic/elasticsearch/pull/22970) in 6.0 
- update some tests wich created non-unique index name which created some troubles