### PR TITLE
Allow dependency increase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.6.0",
         "psr/log": "~1.0",
-        "elasticsearch/elasticsearch": "5.3.0"
+        "elasticsearch/elasticsearch": "5.3.*"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",


### PR DESCRIPTION
Dependency `elasticsearch/elasticsearch` is at version 5.3.2 currently but cannot installed right now.