### PR TITLE
add request params to client->deleteDocuments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file based on the
 
 ### Added
 
+* Added request parameters to `Client->deleteDocuments()`. [#1419](https://github.com/ruflin/Elastica/pull/1419)
+
 ### Improvements
 
 ### Deprecated

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -481,12 +481,13 @@ class Client
      * Bulk deletes documents.
      *
      * @param array|\Elastica\Document[] $docs
+     * @param array                      $requestParams
      *
      * @throws \Elastica\Exception\InvalidException
      *
      * @return \Elastica\Bulk\ResponseSet
      */
-    public function deleteDocuments(array $docs)
+    public function deleteDocuments(array $docs, array $requestParams = [])
     {
         if (empty($docs)) {
             throw new InvalidException('Array has to consist of at least one element');
@@ -494,6 +495,10 @@ class Client
 
         $bulk = new Bulk($this);
         $bulk->addDocuments($docs, Action::OP_TYPE_DELETE);
+
+        foreach ($requestParams as $key => $value) {
+            $bulk->setRequestParam($key, $value);
+        }
 
         return $bulk->send();
     }

--- a/test/Elastica/ClientTest.php
+++ b/test/Elastica/ClientTest.php
@@ -930,6 +930,49 @@ class ClientTest extends BaseTest
     /**
      * @group functional
      */
+    public function testDeleteDocumentsWithRequestParameters()
+    {
+        $index = $this->_createIndex();
+        $type = $index->getType('test');
+        $client = $index->getClient();
+
+        $docs = [
+            new Document(1, ['field' => 'value1'], $type, $index),
+            new Document(2, ['field' => 'value2'], $type, $index),
+            new Document(3, ['field' => 'value3'], $type, $index),
+        ];
+
+        $response = $client->addDocuments($docs);
+
+        $this->assertInstanceOf(ResponseSet::class, $response);
+        $this->assertEquals(3, count($response));
+        $this->assertTrue($response->isOk());
+        $this->assertFalse($response->hasError());
+        $this->assertEquals('', $response->getError());
+
+        $index->refresh();
+
+        $this->assertEquals(3, $type->count());
+
+        $deleteDocs = [
+            $docs[0],
+            $docs[2],
+        ];
+
+        $response = $client->deleteDocuments($deleteDocs, ['refresh' => true]);
+
+        $this->assertInstanceOf(ResponseSet::class, $response);
+        $this->assertEquals(2, count($response));
+        $this->assertTrue($response->isOk());
+        $this->assertFalse($response->hasError());
+        $this->assertEquals('', $response->getError());
+
+        $this->assertEquals(1, $type->count());
+    }
+
+    /**
+     * @group functional
+     */
     public function testLastRequestResponse()
     {
         $client = $this->_getClient();


### PR DESCRIPTION
To have the same behaviour than addDocuments or updateDocuments.