### PR TITLE
update to es6-rc2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/6.0.0-beta1...master)
 
 ### Backward Compatibility Breaks
+- Return the [_source of inner hit nested](https://github.com/elastic/elasticsearch/pull/26982) as is without wrapping it into its full path context [#1398](https://github.com/ruflin/Elastica/pull/1398)
 
 ### Bugfixes
 

--- a/env/elasticsearch/Dockerfile
+++ b/env/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0-rc1
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.0.0-rc2
 MAINTAINER Nicolas Ruflin <spam@ruflin.com>
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install ingest-attachment

--- a/test/Elastica/Query/InnerHitsTest.php
+++ b/test/Elastica/Query/InnerHitsTest.php
@@ -343,7 +343,7 @@ class InnerHitsTest extends BaseTest
         $innerHitsResults = $firstResult->getInnerHits();
 
         $this->assertEquals($firstResult->getId(), 4);
-        $this->assertEquals($innerHitsResults['users']['hits']['hits'][0]['_source']['users']['name'], 'Newton');
+        $this->assertEquals($innerHitsResults['users']['hits']['hits'][0]['_source']['name'], 'Newton');
     }
 
     /**


### PR DESCRIPTION
This PR will 

- update the docker image to ES6 RC2
- removed xdebug 2.4 from the Dockerfile as it could lead to some errors on TRAVIS. Travis already has xdebug
- solves a BC break on innerHits Query