### PR TITLE
Missing implementations on Percentiles Aggregation (compression, hdr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,26 @@ All notable changes to this project will be documented in this file based on the
   * `\Elastica\ResultSet::next` returns `void` instead of `\Elastica\Result|false`
   * `\Elastica\Bulk\ResponseSet::current` returns `\Elastica\Bulk\Response` instead of `\Elastica\Bulk\Response|false`
   * `\Elastica\Multi\ResultSet::current` returns `\Elastica\ResultSet` instead of `\Elastica\ResultSet|false`
-* Aggreation\Percentiles updated to a newer version of the Algorithm (T-Digest 3.2) and Percentiles results changed a bit Have a [look at here](https://github.com/elastic/elasticsearch/pull/28305), so updated tests in order not to fail. [#1531]([#1352](https://github.com/ruflin/Elastica/pull/1531))
+* `Aggreation\Percentiles` updated to a newer version of the Algorithm (T-Digest 3.2) and Percentiles results changed a bit Have a [look at here](https://github.com/elastic/elasticsearch/pull/28305), so updated tests in order not to fail. [#1531]([#1352](https://github.com/ruflin/Elastica/pull/1531))
+* `Aggregation\Percentiles` have been updated since [Elasticsearch 2.3](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-aggregations-metrics-percentile-aggregation.html). In this version `compression, HDR histogram` changed their implementations. The `missing` field has never been implemented. [#1532](https://github.com/ruflin/Elastica/pull/1532)
+  
+  Before 
+  ```json
+    "compression" : 200,
+    "method" : "hdr", 
+    "number_of_significant_value_digits" : 3
+  ```
+
+  Now 
+  ```json
+    "tdigest": {
+      "compression" : 200 
+    },
+    "hdr": { 
+      "number_of_significant_value_digits" : 3 
+    }
+  ```
+* Never implemented the method *Missing* on [`Aggregation\Percentiles`](https://www.elastic.co/guide/en/elasticsearch/reference/6.4/search-aggregations-metrics-percentile-aggregation.html)
 
 ### Bugfixes
 

--- a/lib/Elastica/Aggregation/Percentiles.php
+++ b/lib/Elastica/Aggregation/Percentiles.php
@@ -26,11 +26,40 @@ class Percentiles extends AbstractSimpleAggregation
      *
      * @param float $value
      *
-     * @return $this
+     * @return Percentiles $this
      */
-    public function setCompression($value)
+    public function setCompression(float $value): Percentiles
     {
-        return $this->setParam('compression', (float) $value);
+        $compression = array('compression' => $value);
+        return $this->setParam('tdigest', $compression);
+    }
+
+    /**
+     * Set hdr parameter.
+     *
+     * @param string $key
+     * @param float $value
+     *
+     * @return Percentiles $this
+     */
+    public function setHdr(string $key, float $value): Percentiles
+    {
+        $compression = array($key => $value);
+        return $this->setParam('hdr', $compression);
+    }
+
+    /**
+     * the keyed flag is set to true which associates a unique string
+     * key with each bucket and returns the ranges as a hash
+     * rather than an array
+     *
+     * @param bool $keyed
+     *
+     * @return Percentiles $this
+     */
+    public function setKeyed(bool $keyed = true): Percentiles
+    {
+        return $this->setParam('keyed', $keyed);
     }
 
     /**
@@ -38,9 +67,9 @@ class Percentiles extends AbstractSimpleAggregation
      *
      * @param float[] $percents
      *
-     * @return $this
+     * @return Percentiles $this
      */
-    public function setPercents(array $percents)
+    public function setPercents(array $percents): Percentiles
     {
         return $this->setParam('percents', $percents);
     }
@@ -50,10 +79,23 @@ class Percentiles extends AbstractSimpleAggregation
      *
      * @param float $percent
      *
-     * @return $this
+     * @return Percentiles $this
      */
-    public function addPercent($percent)
+    public function addPercent(float $percent): Percentiles
     {
-        return $this->addParam('percents', (float) $percent);
+        return $this->addParam('percents', $percent);
+    }
+
+    /**
+     * Defines how documents that are missing a value should
+     * be treated
+     *
+     * @param float $missing
+     *
+     * @return Percentiles
+     */
+    public function setMissing(float $missing): Percentiles
+    {
+        return $this->setParam('missing', $missing);
     }
 }


### PR DESCRIPTION
`Aggregation\Percentiles` have been updated since [Elasticsearch 2.3](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-aggregations-metrics-percentile-aggregation.html). 

Since this version these fields has changed implementation:
- compression 
- HDR histogram

The `missing` field has never been implemented.