### PR TITLE
Add support for specifying a pipeline when indexing documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file based on the
 
 ### Added
 
+* Added support for pipeline when indexing document. [#1455](https://github.com/ruflin/Elastica/pull/1455)
+
 ### Improvements
 
 

--- a/lib/Elastica/Document.php
+++ b/lib/Elastica/Document.php
@@ -276,6 +276,34 @@ class Document extends AbstractUpdateAction
     }
 
     /**
+     * Sets pipeline
+     *
+     * @param string $pipeline
+     *
+     * @return $this
+     */
+    public function setPipeline($pipeline)
+    {
+        return $this->setParam('_pipeline', $pipeline);
+    }
+
+    /**
+     * @return string
+     */
+    public function getPipeline()
+    {
+        return $this->getParam('_pipeline');
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPipeline()
+    {
+        return $this->hasParam('_pipeline');
+    }
+
+    /**
      * Returns the document as an array.
      *
      * @return array

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -82,6 +82,7 @@ class Type implements SearchableInterface
                 'replication',
                 'refresh',
                 'timeout',
+                'pipeline',
             ]
         );
 

--- a/test/Elastica/Base.php
+++ b/test/Elastica/Base.php
@@ -4,6 +4,7 @@ namespace Elastica\Test;
 use Elastica\Client;
 use Elastica\Connection;
 use Elastica\Index;
+use Elasticsearch\Endpoints\Ingest\Pipeline\Put;
 use Psr\Log\LoggerInterface;
 
 class Base extends \PHPUnit_Framework_TestCase
@@ -126,6 +127,27 @@ class Base extends \PHPUnit_Framework_TestCase
         $index->create(['index' => ['number_of_shards' => $shards, 'number_of_replicas' => 1]], $delete);
 
         return $index;
+    }
+
+    protected function _createRenamePipeline()
+    {
+        $client = $this->_getClient();
+
+        $endpoint = new Put();
+        $endpoint->setID('renaming');
+        $endpoint->setBody(array(
+            'description' => 'Rename field',
+            'processors' => array(
+                array(
+                    'rename' => array(
+                        'field' => 'old',
+                        'target_field' => 'new',
+                    ),
+                ),
+            ),
+        ));
+
+        $client->requestEndpoint($endpoint);
     }
 
     protected function _checkScriptInlineSetting()

--- a/test/Elastica/ClientTest.php
+++ b/test/Elastica/ClientTest.php
@@ -1039,6 +1039,34 @@ class ClientTest extends BaseTest
     }
 
     /**
+     * @group functional
+     */
+    public function testAddDocumentsPipeline()
+    {
+        $docs = [];
+        for ($i = 0; $i < 10; ++$i) {
+            $docs[] = new Document(null, ['old' => $i]);
+        }
+
+        $index = $this->_createIndex();
+        $this->_createRenamePipeline();
+
+        $client = $index->getClient();
+        $client->setConfigValue('document', ['autoPopulate' => true]);
+
+        $type = $index->getType('test');
+        $type->addDocuments($docs, ['pipeline' => 'renaming']);
+
+        foreach ($docs as $i => $doc) {
+            $foundDoc = $type->getDocument($doc->getId());
+            $this->assertInstanceOf(Document::class, $foundDoc);
+            $data = $foundDoc->getData();
+            $this->assertArrayHasKey('new', $data);
+            $this->assertEquals($i, $data['new']);
+        }
+    }
+
+    /**
      * @group unit
      */
     public function testConfigValue()

--- a/test/Elastica/TypeTest.php
+++ b/test/Elastica/TypeTest.php
@@ -843,6 +843,30 @@ class TypeTest extends BaseTest
 
     /**
      * @group functional
+     */
+    public function testAddDocumentPipeline()
+    {
+        $index = $this->_createIndex();
+        $type = $index->getType('elastica_type');
+        $this->_createRenamePipeline();
+
+        $document = new Document();
+        $document->setAutoPopulate();
+        $document->set('old', 'ruflin');
+        $document->setPipeline('renaming');
+
+        $type->addDocument($document);
+
+        $foundDoc = $type->getDocument($document->getId());
+        $this->assertInstanceOf(Document::class, $foundDoc);
+        $this->assertEquals($document->getId(), $foundDoc->getId());
+        $data = $foundDoc->getData();
+        $this->assertArrayHasKey('new', $data);
+        $this->assertEquals('ruflin', $data['new']);
+    }
+
+    /**
+     * @group functional
      * @expectedException \Elastica\Exception\RuntimeException
      */
     public function testAddDocumentWithoutSerializer()


### PR DESCRIPTION
this is #1455 cherry-picked on 5.x