### PR TITLE
update ES6 to RC1 and some minor bc's solved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ All notable changes to this project will be documented in this file based on the
 - [Analyze Explain](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/_explain_analyze.html) no more support [request parameters](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/indices-analyze.html), use request body instead. [#1370](https://github.com/ruflin/Elastica/pull/1370) 
 - [Mapper Attachment plugin has been removed](https://github.com/elastic/elasticsearch/pull/20416) Use Ingest-attachment plugin and attachment processors with pipeline to ingest new documents. [#1375](https://github.com/ruflin/Elastica/pull/1375)
 - [Indices](https://github.com/elastic/elasticsearch/pull/21837) Query has been removed in Elasticsearch 6.0 [#1376](https://github.com/ruflin/Elastica/pull/1376)
+- Remove deprecated [type and slop](https://github.com/elastic/elasticsearch/pull/26720) field in match query [#1382](https://github.com/ruflin/Elastica/pull/1382)
+- Remove [several parse field](https://github.com/elastic/elasticsearch/pull/26711) deprecations in query builders [#1382](https://github.com/ruflin/Elastica/pull/1382)
+- Remove [deprecated parameters](https://github.com/elastic/elasticsearch/pull/26508) from ids_query [#1382](https://github.com/ruflin/Elastica/pull/1382)
 
 ### Bugfixes
 - Enforce [Content-Type requirement on the layer Rest](https://github.com/elastic/elasticsearch/pull/23146), a [PR on Elastica #1301](https://github.com/ruflin/Elastica/issues/1301) solved it (it has been implemented only in the HTTP Transport), but it was not implemented in the Guzzle Transport. [#1349](https://github.com/ruflin/Elastica/pull/1349)

--- a/env/elasticsearch/Dockerfile
+++ b/env/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0-beta2
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0-rc1
 MAINTAINER Nicolas Ruflin <spam@ruflin.com>
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install ingest-attachment

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -37,24 +37,6 @@ class ConstantScore extends AbstractQuery
     }
 
     /**
-     * Set query.
-     *
-     * @param array|AbstractQuery $query
-     *
-     * @throws InvalidException If query is not an array or instance of AbstractQuery
-     *
-     * @return $this
-     */
-    public function setQuery($query)
-    {
-        if (!is_array($query) && !($query instanceof AbstractQuery)) {
-            throw new InvalidException('Invalid parameter. Has to be array or instance of Elastica\Query\AbstractQuery');
-        }
-
-        return $this->setParam('query', $query);
-    }
-
-    /**
      * Set boost.
      *
      * @param float $boost

--- a/lib/Elastica/Query/Ids.php
+++ b/lib/Elastica/Query/Ids.php
@@ -17,12 +17,10 @@ class Ids extends AbstractQuery
     /**
      * Creates filter object.
      *
-     * @param string|\Elastica\Type $type Type to filter on
      * @param array                 $ids  List of ids
      */
-    public function __construct($type = null, array $ids = [])
+    public function __construct(array $ids = [])
     {
-        $this->setType($type);
         $this->setIds($ids);
     }
 
@@ -36,48 +34,6 @@ class Ids extends AbstractQuery
     public function addId($id)
     {
         $this->_params['values'][] = $id;
-
-        return $this;
-    }
-
-    /**
-     * Adds one more type to query.
-     *
-     * @param string|\Elastica\Type $type Type name or object
-     *
-     * @return $this
-     */
-    public function addType($type)
-    {
-        if ($type instanceof ElasticaType) {
-            $type = $type->getName();
-        } elseif (empty($type) && !is_numeric($type)) {
-            // A type can be 0, but cannot be empty
-            return $this;
-        }
-
-        $this->_params['type'][] = $type;
-
-        return $this;
-    }
-
-    /**
-     * Set type.
-     *
-     * @param array|string|\Elastica\Type $type Type name or object
-     *
-     * @return $this
-     */
-    public function setType($type)
-    {
-        if ($type instanceof ElasticaType) {
-            $type = $type->getName();
-        } elseif (empty($type) && !is_numeric($type)) {
-            // A type can be 0, but cannot be empty
-            return $this;
-        }
-
-        $this->_params['type'] = (array) $type;
 
         return $this;
     }

--- a/lib/Elastica/Query/Match.php
+++ b/lib/Elastica/Query/Match.php
@@ -77,23 +77,6 @@ class Match extends AbstractQuery
     }
 
     /**
-     * Set field type.
-     *
-     * @param string $field
-     * @param string $type
-     *
-     * @return $this
-     *
-     * @deprecated Replaced by Elastica\Query\MatchPhrase and Elastica\Query\MatchPhrasePrefix
-     */
-    public function setFieldType($field, $type)
-    {
-        trigger_error('Deprecated: Elastica\Query\Match::setFieldType() is deprecated and will be removed in further Elastica releases. Use Elastica\Query\MatchPhrase and Elastica\Query\MatchPhrasePrefix instead.', E_USER_DEPRECATED);
-
-        return $this->setFieldParam($field, 'type', $type);
-    }
-
-    /**
      * Set field operator.
      *
      * @param string $field

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -225,14 +225,13 @@ class Query implements DSL
      *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
      *
-     * @param array|string|\Elastica\Type $type
      * @param array                       $ids
      *
      * @return Ids
      */
-    public function ids($type = null, array $ids = [])
+    public function ids(array $ids = [])
     {
-        return new Ids($type, $ids);
+        return new Ids($ids);
     }
 
     /**

--- a/lib/Elastica/Suggest/Term.php
+++ b/lib/Elastica/Suggest/Term.php
@@ -90,7 +90,7 @@ class Term extends AbstractSuggest
      */
     public function setMinWordLength($length)
     {
-        return $this->setParam('min_word_len', (int) $length);
+        return $this->setParam('min_word_length', (int) $length);
     }
 
     /**

--- a/test/Elastica/Query/ConstantScoreTest.php
+++ b/test/Elastica/Query/ConstantScoreTest.php
@@ -53,46 +53,6 @@ class ConstantScoreTest extends BaseTest
     }
 
     /**
-     * @group functional
-     */
-    public function testQuery()
-    {
-        $index = $this->_createIndex();
-
-        $type = $index->getType('constant_score');
-        $type->addDocuments([
-            new Document(1, ['id' => 1, 'email' => 'hans@test.com', 'username' => 'hans']),
-            new Document(2, ['id' => 2, 'email' => 'emil@test.com', 'username' => 'emil']),
-            new Document(3, ['id' => 3, 'email' => 'ruth@test.com', 'username' => 'ruth']),
-        ]);
-
-        // Refresh index
-        $index->refresh();
-
-        $boost = 1.3;
-        $query_match = new MatchAll();
-
-        $query = new ConstantScore();
-        $query->setQuery($query_match);
-        $query->setBoost($boost);
-
-        $expectedArray = [
-            'constant_score' => [
-                'query' => $query_match->toArray(),
-                'boost' => $boost,
-            ],
-        ];
-
-        $this->assertEquals($expectedArray, $query->toArray());
-        $resultSet = $type->search($query);
-
-        $results = $resultSet->getResults();
-
-        $this->assertEquals($resultSet->count(), 3);
-        $this->assertEquals($results[1]->getScore(), 1.3);
-    }
-
-    /**
      * @group unit
      */
     public function testConstructEmpty()

--- a/test/Elastica/Query/IdsTest.php
+++ b/test/Elastica/Query/IdsTest.php
@@ -97,7 +97,6 @@ class IdsTest extends BaseTest
         $query = new Ids();
 
         $query->setIds('1');
-        $query->setType('helloworld1');
 
         $resultSet = $this->_index->search($query);
 
@@ -112,7 +111,6 @@ class IdsTest extends BaseTest
         $query = new Ids();
 
         $query->setIds(['1', '2']);
-        $query->setType('helloworld1');
 
         $resultSet = $this->_index->search($query);
 
@@ -128,7 +126,6 @@ class IdsTest extends BaseTest
 
         // Doc 4 is in the second type...
         $query->setIds('4');
-        $query->setType('helloworld1');
 
         $resultSet = $this->_index->search($query);
 
@@ -145,7 +142,6 @@ class IdsTest extends BaseTest
 
         // Doc 4 is in the second type...
         $query->setIds(['1', '4']);
-        $query->setType('helloworld1');
 
         $resultSet = $this->_index->search($query);
 

--- a/test/Elastica/Query/MatchTest.php
+++ b/test/Elastica/Query/MatchTest.php
@@ -14,7 +14,6 @@ class MatchTest extends BaseTest
     {
         $field = 'test';
         $testQuery = 'Nicolas Ruflin';
-        $type = 'phrase';
         $operator = 'and';
         $analyzer = 'myanalyzer';
         $boost = 2.0;
@@ -27,7 +26,6 @@ class MatchTest extends BaseTest
         $query = new Match();
         $query->setFieldQuery($field, $testQuery);
         $this->hideDeprecated();
-        $query->setFieldType($field, $type);
         $this->showDeprecated();
         $query->setFieldOperator($field, $operator);
         $query->setFieldAnalyzer($field, $analyzer);
@@ -42,7 +40,6 @@ class MatchTest extends BaseTest
             'match' => [
                 $field => [
                     'query' => $testQuery,
-                    'type' => $type,
                     'operator' => $operator,
                     'analyzer' => $analyzer,
                     'boost' => $boost,
@@ -173,72 +170,6 @@ class MatchTest extends BaseTest
         $query = new Match();
         $query->setFieldQuery('name', '');
         $query->setFieldZeroTermsQuery('name', Match::ZERO_TERM_ALL);
-
-        $resultSet = $index->search($query);
-
-        $this->assertEquals(2, $resultSet->count());
-    }
-
-    /**
-     * @group functional
-     */
-    public function testMatchPhraseType()
-    {
-        $client = $this->_getClient();
-        $index = $client->getIndex('test');
-        $index->create([], true);
-        $type = $index->getType('test');
-
-        $type->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'New Hampshire']),
-            new Document(4, ['name' => 'Basel Land']),
-        ]);
-
-        $index->refresh();
-
-        $field = 'name';
-        $type = 'phrase';
-
-        $query = new Match();
-        $query->setFieldQuery($field, 'New York');
-        $this->hideDeprecated();
-        $query->setFieldType($field, $type);
-        $this->showDeprecated();
-
-        $resultSet = $index->search($query);
-
-        $this->assertEquals(1, $resultSet->count());
-    }
-
-    /**
-     * @group functional
-     */
-    public function testMatchPhrasePrefixType()
-    {
-        $client = $this->_getClient();
-        $index = $client->getIndex('test');
-        $index->create([], true);
-        $type = $index->getType('test');
-
-        $type->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'New Hampshire']),
-            new Document(4, ['name' => 'Basel Land']),
-        ]);
-
-        $index->refresh();
-
-        $field = 'name';
-        $type = 'phrase_prefix';
-
-        $query = new Match();
-        $query->setFieldQuery($field, 'New');
-        $this->hideDeprecated();
-        $query->setFieldType($field, $type);
-        $this->showDeprecated();
 
         $resultSet = $index->search($query);
 

--- a/test/Elastica/QueryBuilder/DSL/QueryTest.php
+++ b/test/Elastica/QueryBuilder/DSL/QueryTest.php
@@ -45,7 +45,7 @@ class QueryTest extends AbstractDSLTest
         $this->_assertImplemented($queryDSL, 'fuzzy', Query\Fuzzy::class, ['field', 'type']);
         $this->_assertImplemented($queryDSL, 'has_child', Query\HasChild::class, [new Match()]);
         $this->_assertImplemented($queryDSL, 'has_parent', Query\HasParent::class, [new Match(), 'type']);
-        $this->_assertImplemented($queryDSL, 'ids', Query\Ids::class, ['type', []]);
+        $this->_assertImplemented($queryDSL, 'ids', Query\Ids::class, [[]]);
         $this->_assertImplemented($queryDSL, 'match', Match::class, ['field', 'values']);
         $this->_assertImplemented($queryDSL, 'match_all', Query\MatchAll::class, []);
         $this->_assertImplemented($queryDSL, 'match_none', Query\MatchNone::class, []);


### PR DESCRIPTION
Updated Elastica to ES6 RC1 and :

- Remove deprecated type and slop field in match query 
- Remove several parse field deprecations in query builders
- Remove deprecated parameters from ids_query