### PR TITLE
Clean elses

### DIFF
--- a/lib/Elastica/Cluster/Settings.php
+++ b/lib/Elastica/Cluster/Settings.php
@@ -55,9 +55,9 @@ class Settings
         if (!empty($setting)) {
             if (isset($settings[$setting])) {
                 return $settings[$setting];
-            } else {
-                return;
             }
+
+            return;
         }
 
         return $settings;
@@ -80,23 +80,23 @@ class Settings
         if (!empty($setting)) {
             if (isset($settings[$setting])) {
                 return $settings[$setting];
-            } else {
-                if (strpos($setting, '.') !== false) {
-                    // convert dot notation to nested arrays
-                    $keys = explode('.', $setting);
-                    foreach ($keys as $key) {
-                        if (isset($settings[$key])) {
-                            $settings = $settings[$key];
-                        } else {
-                            return;
-                        }
-                    }
+            }
 
-                    return $settings;
+            if (strpos($setting, '.') !== false) {
+                // convert dot notation to nested arrays
+                $keys = explode('.', $setting);
+                foreach ($keys as $key) {
+                    if (isset($settings[$key])) {
+                        $settings = $settings[$key];
+                    } else {
+                        return;
+                    }
                 }
 
-                return;
+                return $settings;
             }
+
+            return;
         }
 
         return $settings;

--- a/lib/Elastica/Exception/ElasticsearchException.php
+++ b/lib/Elastica/Exception/ElasticsearchException.php
@@ -71,9 +71,9 @@ class ElasticsearchException extends \Exception implements ExceptionInterface
     {
         if (preg_match('/^(\w+)\[.*\]/', $error, $matches)) {
             return $matches[1];
-        } else {
-            return;
         }
+
+        return;
     }
 
     /**

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -242,9 +242,9 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     {
         if ($this->valid()) {
             return $this->_results[$this->key()];
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -314,9 +314,9 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     {
         if ($this->offsetExists($offset)) {
             return $this->_results[$offset];
-        } else {
-            throw new InvalidException('Offset does not exist.');
         }
+
+        throw new InvalidException('Offset does not exist.');
     }
 
     /**


### PR DESCRIPTION
I've removed the `else`s when we have already returned something :put_litter_in_its_place: