### PR TITLE
Update wrong typing PHPDoc on the setRefreshInterval method

### DIFF
--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -263,7 +263,7 @@ class Settings
      * Sets the index refresh interval.
      *
      * Value can be for example 3s for 3 seconds or
-     * 5m for 5 minutes. -1 refreshing is disabled.
+     * 5m for 5 minutes. -1 to disabled refresh.
      *
      * @param string $interval Duration of the refresh interval
      *

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -265,7 +265,7 @@ class Settings
      * Value can be for example 3s for 3 seconds or
      * 5m for 5 minutes. -1 refreshing is disabled.
      *
-     * @param int $interval Number of milliseconds
+     * @param string $interval Duration of the refresh interval
      *
      * @return \Elastica\Response Response object
      */


### PR DESCRIPTION
The `setRefreshInterval` method expect a string but the method documentation ask for integer.

Also the comment tells that this value is milliseconds but that's not the case anymore in Elasticsearch.