### PR TITLE
Remove "<" and ">" as they cannot be escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Breaks
 
 ### Bugfixes
+- Characters "<" and ">" will be removed when a query term is passed to [`Util::escapeTerm`](https://github.com/ruflin/Elastica/pull/1415/files). Since v5.1 the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-dsl-query-string-query.html#_reserved_characters) states that these symbols cannot be escaped ever.
 
 ### Added
 

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -72,12 +72,12 @@ class Util
     }
 
     /**
-     * Replace the following reserved words: AND OR NOT
+     * Replace known reserved words (e.g. AND OR NOT)
      * and
-     * escapes the following terms: + - && || ! ( ) { } [ ] ^ " ~ * ? : \.
+     * escape known special characters (e.g. + - && || ! ( ) { } [ ] ^ " ~ * ? : etc.)
      *
-     * @link http://lucene.apache.org/java/2_4_0/queryparsersyntax.html#Boolean%20operators
-     * @link http://lucene.apache.org/java/2_4_0/queryparsersyntax.html#Escaping%20Special%20Characters
+     * @link https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-dsl-query-string-query.html#_boolean_operators
+     * @link https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-dsl-query-string-query.html#_reserved_characters
      *
      * @param string $term Query term to replace and escape
      *

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -106,10 +106,18 @@ class Util
     {
         $result = $term;
         // \ escaping has to be first, otherwise escaped later once again
-        $chars = ['\\', '+', '-', '&&', '||', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '/', '<', '>'];
+        $escapableChars = ['\\', '+', '-', '&&', '||', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '/'];
 
-        foreach ($chars as $char) {
+        foreach ($escapableChars as $char) {
             $result = str_replace($char, '\\'.$char, $result);
+        }
+        
+        // < and > cannot be escaped, so they should be removed
+        // @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
+        $nonEscapableChars = ['<', '>'];
+
+        foreach ($nonEscapableChars as $char) {
+            $result = str_replace($char, '', $result);
         }
 
         return $result;

--- a/test/Elastica/UtilTest.php
+++ b/test/Elastica/UtilTest.php
@@ -109,7 +109,7 @@ class UtilTest extends BaseTest
     public function testEscapeTermSpecialCharacters()
     {
         $before = '\\+-&&||!(){}[]^"~*?:/<>';
-        $after = '\\\\\\+\\-\\&&\\||\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\/\<\>';
+        $after = '\\\\\\+\\-\\&&\\||\\!\\(\\)\\{\\}\\[\\]\\^\\"\\~\\*\\?\\:\\/';
 
         $this->assertEquals(Util::escapeTerm($before), $after);
     }


### PR DESCRIPTION
`<` and `>` cannot be escaped according to [the documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters), that's why try to remove them.
