### PR TITLE
Do not call toArray method in Query::toArray

### DIFF
--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -330,7 +330,7 @@ class Query extends Param
             $this->setQuery(new MatchAll());
         }
 
-        if (isset($this->_params['post_filter']) && 0 === count(($this->_params['post_filter'])->toArray())) {
+        if (isset($this->_params['post_filter']) && 0 === count($this->_params['post_filter'])) {
             unset($this->_params['post_filter']);
         }
 

--- a/lib/Elastica/Query/GeoPolygon.php
+++ b/lib/Elastica/Query/GeoPolygon.php
@@ -61,6 +61,6 @@ class GeoPolygon extends AbstractQuery
      */
     public function count()
     {
-        return count($this->_key);
+        return count($this->_points);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ruflin/Elastica/issues/1429, introduced in https://github.com/ruflin/Elastica/pull/1378

Unless I'm missing something, we should not call `toArray` in Query::toArray. Either `post_filter` is already an array, or it is an instance of `AbstractQuery` which implements `Countable` through `Param` anyway.