### PR TITLE
Analyze removed support for request parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to this project will be documented in this file based on the
 - The geo_distance_range query, which was deprecated in 5.0, has been removed. [#1369](https://github.com/ruflin/Elastica/pull/1369)
 - The optimize_bbox parameter has been removed from geo_distance queries. [#1369](https://github.com/ruflin/Elastica/pull/1369)
 - The disable_coord parameter of the bool and common_terms queries has been removed. If provided, it will be ignored and issue a deprecation warning. [#1369](https://github.com/ruflin/Elastica/pull/1369)
+- [Unfiltered nested source](https://github.com/elastic/elasticsearch/pull/26102) should keep its full path [#1366](https://github.com/ruflin/Elastica/pull/1366) 
+- [Analyze Explain](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/_explain_analyze.html) no more support [request parameters](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/indices-analyze.html), use request body instead. [#1370](https://github.com/ruflin/Elastica/pull/1370) 
+
 ### Bugfixes
 - Enforce [Content-Type requirement on the layer Rest](https://github.com/elastic/elasticsearch/pull/23146), a [PR on Elastica #1301](https://github.com/ruflin/Elastica/issues/1301) solved it (it has been implemented only in the HTTP Transport), but it was not implemented in the Guzzle Transport. [#1349](https://github.com/ruflin/Elastica/pull/1349)
 - Scroll no longer does an extra iteration both on an empty result and on searches where the last page has a significantly smaller number of results than the pages before it.

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -548,24 +548,24 @@ class Index implements SearchableInterface
      *
      * Detailed arguments can be found here in the link
      *
-     * @param string $text String to be analyzed
+     * @param array $body String to be analyzed
      * @param array  $args OPTIONAL Additional arguments
      *
      * @return array Server response
      *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html
      */
-    public function analyze($text, $args = [])
+    public function analyze(array $body, $args = [])
     {
         $endpoint = new Analyze();
-        $endpoint->setBody(['text' => $text]);
+        $endpoint->setBody($body);
         $endpoint->setParams($args);
 
         $data = $this->requestEndpoint($endpoint)->getData();
 
         // Support for "Explain" parameter, that returns a different response structure from Elastic
         // @see: https://www.elastic.co/guide/en/elasticsearch/reference/current/_explain_analyze.html
-        if (isset($args['explain']) && $args['explain']) {
+        if (isset($body['explain']) && $body['explain']) {
             return $data['detail'];
         }
 

--- a/test/Elastica/IndexTest.php
+++ b/test/Elastica/IndexTest.php
@@ -928,7 +928,7 @@ class IndexTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->refresh();
-        $returnedTokens = $index->analyze('foo');
+        $returnedTokens = $index->analyze(['text' => 'foo']);
 
         $tokens = [
             [
@@ -973,11 +973,9 @@ class IndexTest extends BaseTest
      */
     public function testAnalyzeExplain()
     {
-        $this->markTestSkipped('ES6 update: request contains unrecognized parameter: [explain]');
-
         $index = $this->_createIndex();
         $index->refresh();
-        $data = $index->analyze('foo', ['explain' => true]);
+        $data = $index->analyze(['text' => 'foo', 'explain' => true], []);
 
         $this->assertArrayHasKey('custom_analyzer', $data);
     }


### PR DESCRIPTION
Analyze endpoint removed support for request parameters, we should use request body instead. I updated the Analyze endpoint in order to accept not only text, but an array of values, so even the explain functionality will work.