### PR TITLE
Disable _all by default, disallow configuring _all on 6.0+ indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file based on the
 - Removed [groovy script](https://github.com/elastic/elasticsearch/pull/21607) [#1364](https://github.com/ruflin/Elastica/pull/1364)
 - Removed [native script](https://github.com/elastic/elasticsearch/pull/24726) [#1364](https://github.com/ruflin/Elastica/pull/1364)
 - Removed old / removed script language support : javascript, python, mvel [#1364](https://github.com/ruflin/Elastica/pull/1364)
+- Disable [_all](https://github.com/elastic/elasticsearch/pull/22144) by default, disallow configuring _all on 6.0+ indices [#1365](https://github.com/ruflin/Elastica/pull/1365)
 
 ### Bugfixes
 - Enforce [Content-Type requirement on the layer Rest](https://github.com/elastic/elasticsearch/pull/23146), a [PR on Elastica #1301](https://github.com/ruflin/Elastica/issues/1301) solved it (it has been implemented only in the HTTP Transport), but it was not implemented in the Guzzle Transport. [#1349](https://github.com/ruflin/Elastica/pull/1349)

--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -145,7 +145,6 @@ class Mapping
      * _id
      * _type
      * _source
-     * _all
      * _analyzer
      * _boost
      * _parent
@@ -178,30 +177,6 @@ class Mapping
     public function getParam($key)
     {
         return isset($this->_mapping[$key]) ? $this->_mapping[$key] : null;
-    }
-
-    /**
-     * Sets params for the "_all" field.
-     *
-     * @param array $params _all Params (enabled, store, term_vector, analyzer)
-     *
-     * @return $this
-     */
-    public function setAllField(array $params)
-    {
-        return $this->setParam('_all', $params);
-    }
-
-    /**
-     * Enables the "_all" field.
-     *
-     * @param bool $enabled OPTIONAL (default = true)
-     *
-     * @return $this
-     */
-    public function enableAllField($enabled = true)
-    {
-        return $this->setAllField(['enabled' => $enabled]);
     }
 
     /**

--- a/test/Elastica/ResponseTest.php
+++ b/test/Elastica/ResponseTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Test;
 
 use Elastica\Document;
+use Elastica\Exception\ResponseException;
 use Elastica\Query;
 use Elastica\Query\MatchAll;
 use Elastica\Request;
@@ -222,14 +223,19 @@ class ResponseTest extends BaseTest
      */
     public function testGetDataEmpty()
     {
-        $this->markTestSkipped('ES6 update: type[[non-existent-type]] missing [index: _all]');
-
         $index = $this->_createIndex();
 
-        $response = $index->request(
-            'non-existent-type/_mapping',
-            Request::GET
-        )->getData();
+        try {
+            $response = $index->request(
+                'non-existent-type/_mapping',
+                Request::GET
+            )->getData();
+        } catch (ResponseException $e) {
+            $error = $e->getResponse()->getFullError();
+            $this->assertEquals('type_missing_exception', $error['type']);
+            $this->assertContains('non-existent-type', $error['reason']);
+        }
+
 
         $this->assertEquals(0, count($response));
     }

--- a/test/Elastica/Type/MappingTest.php
+++ b/test/Elastica/Type/MappingTest.php
@@ -66,29 +66,6 @@ class MappingTest extends BaseTest
     /**
      * @group functional
      */
-    public function testEnableAllField()
-    {
-        $this->markTestSkipped('ES6 update: [_all] is disabled in 6.0. As a replacement, you can use an [copy_to] on mapping fields to create your own catch all field.');
-
-        $index = $this->_createIndex();
-        $type = $index->getType('test');
-
-        $mapping = new Mapping($type, []);
-
-        $mapping->enableAllField();
-
-        $data = $mapping->toArray();
-        $this->assertTrue($data[$type->getName()]['_all']['enabled']);
-
-        $response = $mapping->send();
-        $this->assertTrue($response->isOk());
-
-        $index->delete();
-    }
-
-    /**
-     * @group functional
-     */
     public function testNestedMapping()
     {
         $client = $this->_getClient();


### PR DESCRIPTION
- disable _[all](https://github.com/elastic/elasticsearch/pull/22144) by default, disallow configuring _all on 6.0+ indices.
- catch an exception on ResponseTest