### PR TITLE
Implement Countable on Objects in PHP7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
 env:
   - TARGET="70"
   - TARGET="71"
+  - TARGET="72"
 
 before_install:
   # check running "docker engine" and "docker-compose" version on travis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to this project will be documented in this file based on the
 
 - Added `Query\SpanContaining`, `Query\SpanWithin` and `Query\SpanNot` [#1319](https://github.com/ruflin/Elastica/pull/1319)
 - Implemented [Pipeline](https://www.elastic.co/guide/en/elasticsearch/reference/current/pipeline.html) and [Processors](https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-processors.html). [#1373](https://github.com/ruflin/Elastica/pull/1373)
+- In PHP 7.2 count() now raises a warning when an invalid parameter is passed. Only arrays and objects implementing the Countable interface should be passed. [#1378](https://github.com/ruflin/Elastica/pull/1378)
 
 
 ## [5.3.0](https://github.com/ruflin/Elastica/compare/5.2.1...5.3.0)

--- a/env/elastica/Docker72
+++ b/env/elastica/Docker72
@@ -1,0 +1,36 @@
+# This image is the base image for the Elastica development and includes all parts which rarely change
+# PHP 7 Docker file with Composer installed
+FROM php:7.2-rc
+MAINTAINER Nicolas Ruflin <spam@ruflin.com>
+
+RUN apt-get update && apt-get install -y \
+	cloc \
+	git \
+	graphviz \
+	libxslt-dev \
+	nano \
+
+	zip unzip \
+	wget
+	# XSL and Graphviz for PhpDocumentor
+
+RUN docker-php-ext-install sockets xsl
+
+RUN rm -r /var/lib/apt/lists/*
+
+## PHP Configuration
+
+RUN echo "memory_limit=1024M" >> /usr/local/etc/php/conf.d/memory-limit.ini
+RUN echo "date.timezone=UTC" >> /usr/local/etc/php/conf.d/timezone.ini
+
+# Install and setup composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ENV COMPOSER_HOME /root/composer
+
+# Add composer bin to the environment
+ENV PATH=/root/composer/vendor/bin:$PATH
+
+COPY composer.json /root/composer/
+
+# Install development tools, prefer source removed as automatic fallback now
+RUN composer global install

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -10,7 +10,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  */
-class Param implements ArrayableInterface
+class Param implements ArrayableInterface, \Countable
 {
     /**
      * Params.
@@ -179,5 +179,15 @@ class Param implements ArrayableInterface
     public function getParams()
     {
         return $this->_params;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->_params);
     }
 }

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -330,7 +330,7 @@ class Query extends Param
             $this->setQuery(new MatchAll());
         }
 
-        if (isset($this->_params['post_filter']) && 0 === count($this->_params['post_filter'])) {
+        if (isset($this->_params['post_filter']) && 0 === count(($this->_params['post_filter'])->toArray())) {
             unset($this->_params['post_filter']);
         }
 

--- a/lib/Elastica/Query/GeoPolygon.php
+++ b/lib/Elastica/Query/GeoPolygon.php
@@ -53,4 +53,15 @@ class GeoPolygon extends AbstractQuery
             ],
         ];
     }
+
+    /**
+     * @inheritdoc
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->_key);
+    }
+
 }

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -220,7 +220,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      */
     public function count()
     {
-        return sizeof($this->_results);
+        return count($this->_results);
     }
 
     /**

--- a/test/Elastica/Query/GeoPolygonTest.php
+++ b/test/Elastica/Query/GeoPolygonTest.php
@@ -49,7 +49,8 @@ class GeoPolygonTest extends BaseTest
 
         $query = new Query(new MatchAll());
         $query->setPostFilter($geoQuery);
-        $this->assertEquals(1, $type->search($query)->count());
+        $a = $type->search($query);
+        $this->assertEquals(1, $a->count());
 
         // Both points should be inside
         $query = new Query();

--- a/test/Elastica/QueryBuilder/VersionTest.php
+++ b/test/Elastica/QueryBuilder/VersionTest.php
@@ -47,7 +47,7 @@ class VersionTest extends BaseTest
         foreach ($version->getSuggesters() as $suggester) {
             $this->assertTrue(
                 method_exists($dsl[2], $suggester),
-                'suggester "'.$suggester.'" in '.get_class($version).' must be defined in '.get_class($dsl[3])
+                'suggester "'.$suggester.'" in '.get_class($version).' must be defined in '.get_class($dsl[2])
             );
         }
     }

--- a/test/Elastica/ResponseTest.php
+++ b/test/Elastica/ResponseTest.php
@@ -236,6 +236,6 @@ class ResponseTest extends BaseTest
             $this->assertContains('non-existent-type', $error['reason']);
         }
 
-        $this->assertEquals(0, count($response));
+        $this->assertNull($response);
     }
 }


### PR DESCRIPTION
as reported #1377 in PHP 7.2 it's possibile to use the function count() only on Arrays and on \Countable objects.

This is a WIP PR, there are still things to do and some tests to check; more then this I will merge this PR when PHP 7.2 will be released (now it's a RC2).