### PR TITLE
add parent_id in QueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file based on the
 * Added a transport class for mocking a HTTP 403 error codes, useful for testing response failures in inheriting clients
 * [Field](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-random) param for `Elastica\Query\FunctionScore::addRandomScoreFunction`
 * [Index Recovery](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html) : the indices recovery API provides insight into on-going index shard recoveries. It was never been implemented into Elastica. [#1537](https://github.com/ruflin/Elastica/pull/1537)
+* add parent_id (reference [#1518](https://github.com/ruflin/Elastica/issues/1518)) in QueryBuilder. [#1533]([#1518](https://github.com/ruflin/Elastica/issues/1533)) 
 
 ### Improvements
 

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -21,6 +21,7 @@ use Elastica\Query\MatchNone;
 use Elastica\Query\MoreLikeThis;
 use Elastica\Query\MultiMatch;
 use Elastica\Query\Nested;
+use Elastica\Query\ParentId;
 use Elastica\Query\Percolate;
 use Elastica\Query\Prefix;
 use Elastica\Query\QueryString;
@@ -280,6 +281,18 @@ class Query implements DSL
     public function nested()
     {
         return new Nested();
+    }
+
+    /**
+     * @param $type
+     * @param $id
+     * @param $ignoreUnmapped
+     *
+     * @return ParentId ParentId
+     */
+    public function parent_id($type, $id, $ignoreUnmapped = false)
+    {
+        return new ParentId($type, $id, $ignoreUnmapped);
     }
 
     /**

--- a/lib/Elastica/QueryBuilder/Version/Version240.php
+++ b/lib/Elastica/QueryBuilder/Version/Version240.php
@@ -29,6 +29,7 @@ class Version240 extends Version
         'match_all',
         'more_like_this',
         'nested',
+        'parent_id',
         'prefix',
         'query_string',
         'simple_query_string',

--- a/test/Elastica/Query/ParentIdTest.php
+++ b/test/Elastica/Query/ParentIdTest.php
@@ -2,6 +2,7 @@
 namespace Elastica\Query;
 
 use Elastica\Document;
+use Elastica\QueryBuilder\DSL\Query;
 use Elastica\Search;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Type\Mapping;
@@ -128,5 +129,96 @@ class ParentIdTest extends BaseTest
         $search = new Search($index->getClient());
         $results = $search->search($parentQuery);
         $this->assertEquals(2, $results->count());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testQueryBuilderParentId()
+    {
+        $client = $this->_getClient();
+        $index = $client->getIndex('testparentid');
+        $index->create([], true);
+        $type = $index->getType('test');
+
+        $mapping = new Mapping();
+        $mapping->setType($type);
+
+        $mapping = new Mapping($type, [
+            'firstname' => ['type' => 'text', 'store' => true],
+            'lastname' => ['type' => 'text'],
+            'my_join_field' => [
+                'type' => 'join',
+                'relations' => [
+                    'question' => 'answer',
+                ],
+            ],
+        ]);
+
+        $type->setMapping($mapping);
+        $index->refresh();
+
+        $doc1 = new Document(1, [
+            'text' => 'this is the 1st question',
+            'my_join_field' => [
+                'name' => 'question',
+            ],
+        ], 'test');
+
+        $doc2 = new Document(2, [
+            'text' => 'this is the 2nd question',
+            'my_join_field' => [
+                'name' => 'question',
+            ],
+        ], 'test');
+
+        $index->addDocuments([$doc1, $doc2]);
+
+        $doc3 = new Document(3, [
+            'text' => 'this is an answer, the 1st',
+            'my_join_field' => [
+                'name' => 'answer',
+                'parent' => 1,
+            ],
+        ], 'test', 'testparentid');
+
+        $doc4 = new Document(4, [
+            'text' => 'this is an answer, the 2nd',
+            'my_join_field' => [
+                'name' => 'answer',
+                'parent' => 2,
+            ],
+        ], 'test', 'testparentid');
+
+        $doc5 = new Document(5, [
+            'text' => 'this is an answer, the 3rd',
+            'my_join_field' => [
+                'name' => 'answer',
+                'parent' => 2,
+            ],
+        ], 'test', 'testparentid');
+
+        $this->_getClient()->addDocuments([$doc3, $doc4, $doc5], ['routing' => 1]);
+        $index->refresh();
+
+        /** @var var Query $queryDSL */
+        $queryDSL = new Query();
+        $parentId = $queryDSL->parent_id('answer', 1, true);
+        $search = new Search($index->getClient());
+        $results = $search->search($parentId);
+
+        $this->assertEquals(1, $results->count());
+
+        $result = $results->current();
+        $data = $result->getData();
+        $this->assertEquals($data['text'], 'this is an answer, the 1st');
+
+
+        $parentId = $queryDSL->parent_id('answer', 2, true);
+        $search = new Search($index->getClient());
+        $results = $search->search($parentId);
+
+        $this->assertEquals(2, $results->count());
+
     }
 }

--- a/test/Elastica/QueryBuilder/DSL/QueryTest.php
+++ b/test/Elastica/QueryBuilder/DSL/QueryTest.php
@@ -52,6 +52,7 @@ class QueryTest extends AbstractDSLTest
         $this->_assertImplemented($queryDSL, 'more_like_this', Query\MoreLikeThis::class, []);
         $this->_assertImplemented($queryDSL, 'multi_match', Query\MultiMatch::class, []);
         $this->_assertImplemented($queryDSL, 'nested', Query\Nested::class, []);
+        $this->_assertImplemented($queryDSL, 'parent_id', Query\ParentId::class, ['test', 1]);
         $this->_assertImplemented($queryDSL, 'prefix', Query\Prefix::class, []);
         $this->_assertImplemented($queryDSL, 'query_string', Query\QueryString::class, []);
         $this->_assertImplemented($queryDSL, 'range', Query\Range::class, ['field', []]);


### PR DESCRIPTION
implement parent_id inside QueryBuilder --> #1518 
I put tests inside ParentIdTest class, I've thought a lot where to place it.
Maybe could be a better place DSL\QueryTest, in fact the test is a copycat of
the test for ParentId implementing QueryBuilder instead of using object itself.
what do u think @ruflin ?
