### PR TITLE
update .travis to latest docker version 17.07

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,20 +16,20 @@ env:
   - TARGET="71"
 
 before_install:
-  # list docker-engine versions, usefull to update the docker engine on travis and trusty
-  #- apt-cache madison docker-engine
-
-  # update docker engine to the desired version
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=17.03.1~ce-0~ubuntu-trusty
-
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/1.13.0/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-
   # check running "docker engine" and "docker-compose" version on travis
   - docker --version
   - docker-compose --version
+
+  # list docker-engine versions, usefull to update the docker engine on travis and trusty
+#  - sudo apt-cache madison docker-engine
+
+  # update docker engine to the desired version
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=17.07.0~ce-0~ubuntu
+
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
 
 before_script:
   - sudo sysctl -w vm.max_map_count=262144


### PR DESCRIPTION
- Docker has been upgraded on travis trusty images to 17.06, I updated our file, which used an older version 17.03 and forces a DOWNGRADE during deploy caused travis to fail.
- docker-compose has been updated too, version now 1.16.1 which support compose version **3.3**

This PR solve the problem that all the builds will fail on Travis