### PR TITLE
Use dedicated PHPUnit assertions

### DIFF
--- a/test/Elastica/Aggregation/ExtendedStatsTest.php
+++ b/test/Elastica/Aggregation/ExtendedStatsTest.php
@@ -40,6 +40,6 @@ class ExtendedStatsTest extends BaseAggregationTest
         $this->assertEquals(8, $results['max']);
         $this->assertEquals((5 + 8 + 1 + 3) / 4.0, $results['avg']);
         $this->assertEquals((5 + 8 + 1 + 3), $results['sum']);
-        $this->assertTrue(array_key_exists('sum_of_squares', $results));
+        $this->assertArrayHasKey('sum_of_squares', $results);
     }
 }

--- a/test/Elastica/Aggregation/HistogramTest.php
+++ b/test/Elastica/Aggregation/HistogramTest.php
@@ -40,7 +40,7 @@ class HistogramTest extends BaseAggregationTest
         $results = $this->_getIndexForTest()->search($query)->getAggregation('hist');
 
         $buckets = $results['buckets'];
-        $this->assertEquals(5, sizeof($buckets));
+        $this->assertCount(5, $buckets);
         $this->assertEquals(30, $buckets[3]['key']);
         $this->assertEquals(2, $buckets[3]['doc_count']);
     }

--- a/test/Elastica/Aggregation/SignificantTermsTest.php
+++ b/test/Elastica/Aggregation/SignificantTermsTest.php
@@ -47,7 +47,7 @@ class SignificantTermsTest extends BaseAggregationTest
         $query->addAggregation($agg);
         $results = $this->_getIndexForTest()->search($query)->getAggregation('significantTerms');
 
-        $this->assertEquals(1, count($results['buckets']));
+        $this->assertCount(1, $results['buckets']);
         $this->assertEquals(63, $results['buckets'][0]['doc_count']);
         $this->assertEquals(79, $results['buckets'][0]['bg_count']);
         $this->assertEquals('1500', $results['buckets'][0]['key']);

--- a/test/Elastica/Bulk/ResponseSetTest.php
+++ b/test/Elastica/Bulk/ResponseSetTest.php
@@ -46,7 +46,7 @@ class ResponseSetTest extends BaseTest
             $this->assertNotEquals('AnotherExceptionMessage', $responseSet->getError());
 
             $actionExceptions = $e->getActionExceptions();
-            $this->assertEquals(2, count($actionExceptions));
+            $this->assertCount(2, $actionExceptions);
 
             $this->assertInstanceOf(ActionException::class, $actionExceptions[0]);
             $this->assertSame($actions[1], $actionExceptions[0]->getAction());
@@ -71,7 +71,7 @@ class ResponseSetTest extends BaseTest
 
         $bulkResponses = $responseSet->getBulkResponses();
         $this->assertInternalType('array', $bulkResponses);
-        $this->assertEquals(3, count($bulkResponses));
+        $this->assertCount(3, $bulkResponses);
 
         foreach ($bulkResponses as $i => $bulkResponse) {
             $this->assertInstanceOf(Bulk\Response::class, $bulkResponse);
@@ -93,7 +93,7 @@ class ResponseSetTest extends BaseTest
 
         $responseSet = $this->_createResponseSet($responseData, $actions);
 
-        $this->assertEquals(3, count($responseSet));
+        $this->assertCount(3, $responseSet);
 
         foreach ($responseSet as $i => $bulkResponse) {
             $this->assertInstanceOf(Bulk\Response::class, $bulkResponse);

--- a/test/Elastica/BulkTest.php
+++ b/test/Elastica/BulkTest.php
@@ -257,7 +257,7 @@ class BulkTest extends BaseTest
         $actions = $bulk->getActions();
 
         $this->assertInternalType('array', $actions);
-        $this->assertEquals(5, count($actions));
+        $this->assertCount(5, $actions);
 
         $this->assertInstanceOf(Action::class, $actions[0]);
         $this->assertEquals('index', $actions[0]->getOpType());
@@ -412,7 +412,7 @@ class BulkTest extends BaseTest
 
         foreach (['Mister', 'Invisible', 'Torch'] as $name) {
             $result = $type->search($name);
-            $this->assertEquals(1, count($result->getResults()));
+            $this->assertCount(1, $result->getResults());
         }
     }
 

--- a/test/Elastica/ClientTest.php
+++ b/test/Elastica/ClientTest.php
@@ -342,8 +342,8 @@ class ClientTest extends BaseTest
         // deleteIds are the type we are testing for
         $idxString = $index->getName();
         $typeString = $type->getName();
-        $this->assertTrue(is_string($idxString));
-        $this->assertTrue(is_string($typeString));
+        $this->assertInternalType('string', $idxString);
+        $this->assertInternalType('string', $typeString);
 
         // Try to delete doc with a routing value which hashes to
         // a different shard then the id.
@@ -418,7 +418,7 @@ class ClientTest extends BaseTest
         // And verify that the variables we are doing to send to
         // deleteIds are the type we are testing for
         $idxString = $index->getName();
-        $this->assertTrue(is_string($idxString));
+        $this->assertInternalType('string', $idxString);
         $this->assertInstanceOf(Type::class, $type);
 
         // Using the existing $index and $type variables which
@@ -483,7 +483,7 @@ class ClientTest extends BaseTest
         // deleteIds are the type we are testing for
         $typeString = $type->getName();
         $this->assertInstanceOf(Index::class, $index);
-        $this->assertTrue(is_string($typeString));
+        $this->assertInternalType('string', $typeString);
 
         // Using the existing $index and $type variables which
         // are \Elastica\Index and \Elastica\Type objects respectively
@@ -579,7 +579,7 @@ class ClientTest extends BaseTest
         $connections = $client->getConnections();
 
         // two connections are setup
-        $this->assertEquals(2, count($connections));
+        $this->assertCount(2, $connections);
 
         // One connection has to be disabled
         $this->assertTrue($connections[0]->isEnabled() == false || $connections[1]->isEnabled() == false);
@@ -607,7 +607,7 @@ class ClientTest extends BaseTest
         $connections = $client->getConnections();
 
         // two connections are setup
-        $this->assertEquals(2, count($connections));
+        $this->assertCount(2, $connections);
 
         // One connection has to be disabled
         $this->assertTrue($connections[0]->isEnabled() == false || $connections[1]->isEnabled() == false);
@@ -900,7 +900,7 @@ class ClientTest extends BaseTest
         $response = $client->addDocuments($docs);
 
         $this->assertInstanceOf(ResponseSet::class, $response);
-        $this->assertEquals(3, count($response));
+        $this->assertCount(3, $response);
         $this->assertTrue($response->isOk());
         $this->assertFalse($response->hasError());
         $this->assertEquals('', $response->getError());
@@ -917,7 +917,7 @@ class ClientTest extends BaseTest
         $response = $client->deleteDocuments($deleteDocs);
 
         $this->assertInstanceOf(ResponseSet::class, $response);
-        $this->assertEquals(2, count($response));
+        $this->assertCount(2, $response);
         $this->assertTrue($response->isOk());
         $this->assertFalse($response->hasError());
         $this->assertEquals('', $response->getError());
@@ -945,7 +945,7 @@ class ClientTest extends BaseTest
         $response = $client->addDocuments($docs);
 
         $this->assertInstanceOf(ResponseSet::class, $response);
-        $this->assertEquals(3, count($response));
+        $this->assertCount(3, $response);
         $this->assertTrue($response->isOk());
         $this->assertFalse($response->hasError());
         $this->assertEquals('', $response->getError());
@@ -962,7 +962,7 @@ class ClientTest extends BaseTest
         $response = $client->deleteDocuments($deleteDocs, ['refresh' => true]);
 
         $this->assertInstanceOf(ResponseSet::class, $response);
-        $this->assertEquals(2, count($response));
+        $this->assertCount(2, $response);
         $this->assertTrue($response->isOk());
         $this->assertFalse($response->hasError());
         $this->assertEquals('', $response->getError());
@@ -1392,7 +1392,7 @@ class ClientTest extends BaseTest
         $endpoint->setParams(['types' => [$type->getName()]]);
         $response = $client->requestEndpoint($endpoint);
 
-        $this->assertTrue(isset($response->getData()['indices'][$index->getName()]['total']['indexing']['types']));
+        $this->assertArrayHasKey('types', $response->getData()['indices'][$index->getName()]['total']['indexing']);
 
         $this->assertEquals(
             ['test'],

--- a/test/Elastica/Cluster/Health/IndexTest.php
+++ b/test/Elastica/Cluster/Health/IndexTest.php
@@ -136,7 +136,7 @@ class IndexTest extends BaseTest
         $shards = $this->_index->getShards();
 
         $this->assertInternalType('array', $shards);
-        $this->assertEquals(3, count($shards));
+        $this->assertCount(3, $shards);
 
         foreach ($shards as $shard) {
             $this->assertInstanceOf(Shard::class, $shard);

--- a/test/Elastica/Cluster/HealthTest.php
+++ b/test/Elastica/Cluster/HealthTest.php
@@ -186,7 +186,7 @@ class HealthTest extends BaseTest
         $indices = $this->_health->getIndices();
 
         $this->assertInternalType('array', $indices);
-        $this->assertEquals(2, count($indices));
+        $this->assertCount(2, $indices);
         $this->assertArrayHasKey('index_one', $indices);
         $this->assertArrayHasKey('index_two', $indices);
 

--- a/test/Elastica/DocumentTest.php
+++ b/test/Elastica/DocumentTest.php
@@ -154,7 +154,7 @@ class DocumentTest extends BaseTest
         $options = $document->getOptions(['index', 'type', 'id', 'parent']);
 
         $this->assertInternalType('array', $options);
-        $this->assertEquals(3, count($options));
+        $this->assertCount(3, $options);
         $this->assertArrayHasKey('index', $options);
         $this->assertArrayHasKey('id', $options);
         $this->assertArrayHasKey('parent', $options);
@@ -170,7 +170,7 @@ class DocumentTest extends BaseTest
         $options = $document->getOptions(['parent', 'op_type', 'percolate'], true);
 
         $this->assertInternalType('array', $options);
-        $this->assertEquals(2, count($options));
+        $this->assertCount(2, $options);
         $this->assertArrayHasKey('_parent', $options);
         $this->assertArrayHasKey('_op_type', $options);
         $this->assertEquals('2', $options['_parent']);
@@ -279,7 +279,7 @@ class DocumentTest extends BaseTest
         }
 
         $this->assertEquals('changed1', $document->field1);
-        $this->assertFalse(isset($document->field3));
+        $this->assertObjectNotHasAttribute('field3', $document);
 
         $newData = $document->getData();
 

--- a/test/Elastica/Exception/PartialShardFailureExceptionTest.php
+++ b/test/Elastica/Exception/PartialShardFailureExceptionTest.php
@@ -50,10 +50,10 @@ class PartialShardFailureExceptionTest extends AbstractExceptionTest
         } catch (PartialShardFailureException $e) {
             $builder = new DefaultBuilder();
             $resultSet = $builder->buildResultSet($e->getResponse(), $query);
-            $this->assertEquals(0, count($resultSet->getResults()));
+            $this->assertCount(0, $resultSet->getResults());
 
             $message = JSON::parse($e->getMessage());
-            $this->assertTrue(isset($message['failures']), 'Failures are absent');
+            $this->assertArrayHasKey('failures', $message, 'Failures are absent');
             $this->assertGreaterThan(0, count($message['failures']), 'Failures are empty');
         }
     }

--- a/test/Elastica/IndexTest.php
+++ b/test/Elastica/IndexTest.php
@@ -480,7 +480,7 @@ class IndexTest extends BaseTest
         $index = $this->_createIndex();
         $indexMappings = $index->getMapping();
 
-        $this->assertTrue(empty($indexMappings['elastica_test']));
+        $this->assertEmpty($indexMappings['elastica_test']);
     }
 
     /**

--- a/test/Elastica/Node/InfoTest.php
+++ b/test/Elastica/Node/InfoTest.php
@@ -59,7 +59,7 @@ class InfoTest extends BaseTest
             $id = $node->getInfo()->getId();
 
             // Checks that the ids are unique
-            $this->assertFalse(in_array($id, $ids));
+            $this->assertNotContains($id, $ids);
             $ids[] = $id;
         }
     }
@@ -90,8 +90,8 @@ class InfoTest extends BaseTest
 
         $info = $client->getCluster()->getNodes()[0]->getInfo();
 
-        $this->assertTrue(isset($info->getData()['plugins']));
+        $this->assertArrayHasKey('plugins', $info->getData());
         $info->refresh(['jvm']);
-        $this->assertFalse(isset($info->getData()['plugins']));
+        $this->assertArrayNotHasKey('plugins', $info->getData());
     }
 }

--- a/test/Elastica/PipelineTest.php
+++ b/test/Elastica/PipelineTest.php
@@ -109,7 +109,7 @@ class PipelineTest extends BasePipeline
         /** @var ResultSet $result */
         $result = $index->search('elastica');
 
-        $this->assertEquals(2, count($result->getResults()));
+        $this->assertCount(2, $result->getResults());
 
         foreach ($result->getResults() as $rx) {
             $value = $rx->getData();

--- a/test/Elastica/Processor/AppendTest.php
+++ b/test/Elastica/Processor/AppendTest.php
@@ -75,11 +75,11 @@ class AppendTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(2, count($result->getResults()));
+        $this->assertCount(2, $result->getResults());
 
         foreach ($result->getResults() as $rx) {
             $value = $rx->getData();
-            $this->assertEquals(4, count($value['foo']));
+            $this->assertCount(4, $value['foo']);
             $this->assertNull($value['foo'][0]);
             $this->assertEquals('item2', $value['foo'][1]);
             $this->assertEquals('item3', $value['foo'][2]);

--- a/test/Elastica/Processor/AttachmentTest.php
+++ b/test/Elastica/Processor/AttachmentTest.php
@@ -237,6 +237,6 @@ class AttachmentTest extends BasePipelineTest
         $data = $type->getDocument($docId)->getData();
         $this->assertEquals($data['title'], $title);
         $this->assertEquals($data['text'], $text);
-        $this->assertFalse(isset($data['file']));
+        $this->assertArrayNotHasKey('file', $data);
     }
 }

--- a/test/Elastica/Processor/ConvertTest.php
+++ b/test/Elastica/Processor/ConvertTest.php
@@ -90,7 +90,7 @@ class ConvertTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('elastica');
 
-        $this->assertEquals(2, count($result->getResults()));
+        $this->assertCount(2, $result->getResults());
 
         $results = $result->getResults();
         foreach ($results as $result) {

--- a/test/Elastica/Processor/DateTest.php
+++ b/test/Elastica/Processor/DateTest.php
@@ -92,7 +92,7 @@ class DateTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(1, count($result->getResults()));
+        $this->assertCount(1, $result->getResults());
 
         $results = $result->getResults();
         $this->assertEquals('2010-06-12T11:05:15.000+02:00', ($results[0]->getHit())['_source']['date_parsed']);

--- a/test/Elastica/Processor/DotExpanderTest.php
+++ b/test/Elastica/Processor/DotExpanderTest.php
@@ -54,7 +54,7 @@ class DotExpanderTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(1, count($result->getResults()));
+        $this->assertCount(1, $result->getResults());
 
         $expect = [
             'foo' => [

--- a/test/Elastica/Processor/JoinTest.php
+++ b/test/Elastica/Processor/JoinTest.php
@@ -55,7 +55,7 @@ class JoinTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(1, count($result->getResults()));
+        $this->assertCount(1, $result->getResults());
 
         $results = $result->getResults();
         $this->assertSame('abc-def-ghij', ($results[0]->getHit())['_source']['name']);

--- a/test/Elastica/Processor/JsonTest.php
+++ b/test/Elastica/Processor/JsonTest.php
@@ -75,7 +75,7 @@ class JsonTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(1, count($result->getResults()));
+        $this->assertCount(1, $result->getResults());
 
         $resultExpected = [
             'foo' => 2000,

--- a/test/Elastica/Processor/LowercaseTest.php
+++ b/test/Elastica/Processor/LowercaseTest.php
@@ -57,7 +57,7 @@ class LowercaseTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(2, count($result->getResults()));
+        $this->assertCount(2, $result->getResults());
 
         $results = $result->getResults();
         $this->assertSame('ruflin', ($results[0]->getHit())['_source']['name']);

--- a/test/Elastica/Processor/RemoveTest.php
+++ b/test/Elastica/Processor/RemoveTest.php
@@ -74,7 +74,7 @@ class RemoveTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(2, count($result->getResults()));
+        $this->assertCount(2, $result->getResults());
 
         foreach ($result->getResults() as $rx) {
             $value = $rx->getData();

--- a/test/Elastica/Processor/RenameTest.php
+++ b/test/Elastica/Processor/RenameTest.php
@@ -76,7 +76,7 @@ class RenameTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(1, count($result->getResults()));
+        $this->assertCount(1, $result->getResults());
 
         $results = $result->getResults();
         $this->assertArrayHasKey('packages', ($results[0]->getHit())['_source']);

--- a/test/Elastica/Processor/SetTest.php
+++ b/test/Elastica/Processor/SetTest.php
@@ -77,7 +77,7 @@ class SetTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(2, count($result->getResults()));
+        $this->assertCount(2, $result->getResults());
 
         foreach ($result->getResults() as $rx) {
             $value = $rx->getData();

--- a/test/Elastica/Processor/SortTest.php
+++ b/test/Elastica/Processor/SortTest.php
@@ -72,7 +72,7 @@ class SortTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(1, count($result->getResults()));
+        $this->assertCount(1, $result->getResults());
 
         $results = $result->getResults();
         $this->assertSame([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], ($results[0]->getHit())['_source']['name']);

--- a/test/Elastica/Processor/SplitTest.php
+++ b/test/Elastica/Processor/SplitTest.php
@@ -76,7 +76,7 @@ class SplitTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(1, count($result->getResults()));
+        $this->assertCount(1, $result->getResults());
 
         $results = $result->getResults();
         $this->assertSame(['nicolas', 'ruflin'], ($results[0]->getHit())['_source']['name']);

--- a/test/Elastica/Processor/TrimTest.php
+++ b/test/Elastica/Processor/TrimTest.php
@@ -57,7 +57,7 @@ class TrimTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(2, count($result->getResults()));
+        $this->assertCount(2, $result->getResults());
 
         $results = $result->getResults();
         $this->assertSame('ruflin', ($results[0]->getHit())['_source']['name']);

--- a/test/Elastica/Processor/UppercaseTest.php
+++ b/test/Elastica/Processor/UppercaseTest.php
@@ -57,7 +57,7 @@ class UppercaseTest extends BasePipelineTest
         /** @var ResultSet $result */
         $result = $index->search('*');
 
-        $this->assertEquals(2, count($result->getResults()));
+        $this->assertCount(2, $result->getResults());
 
         $results = $result->getResults();
         $this->assertSame('RUFLIN', ($results[0]->getHit())['_source']['name']);

--- a/test/Elastica/Query/CommonTest.php
+++ b/test/Elastica/Query/CommonTest.php
@@ -52,7 +52,7 @@ class CommonTest extends BaseTest
         $results = $type->search($query)->getResults();
 
         //documents containing only common words should not be returned
-        $this->assertEquals(3, sizeof($results));
+        $this->assertCount(3, $results);
 
         $query->setMinimumShouldMatch(2);
         $results = $type->search($query);

--- a/test/Elastica/QueryBuilder/DSL/AbstractDSLTest.php
+++ b/test/Elastica/QueryBuilder/DSL/AbstractDSLTest.php
@@ -53,7 +53,7 @@ abstract class AbstractDSLTest extends BaseTest
      */
     protected function _assertParametersEquals($left, $right)
     {
-        $this->assertEquals(count($left), count($right), 'Parameters count mismatch');
+        $this->assertCount(count($left), $right, 'Parameters count mismatch');
 
         for ($i = 0; $i < count($left); ++$i) {
             $this->assertEquals($left[$i]->getName(), $right[$i]->getName(), 'Parameters names mismatch');

--- a/test/Elastica/ResponseTest.php
+++ b/test/Elastica/ResponseTest.php
@@ -43,7 +43,7 @@ class ResponseTest extends BaseTest
         $shardsStats = $resultSet->getResponse()->getShardsStatistics();
 
         $this->assertInternalType('int', $engineTime);
-        $this->assertTrue(is_array($shardsStats));
+        $this->assertInternalType('array', $shardsStats);
         $this->assertArrayHasKey('total', $shardsStats);
         $this->assertArrayHasKey('successful', $shardsStats);
     }
@@ -215,7 +215,7 @@ class ResponseTest extends BaseTest
         ]));
         $response->setJsonBigintConversion(true);
 
-        $this->assertTrue(is_array($response->getData()));
+        $this->assertInternalType('array', $response->getData());
     }
 
     /**

--- a/test/Elastica/ResultSetTest.php
+++ b/test/Elastica/ResultSetTest.php
@@ -32,7 +32,7 @@ class ResultSetTest extends BaseTest
         $this->assertNotTrue($resultSet->hasAggregations());
         $this->assertNotTrue($resultSet->hasSuggests());
         $this->assertInternalType('array', $resultSet->getResults());
-        $this->assertEquals(3, count($resultSet));
+        $this->assertCount(3, $resultSet);
     }
 
     /**
@@ -57,7 +57,7 @@ class ResultSetTest extends BaseTest
         $this->assertInstanceOf(Result::class, $resultSet[1]);
         $this->assertInstanceOf(Result::class, $resultSet[2]);
 
-        $this->assertFalse(isset($resultSet[3]));
+        $this->assertArrayNotHasKey(3, $resultSet);
     }
 
     /**
@@ -82,11 +82,11 @@ class ResultSetTest extends BaseTest
         $documents = $resultSet->getDocuments();
 
         $this->assertInternalType('array', $documents);
-        $this->assertEquals(3, count($documents));
+        $this->assertCount(3, $documents);
         $this->assertInstanceOf(Document::class, $documents[0]);
         $this->assertInstanceOf(Document::class, $documents[1]);
         $this->assertInstanceOf(Document::class, $documents[2]);
-        $this->assertFalse(isset($documents[3]));
+        $this->assertArrayNotHasKey(3, $documents);
         $this->assertEquals('elastica search', $documents[0]->get('name'));
     }
 

--- a/test/Elastica/SearchTest.php
+++ b/test/Elastica/SearchTest.php
@@ -43,22 +43,22 @@ class SearchTest extends BaseTest
         $search->addIndex($index1);
         $indices = $search->getIndices();
 
-        $this->assertEquals(1, count($indices));
+        $this->assertCount(1, $indices);
 
         $search->addIndex($index2);
         $indices = $search->getIndices();
 
-        $this->assertEquals(2, count($indices));
+        $this->assertCount(2, $indices);
 
-        $this->assertTrue(in_array($index1->getName(), $indices));
-        $this->assertTrue(in_array($index2->getName(), $indices));
+        $this->assertContains($index1->getName(), $indices);
+        $this->assertContains($index2->getName(), $indices);
 
         // Add string
         $search->addIndex('test3');
         $indices = $search->getIndices();
 
-        $this->assertEquals(3, count($indices));
-        $this->assertTrue(in_array('test3', $indices));
+        $this->assertCount(3, $indices);
+        $this->assertContains('test3', $indices);
     }
 
     /**
@@ -75,7 +75,7 @@ class SearchTest extends BaseTest
 
         $search->addIndices($indices);
 
-        $this->assertEquals(2, count($search->getIndices()));
+        $this->assertCount(2, $search->getIndices());
     }
 
     /**
@@ -96,22 +96,22 @@ class SearchTest extends BaseTest
         $search->addType($type1);
         $types = $search->getTypes();
 
-        $this->assertEquals(1, count($types));
+        $this->assertCount(1, $types);
 
         $search->addType($type2);
         $types = $search->getTypes();
 
-        $this->assertEquals(2, count($types));
+        $this->assertCount(2, $types);
 
-        $this->assertTrue(in_array($type1->getName(), $types));
-        $this->assertTrue(in_array($type2->getName(), $types));
+        $this->assertContains($type1->getName(), $types);
+        $this->assertContains($type2->getName(), $types);
 
         // Add string
         $search->addType('test3');
         $types = $search->getTypes();
 
-        $this->assertEquals(3, count($types));
-        $this->assertTrue(in_array('test3', $types));
+        $this->assertCount(3, $types);
+        $this->assertContains('test3', $types);
     }
 
     /**
@@ -130,7 +130,7 @@ class SearchTest extends BaseTest
 
         $search->addTypes($types);
 
-        $this->assertEquals(2, count($search->getTypes()));
+        $this->assertCount(2, $search->getTypes());
     }
 
     /**
@@ -265,7 +265,7 @@ class SearchTest extends BaseTest
 
         $scrollId = $result->getResponse()->getScrollId();
         $this->assertNotEmpty($scrollId);
-        $this->assertEquals(5, count($result->getResults()));
+        $this->assertCount(5, $result->getResults());
 
         //There are 10 items, and we're scrolling with a size of 5
         //So we should get two results of 5 items, and then no items
@@ -276,7 +276,7 @@ class SearchTest extends BaseTest
             Search::OPTION_SCROLL_ID => $scrollId,
         ]);
         $this->assertFalse($result->getResponse()->hasError());
-        $this->assertEquals(5, count($result->getResults()));
+        $this->assertCount(5, $result->getResults());
         $this->assertArrayNotHasKey(Search::OPTION_SCROLL_ID, $search->getClient()->getLastRequest()->getQuery());
         $this->assertEquals([Search::OPTION_SCROLL_ID => $scrollId], $search->getClient()->getLastRequest()->getData());
 
@@ -285,7 +285,7 @@ class SearchTest extends BaseTest
             Search::OPTION_SCROLL_ID => $scrollId,
         ]);
         $this->assertFalse($result->getResponse()->hasError());
-        $this->assertEquals(0, count($result->getResults()));
+        $this->assertCount(0, $result->getResults());
         $this->assertArrayNotHasKey(Search::OPTION_SCROLL_ID, $search->getClient()->getLastRequest()->getQuery());
         $this->assertEquals([Search::OPTION_SCROLL_ID => $scrollId], $search->getClient()->getLastRequest()->getData());
     }

--- a/test/Elastica/SnapshotTest.php
+++ b/test/Elastica/SnapshotTest.php
@@ -80,7 +80,7 @@ class SnapshotTest extends Base
         $this->assertArrayHasKey('snapshot', $response->getData());
         $data = $response->getData();
         $this->assertContains($this->_index->getName(), $data['snapshot']['indices']);
-        $this->assertEquals(1, sizeof($data['snapshot']['indices'])); // only the specified index should be present
+        $this->assertCount(1, $data['snapshot']['indices']); // only the specified index should be present
         $this->assertEquals($snapshotName, $data['snapshot']['snapshot']);
 
         // retrieve data regarding the snapshot

--- a/test/Elastica/Suggest/PhraseTest.php
+++ b/test/Elastica/Suggest/PhraseTest.php
@@ -74,7 +74,7 @@ class PhraseTest extends BaseTest
         $suggests = $result->getSuggests();
 
         // 3 suggestions should be returned: One in which both misspellings are corrected, and two in which only one misspelling is corrected.
-        $this->assertEquals(3, sizeof($suggests['suggest1'][0]['options']));
+        $this->assertCount(3, $suggests['suggest1'][0]['options']);
 
         $this->assertEquals('elasticsearch is <suggest>bonsai cool</suggest>', $suggests['suggest1'][0]['options'][0]['highlighted']);
         $this->assertEquals('elasticsearch is bonsai cool', $suggests['suggest1'][0]['options'][0]['text']);

--- a/test/Elastica/Suggest/TermTest.php
+++ b/test/Elastica/Suggest/TermTest.php
@@ -86,7 +86,7 @@ class TermTest extends BaseTest
         $suggests = $result->getSuggests();
 
         // Ensure that two suggestion results are returned for suggest1
-        $this->assertEquals(2, sizeof($suggests['suggest1']));
+        $this->assertCount(2, $suggests['suggest1']);
 
         $this->assertEquals('github', $suggests['suggest2'][0]['options'][0]['text']);
         $this->assertEquals('food', $suggests['suggest1'][0]['options'][0]['text']);
@@ -107,6 +107,6 @@ class TermTest extends BaseTest
 
         // Assert that no suggestions were returned
         $suggests = $result->getSuggests();
-        $this->assertEquals(0, sizeof($suggests['suggest1'][0]['options']));
+        $this->assertCount(0, $suggests['suggest1'][0]['options']);
     }
 }

--- a/test/Elastica/Type/MappingTest.php
+++ b/test/Elastica/Type/MappingTest.php
@@ -53,7 +53,7 @@ class MappingTest extends BaseTest
 
         $this->assertEquals($firstname, $fields['firstname'][0]);
         $this->assertArrayNotHasKey('lastname', $fields);
-        $this->assertEquals(1, count($fields));
+        $this->assertCount(1, $fields);
 
         $index->flush();
         $document = $type->getDocument(1);


### PR DESCRIPTION
Using PHPUnit dedicated assertions will give us better error messages, making easier to debug fails. For example:
```diff
-$this->assertTrue(in_array('foo', ['bar', 'baz']));
+$this->assertContains('foo', ['baz', 'bar']);
```

Will give us:
```diff
-Failed asserting that false is true.
+Failed asserting that an array contains 'foo'.
```