### PR TITLE
Fix missing phpdoc types in deleteByQuery

### DIFF
--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -185,8 +185,8 @@ class Index implements SearchableInterface
     /**
      * Deletes entries in the db based on a query.
      *
-     * @param \Elastica\Query|string|array $query   Query object or array
-     * @param array                        $options Optional params
+     * @param \Elastica\Query|\Elastica\Query\AbstractQuery|string|array $query   Query object or array
+     * @param array                                                      $options Optional params
      *
      * @return \Elastica\Response
      *

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -477,8 +477,8 @@ class Type implements SearchableInterface
     /**
      * Deletes entries in the db based on a query.
      *
-     * @param \Elastica\Query|string $query   Query object
-     * @param array                  $options Optional params
+     * @param \Elastica\Query|\Elastica\Query\AbstractQuery|string|array $query   Query object
+     * @param array                                                      $options Optional params
      *
      * @return \Elastica\Response
      *


### PR DESCRIPTION
This fixes false phpstan reports like

> Parameter #1 $query of method Elastica\Type::deleteByQuery() expects Elastica\Query|string, Elastica\Query\Ids given. 