### PR TITLE
Added username and password in connections def

### DIFF
--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -37,7 +37,7 @@ class Client
         'transport' => null,
         'persistent' => true,
         'timeout' => null,
-        'connections' => [], // host, port, path, timeout, transport, compression, persistent, timeout, config -> (curl, headers, url)
+        'connections' => [], // host, port, path, timeout, transport, compression, persistent, timeout, username, password, config -> (curl, headers, url)
         'roundRobin' => false,
         'log' => false,
         'retryOnConflict' => 0,


### PR DESCRIPTION
If you set your server configuration by using the connections array instead of the basic config mode, then you must explicitely tell, per each connection, the user and the password.