### PR TITLE
Make ResultSet iterator current() not return a mixed value

### DIFF
--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -236,15 +236,11 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     /**
      * Returns the current object of the set.
      *
-     * @return \Elastica\Result|bool Set object or false if not valid (no more entries)
+     * @return \Elastica\Result Set object
      */
     public function current()
     {
-        if ($this->valid()) {
-            return $this->_results[$this->key()];
-        }
-
-        return false;
+        return $this->_results[$this->key()];
     }
 
     /**
@@ -253,8 +249,6 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     public function next()
     {
         ++$this->_position;
-
-        return $this->current();
     }
 
     /**
@@ -308,7 +302,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @throws Exception\InvalidException If offset doesn't exist
      *
-     * @return Result|null
+     * @return Result
      */
     public function offsetGet($offset)
     {


### PR DESCRIPTION
Returning potentially false from the iterator current() means each result set item could be `false` which makes it impractical to safely use it.
When using phpstan, you will get errors like `Cannot call method getId() on bool|Elastica\Result.` when you just iterate over the result set.

Also `current()` should not need to check `valid()` again because that is done automatically by php when using foreach. When valid returns false, the loop is ended. So that is part of the Iterator spec. So using current on a non-existing item should not happen unless you misuse the Iterator.