### PR TITLE
Desynchronize from driver lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.0",
         "psr/log": "~1.0",
-        "elasticsearch/elasticsearch": "6.0.*"
+        "elasticsearch/elasticsearch": "^6.0"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",


### PR DESCRIPTION
This has several benefits:

- Elastica can now make its own BC-breaks and release majors even if
there is no new elasticsearch/elasticsearch version.
- Elastica can benefit from minor features faster.
- Elastica does not have to make new major releases if there is no need
to.
- If Elastica starts supporting several versions of
elasticsearch/elasticsearch, users will have an easier time migrating.
- Elastica users now only have one compatibility matrix to look at, and
don't have to keep in mind that both libs are synchronized, and will let
Composer resolve dependencies like it should.