### PR TITLE
Add support for multiple bucket sort orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 * Added support for pipeline when indexing document. [#1455](https://github.com/ruflin/Elastica/pull/1455)
+* Added support for multiple bucket sort orders for aggregations.
 
 ### Improvements
 

--- a/lib/Elastica/Aggregation/Terms.php
+++ b/lib/Elastica/Aggregation/Terms.php
@@ -20,4 +20,16 @@ class Terms extends AbstractTermsAggregation
     {
         return $this->setParam('order', [$order => $direction]);
     }
+
+    /**
+     * Sets a list of bucket sort orders.
+     *
+     * @param array $orders A list of [<aggregationField>|"_count"|"_term" => <direction>] definitions.
+     *
+     * @return $this
+     */
+    public function setOrders(array $orders)
+    {
+        return $this->setParam('order', $orders);
+    }
 }

--- a/lib/Elastica/Document.php
+++ b/lib/Elastica/Document.php
@@ -276,7 +276,7 @@ class Document extends AbstractUpdateAction
     }
 
     /**
-     * Sets pipeline
+     * Sets pipeline.
      *
      * @param string $pipeline
      *

--- a/test/Elastica/Aggregation/TermsTest.php
+++ b/test/Elastica/Aggregation/TermsTest.php
@@ -60,4 +60,25 @@ class TermsTest extends BaseAggregationTest
 
         $this->assertEquals('blue', $results['buckets'][2]['key']);
     }
+
+    /**
+     * @group functional
+     */
+    public function testTermsSetOrders()
+    {
+        $agg = new Terms('terms');
+        $agg->setField('color');
+        $agg->setOrders([
+            ['_count' => 'asc'], // 1. red,   2. green, 3. blue
+            ['_key' => 'asc'],   // 1. green, 2. red,   3. blue
+        ]);
+
+        $query = new Query();
+        $query->addAggregation($agg);
+        $results = $this->_getIndexForTest()->search($query)->getAggregation('terms');
+
+        $this->assertSame('green', $results['buckets'][0]['key']);
+        $this->assertSame('red', $results['buckets'][1]['key']);
+        $this->assertSame('blue', $results['buckets'][2]['key']);
+    }
 }


### PR DESCRIPTION
* Added `Aggregation\Terms::setOrders`
* Added test for `Aggregation\Terms::setOrders`
* Linter fixed another comment

If you want me to remove the linter fix, I'll can remove it. But I just followed the instructions and the linter changed the line. And since it was just one small change I took it into my PR.