### PR TITLE
script types are all allowed by default

### DIFF
--- a/test/Elastica/Aggregation/BucketScriptTest.php
+++ b/test/Elastica/Aggregation/BucketScriptTest.php
@@ -29,8 +29,6 @@ class BucketScriptTest extends BaseAggregationTest
      */
     public function testBucketScriptAggregation()
     {
-        $this->_checkScriptInlineSetting();
-
         $bucketScriptAggregation = new BucketScript(
             'result',
             [

--- a/test/Elastica/Aggregation/MaxTest.php
+++ b/test/Elastica/Aggregation/MaxTest.php
@@ -61,7 +61,6 @@ class MaxTest extends BaseAggregationTest
      */
     public function testMaxAggregation()
     {
-        $this->_checkScriptInlineSetting();
         $index = $this->_getIndexForTest();
 
         $agg = new Max('max_price');

--- a/test/Elastica/Aggregation/ScriptTest.php
+++ b/test/Elastica/Aggregation/ScriptTest.php
@@ -29,7 +29,6 @@ class ScriptTest extends BaseAggregationTest
      */
     public function testAggregationScript()
     {
-        $this->_checkScriptInlineSetting();
         $agg = new Sum('sum');
         $script = new Script("return doc['price'].value", null, Script::LANG_PAINLESS);
         $agg->setScript($script);
@@ -46,7 +45,6 @@ class ScriptTest extends BaseAggregationTest
      */
     public function testAggregationScriptAsString()
     {
-        $this->_checkScriptInlineSetting();
         $agg = new Sum('sum');
         $agg->setScript(new Script("doc['price'].value", null, Script::LANG_PAINLESS));
 

--- a/test/Elastica/Aggregation/ScriptedMetricTest.php
+++ b/test/Elastica/Aggregation/ScriptedMetricTest.php
@@ -34,7 +34,6 @@ class ScriptedMetricTest extends BaseAggregationTest
      */
     public function testScriptedMetricAggregation()
     {
-        $this->_checkScriptInlineSetting();
         $agg = new ScriptedMetric(
             'scripted',
             'params._agg.durations = []',

--- a/test/Elastica/Aggregation/TopHitsTest.php
+++ b/test/Elastica/Aggregation/TopHitsTest.php
@@ -339,7 +339,6 @@ class TopHitsTest extends BaseAggregationTest
     public function testAggregateWithScriptFields()
     {
         $this->markTestSkipped('ES6 update: the final mapping would have more than 1 type');
-        $this->_checkScriptInlineSetting();
         $aggr = new TopHits('top_tag_hits');
         $aggr->setSize(1);
         $aggr->setScriptFields(['three' => new Script('1 + 2')]);

--- a/test/Elastica/Base.php
+++ b/test/Elastica/Base.php
@@ -130,16 +130,6 @@ class Base extends \PHPUnit_Framework_TestCase
         return $index;
     }
 
-    protected function _checkScriptInlineSetting()
-    {
-        $nodes = $this->_getClient()->getCluster()->getNodes();
-        $scriptInline = $nodes[0]->getInfo()->get('settings', 'script', 'inline');
-
-        if ($this->_getVersion() < 6 && $scriptInline != 'true') {
-            $this->markTestSkipped('script.inline is not enabled. This is required for this test');
-        }
-    }
-
     protected function _checkPlugin($plugin)
     {
         $nodes = $this->_getClient()->getCluster()->getNodes();

--- a/test/Elastica/BulkTest.php
+++ b/test/Elastica/BulkTest.php
@@ -428,7 +428,6 @@ class BulkTest extends BaseTest
      */
     public function testUpdate()
     {
-        $this->_checkScriptInlineSetting();
         $index = $this->_createIndex();
         $type = $index->getType('bulk_test');
         $client = $index->getClient();

--- a/test/Elastica/ClientTest.php
+++ b/test/Elastica/ClientTest.php
@@ -699,7 +699,6 @@ class ClientTest extends BaseTest
      */
     public function testUpdateDocumentByScript()
     {
-        $this->_checkScriptInlineSetting();
         $index = $this->_createIndex();
         $type = $index->getType('test');
         $client = $index->getClient();
@@ -728,7 +727,6 @@ class ClientTest extends BaseTest
      */
     public function testUpdateDocumentByScriptWithUpsert()
     {
-        $this->_checkScriptInlineSetting();
         $index = $this->_createIndex();
         $type = $index->getType('test');
         $client = $index->getClient();
@@ -954,7 +952,6 @@ class ClientTest extends BaseTest
      */
     public function testUpdateDocumentPopulateFields()
     {
-        $this->_checkScriptInlineSetting();
         $index = $this->_createIndex();
         $type = $index->getType('test');
         $client = $index->getClient();

--- a/test/Elastica/Exception/PartialShardFailureExceptionTest.php
+++ b/test/Elastica/Exception/PartialShardFailureExceptionTest.php
@@ -14,7 +14,6 @@ class PartialShardFailureExceptionTest extends AbstractExceptionTest
      */
     public function testPartialFailure()
     {
-        $this->_checkScriptInlineSetting();
         $client = $this->_getClient();
         $index = $client->getIndex('elastica_partial_failure');
         $index->create([

--- a/test/Elastica/Query/FunctionScoreTest.php
+++ b/test/Elastica/Query/FunctionScoreTest.php
@@ -439,7 +439,6 @@ class FunctionScoreTest extends BaseTest
      */
     public function testScriptScore()
     {
-        $this->_checkScriptInlineSetting();
         $scriptString = "_score * doc['price'].value";
         $script = new Script($scriptString, null, Script::LANG_PAINLESS);
         $query = new FunctionScore();

--- a/test/Elastica/Script/ScriptFieldsTest.php
+++ b/test/Elastica/Script/ScriptFieldsTest.php
@@ -70,8 +70,6 @@ class ScriptFieldsTest extends BaseTest
      */
     public function testQuery()
     {
-        $this->_checkScriptInlineSetting();
-
         $index = $this->_createIndex();
 
         $type = $index->getType('test');

--- a/test/Elastica/TypeTest.php
+++ b/test/Elastica/TypeTest.php
@@ -580,7 +580,6 @@ class TypeTest extends BaseTest
      */
     public function testUpdateDocument()
     {
-        $this->_checkScriptInlineSetting();
         $client = $this->_getClient();
         $index = $client->getIndex('elastica_test');
         $type = $index->getType('update_type');
@@ -611,7 +610,6 @@ class TypeTest extends BaseTest
      */
     public function testUpdateDocumentWithIdForwardSlashes()
     {
-        $this->_checkScriptInlineSetting();
         $client = $this->_getClient();
         $index = $client->getIndex('elastica_test');
         $type = $index->getType('update_type');
@@ -681,7 +679,6 @@ class TypeTest extends BaseTest
      */
     public function testUpdateDocumentWithFieldsSource()
     {
-        $this->_checkScriptInlineSetting();
         $client = $this->_getClient();
         $index = $client->getIndex('elastica_test');
         $type = $index->getType('update_type');


### PR DESCRIPTION
- By default all script types are allowed to be executed.
- By default all script contexts are allowed to be executed. 

I updated Base.php as now you by config you can only disable them