### PR TITLE
Backport fix for exception messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,10 @@ All notable changes to this project will be documented in this file based on the
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/2.3.1...HEAD)
 
-### Backward Compatibility Breaks
-
-### Bugfixes
-
-### Added
-
 ### Improvements
 
-### Deprecated
+- Introduce getFullError() for ResponseSet
+- Use the above to improve the output of getError() on Response
 
 
 ## [2.3.1](https://github.com/ruflin/Elastica/releases/tag/2.3.1) - 2015-10-17

--- a/lib/Elastica/Bulk/ResponseSet.php
+++ b/lib/Elastica/Bulk/ResponseSet.php
@@ -54,6 +54,25 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
     }
 
     /**
+     * Returns first found error (full array).
+     *
+     * @return array|string
+     */
+    public function getFullError()
+    {
+        $error = '';
+
+        foreach ($this->getBulkResponses() as $bulkResponse) {
+            if ($bulkResponse->hasError()) {
+                $error = $bulkResponse->getFullError();
+                break;
+            }
+        }
+
+        return $error;
+    }
+
+    /**
      * @return bool
      */
     public function isOk()

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -78,14 +78,43 @@ class Response
      */
     public function getError()
     {
-        $message = '';
-        $response = $this->getData();
+        $error = $this->getFullError();
+        if (!$error) {
+            return '';
+        }
 
-        if (isset($response['error'])) {
-            $message = $response['error'];
+        if (is_string($error)) {
+            return $error;
+        }
+
+        if (isset($error['root_cause'][0])) {
+            $error = $error['root_cause'][0];
+        }
+
+        $message = $error['reason'];
+        if (isset($error['index'])) {
+            $message .= ' [index: '.$error['index'].']';
         }
 
         return $message;
+    }
+
+    /**
+     * A keyed array representing any errors that occured.
+     *
+     * In case of http://localhost:9200/_alias/test the error is a string
+     *
+     * @return array|string Error data
+     */
+    public function getFullError()
+    {
+        $response = $this->getData();
+
+        if (isset($response['error'])) {
+            return $response['error'];
+        }
+
+        return;
     }
 
     /**


### PR DESCRIPTION
A fix was made in 3.x branch for exception messages to stop an un-useful
error `Error: Wrong parameters for Exception([string $exception [, long $code [, Exception $previous
  = NULL]]])` appearing. This commit backports that same fix into the
2.x branch.

Here's the commit in question: https://github.com/ruflin/Elastica/commit/99d7cd147c469e20e0c8e550c431712edda4dd19#diff-e1d9f3f0154639bb558fbe6fbe46d323

I appreciate 2.x is unlikely maintained anymore, but due to things outside of my control I can't easily upgrade to 3.x so would appreciate this merge and a new 2.x tag created if possible 🙏 

(I couldn't see a 2.x branch but noticed a `release-2.3` so am opening this against that branch, let me know if this isn't correct)