### PR TITLE
Use builtin functions from global namespace

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,32 +1,30 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
-    ->in(['lib', 'test']);
+$finder = PhpCsFixer\Finder::create()
+    ->in([__DIR__])
+    ->exclude(['vendor', 'var'])
+    ->notPath('/cache/')
+;
 
-$config = Symfony\CS\Config\Config::create()
-    ->setUsingCache(true)
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers([
-        // [contrib] Multi-line whitespace before closing semicolon are prohibited.
-        'multiline_spaces_before_semicolon',
-        // [contrib] There should be no blank lines before a namespace declaration.
-        'no_blank_lines_before_namespace',
-        // [contrib] Ordering use statements.
-        'ordered_use',
-        // [contrib] Annotations should be ordered so that param annotations come first, then throws annotations, then return annotations.
-        'phpdoc_order',
-        // [contrib] Arrays should use the short syntax.
-        'short_array_syntax',
-        // [contrib] Ensure there is no code on the same line as the PHP open tag.
-        'newline_after_open_tag',
-        // [contrib] Use null coalescing operator ?? where possible
-        'ternary_to_null_coalescing',
-        // [contrib] There should not be useless else cases.
-        'no_useless_else',
-        // [contrib] Use dedicated PHPUnit assertions for better error messages.
-        '@PHPUnit60Migration:risky' => true,
-        //'php_unit_dedicate_assert' => ['target' => 'newest'],
+return PhpCsFixer\Config::create()
+    ->setFinder($finder)
+    ->setRules([
+        '@PSR2' => true,
+        '@Symfony' => true,
+        'psr0' => false,
+        'array_syntax' => ['syntax' => 'short'],
+        'concat_space' => ['spacing' => 'one'],
+        'blank_line_after_opening_tag' => false,
+        'lowercase_cast' => true,
+        'lowercase_constants' => true,
+        'lowercase_keywords' => true,
+        'no_trailing_comma_in_singleline_array' => true,
+        'no_unused_imports' => true,
+        'ordered_imports' => true,
+        'native_function_invocation' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'php_unit_dedicate_assert' => ['target' => 'newest'],
+        'ternary_to_null_coalescing' => true,
+        'phpdoc_order' => true,
     ])
-    ->finder($finder);
-
-return $config;
+;

--- a/env/elastica/composer.json
+++ b/env/elastica/composer.json
@@ -13,14 +13,14 @@
     ],
     "require": {
         "php": "^7.0",
-        "phpdocumentor/phpdocumentor":"~2.8",
-        "fabpot/php-cs-fixer":"1.11.*",
-        "mayflower/php-codebrowser":"~1.1",
-        "pdepend/pdepend":"~2.2",
-        "phploc/phploc":"~2.1",
-        "phpmd/phpmd":"~2.3",
-        "phpunit/phpunit":"~5.6",
-        "sebastian/phpcpd":"~2.0",
-        "squizlabs/php_codesniffer":"~2.5"
+        "phpdocumentor/phpdocumentor": "~2.8",
+        "friendsofphp/php-cs-fixer": "^2.0",
+        "mayflower/php-codebrowser": "~1.1",
+        "pdepend/pdepend": "~2.2",
+        "phploc/phploc": "~2.1",
+        "phpmd/phpmd": "~2.3",
+        "phpunit/phpunit": "~5.6",
+        "sebastian/phpcpd": "~2.0",
+        "squizlabs/php_codesniffer": "~2.5"
     }
 }


### PR DESCRIPTION
Hey all, thank you for Elastica!

As stated here https://github.com/ruflin/Elastica/pull/1523#discussion_r225459352 (deeper informations can be found here: https://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/), calling builtin functions from the global namespace can improve OP cache performance.

I think I've just covered all function calls (or I hope so 😄)