### PR TITLE
Base PHP-cs-fixer migration to version 2 plus style fix

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,32 +1,26 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
-    ->in(['lib', 'test']);
+$finder = PhpCsFixer\Finder::create()
+    ->exclude(['vendor', 'var'])
+    ->in([__DIR__])
+;
 
-$config = Symfony\CS\Config\Config::create()
-    ->setUsingCache(true)
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers([
-        // [contrib] Multi-line whitespace before closing semicolon are prohibited.
-        'multiline_spaces_before_semicolon',
-        // [contrib] There should be no blank lines before a namespace declaration.
-        'no_blank_lines_before_namespace',
-        // [contrib] Ordering use statements.
-        'ordered_use',
-        // [contrib] Annotations should be ordered so that param annotations come first, then throws annotations, then return annotations.
-        'phpdoc_order',
-        // [contrib] Arrays should use the short syntax.
-        'short_array_syntax',
-        // [contrib] Ensure there is no code on the same line as the PHP open tag.
-        'newline_after_open_tag',
-        // [contrib] Use null coalescing operator ?? where possible
-        'ternary_to_null_coalescing',
-        // [contrib] There should not be useless else cases.
-        'no_useless_else',
-        // [contrib] Use dedicated PHPUnit assertions for better error messages.
+$config = PhpCsFixer\Config::create()
+    ->setFinder($finder)
+    ->setRules([
+        '@PSR2' => true,
+        '@Symfony' => true,
+        'psr0' => false,
+        'single_blank_line_before_namespace' => false,
+        'ordered_imports' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'phpdoc_order' => true,
+        'blank_line_after_namespace' => true,
+        'ternary_to_null_coalescing' => true,
+        'no_useless_else' => true,
         '@PHPUnit60Migration:risky' => true,
-        //'php_unit_dedicate_assert' => ['target' => 'newest'],
+        'php_unit_dedicate_assert' => ['target' => 'newest'],
     ])
-    ->finder($finder);
+;
 
 return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
     - TARGET="71"
     - TARGET="72"
     - TARGET="73"
+    - TARGET="Lint"
 
 before_install:
   # check running "docker engine" and "docker-compose" version on travis
@@ -41,8 +42,8 @@ before_script:
   - sudo sysctl -w vm.max_map_count=262144
 
 script:
-  - make tests TARGET=$TARGET
-  - if [ "$TARGET" == "72" ] ; then make check-style ; fi
+  - if [ "$TARGET" != "Lint" ] ; then make tests TARGET=$TARGET ; fi
+  - if [ "$TARGET" == "Lint" ] ; then make check-style ; fi
 
 after_script:
   - cat /var/log/elasticsearch/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_script:
 
 script:
   - make tests TARGET=$TARGET
+  - if [ "$TARGET" == "72" ] ; then make check-style ; fi
 
 after_script:
   - cat /var/log/elasticsearch/*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file based on the
 * Added `BucketSelector` aggregation [#1554](https://github.com/ruflin/Elastica/pull/1554)
 * Added `DerivativeAggregation` [#1553](https://github.com/ruflin/Elastica/pull/1553)
 * The preferred type name is [_doc](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/removal-of-types.html), so that index APIs have the same path as they will have in 7.0
+* Introduced new version of PHP-CS-Fixer and new Lint travis step
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file based on the
 * Added `BucketSelector` aggregation [#1554](https://github.com/ruflin/Elastica/pull/1554)
 * Added `DerivativeAggregation` [#1553](https://github.com/ruflin/Elastica/pull/1553)
 * The preferred type name is [_doc](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/removal-of-types.html), so that index APIs have the same path as they will have in 7.0
-* Introduced new version of PHP-CS-Fixer and new Lint travis step
+* Introduced new version of PHP-CS-Fixer and new Lint travis step. [#1555](https://github.com/ruflin/Elastica/pull/1555)
 
 ### Improvements
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ tests:
 	make start
 	mkdir -p build
 
-	docker run -e "ES_HOST=elasticsearch" --network=elastica_esnet elastica_elastica  make phpunit
+	docker run -e "ES_HOST=elasticsearch" --network=elastica_esnet elastica_elastica make phpunit
 	docker cp elastica:/elastica/build/coverage/ $(shell pwd)/build/coverage
 
 # Makes it easy to run a single test file. Example to run IndexTest.php: make test TEST="IndexTest.php"
@@ -83,6 +83,11 @@ lint:
 
 .PHONY: check-style
 check-style:
+	docker build -t ruflin/elastica-dev-base -f env/elastica/${TARGET} env/elastica/
+	docker build -t ruflin/elastica .
+	make start
+	mkdir -p build
+
 	${RUN_ENV} php-cs-fixer fix --allow-risky=yes --dry-run
 
 .PHONY: loc

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ doc:
 # Uses the preconfigured standards in .php_cs
 .PHONY: lint
 lint:
-	${RUN_ENV} php-cs-fixer fix
+	${RUN_ENV} php-cs-fixer fix --allow-risky=yes
 
 .PHONY: loc
 loc:
@@ -140,7 +140,7 @@ gource:
 
 ## DOCKER IMAGES
 
-.PHONY: elastica-image
+	.PHONY: elastica-image
 elastica-image:
 	docker build -t ruflin/elastica-dev-base -f env/elastica/Docker${TARGET} env/elastica/
 	docker build -t ruflin/elastica .

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ doc:
 lint:
 	${RUN_ENV} php-cs-fixer fix --allow-risky=yes
 
+.PHONY: check-style
+check-style:
+	${RUN_ENV} php-cs-fixer fix --allow-risky=yes --dry-run
+
 .PHONY: loc
 loc:
 	${RUN_ENV} cloc --by-file --xml --exclude-dir=build -out=build/cloc.xml .

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ gource:
 
 ## DOCKER IMAGES
 
-	.PHONY: elastica-image
+.PHONY: elastica-image
 elastica-image:
 	docker build -t ruflin/elastica-dev-base -f env/elastica/Docker${TARGET} env/elastica/
 	docker build -t ruflin/elastica .

--- a/env/elastica/Docker70
+++ b/env/elastica/Docker70
@@ -34,5 +34,7 @@ ENV PATH=/root/composer/vendor/bin:$PATH
 
 COPY composer.json /root/composer/
 
+RUN composer global require --no-update friendsofphp/php-cs-fixer:^2.0
+
 # Install development tools, prefer source removed as automatic fallback now
 RUN composer global install

--- a/env/elastica/Docker71
+++ b/env/elastica/Docker71
@@ -34,7 +34,5 @@ ENV PATH=/root/composer/vendor/bin:$PATH
 
 COPY composer.json /root/composer/
 
-RUN composer global require --no-update friendsofphp/php-cs-fixer:^2.0
-
 # Install development tools, prefer source removed as automatic fallback now
 RUN composer global install

--- a/env/elastica/Docker71
+++ b/env/elastica/Docker71
@@ -34,5 +34,7 @@ ENV PATH=/root/composer/vendor/bin:$PATH
 
 COPY composer.json /root/composer/
 
+RUN composer global require --no-update friendsofphp/php-cs-fixer:^2.0
+
 # Install development tools, prefer source removed as automatic fallback now
 RUN composer global install

--- a/env/elastica/Docker72
+++ b/env/elastica/Docker72
@@ -32,7 +32,5 @@ ENV PATH=/root/composer/vendor/bin:$PATH
 
 COPY composer.json /root/composer/
 
-RUN composer global require --no-update friendsofphp/php-cs-fixer:^2.0
-
 # Install development tools, prefer source removed as automatic fallback now
 RUN composer global install

--- a/env/elastica/Docker72
+++ b/env/elastica/Docker72
@@ -32,5 +32,7 @@ ENV PATH=/root/composer/vendor/bin:$PATH
 
 COPY composer.json /root/composer/
 
+RUN composer global require --no-update friendsofphp/php-cs-fixer:^2.0
+
 # Install development tools, prefer source removed as automatic fallback now
 RUN composer global install

--- a/env/elastica/Lint
+++ b/env/elastica/Lint
@@ -1,6 +1,6 @@
 # This image is the base image for the Elastica development and includes all parts which rarely change
 # PHP 7 Docker file with Composer installed
-FROM php:7.0
+FROM php:7.2
 MAINTAINER Nicolas Ruflin <spam@ruflin.com>
 
 RUN apt-get update && apt-get install -y \
@@ -20,8 +20,6 @@ RUN rm -r /var/lib/apt/lists/*
 # Xdebug for coverage report
 RUN pecl install xdebug-2.6.1
 
-## PHP Configuration
-
 RUN echo "memory_limit=1024M" >> /usr/local/etc/php/conf.d/memory-limit.ini
 RUN echo "date.timezone=UTC" >> /usr/local/etc/php/conf.d/timezone.ini
 
@@ -34,5 +32,8 @@ ENV PATH=/root/composer/vendor/bin:$PATH
 
 COPY composer.json /root/composer/
 
+RUN composer global remove --no-update phpdocumentor/phpdocumentor -vvv
+RUN composer global require --no-update friendsofphp/php-cs-fixer:^2.0
+
 # Install development tools, prefer source removed as automatic fallback now
-RUN composer global install
+RUN composer global install -vvv

--- a/env/elastica/composer.json
+++ b/env/elastica/composer.json
@@ -13,8 +13,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "phpdocumentor/phpdocumentor": "^2.9",
-        "fabpot/php-cs-fixer": "1.11.*",
+        "friendsofphp/php-cs-fixer": "^2.0",
         "mayflower/php-codebrowser": "~1.1",
         "pdepend/pdepend": "^2.5",
         "phploc/phploc": "^4.0",

--- a/env/elastica/composer.json
+++ b/env/elastica/composer.json
@@ -13,7 +13,6 @@
     ],
     "require": {
         "php": "^7.0",
-        "friendsofphp/php-cs-fixer": "^2.0",
         "mayflower/php-codebrowser": "~1.1",
         "pdepend/pdepend": "^2.5",
         "phploc/phploc": "^4.0",

--- a/env/elastica/composer.json
+++ b/env/elastica/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": "^7.0",
+        "phpdocumentor/phpdocumentor": "^2.9",
         "mayflower/php-codebrowser": "~1.1",
         "pdepend/pdepend": "^2.5",
         "phploc/phploc": "^4.0",

--- a/lib/Elastica/AbstractUpdateAction.php
+++ b/lib/Elastica/AbstractUpdateAction.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 /**
@@ -108,7 +109,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/blog/versioning
+     * @see https://www.elastic.co/blog/versioning
      */
     public function setVersion($version)
     {
@@ -171,7 +172,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-parent-field.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-parent-field.html
      */
     public function setParent($parent)
     {

--- a/lib/Elastica/Aggregation/AbstractAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractAggregation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractSimpleAggregation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Aggregation/AbstractTermsAggregation.php
+++ b/lib/Elastica/Aggregation/AbstractTermsAggregation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
@@ -61,7 +62,7 @@ abstract class AbstractTermsAggregation extends AbstractSimpleAggregation
     /**
      * Sets the amount of terms to be returned.
      *
-     * @param int $size The amount of terms to be returned.
+     * @param int $size the amount of terms to be returned
      *
      * @return $this
      */
@@ -73,7 +74,7 @@ abstract class AbstractTermsAggregation extends AbstractSimpleAggregation
     /**
      * Sets how many terms the coordinating node will request from each shard.
      *
-     * @param int $shard_size The amount of terms to be returned.
+     * @param int $shard_size the amount of terms to be returned
      *
      * @return $this
      */

--- a/lib/Elastica/Aggregation/Avg.php
+++ b/lib/Elastica/Aggregation/Avg.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Avg.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-avg-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-avg-aggregation.html
  */
 class Avg extends AbstractSimpleAggregation
 {

--- a/lib/Elastica/Aggregation/AvgBucket.php
+++ b/lib/Elastica/Aggregation/AvgBucket.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -6,7 +7,7 @@ use Elastica\Exception\InvalidException;
 /**
  * Class AvgBucket.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-avg-bucket-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-avg-bucket-aggregation.html
  */
 class AvgBucket extends AbstractAggregation
 {
@@ -18,7 +19,7 @@ class AvgBucket extends AbstractAggregation
     {
         parent::__construct($name);
 
-        if ($bucketsPath !== null) {
+        if (null !== $bucketsPath) {
             $this->setBucketsPath($bucketsPath);
         }
     }

--- a/lib/Elastica/Aggregation/BucketScript.php
+++ b/lib/Elastica/Aggregation/BucketScript.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -6,7 +7,7 @@ use Elastica\Exception\InvalidException;
 /**
  * Class BucketScript.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-script-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-script-aggregation.html
  */
 class BucketScript extends AbstractAggregation
 {
@@ -19,11 +20,11 @@ class BucketScript extends AbstractAggregation
     {
         parent::__construct($name);
 
-        if ($bucketsPath !== null) {
+        if (null !== $bucketsPath) {
             $this->setBucketsPath($bucketsPath);
         }
 
-        if ($script !== null) {
+        if (null !== $script) {
             $this->setScript($script);
         }
     }

--- a/lib/Elastica/Aggregation/BucketSelector.php
+++ b/lib/Elastica/Aggregation/BucketSelector.php
@@ -1,9 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class BucketSelector.
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-selector-aggregation.html
+ *
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-selector-aggregation.html
  */
 class BucketSelector extends AbstractSimpleAggregation
 {
@@ -16,11 +18,11 @@ class BucketSelector extends AbstractSimpleAggregation
     {
         parent::__construct($name);
 
-        if ($bucketsPath !== null) {
+        if (null !== $bucketsPath) {
             $this->setBucketsPath($bucketsPath);
         }
 
-        if ($script !== null) {
+        if (null !== $script) {
             $this->setScript($script);
         }
     }
@@ -49,4 +51,3 @@ class BucketSelector extends AbstractSimpleAggregation
         return $this->setParam('gap_policy', $gapPolicy);
     }
 }
-

--- a/lib/Elastica/Aggregation/Cardinality.php
+++ b/lib/Elastica/Aggregation/Cardinality.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Cardinality.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html
  */
 class Cardinality extends AbstractSimpleAggregation
 {

--- a/lib/Elastica/Aggregation/Children.php
+++ b/lib/Elastica/Aggregation/Children.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Children.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-aggregations-bucket-children-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-aggregations-bucket-children-aggregation.html
  */
 class Children extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/DateHistogram.php
+++ b/lib/Elastica/Aggregation/DateHistogram.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class DateHistogram.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html
  */
 class DateHistogram extends Histogram
 {
@@ -47,7 +48,7 @@ class DateHistogram extends Histogram
     /**
      * Set the format for returned bucket key_as_string values.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-daterange-aggregation.html#date-format-pattern
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-daterange-aggregation.html#date-format-pattern
      *
      * @param string $format see link for formatting options
      *
@@ -61,7 +62,7 @@ class DateHistogram extends Histogram
     /**
      * Set extended bounds option.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html#search-aggregations-bucket-histogram-aggregation-extended-bounds
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html#search-aggregations-bucket-histogram-aggregation-extended-bounds
      *
      * @param string $min see link for formatting options
      * @param string $max see link for formatting options

--- a/lib/Elastica/Aggregation/DateRange.php
+++ b/lib/Elastica/Aggregation/DateRange.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class DateRange.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-daterange-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-daterange-aggregation.html
  */
 class DateRange extends Range
 {

--- a/lib/Elastica/Aggregation/Derivative.php
+++ b/lib/Elastica/Aggregation/Derivative.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -6,7 +7,7 @@ use Elastica\Exception\InvalidException;
 /**
  * Class Derivative.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-derivative-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-derivative-aggregation.html
  */
 class Derivative extends AbstractAggregation
 {
@@ -18,7 +19,7 @@ class Derivative extends AbstractAggregation
     {
         parent::__construct($name);
 
-        if ($bucketsPath !== null) {
+        if (null !== $bucketsPath) {
             $this->setBucketsPath($bucketsPath);
         }
     }

--- a/lib/Elastica/Aggregation/ExtendedStats.php
+++ b/lib/Elastica/Aggregation/ExtendedStats.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class ExtendedStats.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html
  */
 class ExtendedStats extends AbstractSimpleAggregation
 {

--- a/lib/Elastica/Aggregation/Filter.php
+++ b/lib/Elastica/Aggregation/Filter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -7,7 +8,7 @@ use Elastica\Query\AbstractQuery;
 /**
  * Class Filter.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filter-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filter-aggregation.html
  */
 class Filter extends AbstractAggregation
 {
@@ -19,7 +20,7 @@ class Filter extends AbstractAggregation
     {
         parent::__construct($name);
 
-        if ($filter !== null) {
+        if (null !== $filter) {
             $this->setFilter($filter);
         }
     }

--- a/lib/Elastica/Aggregation/Filters.php
+++ b/lib/Elastica/Aggregation/Filters.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -7,7 +8,7 @@ use Elastica\Query\AbstractQuery;
 /**
  * Class Filters.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filters-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filters-aggregation.html
  */
 class Filters extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/GeoBounds.php
+++ b/lib/Elastica/Aggregation/GeoBounds.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * A metric aggregation that computes the bounding box containing all geo_point values for a field.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-geobounds-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-geobounds-aggregation.html
  */
 class GeoBounds extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/GeoCentroid.php
+++ b/lib/Elastica/Aggregation/GeoCentroid.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class GeoCentroid.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-geocentroid-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-geocentroid-aggregation.html
  */
 class GeoCentroid extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/GeoDistance.php
+++ b/lib/Elastica/Aggregation/GeoDistance.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -6,7 +7,7 @@ use Elastica\Exception\InvalidException;
 /**
  * Class GeoDistance.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geodistance-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geodistance-aggregation.html
  */
 class GeoDistance extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/GeohashGrid.php
+++ b/lib/Elastica/Aggregation/GeohashGrid.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class GeohashGrid.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html
  */
 class GeohashGrid extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/GlobalAggregation.php
+++ b/lib/Elastica/Aggregation/GlobalAggregation.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class GlobalAggregation.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-global-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-global-aggregation.html
  */
 class GlobalAggregation extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/Histogram.php
+++ b/lib/Elastica/Aggregation/Histogram.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Histogram.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html
  */
 class Histogram extends AbstractSimpleAggregation
 {

--- a/lib/Elastica/Aggregation/IpRange.php
+++ b/lib/Elastica/Aggregation/IpRange.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -6,7 +7,7 @@ use Elastica\Exception\InvalidException;
 /**
  * Class IpRange.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-iprange-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-iprange-aggregation.html
  */
 class IpRange extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/Max.php
+++ b/lib/Elastica/Aggregation/Max.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Max.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html
  */
 class Max extends AbstractSimpleAggregation
 {

--- a/lib/Elastica/Aggregation/Min.php
+++ b/lib/Elastica/Aggregation/Min.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Min.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html
  */
 class Min extends AbstractSimpleAggregation
 {

--- a/lib/Elastica/Aggregation/Missing.php
+++ b/lib/Elastica/Aggregation/Missing.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Missing.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-missing-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-missing-aggregation.html
  */
 class Missing extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/Nested.php
+++ b/lib/Elastica/Aggregation/Nested.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Nested.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-nested-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-nested-aggregation.html
  */
 class Nested extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/Percentiles.php
+++ b/lib/Elastica/Aggregation/Percentiles.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Percentiles.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-aggregation.html
  */
 class Percentiles extends AbstractSimpleAggregation
 {

--- a/lib/Elastica/Aggregation/Range.php
+++ b/lib/Elastica/Aggregation/Range.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -6,7 +7,7 @@ use Elastica\Exception\InvalidException;
 /**
  * Class Range.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-range-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-range-aggregation.html
  */
 class Range extends AbstractSimpleAggregation
 {

--- a/lib/Elastica/Aggregation/ReverseNested.php
+++ b/lib/Elastica/Aggregation/ReverseNested.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Reversed Nested Aggregation.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-reverse-nested-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-reverse-nested-aggregation.html
  */
 class ReverseNested extends AbstractAggregation
 {
@@ -16,7 +17,7 @@ class ReverseNested extends AbstractAggregation
     {
         parent::__construct($name);
 
-        if ($path !== null) {
+        if (null !== $path) {
             $this->setPath($path);
         }
     }

--- a/lib/Elastica/Aggregation/ScriptedMetric.php
+++ b/lib/Elastica/Aggregation/ScriptedMetric.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class ScriptedMetric.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-scripted-metric-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-scripted-metric-aggregation.html
  */
 class ScriptedMetric extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/SerialDiff.php
+++ b/lib/Elastica/Aggregation/SerialDiff.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -6,7 +7,7 @@ use Elastica\Exception\InvalidException;
 /**
  * Class SerialDiff.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-serialdiff-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-serialdiff-aggregation.html
  */
 class SerialDiff extends AbstractAggregation
 {
@@ -18,7 +19,7 @@ class SerialDiff extends AbstractAggregation
     {
         parent::__construct($name);
 
-        if ($bucketsPath !== null) {
+        if (null !== $bucketsPath) {
             $this->setBucketsPath($bucketsPath);
         }
     }

--- a/lib/Elastica/Aggregation/SignificantTerms.php
+++ b/lib/Elastica/Aggregation/SignificantTerms.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Query\AbstractQuery;
@@ -6,7 +7,7 @@ use Elastica\Query\AbstractQuery;
 /**
  * Class SignificantTerms.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html
  */
 class SignificantTerms extends AbstractTermsAggregation
 {

--- a/lib/Elastica/Aggregation/Stats.php
+++ b/lib/Elastica/Aggregation/Stats.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Stats.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html
  */
 class Stats extends AbstractSimpleAggregation
 {

--- a/lib/Elastica/Aggregation/StatsBucket.php
+++ b/lib/Elastica/Aggregation/StatsBucket.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -6,7 +7,7 @@ use Elastica\Exception\InvalidException;
 /**
  * Class StatsBucket.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-stats-bucket-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-stats-bucket-aggregation.html
  */
 class StatsBucket extends AbstractAggregation
 {
@@ -18,7 +19,7 @@ class StatsBucket extends AbstractAggregation
     {
         parent::__construct($name);
 
-        if ($bucketsPath !== null) {
+        if (null !== $bucketsPath) {
             $this->setBucketsPath($bucketsPath);
         }
     }

--- a/lib/Elastica/Aggregation/Sum.php
+++ b/lib/Elastica/Aggregation/Sum.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Sum.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-sum-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-sum-aggregation.html
  */
 class Sum extends AbstractSimpleAggregation
 {

--- a/lib/Elastica/Aggregation/SumBucket.php
+++ b/lib/Elastica/Aggregation/SumBucket.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
@@ -6,7 +7,7 @@ use Elastica\Exception\InvalidException;
 /**
  * Class SumBucket.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-sum-bucket-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-sum-bucket-aggregation.html
  */
 class SumBucket extends AbstractAggregation
 {
@@ -18,7 +19,7 @@ class SumBucket extends AbstractAggregation
     {
         parent::__construct($name);
 
-        if ($bucketsPath !== null) {
+        if (null !== $bucketsPath) {
             $this->setBucketsPath($bucketsPath);
         }
     }

--- a/lib/Elastica/Aggregation/Terms.php
+++ b/lib/Elastica/Aggregation/Terms.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class Terms.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html
  */
 class Terms extends AbstractTermsAggregation
 {
@@ -24,7 +25,7 @@ class Terms extends AbstractTermsAggregation
     /**
      * Sets a list of bucket sort orders.
      *
-     * @param array $orders A list of [<aggregationField>|"_count"|"_term" => <direction>] definitions.
+     * @param array $orders a list of [<aggregationField>|"_count"|"_term" => <direction>] definitions
      *
      * @return $this
      */

--- a/lib/Elastica/Aggregation/TopHits.php
+++ b/lib/Elastica/Aggregation/TopHits.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 use Elastica\Script\AbstractScript;
@@ -7,7 +8,7 @@ use Elastica\Script\ScriptFields;
 /**
  * Class TopHits.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html
  */
 class TopHits extends AbstractAggregation
 {

--- a/lib/Elastica/Aggregation/ValueCount.php
+++ b/lib/Elastica/Aggregation/ValueCount.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Aggregation;
 
 /**
  * Class ValueCount.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-valuecount-aggregation.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-valuecount-aggregation.html
  */
 class ValueCount extends AbstractAggregation
 {

--- a/lib/Elastica/ArrayableInterface.php
+++ b/lib/Elastica/ArrayableInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 /**

--- a/lib/Elastica/Bulk.php
+++ b/lib/Elastica/Bulk.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Bulk\Action;

--- a/lib/Elastica/Bulk/Action.php
+++ b/lib/Elastica/Bulk/Action.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Bulk;
 
 use Elastica\Bulk;

--- a/lib/Elastica/Bulk/Action/AbstractDocument.php
+++ b/lib/Elastica/Bulk/Action/AbstractDocument.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Bulk\Action;
 
 use Elastica\AbstractUpdateAction;
@@ -142,9 +143,9 @@ abstract class AbstractDocument extends Action
 
         //Check that scripts can only be used for updates
         if ($data instanceof AbstractScript) {
-            if ($opType === null) {
+            if (null === $opType) {
                 $opType = self::OP_TYPE_UPDATE;
-            } elseif ($opType != self::OP_TYPE_UPDATE) {
+            } elseif (self::OP_TYPE_UPDATE != $opType) {
                 throw new \InvalidArgumentException('Scripts can only be used with the update operation type.');
             }
         }

--- a/lib/Elastica/Bulk/Action/CreateDocument.php
+++ b/lib/Elastica/Bulk/Action/CreateDocument.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Bulk\Action;
 
 class CreateDocument extends IndexDocument

--- a/lib/Elastica/Bulk/Action/DeleteDocument.php
+++ b/lib/Elastica/Bulk/Action/DeleteDocument.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Bulk\Action;
 
 use Elastica\AbstractUpdateAction;

--- a/lib/Elastica/Bulk/Action/IndexDocument.php
+++ b/lib/Elastica/Bulk/Action/IndexDocument.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Bulk\Action;
 
 use Elastica\AbstractUpdateAction;

--- a/lib/Elastica/Bulk/Action/UpdateDocument.php
+++ b/lib/Elastica/Bulk/Action/UpdateDocument.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Bulk\Action;
 
 use Elastica\Document;

--- a/lib/Elastica/Bulk/Response.php
+++ b/lib/Elastica/Bulk/Response.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Bulk;
 
 use Elastica\Response as BaseResponse;

--- a/lib/Elastica/Bulk/ResponseSet.php
+++ b/lib/Elastica/Bulk/ResponseSet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Bulk;
 
 use Elastica\Response as BaseResponse;
@@ -102,8 +103,6 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
         return $this->_bulkResponses[$this->key()];
     }
 
-    /**
-     */
     public function next()
     {
         ++$this->_position;
@@ -125,8 +124,6 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
         return isset($this->_bulkResponses[$this->key()]);
     }
 
-    /**
-     */
     public function rewind()
     {
         $this->_position = 0;

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Bulk\Action;
@@ -135,7 +136,7 @@ class Client
         }
 
         if (!isset($this->_config['connectionStrategy'])) {
-            if ($this->getConfig('roundRobin') === true) {
+            if (true === $this->getConfig('roundRobin')) {
                 $this->setConfigValue('connectionStrategy', 'RoundRobin');
             } else {
                 $this->setConfigValue('connectionStrategy', 'Simple');
@@ -303,7 +304,7 @@ class Client
      * set inside the document, because for bulk settings documents,
      * documents can belong to any type and index
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      *
      * @param array|\Elastica\Document[] $docs          Array of Elastica\Document
      * @param array                      $requestParams
@@ -335,7 +336,7 @@ class Client
      * set inside the document, because for bulk settings documents,
      * documents can belong to any type and index
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      *
      * @param array|\Elastica\Document[] $docs          Array of Elastica\Document
      * @param array                      $requestParams
@@ -372,7 +373,7 @@ class Client
      *
      * @return \Elastica\Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html
      */
     public function updateDocument($id, $data, $index, $type, array $options = [])
     {
@@ -594,7 +595,7 @@ class Client
     /**
      * Deletes documents with the given ids, index, type from the index.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      *
      * @param array                  $ids     Document ids
      * @param string|\Elastica\Index $index   Index name
@@ -641,7 +642,7 @@ class Client
      *         array('delete' => array('_index' => 'test', '_type' => 'user', '_id' => '2'))
      * );
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      *
      * @param array $params Parameter array
      *
@@ -763,7 +764,7 @@ class Client
      * @return \Elastica\Response Response object
      *
      * @deprecated Replaced by forcemergeAll
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-optimize.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-optimize.html
      */
     public function optimizeAll($args = [])
     {
@@ -779,7 +780,7 @@ class Client
      *
      * @return \Elastica\Response Response object
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html
      */
     public function forcemergeAll($args = [])
     {
@@ -794,7 +795,7 @@ class Client
      *
      * @return \Elastica\Response Response object
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
      */
     public function refreshAll()
     {

--- a/lib/Elastica/Cluster.php
+++ b/lib/Elastica/Cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Cluster\Health;
@@ -11,7 +12,7 @@ use Elasticsearch\Endpoints\Cluster\State;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html
  */
 class Cluster
 {
@@ -81,7 +82,7 @@ class Cluster
      *
      * @return array State array
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-state.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-state.html
      */
     public function getState()
     {
@@ -134,7 +135,7 @@ class Cluster
     /**
      * Returns the cluster information (not implemented yet).
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
      *
      * @param array $args Additional arguments
      *
@@ -148,7 +149,7 @@ class Cluster
     /**
      * Return Cluster health.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
      *
      * @return \Elastica\Cluster\Health
      */

--- a/lib/Elastica/Cluster/Health.php
+++ b/lib/Elastica/Cluster/Health.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Cluster;
 
 use Elastica\Client;
@@ -9,22 +10,22 @@ use Elastica\Cluster\Health\Index;
  *
  * @author Ray Ward <ray.ward@bigcommerce.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
  */
 class Health
 {
     /**
-     * @var \Elastica\Client Client object.
+     * @var \Elastica\Client client object
      */
     protected $_client;
 
     /**
-     * @var array The cluster health data.
+     * @var array the cluster health data
      */
     protected $_data;
 
     /**
-     * @param \Elastica\Client $client The Elastica client.
+     * @param \Elastica\Client $client the Elastica client
      */
     public function __construct(Client $client)
     {
@@ -82,7 +83,7 @@ class Health
     /**
      * Gets the status of the cluster.
      *
-     * @return string green, yellow or red.
+     * @return string green, yellow or red
      */
     public function getStatus()
     {

--- a/lib/Elastica/Cluster/Health/Index.php
+++ b/lib/Elastica/Cluster/Health/Index.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Cluster\Health;
 
 /**
@@ -6,23 +7,23 @@ namespace Elastica\Cluster\Health;
  *
  * @author Ray Ward <ray.ward@bigcommerce.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
  */
 class Index
 {
     /**
-     * @var string The name of the index.
+     * @var string the name of the index
      */
     protected $_name;
 
     /**
-     * @var array The index health data.
+     * @var array the index health data
      */
     protected $_data;
 
     /**
-     * @param string $name The name of the index.
-     * @param array  $data The index health data.
+     * @param string $name the name of the index
+     * @param array  $data the index health data
      */
     public function __construct($name, $data)
     {
@@ -43,7 +44,7 @@ class Index
     /**
      * Gets the status of the index.
      *
-     * @return string green, yellow or red.
+     * @return string green, yellow or red
      */
     public function getStatus()
     {

--- a/lib/Elastica/Cluster/Health/Shard.php
+++ b/lib/Elastica/Cluster/Health/Shard.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Cluster\Health;
 
 /**
@@ -6,23 +7,23 @@ namespace Elastica\Cluster\Health;
  *
  * @author Ray Ward <ray.ward@bigcommerce.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
  */
 class Shard
 {
     /**
-     * @var int The shard index/number.
+     * @var int the shard index/number
      */
     protected $_shardNumber;
 
     /**
-     * @var array The shard health data.
+     * @var array the shard health data
      */
     protected $_data;
 
     /**
-     * @param int   $shardNumber The shard index/number.
-     * @param array $data        The shard health data.
+     * @param int   $shardNumber the shard index/number
+     * @param array $data        the shard health data
      */
     public function __construct($shardNumber, $data)
     {
@@ -43,7 +44,7 @@ class Shard
     /**
      * Gets the status of this shard.
      *
-     * @return string green, yellow or red.
+     * @return string green, yellow or red
      */
     public function getStatus()
     {
@@ -67,7 +68,7 @@ class Shard
      */
     public function isActive()
     {
-        return $this->_data['active_shards'] == 1;
+        return 1 == $this->_data['active_shards'];
     }
 
     /**
@@ -77,7 +78,7 @@ class Shard
      */
     public function isRelocating()
     {
-        return $this->_data['relocating_shards'] == 1;
+        return 1 == $this->_data['relocating_shards'];
     }
 
     /**
@@ -87,7 +88,7 @@ class Shard
      */
     public function isInitialized()
     {
-        return $this->_data['initializing_shards'] == 1;
+        return 1 == $this->_data['initializing_shards'];
     }
 
     /**
@@ -97,6 +98,6 @@ class Shard
      */
     public function isUnassigned()
     {
-        return $this->_data['unassigned_shards'] == 1;
+        return 1 == $this->_data['unassigned_shards'];
     }
 }

--- a/lib/Elastica/Cluster/Settings.php
+++ b/lib/Elastica/Cluster/Settings.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Cluster;
 
 use Elastica\Client;
@@ -9,7 +10,7 @@ use Elastica\Request;
  *
  * @author   Nicolas Ruflin <spam@ruflin.com>
  *
- * @link     https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html
+ * @see     https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html
  */
 class Settings
 {
@@ -82,7 +83,7 @@ class Settings
                 return $settings[$setting];
             }
 
-            if (strpos($setting, '.') !== false) {
+            if (false !== strpos($setting, '.')) {
                 // convert dot notation to nested arrays
                 $keys = explode('.', $setting);
                 foreach ($keys as $key) {

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Connection/ConnectionPool.php
+++ b/lib/Elastica/Connection/ConnectionPool.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Connection;
 
 use Elastica\Client;

--- a/lib/Elastica/Connection/Strategy/CallbackStrategy.php
+++ b/lib/Elastica/Connection/Strategy/CallbackStrategy.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Connection\Strategy;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Connection/Strategy/RoundRobin.php
+++ b/lib/Elastica/Connection/Strategy/RoundRobin.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Connection\Strategy;
 
 /**

--- a/lib/Elastica/Connection/Strategy/Simple.php
+++ b/lib/Elastica/Connection/Strategy/Simple.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Connection\Strategy;
 
 use Elastica\Exception\ClientException;

--- a/lib/Elastica/Connection/Strategy/StrategyFactory.php
+++ b/lib/Elastica/Connection/Strategy/StrategyFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Connection\Strategy;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Connection/Strategy/StrategyInterface.php
+++ b/lib/Elastica/Connection/Strategy/StrategyInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Connection\Strategy;
 
 /**

--- a/lib/Elastica/Document.php
+++ b/lib/Elastica/Document.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Bulk\Action;
@@ -198,7 +199,7 @@ class Document extends AbstractUpdateAction
      * @param float  $latitude  Latitude value
      * @param float  $longitude Longitude value
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-geo-point-type.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-geo-point-type.html
      *
      * @return $this
      */

--- a/lib/Elastica/Exception/Bulk/Response/ActionException.php
+++ b/lib/Elastica/Exception/Bulk/Response/ActionException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception\Bulk\Response;
 
 use Elastica\Bulk\Response;

--- a/lib/Elastica/Exception/Bulk/ResponseException.php
+++ b/lib/Elastica/Exception/Bulk/ResponseException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception\Bulk;
 
 use Elastica\Bulk\ResponseSet;

--- a/lib/Elastica/Exception/BulkException.php
+++ b/lib/Elastica/Exception/BulkException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 class BulkException extends \RuntimeException implements ExceptionInterface

--- a/lib/Elastica/Exception/ClientException.php
+++ b/lib/Elastica/Exception/ClientException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/Connection/GuzzleException.php
+++ b/lib/Elastica/Exception/Connection/GuzzleException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception\Connection;
 
 use Elastica\Exception\ConnectionException;

--- a/lib/Elastica/Exception/Connection/HttpException.php
+++ b/lib/Elastica/Exception/Connection/HttpException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception\Connection;
 
 use Elastica\Exception\ConnectionException;

--- a/lib/Elastica/Exception/ConnectionException.php
+++ b/lib/Elastica/Exception/ConnectionException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 use Elastica\Request;

--- a/lib/Elastica/Exception/DeprecatedException.php
+++ b/lib/Elastica/Exception/DeprecatedException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/ElasticsearchException.php
+++ b/lib/Elastica/Exception/ElasticsearchException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 trigger_error('Elastica\Exception\ElasticsearchException is deprecated. Use Elastica\Exception\ResponseException::getResponse::getFullError instead.', E_USER_DEPRECATED);
@@ -48,10 +49,10 @@ class ElasticsearchException extends \Exception implements ExceptionInterface
     {
         $errors = explode(']; nested: ', $error);
 
-        if (count($errors) == 1) {
+        if (1 == count($errors)) {
             $this->_exception = $this->_extractException($errors[0]);
         } else {
-            if ($this->_extractException($errors[0]) == self::REMOTE_TRANSPORT_EXCEPTION) {
+            if (self::REMOTE_TRANSPORT_EXCEPTION == $this->_extractException($errors[0])) {
                 $this->_isRemote = true;
                 $this->_exception = $this->_extractException($errors[1]);
             } else {

--- a/lib/Elastica/Exception/ExceptionInterface.php
+++ b/lib/Elastica/Exception/ExceptionInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/InvalidException.php
+++ b/lib/Elastica/Exception/InvalidException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/JSONParseException.php
+++ b/lib/Elastica/Exception/JSONParseException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/NotFoundException.php
+++ b/lib/Elastica/Exception/NotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/NotImplementedException.php
+++ b/lib/Elastica/Exception/NotImplementedException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/PartialShardFailureException.php
+++ b/lib/Elastica/Exception/PartialShardFailureException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 use Elastica\JSON;

--- a/lib/Elastica/Exception/QueryBuilderException.php
+++ b/lib/Elastica/Exception/QueryBuilderException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Exception/ResponseException.php
+++ b/lib/Elastica/Exception/ResponseException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 use Elastica\Request;

--- a/lib/Elastica/Exception/RuntimeException.php
+++ b/lib/Elastica/Exception/RuntimeException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Exception;
 
 /**

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
@@ -136,7 +137,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Bulk\ResponseSet
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
     public function updateDocuments(array $docs, array $options = [])
     {
@@ -156,7 +157,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html
      */
     public function updateByQuery($query, AbstractScript $script, array $options = [])
     {
@@ -182,7 +183,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Bulk\ResponseSet
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
     public function addDocuments(array $docs, array $options = [])
     {
@@ -201,7 +202,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/5.0/docs-delete-by-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.0/docs-delete-by-query.html
      */
     public function deleteByQuery($query, array $options = [])
     {
@@ -231,7 +232,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Bulk\ResponseSet
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
     public function deleteDocuments(array $docs)
     {
@@ -251,7 +252,7 @@ class Index implements SearchableInterface
      *
      * @return Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html
      */
     public function forcemerge($args = [])
     {
@@ -266,7 +267,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Response Response object
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
      */
     public function refresh()
     {
@@ -276,7 +277,7 @@ class Index implements SearchableInterface
     /**
      * Creates a new index with the given arguments.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
      *
      * @param array      $args    OPTIONAL Arguments to use
      * @param bool|array $options OPTIONAL
@@ -328,7 +329,7 @@ class Index implements SearchableInterface
     {
         $response = $this->requestEndpoint(new Exists());
 
-        return $response->getStatus() === 200;
+        return 200 === $response->getStatus();
     }
 
     /**
@@ -385,7 +386,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Response Response object
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
      */
     public function open()
     {
@@ -397,7 +398,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Response Response object
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
      */
     public function close()
     {
@@ -432,7 +433,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Response Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
      */
     public function addAlias($name, $replace = false)
     {
@@ -460,7 +461,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Response Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
      */
     public function removeAlias($name)
     {
@@ -511,7 +512,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Response Response object
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clearcache.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clearcache.html
      */
     public function clearCache()
     {
@@ -526,7 +527,7 @@ class Index implements SearchableInterface
      *
      * @return Response Response object
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html
      */
     public function flush(array $options = [])
     {
@@ -543,7 +544,7 @@ class Index implements SearchableInterface
      *
      * @return \Elastica\Response Response object
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
      */
     public function setSettings(array $data)
     {
@@ -595,7 +596,7 @@ class Index implements SearchableInterface
      *
      * @return array Server response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html
      */
     public function analyze(array $body, $args = [])
     {

--- a/lib/Elastica/Index/Recovery.php
+++ b/lib/Elastica/Index/Recovery.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Index;
 
 use Elastica\Index as BaseIndex;
@@ -8,7 +9,7 @@ use Elastica\Index as BaseIndex;
  *
  * @author Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html
  */
 class Recovery
 {

--- a/lib/Elastica/Index/Settings.php
+++ b/lib/Elastica/Index/Settings.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Index;
 
 use Elastica\Exception\NotFoundException;
@@ -15,8 +16,8 @@ use Elastica\Request;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-merge.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-merge.html
  */
 class Settings
 {
@@ -67,7 +68,7 @@ class Settings
      *
      * @return array|string|null Settings data
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
      */
     public function get($setting = '')
     {
@@ -87,23 +88,22 @@ class Settings
 
         if (isset($settings[$setting])) {
             return $settings[$setting];
-        } else {
-            if (strpos($setting, '.') !== false) {
-                // translate old dot-notation settings to nested arrays
-                $keys = explode('.', $setting);
-                foreach ($keys as $key) {
-                    if (isset($settings[$key])) {
-                        $settings = $settings[$key];
-                    } else {
-                        return;
-                    }
+        }
+        if (false !== strpos($setting, '.')) {
+            // translate old dot-notation settings to nested arrays
+            $keys = explode('.', $setting);
+            foreach ($keys as $key) {
+                if (isset($settings[$key])) {
+                    $settings = $settings[$key];
+                } else {
+                    return;
                 }
-
-                return $settings;
             }
 
-            return;
+            return $settings;
         }
+
+        return;
     }
 
     /**
@@ -239,7 +239,7 @@ class Settings
         try {
             return $this->getBool('blocks.metadata');
         } catch (ResponseException $e) {
-            if ($e->getResponse()->getFullError()['type'] === 'cluster_block_exception') {
+            if ('cluster_block_exception' === $e->getResponse()->getFullError()['type']) {
                 return true;
             }
 
@@ -302,7 +302,7 @@ class Settings
      *
      * @return \Elastica\Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-merge.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-merge.html
      */
     public function setMergePolicy($key, $value)
     {
@@ -320,7 +320,7 @@ class Settings
      *
      * @return string Refresh interval
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-merge.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-merge.html
      */
     public function getMergePolicy($key)
     {

--- a/lib/Elastica/Index/Stats.php
+++ b/lib/Elastica/Index/Stats.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Index;
 
 use Elastica\Index as BaseIndex;
@@ -8,7 +9,7 @@ use Elastica\Index as BaseIndex;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html
  */
 class Stats
 {

--- a/lib/Elastica/IndexTemplate.php
+++ b/lib/Elastica/IndexTemplate.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
@@ -8,7 +9,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Dmitry Balabka <dmitry.balabka@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
  */
 class IndexTemplate
 {
@@ -59,7 +60,7 @@ class IndexTemplate
     /**
      * Creates a new index template with the given arguments.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
      *
      * @param array $args OPTIONAL Arguments to use
      *
@@ -79,7 +80,7 @@ class IndexTemplate
     {
         $response = $this->request(Request::HEAD);
 
-        return $response->getStatus() === 200;
+        return 200 === $response->getStatus();
     }
 
     /**

--- a/lib/Elastica/JSON.php
+++ b/lib/Elastica/JSON.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\JSONParseException;
@@ -11,8 +12,8 @@ class JSON
     /**
      * Parse JSON string to an array.
      *
-     * @link http://php.net/manual/en/function.json-decode.php
-     * @link http://php.net/manual/en/function.json-last-error.php
+     * @see http://php.net/manual/en/function.json-decode.php
+     * @see http://php.net/manual/en/function.json-last-error.php
      *
      * @param string $args,... JSON string to parse
      *
@@ -26,7 +27,7 @@ class JSON
         $args = func_get_args();
 
         // default to decoding into an assoc array
-        if (count($args) === 1) {
+        if (1 === count($args)) {
             $args[] = true;
         }
 
@@ -45,8 +46,8 @@ class JSON
     /**
      * Convert input to JSON string with standard options.
      *
-     * @link http://php.net/manual/en/function.json-encode.php
-     * @link http://php.net/manual/en/function.json-last-error.php
+     * @see http://php.net/manual/en/function.json-encode.php
+     * @see http://php.net/manual/en/function.json-last-error.php
      *
      * @param mixed $args,... Target to stringify
      *
@@ -74,9 +75,9 @@ class JSON
     /**
      * Get Json Last Error.
      *
-     * @link http://php.net/manual/en/function.json-last-error.php
-     * @link http://php.net/manual/en/function.json-last-error-msg.php
-     * @link https://github.com/php/php-src/blob/master/ext/json/json.c#L308
+     * @see http://php.net/manual/en/function.json-last-error.php
+     * @see http://php.net/manual/en/function.json-last-error-msg.php
+     * @see https://github.com/php/php-src/blob/master/ext/json/json.c#L308
      *
      * @return string
      */

--- a/lib/Elastica/Log.php
+++ b/lib/Elastica/Log.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Psr\Log\AbstractLogger;

--- a/lib/Elastica/Multi/MultiBuilder.php
+++ b/lib/Elastica/Multi/MultiBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Multi;
 
 use Elastica\Response;

--- a/lib/Elastica/Multi/MultiBuilderInterface.php
+++ b/lib/Elastica/Multi/MultiBuilderInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Multi;
 
 use Elastica\Response;

--- a/lib/Elastica/Multi/ResultSet.php
+++ b/lib/Elastica/Multi/ResultSet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Multi;
 
 use Elastica\Response;
@@ -86,8 +87,6 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
         return $this->_resultSets[$this->key()];
     }
 
-    /**
-     */
     public function next()
     {
         ++$this->_position;
@@ -109,8 +108,6 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
         return isset($this->_resultSets[$this->key()]);
     }
 
-    /**
-     */
     public function rewind()
     {
         $this->_position = 0;
@@ -127,7 +124,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     /**
      * @param string|int $offset
      *
-     * @return bool true on success or false on failure.
+     * @return bool true on success or false on failure
      */
     public function offsetExists($offset)
     {
@@ -137,7 +134,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     /**
      * @param mixed $offset
      *
-     * @return mixed Can return all value types.
+     * @return mixed can return all value types
      */
     public function offsetGet($offset)
     {

--- a/lib/Elastica/Multi/Search.php
+++ b/lib/Elastica/Multi/Search.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Multi;
 
 use Elastica\Client;
@@ -11,7 +12,7 @@ use Elastica\Search as BaseSearch;
  *
  * @author munkie
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html
  */
 class Search
 {

--- a/lib/Elastica/NameableInterface.php
+++ b/lib/Elastica/NameableInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 /**

--- a/lib/Elastica/Node.php
+++ b/lib/Elastica/Node.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Node\Info;
@@ -103,7 +104,7 @@ class Node
     /**
      * Return stats object of the current node.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html
      *
      * @return \Elastica\Node\Stats Node stats
      */
@@ -119,7 +120,7 @@ class Node
     /**
      * Return info object of the current node.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
      *
      * @return \Elastica\Node\Info Node info object
      */

--- a/lib/Elastica/Node/Info.php
+++ b/lib/Elastica/Node/Info.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Node;
 
 use Elastica\Node as BaseNode;
@@ -8,7 +9,7 @@ use Elastica\Node as BaseNode;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-status.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-status.html
  */
 class Info
 {
@@ -119,7 +120,7 @@ class Info
      *
      * @return array plugin data
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
      */
     public function getPlugins()
     {

--- a/lib/Elastica/Node/Stats.php
+++ b/lib/Elastica/Node/Stats.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Node;
 
 use Elastica\Node as BaseNode;
@@ -8,7 +9,7 @@ use Elastica\Node as BaseNode;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-status.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-status.html
  */
 class Stats
 {

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Pipeline.php
+++ b/lib/Elastica/Pipeline.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
@@ -16,7 +17,7 @@ use Elasticsearch\Endpoints\Ingest\Pipeline\Put;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-processors.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-processors.html
  */
 class Pipeline extends Param
 {
@@ -54,7 +55,7 @@ class Pipeline extends Param
      *
      * @return Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/put-pipeline-api.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/put-pipeline-api.html
      */
     public function create()
     {
@@ -84,7 +85,7 @@ class Pipeline extends Param
      *
      * @return Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/get-pipeline-api.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/get-pipeline-api.html
      */
     public function getPipeline(string $id)
     {
@@ -101,7 +102,7 @@ class Pipeline extends Param
      *
      * @return Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-pipeline-api.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-pipeline-api.html
      */
     public function deletePipeline(string $id)
     {

--- a/lib/Elastica/Processor/AbstractProcessor.php
+++ b/lib/Elastica/Processor/AbstractProcessor.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 use Elastica\Param;
@@ -8,7 +9,7 @@ use Elastica\Param;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-processors.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-processors.html
  */
 abstract class AbstractProcessor extends Param
 {

--- a/lib/Elastica/Processor/Append.php
+++ b/lib/Elastica/Processor/Append.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/append-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/append-processor.html
  */
 class Append extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Attachment.php
+++ b/lib/Elastica/Processor/Attachment.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 class Attachment extends AbstractProcessor

--- a/lib/Elastica/Processor/Convert.php
+++ b/lib/Elastica/Processor/Convert.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/append-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/append-processor.html
  */
 class Convert extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Date.php
+++ b/lib/Elastica/Processor/Date.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/date-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/date-processor.html
  */
 class Date extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/DateIndexName.php
+++ b/lib/Elastica/Processor/DateIndexName.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/date-index-name-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/date-index-name-processor.html
  */
 class DateIndexName extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/DotExpander.php
+++ b/lib/Elastica/Processor/DotExpander.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/dot-expand-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/dot-expand-processor.html
  */
 class DotExpander extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Fail.php
+++ b/lib/Elastica/Processor/Fail.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/fail-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/fail-processor.html
  */
 class Fail extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Join.php
+++ b/lib/Elastica/Processor/Join.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/join-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/join-processor.html
  */
 class Join extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Json.php
+++ b/lib/Elastica/Processor/Json.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/json-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/json-processor.html
  */
 class Json extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Kv.php
+++ b/lib/Elastica/Processor/Kv.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/kv-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/kv-processor.html
  */
 class Kv extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Lowercase.php
+++ b/lib/Elastica/Processor/Lowercase.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/lowercase-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/lowercase-processor.html
  */
 class Lowercase extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Remove.php
+++ b/lib/Elastica/Processor/Remove.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/remove-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/remove-processor.html
  */
 class Remove extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Rename.php
+++ b/lib/Elastica/Processor/Rename.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/rename-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/rename-processor.html
  */
 class Rename extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Set.php
+++ b/lib/Elastica/Processor/Set.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-processors.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-processors.html
  */
 class Set extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Sort.php
+++ b/lib/Elastica/Processor/Sort.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-processor.html
  */
 class Sort extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Split.php
+++ b/lib/Elastica/Processor/Split.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/split-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/split-processor.html
  */
 class Split extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Trim.php
+++ b/lib/Elastica/Processor/Trim.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/trim-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/trim-processor.html
  */
 class Trim extends AbstractProcessor
 {

--- a/lib/Elastica/Processor/Uppercase.php
+++ b/lib/Elastica/Processor/Uppercase.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Processor;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Processor;
  *
  * @author   Federico Panini <fpanini@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/uppercase-processor.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/uppercase-processor.html
  */
 class Uppercase extends AbstractProcessor
 {

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Aggregation\AbstractAggregation;
@@ -17,7 +18,7 @@ use Elastica\Suggest\AbstractSuggest;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html
  */
 class Query extends Param
 {
@@ -73,7 +74,6 @@ class Query extends Param
 
             case $query instanceof Suggest:
                 return new self($query);
-
         }
 
         throw new InvalidException('Unexpected argument to create a query for.');
@@ -135,7 +135,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
      */
     public function setSort(array $sortArgs)
     {
@@ -149,7 +149,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
      */
     public function addSort($sort)
     {
@@ -163,7 +163,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html#_track_scores
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html#_track_scores
      */
     public function setTrackScores($trackScores = true)
     {
@@ -177,7 +177,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
      */
     public function setHighlight(array $highlightArgs)
     {
@@ -191,7 +191,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
      */
     public function addHighlight($highlight)
     {
@@ -217,7 +217,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-explain.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-explain.html
      */
     public function setExplain($explain = true)
     {
@@ -231,7 +231,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
      */
     public function setVersion($version = true)
     {
@@ -247,7 +247,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fields.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fields.html
      */
     public function setStoredFields(array $fields)
     {
@@ -261,7 +261,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fielddata-fields.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fielddata-fields.html
      */
     public function setFieldDataFields(array $fieldDataFields)
     {
@@ -275,7 +275,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
      */
     public function setScriptFields($scriptFields)
     {
@@ -326,7 +326,7 @@ class Query extends Param
      */
     public function toArray()
     {
-        if (!isset($this->_params['query']) && ($this->_suggest == 0)) {
+        if (!isset($this->_params['query']) && (0 == $this->_suggest)) {
             $this->setQuery(new MatchAll());
         }
 
@@ -390,7 +390,7 @@ class Query extends Param
             $buffer = [];
 
             foreach ($rescore as $rescoreQuery) {
-                $buffer [] = $rescoreQuery;
+                $buffer[] = $rescoreQuery;
             }
         } else {
             $buffer = $rescore;
@@ -406,7 +406,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link   https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
+     * @see   https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
      */
     public function setSource($params)
     {
@@ -420,7 +420,7 @@ class Query extends Param
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-post-filter.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-post-filter.html
      */
     public function setPostFilter(AbstractQuery $filter)
     {

--- a/lib/Elastica/Query/AbstractGeoDistance.php
+++ b/lib/Elastica/Query/AbstractGeoDistance.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -8,7 +9,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html
  */
 abstract class AbstractGeoDistance extends AbstractQuery
 {
@@ -158,7 +159,7 @@ abstract class AbstractGeoDistance extends AbstractQuery
      */
     protected function _getLocationData()
     {
-        if ($this->_locationType === self::LOCATION_TYPE_LATLON) { // Latitude/longitude
+        if (self::LOCATION_TYPE_LATLON === $this->_locationType) { // Latitude/longitude
             $location = [];
 
             if (isset($this->_latitude)) { // Latitude
@@ -172,7 +173,7 @@ abstract class AbstractGeoDistance extends AbstractQuery
             } else {
                 throw new InvalidException('Longitude has to be set');
             }
-        } elseif ($this->_locationType === self::LOCATION_TYPE_GEOHASH) { // Geohash
+        } elseif (self::LOCATION_TYPE_GEOHASH === $this->_locationType) { // Geohash
             $location = $this->_geohash;
         } else { // Invalid location type
             throw new InvalidException('Invalid location type');

--- a/lib/Elastica/Query/AbstractGeoShape.php
+++ b/lib/Elastica/Query/AbstractGeoShape.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Bennie Krijger <benniekrijger@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
  */
 abstract class AbstractGeoShape extends AbstractQuery
 {

--- a/lib/Elastica/Query/AbstractQuery.php
+++ b/lib/Elastica/Query/AbstractQuery.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Param;

--- a/lib/Elastica/Query/AbstractSpanQuery.php
+++ b/lib/Elastica/Query/AbstractSpanQuery.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -7,7 +8,7 @@ namespace Elastica\Query;
  * @author Marek Hernik <marek.hernik@gmail.com>
  * @author Alessandro Chitolina <alekitto@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/span-queries.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/span-queries.html
  */
 abstract class AbstractSpanQuery extends AbstractQuery
 {

--- a/lib/Elastica/Query/BoolQuery.php
+++ b/lib/Elastica/Query/BoolQuery.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -8,7 +9,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
  */
 class BoolQuery extends AbstractQuery
 {

--- a/lib/Elastica/Query/Boosting.php
+++ b/lib/Elastica/Query/Boosting.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Balazs Nadasdi <yitsushi@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-boosting-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-boosting-query.html
  */
 class Boosting extends AbstractQuery
 {

--- a/lib/Elastica/Query/Common.php
+++ b/lib/Elastica/Query/Common.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
  * Class Common.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html
  */
 class Common extends AbstractQuery
 {
@@ -102,7 +103,7 @@ class Common extends AbstractQuery
      *
      * @return $this
      *
-     * @link Possible values for minimum_should_match https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
+     * @see Possible values for minimum_should_match https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
      */
     public function setMinimumShouldMatch($minimum)
     {

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-constant-score-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-constant-score-query.html
  */
 class ConstantScore extends AbstractQuery
 {

--- a/lib/Elastica/Query/DisMax.php
+++ b/lib/Elastica/Query/DisMax.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -8,7 +9,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Hung Tran <oohnoitz@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-dis-max-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-dis-max-query.html
  */
 class DisMax extends AbstractQuery
 {

--- a/lib/Elastica/Query/Exists.php
+++ b/lib/Elastica/Query/Exists.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Oleg Cherniy <oleg.cherniy@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html
  */
 class Exists extends AbstractQuery
 {

--- a/lib/Elastica/Query/FunctionScore.php
+++ b/lib/Elastica/Query/FunctionScore.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Script\AbstractScript;
@@ -6,7 +7,7 @@ use Elastica\Script\AbstractScript;
 /**
  * Class FunctionScore.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
  */
 class FunctionScore extends AbstractQuery
 {
@@ -81,7 +82,7 @@ class FunctionScore extends AbstractQuery
             $function['filter'] = $filter;
         }
 
-        if ($weight !== null) {
+        if (null !== $weight) {
             $function['weight'] = $weight;
         }
 
@@ -250,7 +251,7 @@ class FunctionScore extends AbstractQuery
     /**
      * If set, this query will return results in random order.
      *
-     * @param int $seed Set a seed value to return results in the same random order for consistent pagination.
+     * @param int $seed set a seed value to return results in the same random order for consistent pagination
      *
      * @return $this
      */

--- a/lib/Elastica/Query/Fuzzy.php
+++ b/lib/Elastica/Query/Fuzzy.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -8,7 +9,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html
  */
 class Fuzzy extends AbstractQuery
 {

--- a/lib/Elastica/Query/GeoBoundingBox.php
+++ b/lib/Elastica/Query/GeoBoundingBox.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -8,7 +9,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Fabian Vogler <fabian@equivalence.ch>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html
  */
 class GeoBoundingBox extends AbstractQuery
 {

--- a/lib/Elastica/Query/GeoDistance.php
+++ b/lib/Elastica/Query/GeoDistance.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html
  */
 class GeoDistance extends AbstractGeoDistance
 {

--- a/lib/Elastica/Query/GeoPolygon.php
+++ b/lib/Elastica/Query/GeoPolygon.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Michael Maclean <mgdm@php.net>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-query.html
  */
 class GeoPolygon extends AbstractQuery
 {

--- a/lib/Elastica/Query/GeoShapePreIndexed.php
+++ b/lib/Elastica/Query/GeoShapePreIndexed.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -8,7 +9,7 @@ namespace Elastica\Query;
  *
  * @author Bennie Krijger <benniekrijger@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
  */
 class GeoShapePreIndexed extends AbstractGeoShape
 {

--- a/lib/Elastica/Query/GeoShapeProvided.php
+++ b/lib/Elastica/Query/GeoShapeProvided.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -8,7 +9,7 @@ namespace Elastica\Query;
  *
  * @author BennieKrijger <benniekrijger@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
  */
 class GeoShapeProvided extends AbstractGeoShape
 {

--- a/lib/Elastica/Query/GeohashCell.php
+++ b/lib/Elastica/Query/GeohashCell.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 trigger_error('Elastica\Query\GeohashCell is deprecated.', E_USER_DEPRECATED);
@@ -6,7 +7,7 @@ trigger_error('Elastica\Query\GeohashCell is deprecated.', E_USER_DEPRECATED);
 /**
  * Class GeohashCell.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-geohash-cell-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-geohash-cell-query.html
  */
 class GeohashCell extends AbstractGeoDistance
 {
@@ -14,7 +15,7 @@ class GeohashCell extends AbstractGeoDistance
      * @param string       $key       The field on which to query
      * @param array|string $location  Location as coordinates array or geohash string ['lat' => 40.3, 'lon' => 45.2]
      * @param string|int   $precision Integer length of geohash prefix or distance (3, or "50m")
-     * @param bool         $neighbors If true, queries cells next to the given cell.
+     * @param bool         $neighbors if true, queries cells next to the given cell
      */
     public function __construct($key, $location, $precision = -1, $neighbors = false)
     {
@@ -38,7 +39,7 @@ class GeohashCell extends AbstractGeoDistance
     /**
      * Set the neighbors option for this query.
      *
-     * @param bool $neighbors If true, queries cells next to the given cell.
+     * @param bool $neighbors if true, queries cells next to the given cell
      *
      * @return $this
      */

--- a/lib/Elastica/Query/HasChild.php
+++ b/lib/Elastica/Query/HasChild.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Query as BaseQuery;
@@ -8,7 +9,7 @@ use Elastica\Query as BaseQuery;
  *
  * @author Fabian Vogler <fabian@equivalence.ch>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
  */
 class HasChild extends AbstractQuery
 {

--- a/lib/Elastica/Query/HasParent.php
+++ b/lib/Elastica/Query/HasParent.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Query as BaseQuery;
@@ -6,7 +7,7 @@ use Elastica\Query as BaseQuery;
 /**
  * Returns child documents having parent docs matching the query.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
  */
 class HasParent extends AbstractQuery
 {

--- a/lib/Elastica/Query/Ids.php
+++ b/lib/Elastica/Query/Ids.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -8,7 +9,7 @@ namespace Elastica\Query;
  * @author Nicolas Ruflin <spam@ruflin.com>
  * @author Tim Rupp
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
  */
 class Ids extends AbstractQuery
 {

--- a/lib/Elastica/Query/InnerHits.php
+++ b/lib/Elastica/Query/InnerHits.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Script\AbstractScript;
@@ -9,7 +10,7 @@ use Elastica\Script\ScriptFields;
  *
  * @author Guillaume Affringue <wamania@yahoo.fr>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-inner-hits.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-inner-hits.html
  */
 class InnerHits extends AbstractQuery
 {

--- a/lib/Elastica/Query/Limit.php
+++ b/lib/Elastica/Query/Limit.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-limit-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-limit-query.html
  */
 class Limit extends AbstractQuery
 {

--- a/lib/Elastica/Query/Match.php
+++ b/lib/Elastica/Query/Match.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -7,7 +8,7 @@ namespace Elastica\Query;
  * @author F21
  * @author WONG Wing Lun <luiges90@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
  */
 class Match extends AbstractQuery
 {
@@ -25,7 +26,7 @@ class Match extends AbstractQuery
      */
     public function __construct($field = null, $values = null)
     {
-        if ($field !== null && $values !== null) {
+        if (null !== $field && null !== $values) {
             $this->setParam($field, $values);
         }
     }
@@ -125,7 +126,7 @@ class Match extends AbstractQuery
      *
      * @return $this
      *
-     * @link Possible values for minimum_should_match https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
+     * @see Possible values for minimum_should_match https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
      */
     public function setFieldMinimumShouldMatch($field, $minimumShouldMatch)
     {

--- a/lib/Elastica/Query/MatchAll.php
+++ b/lib/Elastica/Query/MatchAll.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html
  */
 class MatchAll extends AbstractQuery
 {

--- a/lib/Elastica/Query/MatchNone.php
+++ b/lib/Elastica/Query/MatchNone.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author David Causse
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html#query-dsl-match-none-query
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html#query-dsl-match-none-query
  */
 class MatchNone extends AbstractQuery
 {

--- a/lib/Elastica/Query/MatchPhrase.php
+++ b/lib/Elastica/Query/MatchPhrase.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -7,7 +8,7 @@ namespace Elastica\Query;
  * @author Jacques Moati <jacques@moati.net>
  * @author Tobias Schultze <http://tobion.de>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html
  */
 class MatchPhrase extends AbstractQuery
 {
@@ -17,7 +18,7 @@ class MatchPhrase extends AbstractQuery
      */
     public function __construct($field = null, $values = null)
     {
-        if ($field !== null && $values !== null) {
+        if (null !== $field && null !== $values) {
             $this->setParam($field, $values);
         }
     }

--- a/lib/Elastica/Query/MatchPhrasePrefix.php
+++ b/lib/Elastica/Query/MatchPhrasePrefix.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -7,7 +8,7 @@ namespace Elastica\Query;
  * @author Jacques Moati <jacques@moati.net>
  * @author Tobias Schultze <http://tobion.de>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase-prefix.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase-prefix.html
  */
 class MatchPhrasePrefix extends MatchPhrase
 {

--- a/lib/Elastica/Query/MoreLikeThis.php
+++ b/lib/Elastica/Query/MoreLikeThis.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Document;
@@ -8,7 +9,7 @@ use Elastica\Document;
  *
  * @author Raul Martinez, Jr <juneym@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html
  */
 class MoreLikeThis extends AbstractQuery
 {

--- a/lib/Elastica/Query/MultiMatch.php
+++ b/lib/Elastica/Query/MultiMatch.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -8,7 +9,7 @@ namespace Elastica\Query;
  * @author Wong Wing Lun <luiges90@gmail.com>
  * @author Tristan Maindron <tmaindron@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
  */
 class MultiMatch extends AbstractQuery
 {

--- a/lib/Elastica/Query/Nested.php
+++ b/lib/Elastica/Query/Nested.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html
  */
 class Nested extends AbstractQuery
 {
@@ -37,7 +38,7 @@ class Nested extends AbstractQuery
     /**
      * Set score method.
      *
-     * @param string $scoreMode Options: avg, total, max and none.
+     * @param string $scoreMode options: avg, total, max and none
      *
      * @return $this
      */

--- a/lib/Elastica/Query/ParentId.php
+++ b/lib/Elastica/Query/ParentId.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
  * ParentId query.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-parent-id-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-parent-id-query.html
  */
 class ParentId extends AbstractQuery
 {

--- a/lib/Elastica/Query/Percolate.php
+++ b/lib/Elastica/Query/Percolate.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Boris Popovschi <zyqsempai@mail.ru>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/5.0/query-dsl-percolate-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.0/query-dsl-percolate-query.html
  */
 /**
  * Class Percolate.

--- a/lib/Elastica/Query/Prefix.php
+++ b/lib/Elastica/Query/Prefix.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
  * Prefix query.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
  */
 class Prefix extends AbstractQuery
 {

--- a/lib/Elastica/Query/QueryString.php
+++ b/lib/Elastica/Query/QueryString.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -8,7 +9,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author   Nicolas Ruflin <spam@ruflin.com>, Jasper van Wanrooy <jasper@vanwanrooy.net>
  *
- * @link     https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
+ * @see     https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
  */
 class QueryString extends AbstractQuery
 {

--- a/lib/Elastica/Query/Range.php
+++ b/lib/Elastica/Query/Range.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
  */
 class Range extends AbstractQuery
 {

--- a/lib/Elastica/Query/Regexp.php
+++ b/lib/Elastica/Query/Regexp.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Aurélien Le Grand <gnitg@yahoo.fr>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html
  */
 class Regexp extends AbstractQuery
 {

--- a/lib/Elastica/Query/Script.php
+++ b/lib/Elastica/Query/Script.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica;
@@ -8,7 +9,7 @@ use Elastica;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-query.html
  */
 class Script extends AbstractQuery
 {

--- a/lib/Elastica/Query/Simple.php
+++ b/lib/Elastica/Query/Simple.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**

--- a/lib/Elastica/Query/SimpleQueryString.php
+++ b/lib/Elastica/Query/SimpleQueryString.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
  * Class SimpleQueryString.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
  */
 class SimpleQueryString extends AbstractQuery
 {

--- a/lib/Elastica/Query/SpanContaining.php
+++ b/lib/Elastica/Query/SpanContaining.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Alessandro Chitolina <alekitto@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-containing-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-containing-query.html
  */
 class SpanContaining extends AbstractSpanQuery
 {

--- a/lib/Elastica/Query/SpanFirst.php
+++ b/lib/Elastica/Query/SpanFirst.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -8,7 +9,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Alessandro Chitolina <alekitto@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-first-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-first-query.html
  */
 class SpanFirst extends AbstractSpanQuery
 {

--- a/lib/Elastica/Query/SpanMulti.php
+++ b/lib/Elastica/Query/SpanMulti.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -9,7 +10,7 @@ use Elastica\Exception\InvalidException;
  * @author Marek Hernik <marek.hernik@gmail.com>
  * @author Alessandro Chitolina <alekitto@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html
  */
 class SpanMulti extends AbstractSpanQuery
 {

--- a/lib/Elastica/Query/SpanNear.php
+++ b/lib/Elastica/Query/SpanNear.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -8,7 +9,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Marek Hernik <marek.hernik@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-near-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-near-query.html
  */
 class SpanNear extends AbstractSpanQuery
 {

--- a/lib/Elastica/Query/SpanNot.php
+++ b/lib/Elastica/Query/SpanNot.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Alessandro Chitolina <alekitto@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-not-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-not-query.html
  */
 class SpanNot extends AbstractSpanQuery
 {

--- a/lib/Elastica/Query/SpanOr.php
+++ b/lib/Elastica/Query/SpanOr.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -8,7 +9,7 @@ use Elastica\Exception\InvalidException;
  *
  * @author Marek Hernik <marek.hernik@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html
  */
 class SpanOr extends AbstractSpanQuery
 {

--- a/lib/Elastica/Query/SpanTerm.php
+++ b/lib/Elastica/Query/SpanTerm.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -7,7 +8,7 @@ namespace Elastica\Query;
  * @author Alessandro Chitolina <alekitto@gmail.com>
  * @author Marek Hernik <marek.hernik@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html
  */
 class SpanTerm extends AbstractSpanQuery
 {

--- a/lib/Elastica/Query/SpanWithin.php
+++ b/lib/Elastica/Query/SpanWithin.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Alessandro Chitolina <alekitto@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-within-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-within-query.html
  */
 class SpanWithin extends AbstractSpanQuery
 {

--- a/lib/Elastica/Query/Term.php
+++ b/lib/Elastica/Query/Term.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html
  */
 class Term extends AbstractQuery
 {

--- a/lib/Elastica/Query/Terms.php
+++ b/lib/Elastica/Query/Terms.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Exception\InvalidException;
@@ -9,7 +10,7 @@ use Elastica\Exception\InvalidException;
  * @author Nicolas Ruflin <spam@ruflin.com>
  * @author Roberto Nygaard <roberto@nygaard.es>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
  */
 class Terms extends AbstractQuery
 {
@@ -42,7 +43,7 @@ class Terms extends AbstractQuery
      * Sets key and terms for the query.
      *
      * @param string $key   Terms key
-     * @param array  $terms Terms for the query.
+     * @param array  $terms terms for the query
      *
      * @return $this
      */
@@ -58,7 +59,7 @@ class Terms extends AbstractQuery
      * Sets key and terms lookup for the query.
      *
      * @param string $key         Terms key
-     * @param array  $termsLookup Terms lookup for the query.
+     * @param array  $termsLookup terms lookup for the query
      *
      * @return $this
      */

--- a/lib/Elastica/Query/Type.php
+++ b/lib/Elastica/Query/Type.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author James Wilson <jwilson556@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html
  */
 class Type extends AbstractQuery
 {

--- a/lib/Elastica/Query/Wildcard.php
+++ b/lib/Elastica/Query/Wildcard.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\Query;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
  */
 class Wildcard extends AbstractQuery
 {

--- a/lib/Elastica/QueryBuilder.php
+++ b/lib/Elastica/QueryBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\QueryBuilderException;

--- a/lib/Elastica/QueryBuilder/DSL.php
+++ b/lib/Elastica/QueryBuilder/DSL.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\QueryBuilder;
 
 /**

--- a/lib/Elastica/QueryBuilder/DSL/Aggregation.php
+++ b/lib/Elastica/QueryBuilder/DSL/Aggregation.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\QueryBuilder\DSL;
 
 use Elastica\Aggregation\Avg;
@@ -40,7 +41,7 @@ use Elastica\QueryBuilder\DSL;
  *
  * @author Manuel Andreo Garcia <andreo.garcia@googlemail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html
  */
 class Aggregation implements DSL
 {
@@ -57,7 +58,7 @@ class Aggregation implements DSL
     /**
      * min aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html
      *
      * @param string $name
      *
@@ -71,7 +72,7 @@ class Aggregation implements DSL
     /**
      * max aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html
      *
      * @param string $name
      *
@@ -85,7 +86,7 @@ class Aggregation implements DSL
     /**
      * sum aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-sum-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-sum-aggregation.html
      *
      * @param string $name
      *
@@ -99,7 +100,7 @@ class Aggregation implements DSL
     /**
      * sum bucket aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-sum-bucket-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-sum-bucket-aggregation.html
      *
      * @param string      $name
      * @param string|null $bucketsPath
@@ -114,7 +115,7 @@ class Aggregation implements DSL
     /**
      * avg aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-avg-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-avg-aggregation.html
      *
      * @param string $name
      *
@@ -128,7 +129,7 @@ class Aggregation implements DSL
     /**
      * avg bucket aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-avg-bucket-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-avg-bucket-aggregation.html
      *
      * @param string      $name
      * @param string|null $bucketsPath
@@ -143,7 +144,7 @@ class Aggregation implements DSL
     /**
      * stats aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html
      *
      * @param string $name
      *
@@ -157,7 +158,7 @@ class Aggregation implements DSL
     /**
      * extended stats aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html
      *
      * @param string $name
      *
@@ -171,7 +172,7 @@ class Aggregation implements DSL
     /**
      * value count aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-valuecount-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-valuecount-aggregation.html
      *
      * @param string $name
      * @param string $field
@@ -186,7 +187,7 @@ class Aggregation implements DSL
     /**
      * percentiles aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-aggregation.html
      *
      * @param string $name  the name of this aggregation
      * @param string $field the field on which to perform this aggregation
@@ -201,7 +202,7 @@ class Aggregation implements DSL
     /**
      * percentile ranks aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-rank-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-percentile-rank-aggregation.html
      *
      * @param string $name
      */
@@ -213,7 +214,7 @@ class Aggregation implements DSL
     /**
      * cardinality aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html
      *
      * @param string $name
      *
@@ -227,7 +228,7 @@ class Aggregation implements DSL
     /**
      * geo bounds aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-geobounds-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-geobounds-aggregation.html
      *
      * @param string $name
      */
@@ -239,7 +240,7 @@ class Aggregation implements DSL
     /**
      * top hits aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html
      *
      * @param string $name
      *
@@ -253,7 +254,7 @@ class Aggregation implements DSL
     /**
      * scripted metric aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-scripted-metric-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-scripted-metric-aggregation.html
      *
      * @param string      $name
      * @param string|null $initScript
@@ -271,7 +272,7 @@ class Aggregation implements DSL
     /**
      * global aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-global-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-global-aggregation.html
      *
      * @param string $name
      *
@@ -285,7 +286,7 @@ class Aggregation implements DSL
     /**
      * filter aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filter-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filter-aggregation.html
      *
      * @param string        $name
      * @param AbstractQuery $filter
@@ -300,7 +301,7 @@ class Aggregation implements DSL
     /**
      * filters aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filters-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filters-aggregation.html
      *
      * @param string $name
      *
@@ -314,7 +315,7 @@ class Aggregation implements DSL
     /**
      * missing aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-missing-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-missing-aggregation.html
      *
      * @param string $name
      * @param string $field
@@ -329,7 +330,7 @@ class Aggregation implements DSL
     /**
      * nested aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-nested-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-nested-aggregation.html
      *
      * @param string $name
      * @param string $path the nested path for this aggregation
@@ -344,7 +345,7 @@ class Aggregation implements DSL
     /**
      * reverse nested aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-reverse-nested-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-reverse-nested-aggregation.html
      *
      * @param string $name The name of this aggregation
      * @param string $path Optional path to the nested object for this aggregation. Defaults to the root of the main document.
@@ -359,7 +360,7 @@ class Aggregation implements DSL
     /**
      * children aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-children-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-children-aggregation.html
      *
      * @param string $name
      */
@@ -371,7 +372,7 @@ class Aggregation implements DSL
     /**
      * terms aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html
      *
      * @param string $name
      *
@@ -385,7 +386,7 @@ class Aggregation implements DSL
     /**
      * significant terms aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html
      *
      * @param string $name
      *
@@ -399,7 +400,7 @@ class Aggregation implements DSL
     /**
      * range aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-range-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-range-aggregation.html
      *
      * @param string $name
      *
@@ -413,7 +414,7 @@ class Aggregation implements DSL
     /**
      * date range aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-daterange-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-daterange-aggregation.html
      *
      * @param string $name
      *
@@ -427,7 +428,7 @@ class Aggregation implements DSL
     /**
      * ipv4 range aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-iprange-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-iprange-aggregation.html
      *
      * @param string $name
      * @param string $field
@@ -442,7 +443,7 @@ class Aggregation implements DSL
     /**
      * histogram aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html
      *
      * @param string $name     the name of this aggregation
      * @param string $field    the name of the field on which to perform the aggregation
@@ -458,7 +459,7 @@ class Aggregation implements DSL
     /**
      * date histogram aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html
      *
      * @param string $name     the name of this aggregation
      * @param string $field    the name of the field on which to perform the aggregation
@@ -474,7 +475,7 @@ class Aggregation implements DSL
     /**
      * geo distance aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geodistance-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geodistance-aggregation.html
      *
      * @param string       $name   the name if this aggregation
      * @param string       $field  the field on which to perform this aggregation
@@ -490,7 +491,7 @@ class Aggregation implements DSL
     /**
      * geohash grid aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html
      *
      * @param string $name  the name of this aggregation
      * @param string $field the field on which to perform this aggregation
@@ -505,7 +506,7 @@ class Aggregation implements DSL
     /**
      * bucket script aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-script-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-script-aggregation.html
      *
      * @param string      $name
      * @param array|null  $bucketsPath
@@ -521,7 +522,7 @@ class Aggregation implements DSL
     /**
      * serial diff aggregation.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-serialdiff-aggregation.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-serialdiff-aggregation.html
      *
      * @param string      $name
      * @param string|null $bucketsPath

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\QueryBuilder\DSL;
 
 use Elastica\Exception\NotImplementedException;
@@ -47,7 +48,7 @@ use Elastica\QueryBuilder\DSL;
  *
  * @author Manuel Andreo Garcia <andreo.garcia@googlemail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-queries.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-queries.html
  */
 class Query implements DSL
 {
@@ -64,7 +65,7 @@ class Query implements DSL
     /**
      * match query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
      *
      * @param string $field
      * @param mixed  $values
@@ -79,7 +80,7 @@ class Query implements DSL
     /**
      * multi match query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
      *
      * @return \Elastica\Query\MultiMatch
      */
@@ -91,7 +92,7 @@ class Query implements DSL
     /**
      * bool query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
      *
      * @return \Elastica\Query\BoolQuery
      */
@@ -103,7 +104,7 @@ class Query implements DSL
     /**
      * boosting query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-boosting-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-boosting-query.html
      *
      * @return Boosting
      */
@@ -115,7 +116,7 @@ class Query implements DSL
     /**
      * common terms query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html
      *
      * @param string $field
      * @param string $query
@@ -131,7 +132,7 @@ class Query implements DSL
     /**
      * constant score query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-constant-score-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-constant-score-query.html
      *
      * @param null|\Elastica\Query\AbstractQuery|array $filter
      *
@@ -145,7 +146,7 @@ class Query implements DSL
     /**
      * dis max query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-dis-max-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-dis-max-query.html
      *
      * @return DisMax
      */
@@ -157,7 +158,7 @@ class Query implements DSL
     /**
      * function score query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
      *
      * @return FunctionScore
      */
@@ -169,7 +170,7 @@ class Query implements DSL
     /**
      * fuzzy query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html
      *
      * @param string $fieldName Field name
      * @param string $value     String to search for
@@ -184,7 +185,7 @@ class Query implements DSL
     /**
      * geo shape query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
      */
     public function geo_shape()
     {
@@ -194,7 +195,7 @@ class Query implements DSL
     /**
      * has child query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
      *
      * @param string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
      * @param string                                               $type  Parent document type
@@ -209,7 +210,7 @@ class Query implements DSL
     /**
      * has parent query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
      *
      * @param string|\Elastica\Query|\Elastica\Query\AbstractQuery $query
      * @param string                                               $type  Parent document type
@@ -224,7 +225,7 @@ class Query implements DSL
     /**
      * ids query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
      *
      * @param array $ids
      *
@@ -238,7 +239,7 @@ class Query implements DSL
     /**
      * match all query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html
      *
      * @return MatchAll
      */
@@ -250,7 +251,7 @@ class Query implements DSL
     /**
      * match none query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html#query-dsl-match-none-query
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html#query-dsl-match-none-query
      *
      * @return MatchNone
      */
@@ -262,7 +263,7 @@ class Query implements DSL
     /**
      * more like this query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html
      *
      * @return MoreLikeThis
      */
@@ -274,7 +275,7 @@ class Query implements DSL
     /**
      * nested query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html
      *
      * @return Nested
      */
@@ -298,7 +299,7 @@ class Query implements DSL
     /**
      * prefix query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
      *
      * @param array $prefix Prefix array
      *
@@ -312,7 +313,7 @@ class Query implements DSL
     /**
      * query string query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
      *
      * @param string $queryString OPTIONAL Query string for object
      *
@@ -326,7 +327,7 @@ class Query implements DSL
     /**
      * simple_query_string query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
      *
      * @param string $query
      * @param array  $fields
@@ -341,7 +342,7 @@ class Query implements DSL
     /**
      * range query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
      *
      * @param string $fieldName
      * @param array  $args
@@ -362,7 +363,7 @@ class Query implements DSL
      *
      * @return Regexp
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html
      */
     public function regexp($key = '', $value = null, $boost = 1.0)
     {
@@ -377,7 +378,7 @@ class Query implements DSL
      *
      * @return SpanFirst
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-first-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-first-query.html
      */
     public function span_first($match = null, $end = null)
     {
@@ -391,7 +392,7 @@ class Query implements DSL
      *
      * @return SpanMulti
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html
      */
     public function span_multi_term($match = null)
     {
@@ -407,7 +408,7 @@ class Query implements DSL
      *
      * @return SpanNear
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-near-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-near-query.html
      */
     public function span_near($clauses = [], $slop = 1, $inOrder = false)
     {
@@ -422,7 +423,7 @@ class Query implements DSL
      *
      * @return SpanNot
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-not-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-not-query.html
      */
     public function span_not(AbstractSpanQuery $include = null, AbstractSpanQuery $exclude = null)
     {
@@ -436,7 +437,7 @@ class Query implements DSL
      *
      * @return SpanOr
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-or-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-or-query.html
      */
     public function span_or($clauses = [])
     {
@@ -450,7 +451,7 @@ class Query implements DSL
      *
      * @return SpanTerm
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html
      */
     public function span_term(array $term = [])
     {
@@ -465,7 +466,7 @@ class Query implements DSL
      *
      * @return SpanContaining
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-containing-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-containing-query.html
      */
     public function span_containing(AbstractSpanQuery $little = null, AbstractSpanQuery $big = null)
     {
@@ -480,7 +481,7 @@ class Query implements DSL
      *
      * @return SpanWithin
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-within-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-within-query.html
      */
     public function span_within(AbstractSpanQuery $little = null, AbstractSpanQuery $big = null)
     {
@@ -490,7 +491,7 @@ class Query implements DSL
     /**
      * term query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html
      *
      * @param array $term
      *
@@ -504,7 +505,7 @@ class Query implements DSL
     /**
      * terms query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
      *
      * @param string $key
      * @param array  $terms
@@ -519,7 +520,7 @@ class Query implements DSL
     /**
      * wildcard query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
      *
      * @param string $key   OPTIONAL Wildcard key
      * @param string $value OPTIONAL Wildcard value
@@ -535,7 +536,7 @@ class Query implements DSL
     /**
      * geo distance query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html
      *
      * @param string       $key
      * @param array|string $location
@@ -551,7 +552,7 @@ class Query implements DSL
     /**
      * exists query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html
      *
      * @param string $field
      *
@@ -565,7 +566,7 @@ class Query implements DSL
     /**
      * type query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html
      *
      * @param string $type Type name
      *
@@ -579,7 +580,7 @@ class Query implements DSL
     /**
      * type query.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/5.0/query-dsl-percolate-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.0/query-dsl-percolate-query.html
      *
      * @return Percolate
      */

--- a/lib/Elastica/QueryBuilder/DSL/Suggest.php
+++ b/lib/Elastica/QueryBuilder/DSL/Suggest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\QueryBuilder\DSL;
 
 use Elastica\Exception\NotImplementedException;
@@ -12,7 +13,7 @@ use Elastica\Suggest\Term;
  *
  * @author Manuel Andreo Garcia <andreo.garcia@googlemail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html
  */
 class Suggest implements DSL
 {
@@ -29,7 +30,7 @@ class Suggest implements DSL
     /**
      * term suggester.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-term.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-term.html
      *
      * @param $name
      * @param $field
@@ -44,7 +45,7 @@ class Suggest implements DSL
     /**
      * phrase suggester.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html
      *
      * @param $name
      * @param $field
@@ -59,7 +60,7 @@ class Suggest implements DSL
     /**
      * completion suggester.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html
      *
      * @param string $name
      * @param string $field
@@ -74,7 +75,7 @@ class Suggest implements DSL
     /**
      * context suggester.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/suggester-context.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/suggester-context.html
      */
     public function context()
     {

--- a/lib/Elastica/QueryBuilder/Facade.php
+++ b/lib/Elastica/QueryBuilder/Facade.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\QueryBuilder;
 
 use Elastica\Exception\QueryBuilderException;

--- a/lib/Elastica/QueryBuilder/Version.php
+++ b/lib/Elastica/QueryBuilder/Version.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\QueryBuilder;
 
 /**

--- a/lib/Elastica/QueryBuilder/Version/Latest.php
+++ b/lib/Elastica/QueryBuilder/Version/Latest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\QueryBuilder\Version;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica\QueryBuilder\Version;
  *
  * Latest refers to the version mentioned in README.md.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
  *
  * @author Manuel Andreo Garcia <andreo.garcia@gmail.com>
  */

--- a/lib/Elastica/QueryBuilder/Version/Version240.php
+++ b/lib/Elastica/QueryBuilder/Version/Version240.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\QueryBuilder\Version;
 
 use Elastica\QueryBuilder\Version;
@@ -6,7 +7,7 @@ use Elastica\QueryBuilder\Version;
 /**
  * elasticsearch 2.4 DSL.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/2.4/index.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/2.4/index.html
  *
  * @author Cariou Pierre-Yves <cariou.p@gmail.com>
  */

--- a/lib/Elastica/Reindex.php
+++ b/lib/Elastica/Reindex.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Query\AbstractQuery;

--- a/lib/Elastica/Request.php
+++ b/lib/Elastica/Request.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Rescore/AbstractRescore.php
+++ b/lib/Elastica/Rescore/AbstractRescore.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Rescore;
 
 use Elastica\Param;
@@ -8,7 +9,7 @@ use Elastica\Param;
  *
  * @author Jason Hu <mjhu91@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-rescore.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-rescore.html
  */
 abstract class AbstractRescore extends Param
 {

--- a/lib/Elastica/Rescore/Query.php
+++ b/lib/Elastica/Rescore/Query.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Rescore;
 
 use Elastica\Query as BaseQuery;
@@ -8,7 +9,7 @@ use Elastica\Query as BaseQuery;
  *
  * @author Jason Hu <mjhu91@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-rescore.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-rescore.html
  */
 class Query extends AbstractRescore
 {

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\JSONParseException;
@@ -212,7 +213,7 @@ class Response
      */
     public function getData()
     {
-        if ($this->_response == null) {
+        if (null == $this->_response) {
             $response = $this->_responseString;
 
             try {
@@ -242,7 +243,7 @@ class Response
     /**
      * Gets the transfer information.
      *
-     * @return array Information about the curl request.
+     * @return array information about the curl request
      */
     public function getTransferInfo()
     {
@@ -253,7 +254,7 @@ class Response
      * Sets the transfer info of the curl request. This function is called
      * from the \Elastica\Client::_callService .
      *
-     * @param array $transferInfo The curl transfer information.
+     * @param array $transferInfo the curl transfer information
      *
      * @return $this
      */

--- a/lib/Elastica/Result.php
+++ b/lib/Elastica/Result.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 /**
@@ -264,6 +265,6 @@ class Result
     {
         $source = $this->getData();
 
-        return array_key_exists($key, $source) && $source[$key] !== null;
+        return array_key_exists($key, $source) && null !== $source[$key];
     }
 }

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
@@ -282,11 +283,11 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     /**
      * Whether a offset exists.
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     * @see http://php.net/manual/en/arrayaccess.offsetexists.php
      *
      * @param int $offset
      *
-     * @return bool true on success or false on failure.
+     * @return bool true on success or false on failure
      */
     public function offsetExists($offset)
     {
@@ -296,7 +297,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     /**
      * Offset to retrieve.
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     * @see http://php.net/manual/en/arrayaccess.offsetget.php
      *
      * @param int $offset
      *
@@ -316,7 +317,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     /**
      * Offset to set.
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetset.php
+     * @see http://php.net/manual/en/arrayaccess.offsetset.php
      *
      * @param int    $offset
      * @param Result $value
@@ -339,7 +340,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     /**
      * Offset to unset.
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     * @see http://php.net/manual/en/arrayaccess.offsetunset.php
      *
      * @param int $offset
      */

--- a/lib/Elastica/ResultSet/BuilderInterface.php
+++ b/lib/Elastica/ResultSet/BuilderInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\ResultSet;
 
 use Elastica\Query;

--- a/lib/Elastica/ResultSet/ChainProcessor.php
+++ b/lib/Elastica/ResultSet/ChainProcessor.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\ResultSet;
 
 use Elastica\ResultSet;

--- a/lib/Elastica/ResultSet/DefaultBuilder.php
+++ b/lib/Elastica/ResultSet/DefaultBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\ResultSet;
 
 use Elastica\Query;

--- a/lib/Elastica/ResultSet/ProcessingBuilder.php
+++ b/lib/Elastica/ResultSet/ProcessingBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\ResultSet;
 
 use Elastica\Query;

--- a/lib/Elastica/ResultSet/ProcessorInterface.php
+++ b/lib/Elastica/ResultSet/ProcessorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\ResultSet;
 
 use Elastica\ResultSet;

--- a/lib/Elastica/Script/AbstractScript.php
+++ b/lib/Elastica/Script/AbstractScript.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Script;
 
 use Elastica\AbstractUpdateAction;
@@ -13,7 +14,7 @@ use Elastica\Exception\InvalidException;
  * @author Tobias Schultze <http://tobion.de>
  * @author Martin Janser <martin.janser@liip.ch>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
  */
 abstract class AbstractScript extends AbstractUpdateAction
 {

--- a/lib/Elastica/Script/Script.php
+++ b/lib/Elastica/Script/Script.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Script;
 
 /**
@@ -8,7 +9,7 @@ namespace Elastica\Script;
  * @author Tobias Schultze <http://tobion.de>
  * @author Martin Janser <martin.janser@liip.ch>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
  */
 class Script extends AbstractScript
 {

--- a/lib/Elastica/Script/ScriptFields.php
+++ b/lib/Elastica/Script/ScriptFields.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Script;
 
 use Elastica\Exception\InvalidException;
@@ -9,7 +10,7 @@ use Elastica\Param;
  *
  * @author Sebastien Lavoie <github@lavoie.sl>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
  */
 class ScriptFields extends Param
 {

--- a/lib/Elastica/Script/ScriptId.php
+++ b/lib/Elastica/Script/ScriptId.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Script;
 
 /**
@@ -7,7 +8,7 @@ namespace Elastica\Script;
  * @author Tobias Schultze <http://tobion.de>
  * @author Martin Janser <martin.janser@liip.ch>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
  */
 class ScriptId extends AbstractScript
 {

--- a/lib/Elastica/Scroll.php
+++ b/lib/Elastica/Scroll.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 /**
@@ -6,7 +7,7 @@ namespace Elastica;
  *
  * @author Manuel Andreo Garcia <andreo.garcia@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
  */
 class Scroll implements \Iterator
 {
@@ -56,7 +57,7 @@ class Scroll implements \Iterator
     /**
      * Returns current result set.
      *
-     * @link http://php.net/manual/en/iterator.current.php
+     * @see http://php.net/manual/en/iterator.current.php
      *
      * @return ResultSet
      */
@@ -68,7 +69,7 @@ class Scroll implements \Iterator
     /**
      * Next scroll search.
      *
-     * @link http://php.net/manual/en/iterator.next.php
+     * @see http://php.net/manual/en/iterator.next.php
      */
     public function next()
     {
@@ -90,7 +91,7 @@ class Scroll implements \Iterator
     /**
      * Returns scroll id.
      *
-     * @link http://php.net/manual/en/iterator.key.php
+     * @see http://php.net/manual/en/iterator.key.php
      *
      * @return string
      */
@@ -102,19 +103,19 @@ class Scroll implements \Iterator
     /**
      * Returns true if current result set contains at least one hit.
      *
-     * @link http://php.net/manual/en/iterator.valid.php
+     * @see http://php.net/manual/en/iterator.valid.php
      *
      * @return bool
      */
     public function valid()
     {
-        return $this->_nextScrollId !== null;
+        return null !== $this->_nextScrollId;
     }
 
     /**
      * Initial scroll search.
      *
-     * @link http://php.net/manual/en/iterator.rewind.php
+     * @see http://php.net/manual/en/iterator.rewind.php
      */
     public function rewind()
     {
@@ -157,7 +158,7 @@ class Scroll implements \Iterator
      */
     protected function _setScrollId(ResultSet $resultSet)
     {
-        if ($this->currentPage === 0) {
+        if (0 === $this->currentPage) {
             $this->totalPages = $resultSet->count() > 0 ? ceil($resultSet->getTotalHits() / $resultSet->count()) : 0;
         }
 

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/SearchableInterface.php
+++ b/lib/Elastica/SearchableInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 /**

--- a/lib/Elastica/Snapshot.php
+++ b/lib/Elastica/Snapshot.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\NotFoundException;
@@ -8,7 +9,7 @@ use Elasticsearch\Endpoints\Snapshot\Restore;
 /**
  * Class Snapshot.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html
  */
 class Snapshot
 {
@@ -59,7 +60,7 @@ class Snapshot
         try {
             $response = $this->request($name);
         } catch (ResponseException $e) {
-            if ($e->getResponse()->getStatus() == 404) {
+            if (404 == $e->getResponse()->getStatus()) {
                 throw new NotFoundException("Repository '".$name."' does not exist.");
             }
             throw $e;
@@ -110,7 +111,7 @@ class Snapshot
         try {
             $response = $this->request($repository.'/'.$name);
         } catch (ResponseException $e) {
-            if ($e->getResponse()->getStatus() == 404) {
+            if (404 == $e->getResponse()->getStatus()) {
                 throw new NotFoundException("Snapshot '".$name."' does not exist in repository '".$repository."'.");
             }
             throw $e;

--- a/lib/Elastica/Status.php
+++ b/lib/Elastica/Status.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\ResponseException;
@@ -10,7 +11,7 @@ use Elasticsearch\Endpoints\Indices\Stats;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-status.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-status.html
  */
 class Status
 {
@@ -113,7 +114,7 @@ class Status
             $response = $this->_client->requestEndpoint($endpoint);
         } catch (ResponseException $e) {
             // 404 means the index alias doesn't exist which means no indexes have it.
-            if ($e->getResponse()->getStatus() === 404) {
+            if (404 === $e->getResponse()->getStatus()) {
                 return [];
             }
             // If we don't have a 404 then this is still unexpected so rethrow the exception.

--- a/lib/Elastica/Suggest.php
+++ b/lib/Elastica/Suggest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\NotImplementedException;
@@ -7,7 +8,7 @@ use Elastica\Suggest\AbstractSuggest;
 /**
  * Class Suggest.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html
  */
 class Suggest extends Param
 {

--- a/lib/Elastica/Suggest/AbstractSuggest.php
+++ b/lib/Elastica/Suggest/AbstractSuggest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Suggest;
 
 use Elastica\Exception\InvalidException;

--- a/lib/Elastica/Suggest/CandidateGenerator/AbstractCandidateGenerator.php
+++ b/lib/Elastica/Suggest/CandidateGenerator/AbstractCandidateGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Suggest\CandidateGenerator;
 
 use Elastica\Param;

--- a/lib/Elastica/Suggest/CandidateGenerator/DirectGenerator.php
+++ b/lib/Elastica/Suggest/CandidateGenerator/DirectGenerator.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Suggest\CandidateGenerator;
 
 /**
  * Class DirectGenerator.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html#_direct_generators
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html#_direct_generators
  */
 class DirectGenerator extends AbstractCandidateGenerator
 {

--- a/lib/Elastica/Suggest/Completion.php
+++ b/lib/Elastica/Suggest/Completion.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Suggest;
 
 /**
@@ -6,14 +7,14 @@ namespace Elastica\Suggest;
  *
  * @author Igor Denisenko <im.denisenko@yahoo.com>
  *
- * @link   https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html
+ * @see   https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html
  */
 class Completion extends AbstractSuggest
 {
     /**
      * Set fuzzy parameter.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html#fuzzy
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html#fuzzy
      *
      * @param array $fuzzy
      *

--- a/lib/Elastica/Suggest/Phrase.php
+++ b/lib/Elastica/Suggest/Phrase.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Suggest;
 
 use Elastica\Suggest\CandidateGenerator\AbstractCandidateGenerator;
@@ -6,7 +7,7 @@ use Elastica\Suggest\CandidateGenerator\AbstractCandidateGenerator;
 /**
  * Class Phrase.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html
  */
 class Phrase extends AbstractSuggest
 {

--- a/lib/Elastica/Suggest/Term.php
+++ b/lib/Elastica/Suggest/Term.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica\Suggest;
 
 /**
  * Class Term.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-term.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-term.html
  */
 class Term extends AbstractSuggest
 {
@@ -72,7 +73,7 @@ class Term extends AbstractSuggest
     /**
      * The number of minimum prefix characters that must match in order to be a suggestion candidate.
      *
-     * @param int $length Defaults to 1.
+     * @param int $length defaults to 1
      *
      * @return $this
      */
@@ -84,7 +85,7 @@ class Term extends AbstractSuggest
     /**
      * The minimum length a suggest text term must have in order to be included.
      *
-     * @param int $length Defaults to 4.
+     * @param int $length defaults to 4
      *
      * @return $this
      */
@@ -94,7 +95,7 @@ class Term extends AbstractSuggest
     }
 
     /**
-     * @param int $max Defaults to 5.
+     * @param int $max defaults to 5
      *
      * @return $this
      */

--- a/lib/Elastica/Task.php
+++ b/lib/Elastica/Task.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Elastica;
 
 /**
  * Represents elasticsearch task.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html
  */
 class Task extends Param
 {
@@ -106,7 +107,7 @@ class Task extends Param
     {
         $data = $this->getData();
 
-        return $data['completed'] === true;
+        return true === $data['completed'];
     }
 
     public function cancel(): Response

--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Transport;
 
 use Elastica\Connection;

--- a/lib/Elastica/Transport/AwsAuthV4.php
+++ b/lib/Elastica/Transport/AwsAuthV4.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Transport;
 
 use Aws\Credentials\CredentialProvider;

--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Transport;
 
 use Elastica\Connection;
@@ -127,11 +128,11 @@ class Guzzle extends AbstractTransport
 
         $data = $request->getData();
         if (!empty($data) || '0' === $data) {
-            if ($req->getMethod() == Request::GET) {
+            if (Request::GET == $req->getMethod()) {
                 $req = $req->withMethod(Request::POST);
             }
 
-            if ($this->hasParam('postWithRequestBody') && $this->getParam('postWithRequestBody') == true) {
+            if ($this->hasParam('postWithRequestBody') && true == $this->getParam('postWithRequestBody')) {
                 $request->setMethod(Request::POST);
                 $req = $req->withMethod(Request::POST);
             }

--- a/lib/Elastica/Transport/Http.php
+++ b/lib/Elastica/Transport/Http.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Transport;
 
 use Elastica\Exception\Connection\HttpException;
@@ -125,7 +126,7 @@ class Http extends AbstractTransport
         $httpMethod = $request->getMethod();
 
         if (!empty($data) || '0' === $data) {
-            if ($this->hasParam('postWithRequestBody') && $this->getParam('postWithRequestBody') == true) {
+            if ($this->hasParam('postWithRequestBody') && true == $this->getParam('postWithRequestBody')) {
                 $httpMethod = Request::POST;
             }
 
@@ -154,7 +155,7 @@ class Http extends AbstractTransport
 
         curl_setopt($conn, CURLOPT_HTTPHEADER, $headers);
 
-        curl_setopt($conn, CURLOPT_NOBODY, $httpMethod == 'HEAD');
+        curl_setopt($conn, CURLOPT_NOBODY, 'HEAD' == $httpMethod);
 
         curl_setopt($conn, CURLOPT_CUSTOMREQUEST, $httpMethod);
 

--- a/lib/Elastica/Transport/HttpAdapter.php
+++ b/lib/Elastica/Transport/HttpAdapter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Transport;
 
 use Elastica\Connection;
@@ -109,11 +110,11 @@ class HttpAdapter extends AbstractTransport
         $method = $elasticaRequest->getMethod();
         $headers = $connection->hasConfig('headers') ?: [];
         if (!empty($data) || '0' === $data) {
-            if ($method == ElasticaRequest::GET) {
+            if (ElasticaRequest::GET == $method) {
                 $method = ElasticaRequest::POST;
             }
 
-            if ($this->hasParam('postWithRequestBody') && $this->getParam('postWithRequestBody') == true) {
+            if ($this->hasParam('postWithRequestBody') && true == $this->getParam('postWithRequestBody')) {
                 $elasticaRequest->setMethod(ElasticaRequest::POST);
                 $method = ElasticaRequest::POST;
             }

--- a/lib/Elastica/Transport/Https.php
+++ b/lib/Elastica/Transport/Https.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Transport;
 
 /**

--- a/lib/Elastica/Transport/NullTransport.php
+++ b/lib/Elastica/Transport/NullTransport.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Transport;
 
 use Elastica\JSON;

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
@@ -136,7 +137,7 @@ class Type implements SearchableInterface
     /**
      * Update document, using update script. Requires elasticsearch >= 0.19.0.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html
      *
      * @param \Elastica\Document|\Elastica\Script\AbstractScript $data    Document with update data
      * @param array                                              $options array of query params to use for query. For possible options check es api
@@ -172,7 +173,7 @@ class Type implements SearchableInterface
      *
      * @return \Elastica\Bulk\ResponseSet
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
     public function updateDocuments(array $docs, array $options = [])
     {
@@ -191,7 +192,7 @@ class Type implements SearchableInterface
      *
      * @return \Elastica\Bulk\ResponseSet
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
     public function addDocuments(array $docs, array $options = [])
     {
@@ -210,7 +211,7 @@ class Type implements SearchableInterface
      *
      * @return Bulk\ResponseSet
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
     public function addObjects(array $objects, array $options = [])
     {
@@ -234,7 +235,7 @@ class Type implements SearchableInterface
      * Get the document from search index.
      *
      * @param string $id      Document id
-     * @param array  $options Options for the get request.
+     * @param array  $options options for the get request
      *
      * @throws \Elastica\Exception\NotFoundException
      * @throws \Elastica\Exception\ResponseException
@@ -250,7 +251,7 @@ class Type implements SearchableInterface
         $response = $this->requestEndpoint($endpoint);
         $result = $response->getData();
 
-        if (!isset($result['found']) || $result['found'] === false) {
+        if (!isset($result['found']) || false === $result['found']) {
             throw new NotFoundException('doc id '.$id.' not found');
         }
 
@@ -416,7 +417,7 @@ class Type implements SearchableInterface
      *
      * @return \Elastica\Bulk\ResponseSet
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
     public function deleteDocuments(array $docs)
     {
@@ -430,7 +431,7 @@ class Type implements SearchableInterface
     /**
      * Deletes an entry by its unique identifier.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html
      *
      * @param int|string $id      Document id
      * @param array      $options
@@ -482,7 +483,7 @@ class Type implements SearchableInterface
      *
      * @return \Elastica\Response
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
      */
     public function deleteByQuery($query, array $options = [])
     {
@@ -552,6 +553,6 @@ class Type implements SearchableInterface
     {
         $response = $this->requestEndpoint(new Exists());
 
-        return $response->getStatus() === 200;
+        return 200 === $response->getStatus();
     }
 }

--- a/lib/Elastica/Type/AbstractType.php
+++ b/lib/Elastica/Type/AbstractType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Type;
 
 use Elastica\Client;

--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Type;
 
 use Elastica\Exception\InvalidException;
@@ -10,7 +11,7 @@ use Elasticsearch\Endpoints\Indices\Mapping\Put;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
  */
 class Mapping
 {
@@ -89,7 +90,7 @@ class Mapping
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta.html
      */
     public function setMeta(array $meta)
     {
@@ -116,7 +117,7 @@ class Mapping
      *
      * @return $this
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html
      */
     public function setSource(array $source)
     {

--- a/lib/Elastica/Util.php
+++ b/lib/Elastica/Util.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica;
 
 /**
@@ -76,8 +77,8 @@ class Util
      * and
      * escape known special characters (e.g. + - && || ! ( ) { } [ ] ^ " ~ * ? : etc.).
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-dsl-query-string-query.html#_boolean_operators
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-dsl-query-string-query.html#_reserved_characters
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-dsl-query-string-query.html#_boolean_operators
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.1/query-dsl-query-string-query.html#_reserved_characters
      *
      * @param string $term Query term to replace and escape
      *
@@ -96,7 +97,7 @@ class Util
      * Escapes the following terms (because part of the query language)
      * + - && || ! ( ) { } [ ] ^ " ~ * ? : \ < >.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
      *
      * @param string $term Query term to escape
      *
@@ -127,7 +128,7 @@ class Util
      * Replace the following reserved words (because part of the query language)
      * AND OR NOT.
      *
-     * @link http://lucene.apache.org/java/2_4_0/queryparsersyntax.html#Boolean%20operators
+     * @see http://lucene.apache.org/java/2_4_0/queryparsersyntax.html#Boolean%20operators
      *
      * @param string $term Query term to replace
      *
@@ -204,7 +205,7 @@ class Util
      */
     public static function convertDateTimeObject(\DateTime $dateTime, $includeTimezone = true)
     {
-        $formatString = 'Y-m-d\TH:i:s'.($includeTimezone === true ? 'P' : '\Z');
+        $formatString = 'Y-m-d\TH:i:s'.(true === $includeTimezone ? 'P' : '\Z');
         $string = $dateTime->format($formatString);
 
         return $string;

--- a/test/Elastica/Aggregation/AbstractSimpleAggregationTest.php
+++ b/test/Elastica/Aggregation/AbstractSimpleAggregationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\AbstractSimpleAggregation;

--- a/test/Elastica/Aggregation/AvgBucketTest.php
+++ b/test/Elastica/Aggregation/AvgBucketTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;
@@ -76,10 +77,11 @@ class AvgBucketTest extends BaseAggregationTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testToArrayInvalidBucketsPath()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $serialDiffAgg = new AvgBucket('avg_bucket');
         $serialDiffAgg->toArray();
     }

--- a/test/Elastica/Aggregation/AvgTest.php
+++ b/test/Elastica/Aggregation/AvgTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;

--- a/test/Elastica/Aggregation/BaseAggregationTest.php
+++ b/test/Elastica/Aggregation/BaseAggregationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Test\Base;

--- a/test/Elastica/Aggregation/BucketScriptTest.php
+++ b/test/Elastica/Aggregation/BucketScriptTest.php
@@ -1,10 +1,12 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\BucketScript;
 use Elastica\Aggregation\Histogram;
 use Elastica\Aggregation\Max;
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Query;
 
 class BucketScriptTest extends BaseAggregationTest
@@ -89,20 +91,22 @@ class BucketScriptTest extends BaseAggregationTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testToArrayInvalidBucketsPath()
     {
+        $this->expectException(InvalidException::class);
+
         $serialDiffAgg = new BucketScript('bucket_scripted');
         $serialDiffAgg->toArray();
     }
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testToArrayInvalidScript()
     {
+        $this->expectException(InvalidException::class);
+
         $serialDiffAgg = new BucketScript('bucket_scripted', ['path' => 'agg']);
         $serialDiffAgg->toArray();
     }

--- a/test/Elastica/Aggregation/BucketSelectorTest.php
+++ b/test/Elastica/Aggregation/BucketSelectorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\BucketSelector;
@@ -81,7 +82,7 @@ class BucketSelectorTest extends BaseAggregationTest
 
         $dateHistogramAggResult = $index->search($query)->getAggregation('histogram_agg')['buckets'];
 
-        $this->assertEquals(4, count($dateHistogramAggResult));
+        $this->assertCount(4, $dateHistogramAggResult);
         $this->assertEquals(6, $dateHistogramAggResult[0]['max_agg']['value']);
         $this->assertEquals(9, $dateHistogramAggResult[1]['max_agg']['value']);
         $this->assertEquals(11, $dateHistogramAggResult[2]['max_agg']['value']);

--- a/test/Elastica/Aggregation/CardinalityTest.php
+++ b/test/Elastica/Aggregation/CardinalityTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Cardinality;
@@ -48,13 +49,14 @@ class CardinalityTest extends BaseAggregationTest
 
     /**
      * @dataProvider invalidPrecisionThresholdProvider
-     * @expectedException \InvalidArgumentException
      * @group unit
      *
      * @param $threshold
      */
     public function testInvalidPrecisionThreshold($threshold)
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $agg = new Cardinality('threshold');
         $agg->setPrecisionThreshold($threshold);
     }
@@ -112,13 +114,14 @@ class CardinalityTest extends BaseAggregationTest
 
     /**
      * @dataProvider invalidRehashProvider
-     * @expectedException \InvalidArgumentException
      * @group unit
      *
      * @param mixed $rehash
      */
     public function testInvalidRehash($rehash)
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $agg = new Cardinality('rehash');
         $agg->setRehash($rehash);
     }

--- a/test/Elastica/Aggregation/ChildrenTest.php
+++ b/test/Elastica/Aggregation/ChildrenTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Children;

--- a/test/Elastica/Aggregation/DateHistogramTest.php
+++ b/test/Elastica/Aggregation/DateHistogramTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\DateHistogram;
@@ -42,7 +43,7 @@ class DateHistogramTest extends BaseAggregationTest
         $docCount = 0;
         $nonDocCount = 0;
         foreach ($results['buckets'] as $bucket) {
-            if ($bucket['doc_count'] == 1) {
+            if (1 == $bucket['doc_count']) {
                 ++$docCount;
             } else {
                 ++$nonDocCount;

--- a/test/Elastica/Aggregation/DateRangeTest.php
+++ b/test/Elastica/Aggregation/DateRangeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\DateRange;

--- a/test/Elastica/Aggregation/DerivativeTest.php
+++ b/test/Elastica/Aggregation/DerivativeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\DateHistogram;
@@ -75,7 +76,7 @@ class DerivativeTest extends BaseAggregationTest
 
         $dateHistogramAggResult = $index->search($query)->getAggregation('histogram_agg')['buckets'];
 
-        $this->assertFalse(array_key_exists('derivative_agg', $dateHistogramAggResult[0]));
+        $this->assertArrayNotHasKey('derivative_agg', $dateHistogramAggResult[0]);
         $this->assertEquals(1, $dateHistogramAggResult[1]['derivative_agg']['value']);
         $this->assertEquals(0, $dateHistogramAggResult[2]['derivative_agg']['value']);
         $this->assertEquals(2, $dateHistogramAggResult[3]['derivative_agg']['value']);

--- a/test/Elastica/Aggregation/ExtendedStatsTest.php
+++ b/test/Elastica/Aggregation/ExtendedStatsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\ExtendedStats;

--- a/test/Elastica/Aggregation/FilterTest.php
+++ b/test/Elastica/Aggregation/FilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;

--- a/test/Elastica/Aggregation/FiltersTest.php
+++ b/test/Elastica/Aggregation/FiltersTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;
@@ -68,22 +69,24 @@ class FiltersTest extends BaseAggregationTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
-     * @expectedExceptionMessage Name must be a string
      */
     public function testWrongName()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectExceptionMessage('Name must be a string');
+
         $agg = new Filters('by_color');
         $agg->addFilter(new Term(['color' => '0']), 0);
     }
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
-     * @expectedExceptionMessage Mix named and anonymous keys are not allowed
      */
     public function testMixNamedAndAnonymousFilters()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectExceptionMessage('Mix named and anonymous keys are not allowed');
+
         $agg = new Filters('by_color');
         $agg->addFilter(new Term(['color' => '0']), '0');
         $agg->addFilter(new Term(['color' => '0']));
@@ -91,11 +94,12 @@ class FiltersTest extends BaseAggregationTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
-     * @expectedExceptionMessage Mix named and anonymous keys are not allowed
      */
     public function testMixAnonymousAndNamedFilters()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectExceptionMessage('Mix named and anonymous keys are not allowed');
+
         $agg = new Filters('by_color');
 
         $agg->addFilter(new Term(['color' => '0']));

--- a/test/Elastica/Aggregation/GeoBoundsTest.php
+++ b/test/Elastica/Aggregation/GeoBoundsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\GeoBounds;

--- a/test/Elastica/Aggregation/GeoCentroidTest.php
+++ b/test/Elastica/Aggregation/GeoCentroidTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\GeoCentroid;

--- a/test/Elastica/Aggregation/GeoDistanceTest.php
+++ b/test/Elastica/Aggregation/GeoDistanceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\GeoDistance;

--- a/test/Elastica/Aggregation/GeohashGridTest.php
+++ b/test/Elastica/Aggregation/GeohashGridTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\GeohashGrid;

--- a/test/Elastica/Aggregation/GlobalAggregationTest.php
+++ b/test/Elastica/Aggregation/GlobalAggregationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;

--- a/test/Elastica/Aggregation/HistogramTest.php
+++ b/test/Elastica/Aggregation/HistogramTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Histogram;

--- a/test/Elastica/Aggregation/IpRangeTest.php
+++ b/test/Elastica/Aggregation/IpRangeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\IpRange;

--- a/test/Elastica/Aggregation/MaxTest.php
+++ b/test/Elastica/Aggregation/MaxTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Max;

--- a/test/Elastica/Aggregation/MinTest.php
+++ b/test/Elastica/Aggregation/MinTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Min;

--- a/test/Elastica/Aggregation/MissingTest.php
+++ b/test/Elastica/Aggregation/MissingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Missing;

--- a/test/Elastica/Aggregation/NestedTest.php
+++ b/test/Elastica/Aggregation/NestedTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Min;

--- a/test/Elastica/Aggregation/PercentilesTest.php
+++ b/test/Elastica/Aggregation/PercentilesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Percentiles;
@@ -44,7 +45,6 @@ class PercentilesTest extends BaseAggregationTest
                     'compression' => 100,
                 ],
             ],
-
         ];
         $aggr = new Percentiles('price_percentile');
         $aggr->setField('price');
@@ -67,7 +67,6 @@ class PercentilesTest extends BaseAggregationTest
                     'number_of_significant_value_digits' => 2.0,
                 ],
             ],
-
         ];
         $aggr = new Percentiles('price_percentile');
         $aggr->setField('price');
@@ -240,7 +239,6 @@ class PercentilesTest extends BaseAggregationTest
                 ],
                 'missing' => 10,
             ],
-
         ];
         $aggr = new Percentiles('price_percentile');
         $aggr->setField('price');

--- a/test/Elastica/Aggregation/RangeTest.php
+++ b/test/Elastica/Aggregation/RangeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Range;

--- a/test/Elastica/Aggregation/ReverseNestedTest.php
+++ b/test/Elastica/Aggregation/ReverseNestedTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Nested;

--- a/test/Elastica/Aggregation/ScriptTest.php
+++ b/test/Elastica/Aggregation/ScriptTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Sum;

--- a/test/Elastica/Aggregation/ScriptedMetricTest.php
+++ b/test/Elastica/Aggregation/ScriptedMetricTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\ScriptedMetric;

--- a/test/Elastica/Aggregation/SerialDiffTest.php
+++ b/test/Elastica/Aggregation/SerialDiffTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\DateHistogram;
@@ -80,10 +81,11 @@ class SerialDiffTest extends BaseAggregationTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testToArrayInvalidBucketsPath()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $serialDiffAgg = new SerialDiff('difference');
         $serialDiffAgg->toArray();
     }

--- a/test/Elastica/Aggregation/SignificantTermsTest.php
+++ b/test/Elastica/Aggregation/SignificantTermsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\SignificantTerms;
@@ -22,7 +23,7 @@ class SignificantTermsTest extends BaseAggregationTest
         $index->getType('_doc')->setMapping($mapping);
 
         $docs = [];
-        for ($i = 0;$i < 250;++$i) {
+        for ($i = 0; $i < 250; ++$i) {
             $docs[] = new Document($i, ['color' => $colors[$i % count($colors)], 'temperature' => $temperatures[$i % count($temperatures)]]);
         }
         $index->getType('_doc')->addDocuments($docs);

--- a/test/Elastica/Aggregation/StatsBucketTest.php
+++ b/test/Elastica/Aggregation/StatsBucketTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Histogram;
@@ -73,10 +74,11 @@ class StatsBucketTest extends BaseAggregationTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testToArrayInvalidBucketsPath()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $serialDiffAgg = new StatsBucket('bucket_part');
         $serialDiffAgg->toArray();
     }

--- a/test/Elastica/Aggregation/StatsTest.php
+++ b/test/Elastica/Aggregation/StatsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Stats;

--- a/test/Elastica/Aggregation/SumBucketTest.php
+++ b/test/Elastica/Aggregation/SumBucketTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Sum;
@@ -76,10 +77,11 @@ class SumBucketTest extends BaseAggregationTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testToArrayInvalidBucketsPath()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $serialDiffAgg = new SumBucket('sum_bucket');
         $serialDiffAgg->toArray();
     }

--- a/test/Elastica/Aggregation/SumTest.php
+++ b/test/Elastica/Aggregation/SumTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Sum;

--- a/test/Elastica/Aggregation/TermsTest.php
+++ b/test/Elastica/Aggregation/TermsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Terms;

--- a/test/Elastica/Aggregation/TopHitsTest.php
+++ b/test/Elastica/Aggregation/TopHitsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Terms;

--- a/test/Elastica/Aggregation/ValueCountTest.php
+++ b/test/Elastica/Aggregation/ValueCountTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\ValueCount;

--- a/test/Elastica/Base.php
+++ b/test/Elastica/Base.php
@@ -1,13 +1,16 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Client;
 use Elastica\Connection;
 use Elastica\Index;
 use Elasticsearch\Endpoints\Ingest\Pipeline\Put;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Test as TestUtil;
 use Psr\Log\LoggerInterface;
 
-class Base extends \PHPUnit\Framework\TestCase
+class Base extends TestCase
 {
     protected static function hideDeprecated()
     {
@@ -195,7 +198,7 @@ class Base extends \PHPUnit\Framework\TestCase
 
             $allocated = true;
             foreach ($indexState['shards'] as $shard) {
-                if ($shard[0]['state'] != 'STARTED') {
+                if ('STARTED' !== $shard[0]['state']) {
                     $allocated = false;
                 }
             }
@@ -223,21 +226,21 @@ class Base extends \PHPUnit\Framework\TestCase
 
     protected function _isUnitGroup()
     {
-        $groups = \PHPUnit\Util\Test::getGroups(get_class($this), $this->getName(false));
+        $groups = TestUtil::getGroups(get_class($this), $this->getName(false));
 
         return in_array('unit', $groups);
     }
 
     protected function _isFunctionalGroup()
     {
-        $groups = \PHPUnit\Util\Test::getGroups(get_class($this), $this->getName(false));
+        $groups = TestUtil::getGroups(get_class($this), $this->getName(false));
 
         return in_array('functional', $groups);
     }
 
     protected function _isBenchmarkGroup()
     {
-        $groups = \PHPUnit\Util\Test::getGroups(get_class($this), $this->getName(false));
+        $groups = TestUtil::getGroups(get_class($this), $this->getName(false));
 
         return in_array('benchmark', $groups);
     }

--- a/test/Elastica/BasePipeline.php
+++ b/test/Elastica/BasePipeline.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Pipeline;

--- a/test/Elastica/Bulk/Action/AbstractDocumentTest.php
+++ b/test/Elastica/Bulk/Action/AbstractDocumentTest.php
@@ -1,30 +1,32 @@
 <?php
+
 namespace Elastica\Test\Bulk\Action;
 
 use Elastica\Bulk\Action\AbstractDocument;
 use Elastica\Script\Script;
 use Elastica\Test\Base as BaseTest;
-use Elastica\Type;
 
 class AbstractDocumentTest extends BaseTest
 {
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The data needs to be a Document or a Script.
      * @group unit
      */
     public function testCreateAbstractDocumentWithInvalidParameter()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The data needs to be a Document or a Script.');
+
         AbstractDocument::create(new \stdClass());
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Scripts can only be used with the update operation type.
      * @group unit
      */
     public function testCreateAbstractDocumentWithScript()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Scripts can only be used with the update operation type.');
+
         AbstractDocument::create(new Script('foobar'), AbstractDocument::OP_TYPE_CREATE);
     }
 }

--- a/test/Elastica/Bulk/Action/UpdateDocumentTest.php
+++ b/test/Elastica/Bulk/Action/UpdateDocumentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\BulkAction;
 
 use Elastica\Bulk\Action\UpdateDocument;

--- a/test/Elastica/Bulk/ActionTest.php
+++ b/test/Elastica/Bulk/ActionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Bulk;
 
 use Elastica\Bulk\Action;

--- a/test/Elastica/Bulk/ResponseSetTest.php
+++ b/test/Elastica/Bulk/ResponseSetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Bulk;
 
 use Elastica\Bulk;

--- a/test/Elastica/BulkTest.php
+++ b/test/Elastica/BulkTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Bulk;
@@ -290,10 +291,11 @@ class BulkTest extends BaseTest
     /**
      * @group unit
      * @dataProvider invalidRawDataProvider
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testInvalidRawData($rawData, $failMessage)
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $bulk = new Bulk($this->_getClient());
 
         $bulk->addRawData($rawData);
@@ -562,9 +564,11 @@ class BulkTest extends BaseTest
         $doc2 = $type->createDocument(2, ['name' => 'Beckenbauer']);
         $doc3 = $type->createDocument(3, ['name' => 'Baggio']);
         $doc4 = $type->createDocument(4, ['name' => 'Cruyff']);
-        $documents = array_map(function ($d) { $d->setDocAsUpsert(true);
+        $documents = array_map(function ($d) {
+            $d->setDocAsUpsert(true);
 
-return $d;}, [$doc1, $doc2, $doc3, $doc4]);
+            return $d;
+        }, [$doc1, $doc2, $doc3, $doc4]);
 
         //index some documents
         $bulk = new Bulk($client);
@@ -635,7 +639,7 @@ return $d;}, [$doc1, $doc2, $doc3, $doc4]);
         $actions = $bulk->getActions();
 
         $metadata = $actions[0]->getMetadata();
-        $this->assertEquals(5, $metadata[ '_retry_on_conflict' ]);
+        $this->assertEquals(5, $metadata['_retry_on_conflict']);
 
         $script = new Script('');
         $script->setRetryOnConflict(5);
@@ -646,7 +650,7 @@ return $d;}, [$doc1, $doc2, $doc3, $doc4]);
         $actions = $bulk->getActions();
 
         $metadata = $actions[0]->getMetadata();
-        $this->assertEquals(5, $metadata[ '_retry_on_conflict' ]);
+        $this->assertEquals(5, $metadata['_retry_on_conflict']);
     }
 
     /**

--- a/test/Elastica/ClientTest.php
+++ b/test/Elastica/ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Bulk;
@@ -33,30 +34,33 @@ class ClientTest extends BaseTest
 
     /**
      * @group functional
-     * @expectedException Elastica\Exception\Connection\HttpException
      */
     public function testConnectionErrors()
     {
+        $this->expectException(\Elastica\Exception\Connection\HttpException::class);
+
         $client = $this->_getClient(['host' => 'foo.bar', 'port' => '9201']);
         $client->getVersion();
     }
 
     /**
      * @group functional
-     * @expectedException Elastica\Exception\Connection\HttpException
      */
     public function testClientBadHost()
     {
+        $this->expectException(\Elastica\Exception\Connection\HttpException::class);
+
         $client = $this->_getClient(['host' => 'localhost', 'port' => '9201']);
         $client->getVersion();
     }
 
     /**
      * @group functional
-     * @expectedException Elastica\Exception\Connection\HttpException
      */
     public function testClientBadHostWithtimeout()
     {
+        $this->expectException(\Elastica\Exception\Connection\HttpException::class);
+
         $client = $this->_getClient(['host' => 'foo.bar', 'timeout' => 10]);
         $client->getVersion();
     }
@@ -208,10 +212,11 @@ class ClientTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testAddDocumentsEmpty()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $client = $this->_getClient();
         $client->addDocuments([]);
     }
@@ -612,7 +617,7 @@ class ClientTest extends BaseTest
         $this->assertCount(2, $connections);
 
         // One connection has to be disabled
-        $this->assertTrue($connections[0]->isEnabled() == false || $connections[1]->isEnabled() == false);
+        $this->assertTrue(false == $connections[0]->isEnabled() || false == $connections[1]->isEnabled());
     }
 
     /**
@@ -640,7 +645,7 @@ class ClientTest extends BaseTest
         $this->assertCount(2, $connections);
 
         // One connection has to be disabled
-        $this->assertTrue($connections[0]->isEnabled() == false || $connections[1]->isEnabled() == false);
+        $this->assertTrue(false == $connections[0]->isEnabled() || false == $connections[1]->isEnabled());
     }
 
     /**
@@ -1329,11 +1334,12 @@ class ClientTest extends BaseTest
     }
 
     /**
-     * @expectedException \Elastica\Exception\Connection\HttpException
      * @group functional
      */
     public function testLoggerOnFailure()
     {
+        $this->expectException(\Elastica\Exception\Connection\HttpException::class);
+
         $logger = $this->createMock('Psr\\Log\\LoggerInterface');
         $client = $this->_getClient(['connections' => [
             ['host' => $this->_getHost(), 'port' => 9201],

--- a/test/Elastica/Cluster/Health/IndexTest.php
+++ b/test/Elastica/Cluster/Health/IndexTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Cluster\Health;
 
 use Elastica\Cluster\Health\Index;

--- a/test/Elastica/Cluster/Health/ShardTest.php
+++ b/test/Elastica/Cluster/Health/ShardTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Cluster\Health;
 
 use Elastica\Cluster\Health\Shard;

--- a/test/Elastica/Cluster/HealthTest.php
+++ b/test/Elastica/Cluster/HealthTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Cluster;
 
 use Elastica\Cluster\Health;

--- a/test/Elastica/Cluster/SettingsTest.php
+++ b/test/Elastica/Cluster/SettingsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Cluster;
 
 use Elastica\Cluster\Settings;

--- a/test/Elastica/ClusterTest.php
+++ b/test/Elastica/ClusterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Cluster;

--- a/test/Elastica/Connection/ConnectionPoolTest.php
+++ b/test/Elastica/Connection/ConnectionPoolTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Connection;
 
 use Elastica\Connection;

--- a/test/Elastica/Connection/Strategy/CallbackStrategyTest.php
+++ b/test/Elastica/Connection/Strategy/CallbackStrategyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection\Strategy\CallbackStrategy;
@@ -81,7 +82,7 @@ class CallbackStrategyTest extends Base
             ++$count;
 
             return current($connections);
-       }];
+        }];
 
         $client = $this->_getClient($config);
         $response = $client->request('_aliases');

--- a/test/Elastica/Connection/Strategy/CallbackStrategyTestHelper.php
+++ b/test/Elastica/Connection/Strategy/CallbackStrategyTestHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Connection\Strategy;
 
 class CallbackStrategyTestHelper

--- a/test/Elastica/Connection/Strategy/EmptyStrategy.php
+++ b/test/Elastica/Connection/Strategy/EmptyStrategy.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection\Strategy\StrategyInterface;

--- a/test/Elastica/Connection/Strategy/RoundRobinTest.php
+++ b/test/Elastica/Connection/Strategy/RoundRobinTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection;
@@ -47,10 +48,11 @@ class RoundRobinTest extends Base
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\ConnectionException
      */
     public function testFailConnection()
     {
+        $this->expectException(\Elastica\Exception\ConnectionException::class);
+
         $config = ['connectionStrategy' => 'RoundRobin', 'host' => '255.255.255.0', 'timeout' => $this->_timeout];
         $client = $this->_getClient($config);
 

--- a/test/Elastica/Connection/Strategy/SimpleTest.php
+++ b/test/Elastica/Connection/Strategy/SimpleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection;
@@ -33,10 +34,11 @@ class SimpleTest extends Base
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\ConnectionException
      */
     public function testFailConnection()
     {
+        $this->expectException(\Elastica\Exception\ConnectionException::class);
+
         $config = ['host' => '255.255.255.0', 'timeout' => $this->_timeout];
         $client = $this->_getClient($config);
 

--- a/test/Elastica/Connection/Strategy/StrategyFactoryTest.php
+++ b/test/Elastica/Connection/Strategy/StrategyFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Connection\Strategy;
 
 use Elastica\Connection\Strategy\CallbackStrategy;
@@ -60,10 +61,11 @@ class StrategyFactoryTest extends Base
 
     /**
      * @group unit
-     * @expectedException \InvalidArgumentException
      */
     public function testFailCreate()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $strategy = new \stdClass();
 
         StrategyFactory::create($strategy);

--- a/test/Elastica/ConnectionTest.php
+++ b/test/Elastica/ConnectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Client;
@@ -41,10 +42,11 @@ class ConnectionTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\ConnectionException
      */
     public function testInvalidConnection()
     {
+        $this->expectException(\Elastica\Exception\ConnectionException::class);
+
         $connection = new Connection(['port' => 9999]);
 
         $request = new Request('_stats', Request::GET);
@@ -73,11 +75,11 @@ class ConnectionTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testCreateInvalid()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         Connection::create('test');
     }
 
@@ -103,21 +105,23 @@ class ConnectionTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
-     * @expectedExceptionMessage Invalid transport
      */
     public function testGetInvalidConfigWithArrayUsedForTransport()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectExceptionMessage('Invalid transport');
+
         $connection = new Connection(['transport' => ['type' => 'invalidtransport']]);
         $connection->getTransportObject();
     }
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testGetConfigInvalidValue()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $connection = new Connection();
         $connection->getConfig('url');
     }

--- a/test/Elastica/DeprecatedClassBase.php
+++ b/test/Elastica/DeprecatedClassBase.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 /**

--- a/test/Elastica/DocumentTest.php
+++ b/test/Elastica/DocumentTest.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;
 use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Test\Base as BaseTest;
-use Elastica\Type;
 
 class DocumentTest extends BaseTest
 {

--- a/test/Elastica/ErrorsCollector.php
+++ b/test/Elastica/ErrorsCollector.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace Elastica\Test;
+
+use PHPUnit\Framework\TestCase;
 
 /**
  * Errors collector for testing.
@@ -11,11 +14,11 @@ class ErrorsCollector
     private $errors = [];
 
     /**
-     * @var \PHPUnit\Framework\TestCase
+     * @var TestCase
      */
     private $testCase;
 
-    public function __construct(\PHPUnit\Framework\TestCase $testCase = null)
+    public function __construct(TestCase $testCase = null)
     {
         $this->testCase = $testCase;
     }

--- a/test/Elastica/ExampleTest.php
+++ b/test/Elastica/ExampleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/Elastica/Exception/AbstractExceptionTest.php
+++ b/test/Elastica/Exception/AbstractExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 use Elastica\Exception\ExceptionInterface;

--- a/test/Elastica/Exception/Bulk/Response/ActionExceptionTest.php
+++ b/test/Elastica/Exception/Bulk/Response/ActionExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception\Bulk\Response;
 
 use Elastica\Test\Exception\AbstractExceptionTest;

--- a/test/Elastica/Exception/Bulk/ResponseExceptionTest.php
+++ b/test/Elastica/Exception/Bulk/ResponseExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception\Bulk;
 
 use Elastica\Test\Exception\AbstractExceptionTest;

--- a/test/Elastica/Exception/BulkExceptionTest.php
+++ b/test/Elastica/Exception/BulkExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 class BulkExceptionTest extends AbstractExceptionTest

--- a/test/Elastica/Exception/ClientExceptionTest.php
+++ b/test/Elastica/Exception/ClientExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 class ClientExceptionTest extends AbstractExceptionTest

--- a/test/Elastica/Exception/Connection/GuzzleExceptionTest.php
+++ b/test/Elastica/Exception/Connection/GuzzleExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception\Connection;
 
 use Elastica\Test\Exception\AbstractExceptionTest;

--- a/test/Elastica/Exception/Connection/HttpExceptionTest.php
+++ b/test/Elastica/Exception/Connection/HttpExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception\Connection;
 
 use Elastica\Test\Exception\AbstractExceptionTest;

--- a/test/Elastica/Exception/ConnectionExceptionTest.php
+++ b/test/Elastica/Exception/ConnectionExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 class ConnectionExceptionTest extends AbstractExceptionTest

--- a/test/Elastica/Exception/InvalidExceptionTest.php
+++ b/test/Elastica/Exception/InvalidExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 class InvalidExceptionTest extends AbstractExceptionTest

--- a/test/Elastica/Exception/JSONParseExceptionTest.php
+++ b/test/Elastica/Exception/JSONParseExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 class JSONParseExceptionTest extends AbstractExceptionTest

--- a/test/Elastica/Exception/NotFoundExceptionTest.php
+++ b/test/Elastica/Exception/NotFoundExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 class NotFoundExceptionTest extends AbstractExceptionTest

--- a/test/Elastica/Exception/NotImplementedExceptionTest.php
+++ b/test/Elastica/Exception/NotImplementedExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 use Elastica\Exception\NotImplementedException;

--- a/test/Elastica/Exception/PartialShardFailureExceptionTest.php
+++ b/test/Elastica/Exception/PartialShardFailureExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 use Elastica\Document;

--- a/test/Elastica/Exception/QueryBuilderExceptionTest.php
+++ b/test/Elastica/Exception/QueryBuilderExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 class QueryBuilderExceptionTest extends AbstractExceptionTest

--- a/test/Elastica/Exception/ResponseExceptionTest.php
+++ b/test/Elastica/Exception/ResponseExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 use Elastica\Document;

--- a/test/Elastica/Exception/RuntimeExceptionTest.php
+++ b/test/Elastica/Exception/RuntimeExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Exception;
 
 class RuntimeExceptionTest extends AbstractExceptionTest

--- a/test/Elastica/Index/RecoveryTest.php
+++ b/test/Elastica/Index/RecoveryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Index;
 
 use Elastica\Index\Recovery;

--- a/test/Elastica/Index/SettingsTest.php
+++ b/test/Elastica/Index/SettingsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Index;
 
 use Elastica\Document;

--- a/test/Elastica/Index/StatsTest.php
+++ b/test/Elastica/Index/StatsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Index;
 
 use Elastica\Index\Stats;

--- a/test/Elastica/IndexTemplateTest.php
+++ b/test/Elastica/IndexTemplateTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Client;
@@ -29,11 +30,12 @@ class IndexTemplateTest extends BaseTest
     }
 
     /**
-     * @expectedException \Elastica\Exception\InvalidException
      * @group unit
      */
     public function testIncorrectInstantiate()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $client = $this->_getClient();
         new IndexTemplate($client, null);
     }

--- a/test/Elastica/IndexTest.php
+++ b/test/Elastica/IndexTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;
@@ -79,10 +80,11 @@ class IndexTest extends BaseTest
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\ResponseException
      */
     public function testAddRemoveAlias()
     {
+        $this->expectException(\Elastica\Exception\ResponseException::class);
+
         $client = $this->_getClient();
 
         $indexName1 = 'test1';
@@ -614,12 +616,12 @@ class IndexTest extends BaseTest
     }
 
     /**
-     * @expectedException \Elastica\Exception\InvalidException
-     *
      * @group unit
      */
     public function testCreateWithInvalidOption()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $client = $this->_getClient();
         $indexName = 'test';
         $index = $client->getIndex($indexName);
@@ -785,10 +787,11 @@ class IndexTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testThrowExceptionIfNotScalar()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $client = $this->_getClient();
         $client->getIndex(new \stdClass());
     }

--- a/test/Elastica/JSONTest.php
+++ b/test/Elastica/JSONTest.php
@@ -1,37 +1,40 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\JSON;
+use PHPUnit\Framework\TestCase;
 
 /**
  * JSONTest.
  *
  * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
  */
-class JSONTest extends \PHPUnit\Framework\TestCase
+class JSONTest extends TestCase
 {
     public function testStringifyMustNotThrowExceptionOnValid()
     {
         JSON::stringify([]);
+        $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Elastica\Exception\JSONParseException
-     * @expectedExceptionMessage Inf and NaN cannot be JSON encoded
-     */
     public function testStringifyMustThrowExceptionNanOrInf()
     {
+        $this->expectException(\Elastica\Exception\JSONParseException::class);
+        $this->expectExceptionMessage('Inf and NaN cannot be JSON encoded');
+
         $arr = [NAN, INF];
         JSON::stringify($arr);
+        $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Elastica\Exception\JSONParseException
-     * @expectedExceptionMessage Maximum stack depth exceeded
-     */
     public function testStringifyMustThrowExceptionMaximumDepth()
     {
+        $this->expectException(\Elastica\Exception\JSONParseException::class);
+        $this->expectExceptionMessage('Maximum stack depth exceeded');
+
         $arr = [[[]]];
         JSON::stringify($arr, 0, 0);
+        $this->assertTrue(true);
     }
 }

--- a/test/Elastica/LogTest.php
+++ b/test/Elastica/LogTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Log;

--- a/test/Elastica/Multi/MultiBuilderTest.php
+++ b/test/Elastica/Multi/MultiBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Multi;
 
 use Elastica\Multi\MultiBuilder;

--- a/test/Elastica/Multi/SearchTest.php
+++ b/test/Elastica/Multi/SearchTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Multi;
 
 use Elastica\Document;

--- a/test/Elastica/Node/InfoTest.php
+++ b/test/Elastica/Node/InfoTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Node;
 
 use Elastica\Node;

--- a/test/Elastica/NodeTest.php
+++ b/test/Elastica/NodeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Node;

--- a/test/Elastica/ParamTest.php
+++ b/test/Elastica/ParamTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Param;
@@ -83,10 +84,11 @@ class ParamTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testGetParamInvalid()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $param = new Param();
 
         $param->getParam('notest');

--- a/test/Elastica/PipelineTest.php
+++ b/test/Elastica/PipelineTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/AppendTest.php
+++ b/test/Elastica/Processor/AppendTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/AttachmentTest.php
+++ b/test/Elastica/Processor/AttachmentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/ConvertTest.php
+++ b/test/Elastica/Processor/ConvertTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/DateIndexNameTest.php
+++ b/test/Elastica/Processor/DateIndexNameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Processor\DateIndexName;

--- a/test/Elastica/Processor/DateTest.php
+++ b/test/Elastica/Processor/DateTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/DotExpanderTest.php
+++ b/test/Elastica/Processor/DotExpanderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/FailTest.php
+++ b/test/Elastica/Processor/FailTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/JoinTest.php
+++ b/test/Elastica/Processor/JoinTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/JsonTest.php
+++ b/test/Elastica/Processor/JsonTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/KvTest.php
+++ b/test/Elastica/Processor/KvTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Processor\Kv;

--- a/test/Elastica/Processor/LowercaseTest.php
+++ b/test/Elastica/Processor/LowercaseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/RemoveTest.php
+++ b/test/Elastica/Processor/RemoveTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/RenameTest.php
+++ b/test/Elastica/Processor/RenameTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/SetTest.php
+++ b/test/Elastica/Processor/SetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/SortTest.php
+++ b/test/Elastica/Processor/SortTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/SplitTest.php
+++ b/test/Elastica/Processor/SplitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/TrimTest.php
+++ b/test/Elastica/Processor/TrimTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Processor/UppercaseTest.php
+++ b/test/Elastica/Processor/UppercaseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Processor;
 
 use Elastica\Bulk;

--- a/test/Elastica/Query/BoolQueryTest.php
+++ b/test/Elastica/Query/BoolQueryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
@@ -61,7 +62,7 @@ class BoolQueryTest extends BaseTest
     /**
      * Test to resolve the following issue.
      *
-     * @link https://groups.google.com/forum/?fromgroups#!topic/elastica-php-client/zK_W_hClfvU
+     * @see https://groups.google.com/forum/?fromgroups#!topic/elastica-php-client/zK_W_hClfvU
      *
      * @group unit
      */

--- a/test/Elastica/Query/BoostingTest.php
+++ b/test/Elastica/Query/BoostingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Boosting;

--- a/test/Elastica/Query/CommonTest.php
+++ b/test/Elastica/Query/CommonTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/ConstantScoreTest.php
+++ b/test/Elastica/Query/ConstantScoreTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\ConstantScore;

--- a/test/Elastica/Query/DisMaxTest.php
+++ b/test/Elastica/Query/DisMaxTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/EscapeStringTest.php
+++ b/test/Elastica/Query/EscapeStringTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/ExistsTest.php
+++ b/test/Elastica/Query/ExistsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Exists;

--- a/test/Elastica/Query/FunctionScoreTest.php
+++ b/test/Elastica/Query/FunctionScoreTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/FuzzyTest.php
+++ b/test/Elastica/Query/FuzzyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/GeoBoundingBoxTest.php
+++ b/test/Elastica/Query/GeoBoundingBoxTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\GeoBoundingBox;
@@ -25,10 +26,11 @@ class GeoBoundingBoxTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testAddCoordinatesInvalidException()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $query = new GeoBoundingBox('foo', []);
     }
 

--- a/test/Elastica/Query/GeoDistanceTest.php
+++ b/test/Elastica/Query/GeoDistanceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/GeoPolygonTest.php
+++ b/test/Elastica/Query/GeoPolygonTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/GeoShapePreIndexedTest.php
+++ b/test/Elastica/Query/GeoShapePreIndexedTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/GeoShapeProvidedTest.php
+++ b/test/Elastica/Query/GeoShapeProvidedTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/GeohashCellTest.php
+++ b/test/Elastica/Query/GeohashCellTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\GeohashCell;

--- a/test/Elastica/Query/HasChildTest.php
+++ b/test/Elastica/Query/HasChildTest.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
-use Elastica\Query;
 use Elastica\Query\HasChild;
 use Elastica\Query\MatchAll;
 use Elastica\Search;

--- a/test/Elastica/Query/HasParentTest.php
+++ b/test/Elastica/Query/HasParentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/HighlightTest.php
+++ b/test/Elastica/Query/HighlightTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/IdsTest.php
+++ b/test/Elastica/Query/IdsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/InnerHitsTest.php
+++ b/test/Elastica/Query/InnerHitsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
@@ -329,6 +330,7 @@ class InnerHitsTest extends BaseTest
         $ind = $this->_getIndexForParentChildrenTest();
         $t = $ind->getType('_doc');
         $r = $t->search($child);
+
         return $this->_getIndexForParentChildrenTest()->getType('_doc')->search($child);
     }
 

--- a/test/Elastica/Query/LimitTest.php
+++ b/test/Elastica/Query/LimitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Limit;

--- a/test/Elastica/Query/MatchAllTest.php
+++ b/test/Elastica/Query/MatchAllTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/MatchNoneTest.php
+++ b/test/Elastica/Query/MatchNoneTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/MatchPhrasePrefixTest.php
+++ b/test/Elastica/Query/MatchPhrasePrefixTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/MatchPhraseTest.php
+++ b/test/Elastica/Query/MatchPhraseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/MatchTest.php
+++ b/test/Elastica/Query/MatchTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/MoreLikeThisTest.php
+++ b/test/Elastica/Query/MoreLikeThisTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/MultiMatchTest.php
+++ b/test/Elastica/Query/MultiMatchTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
@@ -6,7 +7,6 @@ use Elastica\Index;
 use Elastica\Query;
 use Elastica\Query\MultiMatch;
 use Elastica\Test\Base as BaseTest;
-use Elastica\Type;
 use Elastica\Type\Mapping;
 
 class MultiMatchTest extends BaseTest

--- a/test/Elastica/Query/NestedTest.php
+++ b/test/Elastica/Query/NestedTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Nested;

--- a/test/Elastica/Query/ParentIdTest.php
+++ b/test/Elastica/Query/ParentIdTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/PercolateTest.php
+++ b/test/Elastica/Query/PercolateTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/PostFilterTest.php
+++ b/test/Elastica/Query/PostFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/PrefixTest.php
+++ b/test/Elastica/Query/PrefixTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Prefix;

--- a/test/Elastica/Query/QueryStringTest.php
+++ b/test/Elastica/Query/QueryStringTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
@@ -255,10 +256,11 @@ class QueryStringTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testSetQueryInvalid()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $query = new QueryString();
         $query->setQuery([]);
     }

--- a/test/Elastica/Query/RangeTest.php
+++ b/test/Elastica/Query/RangeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/RegexpTest.php
+++ b/test/Elastica/Query/RegexpTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Regexp;

--- a/test/Elastica/Query/RescoreTest.php
+++ b/test/Elastica/Query/RescoreTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query;

--- a/test/Elastica/Query/ScriptTest.php
+++ b/test/Elastica/Query/ScriptTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Script as ScriptQuery;

--- a/test/Elastica/Query/SimpleQueryStringTest.php
+++ b/test/Elastica/Query/SimpleQueryStringTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/SimpleTest.php
+++ b/test/Elastica/Query/SimpleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Simple;

--- a/test/Elastica/Query/SpanContainingTest.php
+++ b/test/Elastica/Query/SpanContainingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/SpanFirstTest.php
+++ b/test/Elastica/Query/SpanFirstTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/SpanMultiTest.php
+++ b/test/Elastica/Query/SpanMultiTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/SpanNearTest.php
+++ b/test/Elastica/Query/SpanNearTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
@@ -11,10 +12,11 @@ class SpanNearTest extends BaseTest
 {
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testConstructWrongTypeInvalid()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $term1 = new Term(['name' => 'marek']);
         $term2 = new Term(['name' => 'nicolas']);
         $spanNearQuery = new SpanNear([$term1, $term2]);
@@ -47,7 +49,6 @@ class SpanNearTest extends BaseTest
                             'name' => 'nicolas',
                         ],
                     ],
-
                 ],
                 'slop' => 5,
                 'in_order' => true,

--- a/test/Elastica/Query/SpanNotTest.php
+++ b/test/Elastica/Query/SpanNotTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/SpanOrTest.php
+++ b/test/Elastica/Query/SpanOrTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
@@ -11,10 +12,11 @@ class SpanOrTest extends BaseTest
 {
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testConstructWrongTypeInvalid()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $term1 = new Term(['name' => 'marek']);
         $term2 = new Term(['name' => 'nicolas']);
         $spanOrQuery = new SpanOr([$term1, $term2]);
@@ -47,7 +49,6 @@ class SpanOrTest extends BaseTest
                             'name' => 'nicolas',
                         ],
                     ],
-
                 ],
             ],
         ];

--- a/test/Elastica/Query/SpanTermTest.php
+++ b/test/Elastica/Query/SpanTermTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/SpanWithinTest.php
+++ b/test/Elastica/Query/SpanWithinTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/Query/TermTest.php
+++ b/test/Elastica/Query/TermTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Term;

--- a/test/Elastica/Query/TermsTest.php
+++ b/test/Elastica/Query/TermsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
@@ -134,10 +135,11 @@ class TermsTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testInvalidParams()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $query = new Terms();
 
         $query->toArray();

--- a/test/Elastica/Query/TypeTest.php
+++ b/test/Elastica/Query/TypeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Query\Type;

--- a/test/Elastica/Query/WildcardTest.php
+++ b/test/Elastica/Query/WildcardTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Query;
 
 use Elastica\Document;

--- a/test/Elastica/QueryBuilder/DSL/AbstractDSLTest.php
+++ b/test/Elastica/QueryBuilder/DSL/AbstractDSLTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\Exception\NotImplementedException;

--- a/test/Elastica/QueryBuilder/DSL/AggregationTest.php
+++ b/test/Elastica/QueryBuilder/DSL/AggregationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\Aggregation;

--- a/test/Elastica/QueryBuilder/DSL/QueryTest.php
+++ b/test/Elastica/QueryBuilder/DSL/QueryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\Query;

--- a/test/Elastica/QueryBuilder/DSL/SuggestTest.php
+++ b/test/Elastica/QueryBuilder/DSL/SuggestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\QueryBuilder\DSL;
 
 use Elastica\QueryBuilder\DSL;

--- a/test/Elastica/QueryBuilder/VersionTest.php
+++ b/test/Elastica/QueryBuilder/VersionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\QueryBuilder;
 
 use Elastica\QueryBuilder\DSL;

--- a/test/Elastica/QueryBuilderTest.php
+++ b/test/Elastica/QueryBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Aggregation\AbstractAggregation;

--- a/test/Elastica/QueryTest.php
+++ b/test/Elastica/QueryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Aggregation\Terms as TermsAggregation;
@@ -7,7 +8,6 @@ use Elastica\Exception\InvalidException;
 use Elastica\Query;
 use Elastica\Query\Term;
 use Elastica\Query\Terms;
-use Elastica\Query\Text;
 use Elastica\Rescore\Query as RescoreQuery;
 use Elastica\Script\Script;
 use Elastica\Script\ScriptFields;
@@ -274,11 +274,11 @@ class QueryTest extends BaseTest
     {
         $query = new Query();
         $scriptFields = new ScriptFields();
-        $scriptFields->addScript('script',  new Script('script'));
+        $scriptFields->addScript('script', new Script('script'));
 
         $query->setScriptFields($scriptFields);
 
-        $scriptFields->addScript('another script',  new Script('another script'));
+        $scriptFields->addScript('another script', new Script('another script'));
 
         $anotherQuery = new Query();
         $anotherQuery->setScriptFields($scriptFields);

--- a/test/Elastica/ReindexTest.php
+++ b/test/Elastica/ReindexTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/Elastica/RequestTest.php
+++ b/test/Elastica/RequestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Connection;
@@ -28,10 +29,11 @@ class RequestTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testInvalidConnection()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $request = new Request('', Request::GET);
         $request->send();
     }

--- a/test/Elastica/ResponseTest.php
+++ b/test/Elastica/ResponseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/Elastica/ResultSet/BuilderTest.php
+++ b/test/Elastica/ResultSet/BuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\ResultSet;
 
 use Elastica\Query;

--- a/test/Elastica/ResultSet/ChainProcessorTest.php
+++ b/test/Elastica/ResultSet/ChainProcessorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Transformer;
 
 use Elastica\Query;

--- a/test/Elastica/ResultSet/ProcessingBuilderTest.php
+++ b/test/Elastica/ResultSet/ProcessingBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\ResultSet;
 
 use Elastica\Query;

--- a/test/Elastica/ResultSetTest.php
+++ b/test/Elastica/ResultSetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;
@@ -92,10 +93,11 @@ class ResultSetTest extends BaseTest
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testInvalidOffsetCreation()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $index = $this->_createIndex();
         $type = $index->getType('_doc');
 
@@ -111,10 +113,11 @@ class ResultSetTest extends BaseTest
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testInvalidOffsetGet()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $index = $this->_createIndex();
         $type = $index->getType('_doc');
 

--- a/test/Elastica/ResultTest.php
+++ b/test/Elastica/ResultTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;
@@ -107,7 +108,7 @@ class ResultTest extends BaseTest
         $this->assertNotNull($resultSet->getTotalTime(), 'Get Total Time should never be a null value');
         $this->assertEquals(
             'integer',
-            getType($resultSet->getTotalTime()),
+            gettype($resultSet->getTotalTime()),
             'Total Time should be an integer'
          );
     }

--- a/test/Elastica/Script/ScriptFieldsTest.php
+++ b/test/Elastica/Script/ScriptFieldsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;
@@ -58,10 +59,11 @@ class ScriptFieldsTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testNameException()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $script = new Script('1 + 2');
         $scriptFields = new ScriptFields([$script]);
     }

--- a/test/Elastica/Script/ScriptIdTest.php
+++ b/test/Elastica/Script/ScriptIdTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Script\ScriptId;
@@ -111,10 +112,11 @@ class ScriptIdTest extends BaseTest
     /**
      * @group unit
      * @dataProvider dataProviderCreateInvalid
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testCreateInvalid($data)
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         ScriptId::create($data);
     }
 

--- a/test/Elastica/Script/ScriptTest.php
+++ b/test/Elastica/Script/ScriptTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Script\Script;
@@ -7,6 +8,7 @@ use Elastica\Test\Base as BaseTest;
 class ScriptTest extends BaseTest
 {
     const SCRIPT = "_score * doc['my_numeric_field'].value";
+
     /**
      * @group unit
      */
@@ -110,10 +112,11 @@ class ScriptTest extends BaseTest
     /**
      * @group unit
      * @dataProvider dataProviderCreateInvalid
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testCreateInvalid($data)
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         Script::create($data);
     }
 

--- a/test/Elastica/ScrollTest.php
+++ b/test/Elastica/ScrollTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Client;
@@ -29,19 +30,19 @@ class ScrollTest extends Base
 
             $results = $resultSet->getResults();
             switch (true) {
-                case $count === 1:
+                case 1 === $count:
                     // hits: 1 - 5
                     $this->assertEquals(5, $resultSet->count());
                     $this->assertEquals('1', $results[0]->getId());
                     $this->assertEquals('5', $results[4]->getId());
                     break;
-                case $count === 2:
+                case 2 === $count:
                     // hits: 6 - 10
                     $this->assertEquals(5, $resultSet->count());
                     $this->assertEquals('6', $results[0]->getId());
                     $this->assertEquals('10', $results[4]->getId());
                     break;
-                case $count === 3:
+                case 3 === $count:
                     // hit: 11
                     $this->assertEquals(1, $resultSet->count());
                     $this->assertEquals('11', $results[0]->getId());

--- a/test/Elastica/SearchTest.php
+++ b/test/Elastica/SearchTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Client;
@@ -135,10 +136,11 @@ class SearchTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testAddTypeInvalid()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $client = $this->_getClient();
         $search = new Search($client);
 
@@ -147,10 +149,11 @@ class SearchTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testAddIndexInvalid()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $client = $this->_getClient();
         $search = new Search($client);
 
@@ -385,7 +388,7 @@ class SearchTest extends BaseTest
         $this->assertEquals(10, $resultSet->count());
 
         $resultSet = $search->search('test', ['limit' => 0]);
-        $this->assertTrue(($resultSet->count() === 0) && $resultSet->getTotalHits() === 11);
+        $this->assertTrue((0 === $resultSet->count()) && 11 === $resultSet->getTotalHits());
 
         //test with filter_path
         $resultSet = $search->search('test', [Search::OPTION_FILTER_PATH => 'hits.hits._source']);
@@ -408,10 +411,11 @@ class SearchTest extends BaseTest
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testInvalidConfigSearch()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $client = $this->_getClient();
         $search = new Search($client);
         // Throws InvalidException
@@ -455,15 +459,15 @@ class SearchTest extends BaseTest
 
         $type = $index->getType('_doc');
         $type->addDocuments([
-            new Document(1,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(2,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(3,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(4,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(5,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(6,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(7,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(8,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(9,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document(2, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document(3, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document(4, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document(5, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document(6, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document(7, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document(8, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document(9, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
             new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
             new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
         ]);

--- a/test/Elastica/SnapshotTest.php
+++ b/test/Elastica/SnapshotTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;

--- a/test/Elastica/StatusTest.php
+++ b/test/Elastica/StatusTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Exception\ResponseException;

--- a/test/Elastica/Suggest/CompletionTest.php
+++ b/test/Elastica/Suggest/CompletionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Suggest;
 
 use Elastica\Document;
@@ -58,7 +59,6 @@ class CompletionTest extends BaseTest
                     'weight' => 3,
                 ],
             ]),
-
         ]);
 
         $index->refresh();

--- a/test/Elastica/Suggest/PhraseTest.php
+++ b/test/Elastica/Suggest/PhraseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Suggest;
 
 use Elastica\Document;

--- a/test/Elastica/Suggest/TermTest.php
+++ b/test/Elastica/Suggest/TermTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Suggest;
 
 use Elastica\Document;

--- a/test/Elastica/SuggestTest.php
+++ b/test/Elastica/SuggestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Exception\NotImplementedException;

--- a/test/Elastica/TaskTest.php
+++ b/test/Elastica/TaskTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;
@@ -61,12 +62,12 @@ class TaskTest extends Base
 
     /**
      * @group unit
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage No task id given
      */
     public function testCancelThrowsExceptionWithEmptyTaskId()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No task id given');
+
         $task = new Task($this->_getClient(), '');
         $task->cancel();
     }

--- a/test/Elastica/Transport/AbstractTransportTest.php
+++ b/test/Elastica/Transport/AbstractTransportTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Transport;
 
 use Elastica\Connection;
@@ -70,11 +71,12 @@ class AbstractTransportTest extends BaseTest
     /**
      * @group unit
      * @dataProvider getInvalidDefinitions
-     * @expectedException \Elastica\Exception\InvalidException
-     * @expectedExceptionMessage Invalid transport
      */
     public function testThrowsExecptionOnInvalidTransportDefinition($transport)
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectExceptionMessage('Invalid transport');
+
         AbstractTransport::create($transport, new Connection());
     }
 
@@ -128,7 +130,7 @@ class AbstractTransportTest extends BaseTest
             $this->fail('Failed to parse value [1] as only [true] or [false] are allowed.');
         }
 
-        if ($transport['transport'] == 'Http') {
+        if ('Http' == $transport['transport']) {
             $info = $results->getResponse()->getTransferInfo();
             $url = $info['url'];
             $this->assertStringEndsWith('version=true', $url);

--- a/test/Elastica/Transport/AwsAuthV4Test.php
+++ b/test/Elastica/Transport/AwsAuthV4Test.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Transport;
 
 use Elastica\Exception\Connection\GuzzleException;

--- a/test/Elastica/Transport/DummyTransport.php
+++ b/test/Elastica/Transport/DummyTransport.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Transport;
 
 use Elastica\Request;

--- a/test/Elastica/Transport/GuzzleTest.php
+++ b/test/Elastica/Transport/GuzzleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Transport;
 
 use Elastica\Document;
@@ -168,10 +169,11 @@ class GuzzleTest extends BaseTest
 
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\Connection\GuzzleException
      */
     public function testInvalidConnection()
     {
+        $this->expectException(\Elastica\Exception\Connection\GuzzleException::class);
+
         $client = $this->_getClient(['transport' => 'Guzzle', 'port' => 4500, 'persistent' => false]);
         $response = $client->request('_stats', 'GET');
         $client->request('_status', 'GET');

--- a/test/Elastica/Transport/HttpTest.php
+++ b/test/Elastica/Transport/HttpTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Transport;
 
 use Elastica\Document;

--- a/test/Elastica/Transport/NullTransportTest.php
+++ b/test/Elastica/Transport/NullTransportTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Transport;
 
 use Elastica\Connection;
@@ -43,9 +44,9 @@ class NullTransportTest extends BaseTest
         $response = $resultSet->getResponse();
         $this->assertNotNull($response);
 
-         // Validate most of the expected fields in the response data.  Consumers of the response
-         // object have a reasonable expectation of finding "hits", "took", etc
-         $responseData = $response->getData();
+        // Validate most of the expected fields in the response data.  Consumers of the response
+        // object have a reasonable expectation of finding "hits", "took", etc
+        $responseData = $response->getData();
         $this->assertContains('took', $responseData);
         $this->assertEquals(0, $responseData['took']);
         $this->assertContains('_shards', $responseData);

--- a/test/Elastica/Transport/TransportBenchmarkTest.php
+++ b/test/Elastica/Transport/TransportBenchmarkTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test\Transport;
 
 use Elastica\Document;
@@ -241,7 +242,7 @@ class TransportBenchmarkTest extends BaseTest
             foreach ($values as $transport => $times) {
                 $perc = 0;
 
-                if ($minMean != 0) {
+                if (0 != $minMean) {
                     $perc = (($times['mean'] - $minMean) / $minMean) * 100;
                 }
 

--- a/test/Elastica/Type/MappingTest.php
+++ b/test/Elastica/Type/MappingTest.php
@@ -1,11 +1,11 @@
 <?php
+
 namespace Elastica\Test\Type;
 
 use Elastica\Document;
 use Elastica\Query;
 use Elastica\Query\QueryString;
 use Elastica\Test\Base as BaseTest;
-use Elastica\Type;
 use Elastica\Type\Mapping;
 
 class MappingTest extends BaseTest
@@ -242,7 +242,7 @@ class MappingTest extends BaseTest
      * Test setting a dynamic template and validate whether the right mapping is applied after adding a document which
      * should match the dynamic template.
      *
-     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-templates.html
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-templates.html
      */
     public function testDynamicTemplate()
     {

--- a/test/Elastica/TypeTest.php
+++ b/test/Elastica/TypeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Document;
@@ -331,10 +332,11 @@ class TypeTest extends BaseTest
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\NotFoundException
      */
     public function testGetDocumentNotExist()
     {
+        $this->expectException(\Elastica\Exception\NotFoundException::class);
+
         $index = $this->_createIndex();
         $type = new Type($index, '_doc');
         $type->addDocument(new Document(1, ['name' => 'ruflin']));
@@ -347,10 +349,11 @@ class TypeTest extends BaseTest
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\ResponseException
      */
     public function testGetDocumentNotExistingIndex()
     {
+        $this->expectException(\Elastica\Exception\ResponseException::class);
+
         $client = $this->_getClient();
         $index = new Index($client, 'index');
         $type = new Type($index, '_doc');
@@ -725,10 +728,11 @@ class TypeTest extends BaseTest
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\InvalidException
      */
     public function testUpdateDocumentWithoutId()
     {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+
         $index = $this->_createIndex();
         $this->_waitForAllocation($index);
         $type = $index->getType('_doc');
@@ -868,10 +872,11 @@ class TypeTest extends BaseTest
 
     /**
      * @group functional
-     * @expectedException \Elastica\Exception\RuntimeException
      */
     public function testAddDocumentWithoutSerializer()
     {
+        $this->expectException(\Elastica\Exception\RuntimeException::class);
+
         $index = $this->_createIndex();
         $this->_waitForAllocation($index);
 

--- a/test/Elastica/UtilTest.php
+++ b/test/Elastica/UtilTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Elastica\Test;
 
 use Elastica\Connection;


### PR DESCRIPTION
Hey there!

As stated here https://github.com/ruflin/Elastica/pull/1540, I'm opening multiple CS fix PRs.

This is the base porting from version 1 to version 2 of the linter. Also, I have applied the CS rules in order to show you how this should look like. 

@ruflin and @p365labs: what's your opinion about this?