### PR TITLE
Clear search context after usage in scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ All notable changes to this project will be documented in this file based on the
 
 ### Added
 
+- Added clear() to `Scroll` for closing search context on ES manually
+
 ### Improvements
+
+- Clear search context on ES after usage in `Scroll`
 
 ### Deprecated
 

--- a/lib/Elastica/Scroll.php
+++ b/lib/Elastica/Scroll.php
@@ -83,9 +83,7 @@ class Scroll implements \Iterator
             $this->_revertOptions();
         } else {
             // If there are no pages left, we do not need to query ES.
-            // Reset scroll ID so valid() returns false.
-            $this->_nextScrollId = null;
-            $this->_currentResultSet = null;
+            $this->clear();
         }
     }
 
@@ -132,6 +130,24 @@ class Scroll implements \Iterator
         $this->_setScrollId($this->_search->search());
 
         $this->_revertOptions();
+    }
+
+    /**
+     * Cleares the search context on ES and marks this Scroll instance as finished.
+     */
+    public function clear()
+    {
+        if (null !== $this->_nextScrollId) {
+            $this->_search->getClient()->request(
+                '_search/scroll',
+                Request::DELETE,
+                [Search::OPTION_SCROLL_ID => [$this->_nextScrollId]]
+            );
+
+            // Reset scroll ID so valid() returns false.
+            $this->_nextScrollId = null;
+            $this->_currentResultSet = null;
+        }
     }
 
     /**

--- a/test/Elastica/ScrollTest.php
+++ b/test/Elastica/ScrollTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Elastica\Test;
 
+use Elastica\Client;
 use Elastica\Document;
 use Elastica\Query;
 use Elastica\ResultSet;
@@ -16,12 +17,16 @@ class ScrollTest extends Base
      */
     public function testForeach()
     {
-        $scroll = new Scroll($this->_prepareSearch());
+        $search = $this->_prepareSearch();
+        $scroll = new Scroll($search);
         $count = 1;
+
+        $this->_assertOpenSearchContexts($search->getClient(), 0);
 
         /** @var ResultSet $resultSet */
         foreach ($scroll as $scrollId => $resultSet) {
             $this->assertNotEmpty($scrollId);
+            $this->_assertOpenSearchContexts($search->getClient(), 1);
 
             $results = $resultSet->getResults();
             switch (true) {
@@ -51,6 +56,8 @@ class ScrollTest extends Base
 
             ++$count;
         }
+
+        $this->_assertOpenSearchContexts($search->getClient(), 0);
     }
 
     /**
@@ -100,5 +107,17 @@ class ScrollTest extends Base
         $search->getQuery()->setSize(5);
 
         return $search;
+    }
+
+    /**
+     * Tests the number of open search contexts on ES.
+     *
+     * @param Client $client
+     * @param int    $count
+     */
+    private function _assertOpenSearchContexts(Client $client, $count)
+    {
+        $stats = $client->getStatus()->getData();
+        $this->assertSame($count, $stats['_all']['total']['search']['open_contexts'], 'Open search contexts should match');
     }
 }


### PR DESCRIPTION
Because open search contexts have a cost they should be explicitly
cleared as soon as the scroll is not being used anymore.

The method `clear()` is exposed in `Scroll` to also be able to clear the
search context manually from outside.