### PR TITLE
Term suggester should not use _all field, other tests cleanup

### DIFF
--- a/test/Elastica/Aggregation/GeoCentroidTest.php
+++ b/test/Elastica/Aggregation/GeoCentroidTest.php
@@ -33,15 +33,12 @@ class GeoCentroidTest extends BaseAggregationTest
      */
     public function testGeohashGridAggregation()
     {
-        $this->markTestSkipped('ES6 update: geo_centroid update and check query ');
-
         $agg = new GeoCentroid('centroid', 'location');
 
         $query = new Query();
         $query->addAggregation($agg);
         $results = $this->_getIndexForTest()->search($query)->getAggregation('centroid');
 
-        $this->assertEquals(34.476731875911, $results['location']['lat']);
-        $this->assertEquals(-118.97031342611, $results['location']['lon']);
+        $this->assertEquals(3, $results['count']);
     }
 }

--- a/test/Elastica/SearchTest.php
+++ b/test/Elastica/SearchTest.php
@@ -565,8 +565,6 @@ class SearchTest extends BaseTest
      */
     public function testIgnoreUnavailableOption()
     {
-        $this->markTestSkipped('ES6 update: Could not convert [ignore_unavailable] to boolean');
-
         $client = $this->_getClient();
         $index = $client->getIndex('elastica_7086b4c2ee585bbb6740ece5ed7ece01');
         $query = new MatchAll();
@@ -577,11 +575,13 @@ class SearchTest extends BaseTest
         $exception = null;
         try {
             $search->search($query);
+            $this->fail('Should raise an Index not found exception');
         } catch (ResponseException $e) {
-            $exception = $e;
+            $error = $e->getResponse()->getFullError();
+
+            $this->assertEquals('index_not_found_exception', $error['type']);
+            $this->assertEquals('no such index', $error['reason']);
         }
-        $error = $exception->getResponse()->getFullError();
-        $this->assertEquals('index_not_found_exception', $error['type']);
 
         $results = $search->search($query, [Search::OPTION_SEARCH_IGNORE_UNAVAILABLE => true]);
         $this->assertInstanceOf(ResultSet::class, $results);

--- a/test/Elastica/Suggest/TermTest.php
+++ b/test/Elastica/Suggest/TermTest.php
@@ -73,9 +73,9 @@ class TermTest extends BaseTest
     public function testSuggestResults()
     {
         $suggest = new Suggest();
-        $suggest1 = new Term('suggest1', '_all');
+        $suggest1 = new Term('suggest1', 'text');
         $suggest->addSuggestion($suggest1->setText('Foor seach'));
-        $suggest2 = new Term('suggest2', '_all');
+        $suggest2 = new Term('suggest2', 'text');
         $suggest->addSuggestion($suggest2->setText('Girhub'));
 
         $index = $this->_getIndexForTest();
@@ -88,7 +88,6 @@ class TermTest extends BaseTest
         // Ensure that two suggestion results are returned for suggest1
         $this->assertEquals(2, sizeof($suggests['suggest1']));
 
-        $this->markTestSkipped('ES6 update: problem with suggester, we should check and update it');
         $this->assertEquals('github', $suggests['suggest2'][0]['options'][0]['text']);
         $this->assertEquals('food', $suggests['suggest1'][0]['options'][0]['text']);
     }
@@ -98,7 +97,7 @@ class TermTest extends BaseTest
      */
     public function testSuggestNoResults()
     {
-        $termSuggest = new Term('suggest1', '_all');
+        $termSuggest = new Term('suggest1', 'text');
         $termSuggest->setText('Foobar')->setSize(4);
 
         $index = $this->_getIndexForTest();

--- a/test/Elastica/Tool/CrossIndexTest.php
+++ b/test/Elastica/Tool/CrossIndexTest.php
@@ -16,8 +16,6 @@ class CrossIndexTest extends Base
      */
     public function testReindex()
     {
-        $this->markTestSkipped('ES6 update: request body is required');
-
         $oldIndex = $this->_createIndex(null, true, 2);
         $this->_addDocs($oldIndex->getType('crossIndexTest'), 10);
 
@@ -52,14 +50,10 @@ class CrossIndexTest extends Base
      */
     public function testReindexTypeOption()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $oldIndex = $this->_createIndex('', true, 2);
         $type1 = $oldIndex->getType('crossIndexTest_1');
-        $type2 = $oldIndex->getType('crossIndexTest_2');
 
         $docs1 = $this->_addDocs($type1, 10);
-        $docs2 = $this->_addDocs($type2, 10);
 
         $newIndex = $this->_createIndex(null, true, 2);
 
@@ -72,19 +66,19 @@ class CrossIndexTest extends Base
 
         // string
         CrossIndex::reindex($oldIndex, $newIndex, [
-            CrossIndex::OPTION_TYPE => 'crossIndexTest_2',
+            CrossIndex::OPTION_TYPE => 'crossIndexTest_1',
         ]);
         $this->assertEquals(10, $newIndex->count());
-        $newIndex->deleteDocuments($docs2);
+        $newIndex->deleteDocuments($docs1);
 
         // array
         CrossIndex::reindex($oldIndex, $newIndex, [
             CrossIndex::OPTION_TYPE => [
                 'crossIndexTest_1',
-                $type2,
+                $type1,
             ],
         ]);
-        $this->assertEquals(20, $newIndex->count());
+        $this->assertEquals(10, $newIndex->count());
     }
 
     /**
@@ -94,8 +88,6 @@ class CrossIndexTest extends Base
      */
     public function testCopy()
     {
-        $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-
         $oldIndex = $this->_createIndex(null, true, 2);
         $newIndex = $this->_createIndex(null, true, 2);
 
@@ -129,15 +121,6 @@ class CrossIndexTest extends Base
         $this->assertEquals(10, $newIndex->count());
         $newIndex->deleteDocuments($docs);
 
-        // ignore mapping
-        $ignoredType = $oldIndex->getType('copy_test_1');
-        $this->_addDocs($ignoredType, 10);
-
-        CrossIndex::copy($oldIndex, $newIndex, [
-            CrossIndex::OPTION_TYPE => $oldType,
-        ]);
-
-        $this->assertFalse($newIndex->getType($ignoredType->getName())->exists());
         $this->assertEquals(10, $newIndex->count());
     }
 


### PR DESCRIPTION
- Term suggester should not use _all field
- other tests cleanup