### PR TITLE
Rename deprecated `min_word_len` to `min_word_length`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 
+- Removed deprecated `min_word_len` field in `Elastica\Suggest\Term`.
+  Use `min_word_length` instead.
+
 ### Added
 
 - Added clear() to `Scroll` for closing search context on ES manually

--- a/lib/Elastica/Suggest/Term.php
+++ b/lib/Elastica/Suggest/Term.php
@@ -90,7 +90,7 @@ class Term extends AbstractSuggest
      */
     public function setMinWordLength($length)
     {
-        return $this->setParam('min_word_len', (int) $length);
+        return $this->setParam('min_word_length', (int) $length);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/ruflin/Elastica/issues/1446