### PR TITLE
Indices Recovery : provides insight into on-going index shard recoveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file based on the
 
 * Added a transport class for mocking a HTTP 403 error codes, useful for testing response failures in inheriting clients
 * [Field](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-random) param for `Elastica\Query\FunctionScore::addRandomScoreFunction`
+* [Index Recovery](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html) : the indices recovery API provides insight into on-going index shard recoveries. It was never been implemented into Elastica. [#1537](https://github.com/ruflin/Elastica/pull/1537)
 
 ### Improvements
 

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -5,6 +5,7 @@ use Elastica\Exception\InvalidException;
 use Elastica\Exception\ResponseException;
 use Elastica\Index\Settings as IndexSettings;
 use Elastica\Index\Stats as IndexStats;
+use Elastica\Index\Recovery as IndexRecovery;
 use Elastica\ResultSet\BuilderInterface;
 use Elastica\Script\AbstractScript;
 use Elasticsearch\Endpoints\AbstractEndpoint;
@@ -85,6 +86,16 @@ class Index implements SearchableInterface
     public function getStats()
     {
         return new IndexStats($this);
+    }
+
+    /**
+     * Return Index Recovery.
+     *
+     * @return \Elastica\Index\Recovery
+     */
+    public function getRecovery()
+    {
+        return new IndexRecovery($this);
     }
 
     /**

--- a/lib/Elastica/Index/Recovery.php
+++ b/lib/Elastica/Index/Recovery.php
@@ -1,0 +1,100 @@
+<?php
+namespace Elastica\Index;
+
+use Elastica\Index as BaseIndex;
+
+/**
+ * Elastica index recovery object.
+ *
+ * @author Federico Panini <fpanini@gmail.com>
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html
+ */
+class Recovery
+{
+    /**
+     * Response.
+     *
+     * @var \Elastica\Response Response object
+     */
+    protected $_response;
+
+    /**
+     * Recovery info.
+     *
+     * @var array Recovery info
+     */
+    protected $_data = [];
+
+    /**
+     * Index.
+     *
+     * @var \Elastica\Index Index object
+     */
+    protected $_index;
+
+    /**
+     * Construct.
+     *
+     * @param \Elastica\Index $index Index object
+     */
+    public function __construct(BaseIndex $index)
+    {
+        $this->_index = $index;
+        $this->refresh();
+    }
+
+    /**
+     * Returns the index object.
+     *
+     * @return \Elastica\Index Index object
+     */
+    public function getIndex()
+    {
+        return $this->_index;
+    }
+
+    /**
+     * Returns response object.
+     *
+     * @return \Elastica\Response Response object
+     */
+    public function getResponse()
+    {
+        return $this->_response;
+    }
+
+    /**
+     * Returns the raw recovery info.
+     *
+     * @return array Recovery info
+     */
+    public function getData()
+    {
+        return $this->_data;
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getRecoveryData()
+    {
+        $endpoint = new \Elasticsearch\Endpoints\Indices\Recovery();
+
+        $this->_response = $this->getIndex()->requestEndpoint($endpoint);
+
+        return $this->getResponse()->getData();
+    }
+
+    /**
+     * Retrieve the Recovery data
+     *
+     * @return $this
+     */
+    public function refresh()
+    {
+        $this->_data = $this->getRecoveryData();
+
+        return $this;
+    }
+}

--- a/test/Elastica/Index/RecoveryTest.php
+++ b/test/Elastica/Index/RecoveryTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace Elastica\Test\Index;
+
+use Elastica\Index\Recovery;
+use Elastica\Test\Base as BaseTest;
+
+class RecoveryTest extends BaseTest
+{
+    /**
+     * @group functional
+     */
+    public function testGetSettings()
+    {
+        $indexName = 'test';
+
+        $client = $this->_getClient();
+        $index = $client->getIndex($indexName);
+        $index->create([], true);
+        $recovery = $index->getRecovery();
+        $this->assertInstanceOf(Recovery::class, $recovery);
+
+        $this->assertTrue($recovery->getResponse()->isOk());
+    }
+}


### PR DESCRIPTION
After having a look at #1536 I've realised that this API is used to retrieve Recovery status for specific indices, or cluster-wide; and is still not implemented in Elastica (it's iin ES since 1.3). Maybe It could be a useful one with Index\Stats in order to get information on ES *state*.