### PR TITLE
Set Content-Type header per Guzzle request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 
+* Guzzle transport now sets the `Content-Type` header per request, rather than reusing the potentially incorrect header from the first request made by the transport
+
 ### Added
 
 * [Field](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-random) param for `Elastica\Query\FunctionScore::addRandomScoreFunction`

--- a/lib/Elastica/Transport/AwsAuthV4.php
+++ b/lib/Elastica/Transport/AwsAuthV4.php
@@ -5,7 +5,6 @@ use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\Signature\SignatureV4;
 use Elastica\Connection;
-use Elastica\Request;
 use GuzzleHttp;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
@@ -14,7 +13,7 @@ use Psr\Http\Message\RequestInterface;
 
 class AwsAuthV4 extends Guzzle
 {
-    protected function _getGuzzleClient($baseUrl, $persistent = true, Request $request)
+    protected function _getGuzzleClient($baseUrl, $persistent = true)
     {
         if (!$persistent || !self::$_guzzleClientConnection) {
             $stack = HandlerStack::create(GuzzleHttp\choose_handler());
@@ -23,9 +22,6 @@ class AwsAuthV4 extends Guzzle
             self::$_guzzleClientConnection = new Client([
                 'base_uri' => $baseUrl,
                 'handler' => $stack,
-                'headers' => [
-                    'Content-Type' => $request->getContentType(),
-                ],
             ]);
         }
 


### PR DESCRIPTION
Hi there!

I've run into a small issue when using the Guzzle transport on one of our projects.

We're performing a Bulk query (`replaceMany` / `updateDocuments`) followed by an `updateByQuery` request, however the second request passes an incorrect `Content-Type` header to Elasticsearch.

In this particular case, the initial Bulk request instantiates the `Guzzle\Client` with a `Content-Type` header of `application/x-ndjson`:

https://github.com/ruflin/Elastica/blob/07db285b4e89ff274b77df0a74f08fff527ae9a4/lib/Elastica/Transport/Guzzle.php#L159-L166

This header value is then re-used for the `updateByQuery` request, which causes Elasticsearch to return an error since it expects `application/json` for the `updateByQuery` request.

I've changed the logic in the Guzzle transport to set the `Content-Type` header per request, taking it from the `Elastica\Request` object.

I haven't submitted a test with this PR as I'm not sure how best to write one for this scenario (it's tricky to inspect the header internals of the Guzzle transport) - if you'd prefer to have one, I'll happily spend some more time on it.

Let me know if I can provide any more information.

Thanks!