### PR TITLE
Reindex more flexible

### DIFF
--- a/lib/Elastica/Reindex.php
+++ b/lib/Elastica/Reindex.php
@@ -3,7 +3,7 @@ namespace Elastica;
 
 use Elastica\Query\AbstractQuery;
 
-class Reindex
+class Reindex extends Param
 {
     const VERSION_TYPE = 'version_type';
     const VERSION_TYPE_INTERNAL = 'internal';
@@ -15,6 +15,8 @@ class Reindex
     const TYPE = 'type';
     const SIZE = 'size';
     const QUERY = 'query';
+    const WAIT_FOR_COMPLETION = 'wait_for_completion';
+    const WAIT_FOR_COMPLETION_FALSE = 'false';
 
     /**
      * @var Index
@@ -31,53 +33,70 @@ class Reindex
      */
     protected $_options;
 
+    /**
+     * @var Response|null
+     */
+    protected $_lastResponse;
+
+    /**
+     * @param array $options - deprecated because not compatible with complete Reindex API
+     */
     public function __construct(Index $oldIndex, Index $newIndex, array $options = [])
     {
         $this->_oldIndex = $oldIndex;
         $this->_newIndex = $newIndex;
-        $this->_options = $options;
+        $this->_params = $this->resolveOptions($options);
     }
 
     public function run()
     {
-        $body = $this->_getBody($this->_oldIndex, $this->_newIndex, $this->_options);
+        $params = $this->_getEndpointParams($this->_params);
+        $body = $this->_getBody($this->_oldIndex, $this->_newIndex, $this->_params);
 
         $reindexEndpoint = new \Elasticsearch\Endpoints\Reindex();
+        $reindexEndpoint->setParams($params);
         $reindexEndpoint->setBody($body);
 
-        $this->_oldIndex->getClient()->requestEndpoint($reindexEndpoint);
+        $this->lastResponse = $this->_oldIndex->getClient()->requestEndpoint($reindexEndpoint);
         $this->_newIndex->refresh();
 
         return $this->_newIndex;
     }
 
-    protected function _getBody($oldIndex, $newIndex, $options)
+    protected function _getBody($oldIndex, $newIndex, $params)
     {
-        $body = array_merge([
-            'source' => $this->_getSourcePartBody($oldIndex, $options),
-            'dest' => $this->_getDestPartBody($newIndex, $options),
-        ], $this->_resolveBodyOptions($options));
+        $body = array_diff_key($params, $this->_getEndpointParams($params));
+
+        $body = array_merge_recursive($body, [
+            'source' => ['index' => $oldIndex->getName()],
+            'dest'   => ['index' => $newIndex->getName()],
+        ]);
 
         return $body;
     }
 
-    protected function _getSourcePartBody(Index $index, array $options)
+    protected function resolveOptions(array $options)
     {
-        $sourceBody = array_merge([
-            'index' => $index->getName(),
-        ], $this->_resolveSourceOptions($options));
+        $params = array_merge([
+            'source' => $this->_getSourcePartBody($options),
+            'dest'   => $this->_getDestPartBody($options),
+        ], $this->_resolveBodyOptions($options));
 
+        return $params;
+    }
+
+    protected function _getSourcePartBody($options)
+    {
+        $sourceBody = $this->_resolveSourceOptions($options);
         $sourceBody = $this->_setSourceQuery($sourceBody);
         $sourceBody = $this->_setSourceType($sourceBody);
 
         return $sourceBody;
     }
 
-    protected function _getDestPartBody(Index $index, array $options)
+    protected function _getDestPartBody(array $options)
     {
-        return array_merge([
-            'index' => $index->getName(),
-        ], $this->_resolveDestOptions($options));
+        return $this->_resolveDestOptions($options);
     }
 
     private function _resolveSourceOptions(array $options)
@@ -137,5 +156,27 @@ class Reindex
         }
 
         return $sourceBody;
+    }
+
+    private function _getEndpointParams(array $params)
+    {
+        return array_intersect_key($params, [
+            self::WAIT_FOR_COMPLETION => null,
+        ]);
+    }
+
+    public function getTaskId()
+    {
+        $taskId = null;
+        if ($this->lastResponse instanceof Response) {
+            $taskId = $this->lastResponse->getData()['task'] ?? null;
+        }
+
+        return $taskId;
+    }
+
+    public function setWaitForCompletion($value)
+    {
+        $this->setParam(self::WAIT_FOR_COMPLETION, $value);
     }
 }

--- a/lib/Elastica/Reindex.php
+++ b/lib/Elastica/Reindex.php
@@ -15,8 +15,13 @@ class Reindex extends Param
     const TYPE = 'type';
     const SIZE = 'size';
     const QUERY = 'query';
+    const REFRESH = 'refresh';
     const WAIT_FOR_COMPLETION = 'wait_for_completion';
     const WAIT_FOR_COMPLETION_FALSE = 'false';
+    const WAIT_FOR_ACTIVE_SHARDS = 'wait_for_active_shards';
+    const TIMEOUT = 'timeout';
+    const SCROLL = 'scroll';
+    const REQUESTS_PER_SECOND = 'requests_per_second';
 
     /**
      * @var Index
@@ -69,7 +74,7 @@ class Reindex extends Param
 
         $body = array_merge_recursive($body, [
             'source' => ['index' => $oldIndex->getName()],
-            'dest'   => ['index' => $newIndex->getName()],
+            'dest' => ['index' => $newIndex->getName()],
         ]);
 
         return $body;
@@ -79,7 +84,7 @@ class Reindex extends Param
     {
         $params = array_merge([
             'source' => $this->_getSourcePartBody($options),
-            'dest'   => $this->_getDestPartBody($options),
+            'dest' => $this->_getDestPartBody($options),
         ], $this->_resolveBodyOptions($options));
 
         return $params;
@@ -161,8 +166,49 @@ class Reindex extends Param
     private function _getEndpointParams(array $params)
     {
         return array_intersect_key($params, [
+            self::REFRESH => null,
             self::WAIT_FOR_COMPLETION => null,
+            self::WAIT_FOR_ACTIVE_SHARDS => null,
+            self::TIMEOUT => null,
+            self::SCROLL => null,
+            self::REQUESTS_PER_SECOND => null,
         ]);
+    }
+
+    public function setWaitForCompletion($value)
+    {
+        is_bool($value) && $value = $value ? 'true' : 'false';
+        $this->setParam(self::WAIT_FOR_COMPLETION, $value);
+    }
+
+    public function setWaitForActiveShards($value)
+    {
+        $this->setParam(self::WAIT_FOR_ACTIVE_SHARDS, $value);
+    }
+
+    public function setTimeout($value)
+    {
+        $this->setParam(self::TIMEOUT, $value);
+    }
+
+    public function setScroll($value)
+    {
+        $this->setParam(self::SCROLL, $value);
+    }
+
+    public function setRequestsPerSecond($value)
+    {
+        $this->setParam(self::REQUESTS_PER_SECOND, $value);
+    }
+
+    public function setSourceParam(string $key, $value)
+    {
+        $this->_params['source'][$key] = $value;
+    }
+
+    public function setDestParam(string $key, $value)
+    {
+        $this->_params['dest'][$key] = $value;
     }
 
     public function getTaskId()
@@ -173,10 +219,5 @@ class Reindex extends Param
         }
 
         return $taskId;
-    }
-
-    public function setWaitForCompletion($value)
-    {
-        $this->setParam(self::WAIT_FOR_COMPLETION, $value);
     }
 }

--- a/test/Elastica/ReindexTest.php
+++ b/test/Elastica/ReindexTest.php
@@ -140,6 +140,23 @@ class ReindexTest extends Base
     }
 
     /**
+     * @group functional
+     */
+    public function testReindexWithFalseSetOnWaitForCompletion()
+    {
+        $oldIndex = $this->_createIndex('idx1', true, 2);
+        $this->_addDocs($oldIndex->getType('reindexTest'), 10);
+
+        $newIndex = $this->_createIndex('idx2', true, 2);
+
+        $reindex = new Reindex($oldIndex, $newIndex);
+        $reindex->setWaitForCompletion(Reindex::WAIT_FOR_COMPLETION_FALSE);
+        $reindex->run();
+
+        $this->assertNotEmpty($reindex->getTaskId());
+    }
+
+    /**
      * @param Type $type
      * @param int  $docs
      *


### PR DESCRIPTION
#1322 
Upgraded Reindex class, still keeping it backward compatible.

The `$options` parameter of constructor is still there, but allows only the old set of limited options, it's just  there for BC.
Plus I added some ways to add some options via dedicated setters or setting raw data via `setParam`.

Not very happy with the result because of that cumbersome BC thing. 
Comments are very very welcome.