### PR TITLE
Request Params passed to Client through Index and Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 * Added request parameters to `Client->deleteDocuments()`. [#1419](https://github.com/ruflin/Elastica/pull/1419)
+* Added request parameters to `Type->updateDocuments()`, `Type->addDocuments()`, `Type->addObjects()`, `Index->addDocuments()`, `Index->updateDocuments()`. [#1427](https://github.com/ruflin/Elastica/pull/1427)
 
 ### Improvements
 

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -119,36 +119,38 @@ class Index implements SearchableInterface
      * Uses _bulk to send documents to the server.
      *
      * @param array|\Elastica\Document[] $docs Array of Elastica\Document
+     * @param array                      $options Array of query params to use for query. For possible options check es api
      *
      * @return \Elastica\Bulk\ResponseSet
      *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
-    public function updateDocuments(array $docs)
+    public function updateDocuments(array $docs, array $options = [])
     {
         foreach ($docs as $doc) {
             $doc->setIndex($this->getName());
         }
 
-        return $this->getClient()->updateDocuments($docs);
+        return $this->getClient()->updateDocuments($docs, $options);
     }
 
     /**
      * Uses _bulk to send documents to the server.
      *
      * @param array|\Elastica\Document[] $docs Array of Elastica\Document
+     * @param array                      $options Array of query params to use for query. For possible options check es api
      *
      * @return \Elastica\Bulk\ResponseSet
      *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
-    public function addDocuments(array $docs)
+    public function addDocuments(array $docs, array $options = [])
     {
         foreach ($docs as $doc) {
             $doc->setIndex($this->getName());
         }
 
-        return $this->getClient()->addDocuments($docs);
+        return $this->getClient()->addDocuments($docs, $options);
     }
 
     /**

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -167,36 +167,37 @@ class Type implements SearchableInterface
      * Uses _bulk to send documents to the server.
      *
      * @param array|\Elastica\Document[] $docs Array of Elastica\Document
+     * @param array                      $options Array of query params to use for query. For possible options check es api
      *
      * @return \Elastica\Bulk\ResponseSet
      *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
-    public function updateDocuments(array $docs)
+    public function updateDocuments(array $docs, array $options = [])
     {
         foreach ($docs as $doc) {
             $doc->setType($this->getName());
         }
 
-        return $this->getIndex()->updateDocuments($docs);
+        return $this->getIndex()->updateDocuments($docs, $options);
     }
 
     /**
      * Uses _bulk to send documents to the server.
      *
      * @param array|\Elastica\Document[] $docs Array of Elastica\Document
-     *
+     * @param array                      $options Array of query params to use for query. For possible options check es api
      * @return \Elastica\Bulk\ResponseSet
      *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
-    public function addDocuments(array $docs)
+    public function addDocuments(array $docs, array $options = [])
     {
         foreach ($docs as $doc) {
             $doc->setType($this->getName());
         }
 
-        return $this->getIndex()->addDocuments($docs);
+        return $this->getIndex()->addDocuments($docs, $options);
     }
 
     /**
@@ -208,7 +209,7 @@ class Type implements SearchableInterface
      *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
-    public function addObjects(array $objects)
+    public function addObjects(array $objects, array $options = [])
     {
         if (!isset($this->_serializer)) {
             throw new RuntimeException('No serializer defined');
@@ -223,7 +224,7 @@ class Type implements SearchableInterface
             $docs[] = $doc;
         }
 
-        return $this->getIndex()->addDocuments($docs);
+        return $this->getIndex()->addDocuments($docs, $options);
     }
 
     /**

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -204,9 +204,9 @@ class Type implements SearchableInterface
      * Uses _bulk to send documents to the server.
      *
      * @param objects[] $objects
+     * @param array     $options Array of query params to use for query. For possible options check es api
      *
-     * @return \Elastica\Bulk\ResponseSet
-     *
+     * @return Bulk\ResponseSet
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
     public function addObjects(array $objects, array $options = [])


### PR DESCRIPTION
Client's methods for updating and adding document have non-required array argument requestParams which can be used, for example, for specifying a pipeline. I added the same argument to the corresponding methods of Index and Type classes.  