### PR TITLE
Fix some tests

### DIFF
--- a/test/Elastica/Aggregation/ChildrenTest.php
+++ b/test/Elastica/Aggregation/ChildrenTest.php
@@ -13,8 +13,11 @@ class ChildrenTest extends BaseAggregationTest
     {
         $client = $this->_getClient();
         $index = $client->getIndex('testaggregationchildren');
-        $index->create([], true);
-        $type = $index->getType('test');
+        $index->create(['index' => ['number_of_shards' => 2, 'number_of_replicas' => 1]], true);
+
+        $type = $index->getType(strtolower(
+            'typechildren'.uniqid()
+        ));
 
         $mapping = new Mapping();
         $mapping->setType($type);
@@ -38,14 +41,14 @@ class ChildrenTest extends BaseAggregationTest
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], $type->getName());
 
         $doc2 = new Document(2, [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], $type->getName());
 
         $index->addDocuments([$doc1, $doc2]);
 
@@ -56,7 +59,7 @@ class ChildrenTest extends BaseAggregationTest
                 'name' => 'answer',
                 'parent' => 1,
             ],
-        ], 'test', 'testaggregationchildren');
+        ], $type->getName(), $index->getName());
 
         $doc4 = new Document(4, [
             'text' => 'this is an top answer, the 2nd',
@@ -65,7 +68,7 @@ class ChildrenTest extends BaseAggregationTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test', 'testaggregationchildren');
+        ], $type->getName(), $index->getName());
 
         $doc5 = new Document(5, [
             'text' => 'this is an answer, the 3rd',
@@ -74,7 +77,7 @@ class ChildrenTest extends BaseAggregationTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test', 'testaggregationchildren');
+        ], $type->getName(), $index->getName());
 
         $this->_getClient()->addDocuments([$doc3, $doc4, $doc5], ['routing' => 1]);
         $index->refresh();
@@ -115,8 +118,6 @@ class ChildrenTest extends BaseAggregationTest
      */
     public function testChildrenAggregationCount()
     {
-        $this->markTestSkipped('weird behaviour executing a single test or the whole test suite');
-
         $agg = new Children('answer');
         $agg->setType('answer');
 

--- a/test/Elastica/BulkTest.php
+++ b/test/Elastica/BulkTest.php
@@ -23,7 +23,6 @@ class BulkTest extends BaseTest
     public function testSend()
     {
         $index = $this->_createIndex();
-        $index2 = $this->_createIndex();
         $indexName = $index->getName();
         $type = $index->getType('bulk_test');
         $client = $index->getClient();

--- a/test/Elastica/Cluster/SettingsTest.php
+++ b/test/Elastica/Cluster/SettingsTest.php
@@ -61,7 +61,6 @@ class SettingsTest extends BaseTest
         $settings = new Settings($this->_getClient());
         $settings->setReadOnly(false);
         $index1 = $this->_createIndex();
-        $index2 = $this->_createIndex();
 
         $doc1 = new Document(null, ['hello' => 'world']);
         $doc2 = new Document(null, ['hello' => 'world']);
@@ -72,7 +71,6 @@ class SettingsTest extends BaseTest
 
         // Check that adding documents work
         $index1->getType('test')->addDocument($doc1);
-        $index2->getType('test')->addDocument($doc2);
 
         $response = $settings->setReadOnly(true);
         $this->assertFalse($response->hasError());
@@ -89,15 +87,6 @@ class SettingsTest extends BaseTest
             $this->assertContains('cluster read-only', $error['reason']);
         }
 
-        try {
-            $index2->getType('test')->addDocument($doc4);
-            $this->fail('should throw read only exception');
-        } catch (ResponseException $e) {
-            $error = $e->getResponse()->getFullError();
-            $this->assertContains('cluster_block_exception', $error['type']);
-            $this->assertContains('cluster read-only', $error['reason']);
-        }
-
         $response = $settings->setReadOnly(false);
         $this->assertFalse($response->hasError());
         $setting = $settings->getTransient('cluster.blocks.read_only');
@@ -105,13 +94,10 @@ class SettingsTest extends BaseTest
 
         // Check that adding documents works again
         $index1->getType('test')->addDocument($doc5);
-        $index2->getType('test')->addDocument($doc6);
 
         $index1->refresh();
-        $index2->refresh();
 
         // 2 docs should be in each index
         $this->assertEquals(2, $index1->count());
-        $this->assertEquals(2, $index2->count());
     }
 }

--- a/test/Elastica/Query/GeoShapePreIndexedTest.php
+++ b/test/Elastica/Query/GeoShapePreIndexedTest.php
@@ -16,19 +16,8 @@ class GeoShapePreIndexedTest extends BaseTest
     public function testSearch()
     {
         $index = $this->_createIndex();
-        $index2 = $this->_createIndex();
         $indexName = $index->getName();
-        $indexName2 = $index2->getName();
-        $type = $index->getType('type');
-        $otherType = $index2->getType('other_type');
-
-        // create mapping
-        $mapping = new Mapping($type, [
-            'location' => [
-                'type' => 'geo_shape',
-            ],
-        ]);
-        $type->setMapping($mapping);
+        $otherType = $index->getType('other_type');
 
         // create other type mapping
         $otherMapping = new Mapping($otherType, [
@@ -37,17 +26,6 @@ class GeoShapePreIndexedTest extends BaseTest
             ],
         ]);
         $otherType->setMapping($otherMapping);
-
-        // add type docs
-        $type->addDocument(new Document('1', [
-            'location' => [
-                'type' => 'envelope',
-                'coordinates' => [
-                    [0.0, 50.0],
-                    [50.0, 0.0],
-                ],
-            ],
-        ]));
 
         // add other type docs
         $otherType->addDocument(new Document('2', [
@@ -61,12 +39,10 @@ class GeoShapePreIndexedTest extends BaseTest
         ]));
 
         $index->forcemerge();
-        $index2->forcemerge();
         $index->refresh();
-        $index2->refresh();
 
         $gsp = new GeoShapePreIndexed(
-            'location', '2', 'other_type', $indexName2, 'location'
+            'location', '2', 'other_type', $indexName, 'location'
         );
 
         $query = new BoolQuery();
@@ -76,8 +52,6 @@ class GeoShapePreIndexedTest extends BaseTest
 
         $gsp->setRelation(AbstractGeoShape::RELATION_DISJOINT);
         $this->assertEquals(0, $otherType->count($query), 'Changing the relation should take effect');
-
-        $index->delete();
     }
 
     /**

--- a/test/Elastica/Query/MatchAllTest.php
+++ b/test/Elastica/Query/MatchAllTest.php
@@ -26,20 +26,17 @@ class MatchAllTest extends BaseTest
     public function testMatchAllIndicesTypes()
     {
         $index1 = $this->_createIndex();
-        $index2 = $this->_createIndex();
 
         $client = $index1->getClient();
 
         $search1 = new Search($client);
         $resultSet1 = $search1->search(new MatchAll());
 
-        $doc1 = new Document(1, ['name' => 'ruflin']);
-        $doc2 = new Document(1, ['name' => 'ruflin']);
-        $index1->getType('test')->addDocument($doc1);
-        $index2->getType('test')->addDocument($doc2);
+        $doc1 = new Document(1, ['name' => 'kimchy']);
+        $doc2 = new Document(2, ['name' => 'ruflin']);
+        $index1->getType('test')->addDocuments([$doc1, $doc2]);
 
         $index1->refresh();
-        $index2->refresh();
 
         $search2 = new Search($client);
         $resultSet2 = $search2->search(new MatchAll());

--- a/test/Elastica/SearchTest.php
+++ b/test/Elastica/SearchTest.php
@@ -216,10 +216,7 @@ class SearchTest extends BaseTest
     {
         $client = $this->_getClient();
         $search1 = new Search($client);
-
         $index1 = $this->_createIndex();
-        $index2 = $this->_createIndex();
-
         $type1 = $index1->getType('hello1');
 
         $result = $search1->search([]);
@@ -229,8 +226,6 @@ class SearchTest extends BaseTest
 
         $result = $search1->search([]);
         $this->assertFalse($result->getResponse()->hasError());
-
-        $search1->addIndex($index2);
 
         $result = $search1->search([]);
         $this->assertFalse($result->getResponse()->hasError());


### PR DESCRIPTION
It looks like when I updated some tests I left some code that should be remove. Removing type did not only mean use two indices in tests. Now it looks like tests are executing without flaky ones.