### PR TITLE
Discovered some tests not working properly

### DIFF
--- a/test/Elastica/Query/CommonTest.php
+++ b/test/Elastica/Query/CommonTest.php
@@ -86,26 +86,16 @@ class CommonTest extends BaseTest
     }
 
     /**
-     * @group
+     * @group unit
+
      */
     public function testSetAnalyzer()
     {
-        $value = 'test';
+        $value = 'standard';
         $query = new Common('body', 'test query', .001);
         $query->setBoost($value);
+        $query->setAnalyzer('standard');
 
         $this->assertEquals($value, $query->toArray()['common']['body']['analyzer']);
-    }
-
-    /**
-     * @group
-     */
-    public function testSetDisableCoord()
-    {
-        $value = true;
-        $query = new Common('body', 'test query', .001);
-        $query->setDisableCoord($value);
-
-        $this->assertEquals($value, $query->toArray()['common']['body']['disable_coord']);
     }
 }

--- a/test/Elastica/Query/QueryStringTest.php
+++ b/test/Elastica/Query/QueryStringTest.php
@@ -144,7 +144,7 @@ class QueryStringTest extends BaseTest
     }
 
     /**
-     * @group
+     * @group unit
      */
     public function testSetAnalyzer()
     {
@@ -228,7 +228,7 @@ class QueryStringTest extends BaseTest
     }
 
     /**
-     * @group
+     * @group unit
      */
     public function testSetTieBreaker()
     {


### PR DESCRIPTION
Just discovered there were 4 unit tests not flagged with the annitation *@group*,

- two of these test were in ```Elastica\Query\Commn```, and one of them failed as it was testing **disable_coord** which has been removed since ES 6.0
- the other two tests were in ```Elastica\Query\Query``` and luckily did't failed