### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/env/elastica/composer.json
+++ b/env/elastica/composer.json
@@ -19,8 +19,8 @@
         "pdepend/pdepend":"~2.2",
         "phploc/phploc":"~2.1",
         "phpmd/phpmd":"~2.3",
-        "phpunit/phpunit":"~5.6",
         "sebastian/phpcpd":"~2.0",
+        "phpunit/phpunit":"~6.5",
         "squizlabs/php_codesniffer":"~2.5"
     }
 }

--- a/test/Elastica/Base.php
+++ b/test/Elastica/Base.php
@@ -4,9 +4,11 @@ namespace Elastica\Test;
 use Elastica\Client;
 use Elastica\Connection;
 use Elastica\Index;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Test;
 use Psr\Log\LoggerInterface;
 
-class Base extends \PHPUnit_Framework_TestCase
+class Base extends TestCase
 {
     protected static function hideDeprecated()
     {
@@ -201,21 +203,21 @@ class Base extends \PHPUnit_Framework_TestCase
 
     protected function _isUnitGroup()
     {
-        $groups = \PHPUnit_Util_Test::getGroups(get_class($this), $this->getName(false));
+        $groups = Test::getGroups(get_class($this), $this->getName(false));
 
         return in_array('unit', $groups);
     }
 
     protected function _isFunctionalGroup()
     {
-        $groups = \PHPUnit_Util_Test::getGroups(get_class($this), $this->getName(false));
+        $groups = Test::getGroups(get_class($this), $this->getName(false));
 
         return in_array('functional', $groups);
     }
 
     protected function _isBenchmarkGroup()
     {
-        $groups = \PHPUnit_Util_Test::getGroups(get_class($this), $this->getName(false));
+        $groups = Test::getGroups(get_class($this), $this->getName(false));
 
         return in_array('benchmark', $groups);
     }

--- a/test/Elastica/JSONTest.php
+++ b/test/Elastica/JSONTest.php
@@ -2,13 +2,14 @@
 namespace Elastica\Test;
 
 use Elastica\JSON;
+use PHPUnit\Framework\TestCase;
 
 /**
  * JSONTest.
  *
  * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
  */
-class JSONTest extends \PHPUnit_Framework_TestCase
+class JSONTest extends TestCase
 {
     public function testStringifyMustNotThrowExceptionOnValid()
     {

--- a/test/phpunit.xml.dist
+++ b/test/phpunit.xml.dist
@@ -3,7 +3,7 @@
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
   backupGlobals                           = "false"
   colors                                  = "true"
   beStrictAboutTestsThatDoNotTestAnything = "true"


### PR DESCRIPTION
As we are on `PHP 7`, we can drop `PHPUnit 5` support and start to use to `PHPUnit 6`.