### PR TITLE
Don't use deprecated `inline` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 
+* Use `source` script field instead of deprecated (since ES 5.6) `inline` field. [#1497](https://github.com/ruflin/Elastica/pull/1497)
+
 ### Deprecated
 
 

--- a/lib/Elastica/Script/AbstractScript.php
+++ b/lib/Elastica/Script/AbstractScript.php
@@ -63,9 +63,9 @@ abstract class AbstractScript extends AbstractUpdateAction
             throw new InvalidException('Script params must be an array');
         }
 
-        if (isset($data['script']['inline'])) {
+        if (isset($data['script']['source'])) {
             return new Script(
-                $data['script']['inline'],
+                $data['script']['source'],
                 $params,
                 $lang
             );

--- a/lib/Elastica/Script/Script.php
+++ b/lib/Elastica/Script/Script.php
@@ -55,6 +55,6 @@ class Script extends AbstractScript
      */
     protected function getScriptTypeArray()
     {
-        return ['inline' => $this->_scriptCode];
+        return ['source' => $this->_scriptCode];
     }
 }

--- a/test/Elastica/Aggregation/MaxTest.php
+++ b/test/Elastica/Aggregation/MaxTest.php
@@ -35,7 +35,7 @@ class MaxTest extends BaseAggregationTest
             'max' => [
                 'field' => 'price',
                 'script' => [
-                    'inline' => '_value * params.conversion_rate',
+                    'source' => '_value * params.conversion_rate',
                     'params' => [
                         'conversion_rate' => 1.2,
                     ],

--- a/test/Elastica/Aggregation/ScriptTest.php
+++ b/test/Elastica/Aggregation/ScriptTest.php
@@ -77,7 +77,7 @@ class ScriptTest extends BaseAggregationTest
         $expected = [
             $aggregation => [
                 'script' => [
-                    'inline' => $string,
+                    'source' => $string,
                     'params' => $params,
                     'lang' => $lang,
                 ],

--- a/test/Elastica/Query/FunctionScoreTest.php
+++ b/test/Elastica/Query/FunctionScoreTest.php
@@ -449,7 +449,7 @@ class FunctionScoreTest extends BaseTest
                     [
                         'script_score' => [
                             'script' => [
-                                'inline' => $scriptString,
+                                'source' => $scriptString,
                                 'lang' => Script::LANG_PAINLESS,
                             ],
                         ],

--- a/test/Elastica/Query/ScriptTest.php
+++ b/test/Elastica/Query/ScriptTest.php
@@ -22,7 +22,7 @@ class ScriptTest extends BaseTest
         $expected = [
             'script' => [
                 'script' => [
-                    'inline' => $string,
+                    'source' => $string,
                 ],
             ],
         ];
@@ -50,7 +50,7 @@ class ScriptTest extends BaseTest
         $expected = [
             'script' => [
                 'script' => [
-                    'inline' => $string,
+                    'source' => $string,
                     'params' => $params,
                     'lang' => $lang,
                 ],

--- a/test/Elastica/Script/ScriptTest.php
+++ b/test/Elastica/Script/ScriptTest.php
@@ -15,7 +15,7 @@ class ScriptTest extends BaseTest
         $script = new Script(self::SCRIPT);
 
         $expected = ['script' => [
-            'inline' => self::SCRIPT,
+            'source' => self::SCRIPT,
         ]];
         $this->assertEquals(self::SCRIPT, $script->getScript());
         $this->assertEquals($expected, $script->toArray());
@@ -28,7 +28,7 @@ class ScriptTest extends BaseTest
         $script = new Script(self::SCRIPT, $params);
 
         $expected = ['script' => [
-            'inline' => self::SCRIPT,
+            'source' => self::SCRIPT,
             'params' => $params,
         ]];
 
@@ -39,7 +39,7 @@ class ScriptTest extends BaseTest
         $script = new Script(self::SCRIPT, $params, Script::LANG_PAINLESS);
 
         $expected = ['script' => [
-            'inline' => self::SCRIPT,
+            'source' => self::SCRIPT,
             'params' => $params,
             'lang' => Script::LANG_PAINLESS,
         ]];
@@ -62,7 +62,7 @@ class ScriptTest extends BaseTest
         $this->assertEquals(self::SCRIPT, $script->getScript());
 
         $expected = ['script' => [
-            'inline' => self::SCRIPT,
+            'source' => self::SCRIPT,
         ]];
         $this->assertEquals($expected, $script->toArray());
     }
@@ -91,7 +91,7 @@ class ScriptTest extends BaseTest
         ];
         $array = [
             'script' => [
-                'inline' => self::SCRIPT,
+                'source' => self::SCRIPT,
                 'lang' => Script::LANG_PAINLESS,
                 'params' => $params,
             ],


### PR DESCRIPTION
Hey there,

this changes script to use `source` field instead of deprecated `inline`.

Fixes #1416 