### PR TITLE
The preferred type name is _doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file based on the
 
 * Added `BucketSelector` aggregation [#1554](https://github.com/ruflin/Elastica/pull/1554)
 * Added `DerivativeAggregation` [#1553](https://github.com/ruflin/Elastica/pull/1553)
+* The preferred type name is [_doc](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/removal-of-types.html), so that index APIs have the same path as they will have in 7.0
 
 ### Improvements
 

--- a/test/Elastica/Aggregation/AvgBucketTest.php
+++ b/test/Elastica/Aggregation/AvgBucketTest.php
@@ -13,7 +13,7 @@ class AvgBucketTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             Document::create(['page' => 1, 'likes' => 180]),
             Document::create(['page' => 1, 'likes' => 156]),
             Document::create(['page' => 2, 'likes' => 155]),

--- a/test/Elastica/Aggregation/AvgTest.php
+++ b/test/Elastica/Aggregation/AvgTest.php
@@ -11,7 +11,7 @@ class AvgTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5]),
             new Document(2, ['price' => 8]),
             new Document(3, ['price' => 1]),

--- a/test/Elastica/Aggregation/BucketScriptTest.php
+++ b/test/Elastica/Aggregation/BucketScriptTest.php
@@ -13,7 +13,7 @@ class BucketScriptTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             Document::create(['weight' => 60, 'height' => 180, 'age' => 25]),
             Document::create(['weight' => 65, 'height' => 156, 'age' => 32]),
             Document::create(['weight' => 50, 'height' => 155, 'age' => 45]),

--- a/test/Elastica/Aggregation/BucketSelectorTest.php
+++ b/test/Elastica/Aggregation/BucketSelectorTest.php
@@ -13,7 +13,7 @@ class BucketSelectorTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['date' => '2018-12-01', 'value' => 1]),
             new Document(2, ['date' => '2018-12-02', 'value' => 2]),
             new Document(3, ['date' => '2018-12-03', 'value' => 5]),

--- a/test/Elastica/Aggregation/CardinalityTest.php
+++ b/test/Elastica/Aggregation/CardinalityTest.php
@@ -12,14 +12,14 @@ class CardinalityTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $mapping = new Mapping($index->getType('test'), [
+        $mapping = new Mapping($index->getType('_doc'), [
             'color' => [
                 'type' => 'keyword',
             ],
         ]);
-        $index->getType('test')->setMapping($mapping);
+        $index->getType('_doc')->setMapping($mapping);
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['color' => 'blue']),
             new Document(2, ['color' => 'blue']),
             new Document(3, ['color' => 'red']),

--- a/test/Elastica/Aggregation/DateHistogramTest.php
+++ b/test/Elastica/Aggregation/DateHistogramTest.php
@@ -11,7 +11,7 @@ class DateHistogramTest extends BaseAggregationTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping(new Mapping(null, [
             'created' => ['type' => 'date'],

--- a/test/Elastica/Aggregation/DateRangeTest.php
+++ b/test/Elastica/Aggregation/DateRangeTest.php
@@ -12,7 +12,7 @@ class DateRangeTest extends BaseAggregationTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping(new Mapping(null, [
             'created' => ['type' => 'date', 'format' => 'epoch_millis'],

--- a/test/Elastica/Aggregation/DerivativeTest.php
+++ b/test/Elastica/Aggregation/DerivativeTest.php
@@ -13,7 +13,7 @@ class DerivativeTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['date' => '2018-12-01', 'value' => 1]),
             new Document(2, ['date' => '2018-12-02', 'value' => 2]),
             new Document(3, ['date' => '2018-12-03', 'value' => 2]),

--- a/test/Elastica/Aggregation/ExtendedStatsTest.php
+++ b/test/Elastica/Aggregation/ExtendedStatsTest.php
@@ -11,7 +11,7 @@ class ExtendedStatsTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5]),
             new Document(2, ['price' => 8]),
             new Document(3, ['price' => 1]),

--- a/test/Elastica/Aggregation/FilterTest.php
+++ b/test/Elastica/Aggregation/FilterTest.php
@@ -14,7 +14,7 @@ class FilterTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5, 'color' => 'blue']),
             new Document(2, ['price' => 8, 'color' => 'blue']),
             new Document(3, ['price' => 1, 'color' => 'red']),

--- a/test/Elastica/Aggregation/FiltersTest.php
+++ b/test/Elastica/Aggregation/FiltersTest.php
@@ -13,7 +13,7 @@ class FiltersTest extends BaseAggregationTest
     {
         $index = $this->_createIndex('filter');
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5, 'color' => 'blue']),
             new Document(2, ['price' => 8, 'color' => 'blue']),
             new Document(3, ['price' => 1, 'color' => 'red']),

--- a/test/Elastica/Aggregation/GeoBoundsTest.php
+++ b/test/Elastica/Aggregation/GeoBoundsTest.php
@@ -11,7 +11,7 @@ class GeoBoundsTest extends BaseAggregationTest
     private function getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping(new Mapping(null, [
             'location' => ['type' => 'geo_point'],

--- a/test/Elastica/Aggregation/GeoCentroidTest.php
+++ b/test/Elastica/Aggregation/GeoCentroidTest.php
@@ -11,7 +11,7 @@ class GeoCentroidTest extends BaseAggregationTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping(new Mapping(null, [
             'location' => ['type' => 'geo_point'],

--- a/test/Elastica/Aggregation/GeoDistanceTest.php
+++ b/test/Elastica/Aggregation/GeoDistanceTest.php
@@ -11,7 +11,7 @@ class GeoDistanceTest extends BaseAggregationTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping(new Mapping(null, [
             'location' => ['type' => 'geo_point'],

--- a/test/Elastica/Aggregation/GeohashGridTest.php
+++ b/test/Elastica/Aggregation/GeohashGridTest.php
@@ -11,7 +11,7 @@ class GeohashGridTest extends BaseAggregationTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping(new Mapping(null, [
             'location' => ['type' => 'geo_point'],

--- a/test/Elastica/Aggregation/HistogramTest.php
+++ b/test/Elastica/Aggregation/HistogramTest.php
@@ -11,7 +11,7 @@ class HistogramTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5, 'color' => 'blue']),
             new Document(2, ['price' => 8, 'color' => 'blue']),
             new Document(3, ['price' => 1, 'color' => 'red']),

--- a/test/Elastica/Aggregation/IpRangeTest.php
+++ b/test/Elastica/Aggregation/IpRangeTest.php
@@ -11,7 +11,7 @@ class IpRangeTest extends BaseAggregationTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping(new Mapping(null, [
             'address' => ['type' => 'ip'],

--- a/test/Elastica/Aggregation/MaxTest.php
+++ b/test/Elastica/Aggregation/MaxTest.php
@@ -14,7 +14,7 @@ class MaxTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5]),
             new Document(2, ['price' => self::MAX_PRICE]),
             new Document(3, ['price' => 1]),

--- a/test/Elastica/Aggregation/MinTest.php
+++ b/test/Elastica/Aggregation/MinTest.php
@@ -13,7 +13,7 @@ class MinTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5]),
             new Document(2, ['price' => 8]),
             new Document(3, ['price' => self::MIN_PRICE]),

--- a/test/Elastica/Aggregation/MissingTest.php
+++ b/test/Elastica/Aggregation/MissingTest.php
@@ -12,13 +12,13 @@ class MissingTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $mapping = new Mapping($index->getType('test'), [
+        $mapping = new Mapping($index->getType('_doc'), [
             'price' => ['type' => 'keyword'],
             'color' => ['type' => 'keyword'],
         ]);
-        $index->getType('test')->setMapping($mapping);
+        $index->getType('_doc')->setMapping($mapping);
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5, 'color' => 'blue']),
             new Document(2, ['price' => 8, 'color' => 'blue']),
             new Document(3, ['price' => 1]),

--- a/test/Elastica/Aggregation/NestedTest.php
+++ b/test/Elastica/Aggregation/NestedTest.php
@@ -12,7 +12,7 @@ class NestedTest extends BaseAggregationTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping(new Mapping(null, [
             'resellers' => [

--- a/test/Elastica/Aggregation/PercentilesTest.php
+++ b/test/Elastica/Aggregation/PercentilesTest.php
@@ -123,7 +123,7 @@ class PercentilesTest extends BaseAggregationTest
     {
         // prepare
         $index = $this->_createIndex();
-        $type = $index->getType('offer');
+        $type = $index->getType('_doc');
         $type->addDocuments([
             new Document(1, ['price' => 100]),
             new Document(2, ['price' => 200]),
@@ -197,7 +197,7 @@ class PercentilesTest extends BaseAggregationTest
 
         // prepare
         $index = $this->_createIndex();
-        $type = $index->getType('offer');
+        $type = $index->getType('_doc');
         $type->addDocuments([
             new Document(1, ['price' => 100]),
             new Document(2, ['price' => 200]),

--- a/test/Elastica/Aggregation/RangeTest.php
+++ b/test/Elastica/Aggregation/RangeTest.php
@@ -11,7 +11,7 @@ class RangeTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5]),
             new Document(2, ['price' => 8]),
             new Document(3, ['price' => 1]),

--- a/test/Elastica/Aggregation/ReverseNestedTest.php
+++ b/test/Elastica/Aggregation/ReverseNestedTest.php
@@ -24,7 +24,7 @@ class ReverseNestedTest extends BaseAggregationTest
             ],
             'tags' => ['type' => 'keyword'],
         ]);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->setMapping($mapping);
 
         $type->addDocuments([

--- a/test/Elastica/Aggregation/ScriptTest.php
+++ b/test/Elastica/Aggregation/ScriptTest.php
@@ -12,7 +12,7 @@ class ScriptTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document('1', ['price' => 5]),
             new Document('2', ['price' => 8]),
             new Document('3', ['price' => 1]),

--- a/test/Elastica/Aggregation/ScriptedMetricTest.php
+++ b/test/Elastica/Aggregation/ScriptedMetricTest.php
@@ -11,7 +11,7 @@ class ScriptedMetricTest extends BaseAggregationTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping(new Mapping(null, [
             'start' => ['type' => 'long'],

--- a/test/Elastica/Aggregation/SerialDiffTest.php
+++ b/test/Elastica/Aggregation/SerialDiffTest.php
@@ -13,7 +13,7 @@ class SerialDiffTest extends BaseAggregationTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping(Mapping::create([
             'value' => ['type' => 'long'],

--- a/test/Elastica/Aggregation/SignificantTermsTest.php
+++ b/test/Elastica/Aggregation/SignificantTermsTest.php
@@ -15,17 +15,17 @@ class SignificantTermsTest extends BaseAggregationTest
         $colors = ['blue', 'blue', 'red', 'red', 'green', 'yellow', 'white', 'cyan', 'magenta'];
         $temperatures = [1500, 1500, 1500, 1500, 2500, 3500, 4500, 5500, 6500, 7500, 7500, 8500, 9500];
 
-        $mapping = new Mapping($index->getType('test'), [
+        $mapping = new Mapping($index->getType('_doc'), [
             'color' => ['type' => 'keyword'],
             'temperature' => ['type' => 'keyword'],
         ]);
-        $index->getType('test')->setMapping($mapping);
+        $index->getType('_doc')->setMapping($mapping);
 
         $docs = [];
         for ($i = 0;$i < 250;++$i) {
             $docs[] = new Document($i, ['color' => $colors[$i % count($colors)], 'temperature' => $temperatures[$i % count($temperatures)]]);
         }
-        $index->getType('test')->addDocuments($docs);
+        $index->getType('_doc')->addDocuments($docs);
         $index->refresh();
 
         return $index;

--- a/test/Elastica/Aggregation/StatsBucketTest.php
+++ b/test/Elastica/Aggregation/StatsBucketTest.php
@@ -13,7 +13,7 @@ class StatsBucketTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             Document::create(['weight' => 60, 'height' => 180, 'age' => 25]),
             Document::create(['weight' => 70, 'height' => 156, 'age' => 32]),
             Document::create(['weight' => 50, 'height' => 155, 'age' => 45]),

--- a/test/Elastica/Aggregation/StatsTest.php
+++ b/test/Elastica/Aggregation/StatsTest.php
@@ -11,7 +11,7 @@ class StatsTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5]),
             new Document(2, ['price' => 8]),
             new Document(3, ['price' => 1]),

--- a/test/Elastica/Aggregation/SumBucketTest.php
+++ b/test/Elastica/Aggregation/SumBucketTest.php
@@ -13,7 +13,7 @@ class SumBucketTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             Document::create(['page' => 1, 'likes' => 180]),
             Document::create(['page' => 1, 'likes' => 156]),
             Document::create(['page' => 2, 'likes' => 155]),

--- a/test/Elastica/Aggregation/SumTest.php
+++ b/test/Elastica/Aggregation/SumTest.php
@@ -11,7 +11,7 @@ class SumTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5]),
             new Document(2, ['price' => 8]),
             new Document(3, ['price' => 1]),

--- a/test/Elastica/Aggregation/TermsTest.php
+++ b/test/Elastica/Aggregation/TermsTest.php
@@ -12,12 +12,12 @@ class TermsTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $mapping = new Mapping($index->getType('test'), [
+        $mapping = new Mapping($index->getType('_doc'), [
             'color' => ['type' => 'keyword'],
         ]);
-        $index->getType('test')->setMapping($mapping);
+        $index->getType('_doc')->setMapping($mapping);
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['color' => 'blue']),
             new Document(2, ['color' => 'blue']),
             new Document(3, ['color' => 'red']),

--- a/test/Elastica/Aggregation/TopHitsTest.php
+++ b/test/Elastica/Aggregation/TopHitsTest.php
@@ -17,7 +17,7 @@ class TopHitsTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $mapping = new Mapping($index->getType('test'), [
+        $mapping = new Mapping($index->getType('_doc'), [
             'tags' => ['type' => 'keyword'],
             'title' => ['type' => 'keyword'],
             'my_join_field' => [

--- a/test/Elastica/Aggregation/ValueCountTest.php
+++ b/test/Elastica/Aggregation/ValueCountTest.php
@@ -11,7 +11,7 @@ class ValueCountTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
 
-        $index->getType('test')->addDocuments([
+        $index->getType('_doc')->addDocuments([
             new Document(1, ['price' => 5]),
             new Document(2, ['price' => 8]),
             new Document(3, ['price' => 1]),

--- a/test/Elastica/Bulk/Action/UpdateDocumentTest.php
+++ b/test/Elastica/Bulk/Action/UpdateDocumentTest.php
@@ -30,35 +30,35 @@ class UpdateDocumentTest extends BaseTest
         $expected .= $docExpected;
         $this->assertEquals($expected, $action->toString());
 
-        $action->setType('type');
+        $action->setType('_doc');
 
-        $expected = '{"update":{"_index":"index","_type":"type"}}'."\n";
+        $expected = '{"update":{"_index":"index","_type":"_doc"}}'."\n";
         $expected .= $docExpected;
         $this->assertEquals($expected, $action->toString());
 
         $action->setId(1);
-        $expected = '{"update":{"_index":"index","_type":"type","_id":1}}'."\n";
+        $expected = '{"update":{"_index":"index","_type":"_doc","_id":1}}'."\n";
         $expected .= $docExpected;
         $this->assertEquals($expected, $action->toString());
 
         $action->setRouting(1);
-        $expected = '{"update":{"_index":"index","_type":"type","_id":1,"_routing":1}}'."\n";
+        $expected = '{"update":{"_index":"index","_type":"_doc","_id":1,"_routing":1}}'."\n";
         $expected .= $docExpected;
         $this->assertEquals($expected, $action->toString());
 
         $client = $this->_getClient();
         $index = new Index($client, 'index2');
-        $type = new Type($index, 'type2');
+        $type = new Type($index, '_doc');
 
         $action->setIndex($index);
 
-        $expected = '{"update":{"_index":"index2","_type":"type","_id":1,"_routing":1}}'."\n";
+        $expected = '{"update":{"_index":"index2","_type":"_doc","_id":1,"_routing":1}}'."\n";
         $expected .= $docExpected;
         $this->assertEquals($expected, $action->toString());
 
         $action->setType($type);
 
-        $expected = '{"update":{"_index":"index2","_type":"type2","_id":1,"_routing":1}}'."\n";
+        $expected = '{"update":{"_index":"index2","_type":"_doc","_id":1,"_routing":1}}'."\n";
         $expected .= $docExpected;
         $this->assertEquals($expected, $action->toString());
     }
@@ -68,14 +68,14 @@ class UpdateDocumentTest extends BaseTest
      */
     public function testUpdateDocumentAsUpsert()
     {
-        $document = new Document(1, ['foo' => 'bar'], 'type', 'index');
+        $document = new Document(1, ['foo' => 'bar'], '_doc', 'index');
         $document->setDocAsUpsert(true);
         $action = new UpdateDocument($document);
 
         $this->assertEquals('update', $action->getOpType());
         $this->assertTrue($action->hasSource());
 
-        $expected = '{"update":{"_index":"index","_type":"type","_id":1}}'."\n"
+        $expected = '{"update":{"_index":"index","_type":"_doc","_id":1}}'."\n"
                 .'{"doc":{"foo":"bar"},"doc_as_upsert":true}'."\n";
         $this->assertEquals($expected, $action->toString());
 
@@ -85,7 +85,7 @@ class UpdateDocumentTest extends BaseTest
 
         $document->setDocAsUpsert(false);
         $action->setDocument($document);
-        $expected = '{"update":{"_index":"index","_type":"type","_id":1}}'."\n"
+        $expected = '{"update":{"_index":"index","_type":"_doc","_id":1}}'."\n"
                 .'{"doc":{"foo":"bar"}}'."\n";
         $this->assertEquals($expected, $action->toString());
 

--- a/test/Elastica/Bulk/ActionTest.php
+++ b/test/Elastica/Bulk/ActionTest.php
@@ -25,36 +25,36 @@ class ActionTest extends BaseTest
         $expected = '{"index":{"_index":"index"}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
-        $action->setType('type');
+        $action->setType('_doc');
 
-        $expected = '{"index":{"_index":"index","_type":"type"}}'."\n";
+        $expected = '{"index":{"_index":"index","_type":"_doc"}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
         $action->setId(1);
-        $expected = '{"index":{"_index":"index","_type":"type","_id":1}}'."\n";
+        $expected = '{"index":{"_index":"index","_type":"_doc","_id":1}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
         $action->setRouting(1);
-        $expected = '{"index":{"_index":"index","_type":"type","_id":1,"_routing":1}}'."\n";
+        $expected = '{"index":{"_index":"index","_type":"_doc","_id":1,"_routing":1}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
         $client = $this->_getClient();
         $index = new Index($client, 'index2');
-        $type = new Type($index, 'type2');
+        $type = new Type($index, '_doc');
 
         $action->setIndex($index);
 
-        $expected = '{"index":{"_index":"index2","_type":"type","_id":1,"_routing":1}}'."\n";
+        $expected = '{"index":{"_index":"index2","_type":"_doc","_id":1,"_routing":1}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
         $action->setType($type);
 
-        $expected = '{"index":{"_index":"index2","_type":"type2","_id":1,"_routing":1}}'."\n";
+        $expected = '{"index":{"_index":"index2","_type":"_doc","_id":1,"_routing":1}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
         $action->setSource(['user' => 'name']);
 
-        $expected = '{"index":{"_index":"index2","_type":"type2","_id":1,"_routing":1}}'."\n";
+        $expected = '{"index":{"_index":"index2","_type":"_doc","_id":1,"_routing":1}}'."\n";
         $expected .= '{"user":"name"}'."\n";
 
         $this->assertEquals($expected, $action->toString());

--- a/test/Elastica/BulkTest.php
+++ b/test/Elastica/BulkTest.php
@@ -24,7 +24,7 @@ class BulkTest extends BaseTest
     {
         $index = $this->_createIndex();
         $indexName = $index->getName();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $newDocument1 = $type->createDocument(1, ['name' => 'Mister Fantastic']);
@@ -66,24 +66,24 @@ class BulkTest extends BaseTest
         $data = $bulk->toArray();
 
         $expected = [
-            ['index' => ['_index' => $indexName, '_type' => 'bulk_test', '_id' => 1]],
+            ['index' => ['_index' => $indexName, '_type' => '_doc', '_id' => 1]],
             ['name' => 'Mister Fantastic'],
             ['index' => ['_id' => 2]],
             ['name' => 'Invisible Woman'],
-            ['create' => ['_index' => $indexName, '_type' => 'bulk_test', '_id' => 3]],
+            ['create' => ['_index' => $indexName, '_type' => '_doc', '_id' => 3]],
             ['name' => 'The Human Torch'],
-            ['index' => ['_index' => $indexName, '_type' => 'bulk_test']],
+            ['index' => ['_index' => $indexName, '_type' => '_doc']],
             ['name' => 'The Thing'],
         ];
         $this->assertEquals($expected, $data);
 
-        $expected = '{"index":{"_index":"'.$indexName.'","_type":"bulk_test","_id":1}}
+        $expected = '{"index":{"_index":"'.$indexName.'","_type":"_doc","_id":1}}
 {"name":"Mister Fantastic"}
 {"index":{"_id":2}}
 {"name":"Invisible Woman"}
-{"create":{"_index":"'.$indexName.'","_type":"bulk_test","_id":3}}
+{"create":{"_index":"'.$indexName.'","_type":"_doc","_id":3}}
 {"name":"The Human Torch"}
-{"index":{"_index":"'.$indexName.'","_type":"bulk_test"}}
+{"index":{"_index":"'.$indexName.'","_type":"_doc"}}
 {"name":"The Thing"}
 ';
 
@@ -114,7 +114,7 @@ class BulkTest extends BaseTest
         $data = $bulk->toArray();
 
         $expected = [
-            ['delete' => ['_index' => $indexName, '_type' => 'bulk_test', '_id' => 3]],
+            ['delete' => ['_index' => $indexName, '_type' => '_doc', '_id' => 3]],
         ];
         $this->assertEquals($expected, $data);
 
@@ -138,7 +138,7 @@ class BulkTest extends BaseTest
     public function testUnicodeBulkSend()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $newDocument1 = $type->createDocument(1, ['name' => 'Сегодня, я вижу, особенно грустен твой взгляд,']);
@@ -169,10 +169,10 @@ class BulkTest extends BaseTest
     {
         $client = $this->_getClient();
         $index = $client->getIndex('index');
-        $type = $index->getType('type');
+        $type = $index->getType('_doc');
 
         $index2 = $client->getIndex('index2');
-        $type2 = $index2->getType('type2');
+        $type2 = $index2->getType('_doc');
 
         $bulk = new Bulk($client);
 
@@ -188,19 +188,19 @@ class BulkTest extends BaseTest
         $this->assertTrue($bulk->hasIndex());
         $this->assertTrue($bulk->hasType());
         $this->assertEquals('index2', $bulk->getIndex());
-        $this->assertEquals('type2', $bulk->getType());
+        $this->assertEquals('_doc', $bulk->getType());
 
         $bulk->setType($type);
         $this->assertTrue($bulk->hasIndex());
         $this->assertTrue($bulk->hasType());
         $this->assertEquals('index', $bulk->getIndex());
-        $this->assertEquals('type', $bulk->getType());
+        $this->assertEquals('_doc', $bulk->getType());
 
         $bulk->setIndex($index2);
         $this->assertTrue($bulk->hasIndex());
         $this->assertTrue($bulk->hasType());
         $this->assertEquals('index2', $bulk->getIndex());
-        $this->assertEquals('type', $bulk->getType());
+        $this->assertEquals('_doc', $bulk->getType());
     }
 
     /**
@@ -347,7 +347,7 @@ class BulkTest extends BaseTest
     public function testErrorRequest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $documents = [
@@ -379,7 +379,7 @@ class BulkTest extends BaseTest
     public function testRawDocumentDataRequest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $documents = [
@@ -422,7 +422,7 @@ class BulkTest extends BaseTest
     public function testUpdate()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $doc1 = $type->createDocument(1, ['name' => 'John']);
@@ -555,7 +555,7 @@ class BulkTest extends BaseTest
     public function testUpsert()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $doc1 = $type->createDocument(1, ['name' => 'Pele']);
@@ -622,7 +622,7 @@ return $d;}, [$doc1, $doc2, $doc3, $doc4]);
     public function testRetry()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $doc1 = $type->createDocument(1, ['name' => 'Mister Fantastic']);
@@ -672,7 +672,7 @@ return $d;}, [$doc1, $doc2, $doc3, $doc4]);
      */
     public function testMemoryUsage()
     {
-        $type = $this->_createIndex()->getType('test');
+        $type = $this->_createIndex()->getType('_doc');
 
         $data = [
             'text1' => 'Very long text for a string',

--- a/test/Elastica/ClientTest.php
+++ b/test/Elastica/ClientTest.php
@@ -81,7 +81,7 @@ class ClientTest extends BaseTest
         $index = $client->getIndex('elastica_test1');
         $index->create([], true);
 
-        $type = $index->getType('user');
+        $type = $index->getType('_doc');
 
         // Adds 1 document to the index
         $doc1 = new Document(1,
@@ -118,7 +118,7 @@ class ClientTest extends BaseTest
         $index = $client->getIndex('elastica_test1');
         $index->create([], true);
 
-        $type = $index->getType('user');
+        $type = $index->getType('_doc');
 
         // Adds 1 document to the index
         $doc1 = new Document(1,
@@ -186,9 +186,9 @@ class ClientTest extends BaseTest
         $client = $this->_getClient();
 
         $params = [
-            ['index' => ['_index' => 'test', '_type' => 'user', '_id' => '1']],
+            ['index' => ['_index' => 'test', '_type' => '_doc', '_id' => '1']],
             ['user' => ['name' => 'hans']],
-            ['index' => ['_index' => 'test', '_type' => 'user', '_id' => '2']],
+            ['index' => ['_index' => 'test', '_type' => '_doc', '_id' => '2']],
             ['user' => ['name' => 'peter']],
         ];
 
@@ -225,28 +225,28 @@ class ClientTest extends BaseTest
     {
         $index = $this->_getClient()->getIndex('cryptocurrencies');
 
-        $anonCoin = new Document(1, ['name' => 'anoncoin'], 'altcoin');
-        $ixCoin = new Document(2, ['name' => 'ixcoin'], 'altcoin');
+        $anonCoin = new Document(1, ['name' => 'anoncoin'], '_doc');
+        $ixCoin = new Document(2, ['name' => 'ixcoin'], '_doc');
 
         $index->addDocuments([$anonCoin, $ixCoin]);
 
-        $this->assertEquals('anoncoin', $index->getType('altcoin')->getDocument(1)->get('name'));
-        $this->assertEquals('ixcoin', $index->getType('altcoin')->getDocument(2)->get('name'));
+        $this->assertEquals('anoncoin', $index->getType('_doc')->getDocument(1)->get('name'));
+        $this->assertEquals('ixcoin', $index->getType('_doc')->getDocument(2)->get('name'));
 
         $index->updateDocuments([
-            new Document(1, ['name' => 'AnonCoin'], 'altcoin'),
-            new Document(2, ['name' => 'iXcoin'], 'altcoin'),
+            new Document(1, ['name' => 'AnonCoin'], '_doc'),
+            new Document(2, ['name' => 'iXcoin'], '_doc'),
         ]);
 
-        $this->assertEquals('AnonCoin', $index->getType('altcoin')->getDocument(1)->get('name'));
-        $this->assertEquals('iXcoin', $index->getType('altcoin')->getDocument(2)->get('name'));
+        $this->assertEquals('AnonCoin', $index->getType('_doc')->getDocument(1)->get('name'));
+        $this->assertEquals('iXcoin', $index->getType('_doc')->getDocument(2)->get('name'));
 
         $ixCoin->setIndex(null);  // Make sure the index gets set properly if missing
         $index->deleteDocuments([$anonCoin, $ixCoin]);
 
         $this->expectException(NotFoundException::class);
-        $index->getType('altcoin')->getDocument(1);
-        $index->getType('altcoin')->getDocument(2);
+        $index->getType('_doc')->getDocument(1);
+        $index->getType('_doc')->getDocument(2);
     }
 
     /**
@@ -256,7 +256,7 @@ class ClientTest extends BaseTest
      */
     public function testBulkType()
     {
-        $type = $this->_getClient()->getIndex('cryptocurrencies')->getType('altcoin');
+        $type = $this->_getClient()->getIndex('cryptocurrencies')->getType('_doc');
 
         $liteCoin = new Document(1, ['name' => 'litecoin']);
         $nameCoin = new Document(2, ['name' => 'namecoin']);
@@ -288,7 +288,7 @@ class ClientTest extends BaseTest
     public function testUpdateDocuments()
     {
         $indexName = 'test';
-        $typeName = 'people';
+        $typeName = '_doc';
 
         $client = $this->_getClient();
         $type = $client->getIndex($indexName)->getType($typeName);
@@ -350,7 +350,7 @@ class ClientTest extends BaseTest
 
         // Create the index, deleting it first if it already exists
         $index->create([], true);
-        $type = $index->getType('user');
+        $type = $index->getType('_doc');
 
         // Adds 1 document to the index
         $doc = new Document(null, $data);
@@ -428,7 +428,7 @@ class ClientTest extends BaseTest
 
         // Create the index, deleting it first if it already exists
         $index->create([], true);
-        $type = $index->getType('user');
+        $type = $index->getType('_doc');
 
         // Adds 1 document to the index
         $doc = new Document(null, $data);
@@ -492,7 +492,7 @@ class ClientTest extends BaseTest
 
         // Create the index, deleting it first if it already exists
         $index->create([], true);
-        $type = $index->getType('user');
+        $type = $index->getType('_doc');
 
         // Adds 1 document to the index
         $doc = new Document(null, $data);
@@ -556,7 +556,7 @@ class ClientTest extends BaseTest
 
         // Create the index, deleting it first if it already exists
         $index->create([], true);
-        $type = $index->getType('user');
+        $type = $index->getType('_doc');
 
         // Adds 1 document to the index
         $doc = new Document(null, $data);
@@ -703,7 +703,7 @@ class ClientTest extends BaseTest
     public function testUpdateDocumentByDocument()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $newDocument = new Document(1, ['field1' => 'value1', 'field2' => 'value2']);
@@ -730,7 +730,7 @@ class ClientTest extends BaseTest
     public function testUpdateDocumentByScript()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $newDocument = new Document(1, ['field1' => 'value1', 'field2' => 10, 'field3' => 'should be removed', 'field4' => 'should be changed']);
@@ -758,7 +758,7 @@ class ClientTest extends BaseTest
     public function testUpdateDocumentByScriptWithUpsert()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $script = new Script('ctx._source.field2 += params.count; ctx._source.remove("field3"); ctx._source.field4 = "changed"', null, Script::LANG_PAINLESS);
@@ -803,7 +803,7 @@ class ClientTest extends BaseTest
     public function testUpdateDocumentByRawData()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $newDocument = new Document(1, ['field1' => 'value1']);
@@ -834,7 +834,7 @@ class ClientTest extends BaseTest
     public function testUpdateDocumentByDocumentWithUpsert()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $newDocument = new Document(1, ['field1' => 'value1updated', 'field2' => 'value2updated']);
@@ -868,7 +868,7 @@ class ClientTest extends BaseTest
     public function testDocAsUpsert()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         //Confirm document one does not exist
@@ -898,7 +898,7 @@ class ClientTest extends BaseTest
     public function testUpdateWithInvalidType()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         //Try to update using a stdClass object
@@ -918,7 +918,7 @@ class ClientTest extends BaseTest
     public function testDeleteDocuments()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $docs = [
@@ -963,7 +963,7 @@ class ClientTest extends BaseTest
     public function testDeleteDocumentsWithRequestParameters()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $docs = [
@@ -1026,7 +1026,7 @@ class ClientTest extends BaseTest
     public function testUpdateDocumentPopulateFields()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $client = $index->getClient();
 
         $newDocument = new Document(1, ['field1' => 'value1', 'field2' => 10, 'field3' => 'should be removed', 'field4' => 'value4']);
@@ -1098,7 +1098,7 @@ class ClientTest extends BaseTest
         $client = $index->getClient();
         $client->setConfigValue('document', ['autoPopulate' => true]);
 
-        $type = $index->getType('pos');
+        $type = $index->getType('_doc');
         $type->addDocuments($docs);
 
         foreach ($docs as $doc) {
@@ -1124,7 +1124,7 @@ class ClientTest extends BaseTest
         $client = $index->getClient();
         $client->setConfigValue('document', ['autoPopulate' => true]);
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->addDocuments($docs, ['pipeline' => 'renaming']);
 
         foreach ($docs as $i => $doc) {
@@ -1174,7 +1174,7 @@ class ClientTest extends BaseTest
 
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->addDocument(new Document(1, ['username' => 'ruflin']));
         $index->refresh();
 
@@ -1203,7 +1203,7 @@ class ClientTest extends BaseTest
 
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->addDocument(new Document(1, ['username' => 'ruflin']));
         $index->refresh();
 
@@ -1373,7 +1373,7 @@ class ClientTest extends BaseTest
         // Also, index should exist (matches $staticIndex)
         $dynamicIndex->refresh();
 
-        $type = $dynamicIndex->getType('some_type');
+        $type = $dynamicIndex->getType('_doc');
         $doc1 = $type->createDocument(1, ['name' => 'one']);
         $doc2 = $type->createDocument(2, ['name' => 'two']);
 
@@ -1409,7 +1409,7 @@ class ClientTest extends BaseTest
     {
         $index = $this->_createIndex();
         $client = $index->getClient();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $doc = new Document(null, ['foo' => 'bar']);
         $doc->setRouting('first_routing');
         $type->addDocument($doc);
@@ -1425,7 +1425,7 @@ class ClientTest extends BaseTest
         $this->assertArrayHasKey('types', $response->getData()['indices'][$index->getName()]['total']['indexing']);
 
         $this->assertEquals(
-            ['test'],
+            ['_doc'],
             array_keys($response->getData()['indices'][$index->getName()]['total']['indexing']['types'])
         );
     }
@@ -1440,7 +1440,7 @@ class ClientTest extends BaseTest
 
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->addDocument(new Document(1, ['username' => 'ruflin']));
         $index->refresh();
 

--- a/test/Elastica/Cluster/SettingsTest.php
+++ b/test/Elastica/Cluster/SettingsTest.php
@@ -70,7 +70,7 @@ class SettingsTest extends BaseTest
         $doc6 = new Document(null, ['hello' => 'world']);
 
         // Check that adding documents work
-        $index1->getType('test')->addDocument($doc1);
+        $index1->getType('_doc')->addDocument($doc1);
 
         $response = $settings->setReadOnly(true);
         $this->assertFalse($response->hasError());
@@ -79,7 +79,7 @@ class SettingsTest extends BaseTest
 
         // Make sure both index are read only
         try {
-            $index1->getType('test')->addDocument($doc3);
+            $index1->getType('_doc')->addDocument($doc3);
             $this->fail('should throw read only exception');
         } catch (ResponseException $e) {
             $error = $e->getResponse()->getFullError();
@@ -93,7 +93,7 @@ class SettingsTest extends BaseTest
         $this->assertEquals('false', $setting);
 
         // Check that adding documents works again
-        $index1->getType('test')->addDocument($doc5);
+        $index1->getType('_doc')->addDocument($doc5);
 
         $index1->refresh();
 

--- a/test/Elastica/DocumentTest.php
+++ b/test/Elastica/DocumentTest.php
@@ -50,7 +50,7 @@ class DocumentTest extends BaseTest
     {
         $id = 17;
         $data = ['hello' => 'world'];
-        $type = 'testtype';
+        $type = '_doc';
         $index = 'textindex';
 
         $doc = new Document($id, $data, $type, $index);
@@ -65,12 +65,12 @@ class DocumentTest extends BaseTest
     public function testSetType()
     {
         $document = new Document();
-        $document->setType('type');
+        $document->setType('_doc');
 
-        $this->assertEquals('type', $document->getType());
+        $this->assertEquals('_doc', $document->getType());
 
         $index = new Index($this->_getClient(), 'index');
-        $type = $index->getType('type');
+        $type = $index->getType('_doc');
 
         $document->setIndex('index2');
         $this->assertEquals('index2', $document->getIndex());
@@ -78,7 +78,7 @@ class DocumentTest extends BaseTest
         $document->setType($type);
 
         $this->assertEquals('index', $document->getIndex());
-        $this->assertEquals('type', $document->getType());
+        $this->assertEquals('_doc', $document->getType());
     }
 
     /**
@@ -88,17 +88,17 @@ class DocumentTest extends BaseTest
     {
         $document = new Document();
         $document->setIndex('index2');
-        $document->setType('type2');
+        $document->setType('_doc');
 
         $this->assertEquals('index2', $document->getIndex());
-        $this->assertEquals('type2', $document->getType());
+        $this->assertEquals('_doc', $document->getType());
 
         $index = new Index($this->_getClient(), 'index');
 
         $document->setIndex($index);
 
         $this->assertEquals('index', $document->getIndex());
-        $this->assertEquals('type2', $document->getType());
+        $this->assertEquals('_doc', $document->getType());
     }
 
     /**

--- a/test/Elastica/ExampleTest.php
+++ b/test/Elastica/ExampleTest.php
@@ -16,7 +16,7 @@ class ExampleTest extends BaseTest
     {
         $client = $this->_getClient();
         $index = $client->getIndex('ruflin');
-        $type = $index->getType('users');
+        $type = $index->getType('_doc');
 
         $id = 2;
         $data = ['firstname' => 'Nicolas', 'lastname' => 'Ruflin'];
@@ -35,7 +35,7 @@ class ExampleTest extends BaseTest
         $index = $client->getIndex('elastica_test');
         $index->create([], true);
 
-        $type = $index->getType('user');
+        $type = $index->getType('_doc');
 
         // Adds 1 document to the index
         $doc1 = new Document(1,

--- a/test/Elastica/Exception/PartialShardFailureExceptionTest.php
+++ b/test/Elastica/Exception/PartialShardFailureExceptionTest.php
@@ -23,7 +23,7 @@ class PartialShardFailureExceptionTest extends AbstractExceptionTest
             ],
         ], true);
 
-        $type = $index->getType('folks');
+        $type = $index->getType('_doc');
 
         $type->addDocument(new Document('', ['name' => 'ruflin']));
         $type->addDocument(new Document('', ['name' => 'bobrik']));

--- a/test/Elastica/Exception/ResponseExceptionTest.php
+++ b/test/Elastica/Exception/ResponseExceptionTest.php
@@ -31,7 +31,7 @@ class ResponseExceptionTest extends AbstractExceptionTest
     public function testBadType()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping([
             'num' => [

--- a/test/Elastica/Index/SettingsTest.php
+++ b/test/Elastica/Index/SettingsTest.php
@@ -262,7 +262,7 @@ class SettingsTest extends BaseTest
         $doc2 = new Document(null, ['hello' => 'world']);
         $doc3 = new Document(null, ['hello' => 'world']);
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->addDocument($doc1);
         $this->assertFalse($index->getSettings()->getReadOnly());
 

--- a/test/Elastica/IndexTest.php
+++ b/test/Elastica/IndexTest.php
@@ -25,7 +25,7 @@ class IndexTest extends BaseTest
         $index = $this->_createIndex();
         $doc = new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'hanswurst', 'test' => ['2', '3', '5']]);
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = ['id' => ['type' => 'integer', 'store' => true], 'email' => ['type' => 'text'],
             'username' => ['type' => 'text'], 'test' => ['type' => 'integer'], ];
@@ -36,11 +36,11 @@ class IndexTest extends BaseTest
 
         $storedMapping = $index->getMapping();
 
-        $this->assertEquals($storedMapping['test']['properties']['id']['type'], 'integer');
-        $this->assertEquals($storedMapping['test']['properties']['id']['store'], true);
-        $this->assertEquals($storedMapping['test']['properties']['email']['type'], 'text');
-        $this->assertEquals($storedMapping['test']['properties']['username']['type'], 'text');
-        $this->assertEquals($storedMapping['test']['properties']['test']['type'], 'integer');
+        $this->assertEquals($storedMapping['_doc']['properties']['id']['type'], 'integer');
+        $this->assertEquals($storedMapping['_doc']['properties']['id']['store'], true);
+        $this->assertEquals($storedMapping['_doc']['properties']['email']['type'], 'text');
+        $this->assertEquals($storedMapping['_doc']['properties']['username']['type'], 'text');
+        $this->assertEquals($storedMapping['_doc']['properties']['test']['type'], 'integer');
 
         $result = $type->search('hanswurst');
     }
@@ -56,7 +56,7 @@ class IndexTest extends BaseTest
         $aliasName = 'test-mapping-alias';
         $index->addAlias($aliasName);
 
-        $type = new Type($index, 'test');
+        $type = new Type($index, '_doc');
         $mapping = new Mapping($type, [
                 'id' => ['type' => 'integer', 'store' => 'true'],
             ]);
@@ -122,7 +122,7 @@ class IndexTest extends BaseTest
         $doc1 = new Document(null, ['name' => 'ruflin']);
         $doc2 = new Document(null, ['name' => 'nicolas']);
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->addDocument($doc1);
         $type->addDocument($doc2);
 
@@ -144,7 +144,7 @@ class IndexTest extends BaseTest
     public function testDeleteByQueryWithQueryString()
     {
         $index = $this->_createIndex();
-        $type1 = new Type($index, 'test1');
+        $type1 = new Type($index, '_doc');
         $type1->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type1->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
@@ -175,7 +175,7 @@ class IndexTest extends BaseTest
     public function testDeleteByQueryWithQuery()
     {
         $index = $this->_createIndex();
-        $type1 = new Type($index, 'test1');
+        $type1 = new Type($index, '_doc');
         $type1->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type1->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
@@ -206,7 +206,7 @@ class IndexTest extends BaseTest
     public function testDeleteByQueryWithArrayQuery()
     {
         $index = $this->_createIndex();
-        $type1 = new Type($index, 'test1');
+        $type1 = new Type($index, '_doc');
         $type1->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type1->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
@@ -241,7 +241,7 @@ class IndexTest extends BaseTest
         $routing1 = 'first_routing';
         $routing2 = 'second_routing';
 
-        $type = new Type($index, 'test');
+        $type = new Type($index, '_doc');
         $doc = new Document(1, ['name' => 'ruflin nicolas']);
         $doc->setRouting($routing1);
         $type->addDocument($doc);
@@ -297,7 +297,7 @@ class IndexTest extends BaseTest
     public function testUpdateByQueryWithQueryString()
     {
         $index = $this->_createIndex();
-        $type1 = new Type($index, 'test1');
+        $type1 = new Type($index, '_doc');
         $type1->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type1->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
@@ -331,7 +331,7 @@ class IndexTest extends BaseTest
     public function testUpdateByQueryAll()
     {
         $index = $this->_createIndex();
-        $type1 = new Type($index, 'test1');
+        $type1 = new Type($index, '_doc');
         $type1->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type1->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
@@ -442,7 +442,7 @@ class IndexTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = new Type($index, 'test');
+        $type = new Type($index, '_doc');
 
         $doc1 = new Document(1);
         $doc1->set('title', 'Hello world');
@@ -523,7 +523,7 @@ class IndexTest extends BaseTest
     public function testIndexGetMapping()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = ['id' => ['type' => 'integer', 'store' => true], 'email' => ['type' => 'text'],
             'username' => ['type' => 'text'], 'test' => ['type' => 'integer'], ];
@@ -532,11 +532,11 @@ class IndexTest extends BaseTest
         $index->refresh();
         $indexMappings = $index->getMapping();
 
-        $this->assertEquals($indexMappings['test']['properties']['id']['type'], 'integer');
-        $this->assertEquals($indexMappings['test']['properties']['id']['store'], true);
-        $this->assertEquals($indexMappings['test']['properties']['email']['type'], 'text');
-        $this->assertEquals($indexMappings['test']['properties']['username']['type'], 'text');
-        $this->assertEquals($indexMappings['test']['properties']['test']['type'], 'integer');
+        $this->assertEquals($indexMappings['_doc']['properties']['id']['type'], 'integer');
+        $this->assertEquals($indexMappings['_doc']['properties']['id']['store'], true);
+        $this->assertEquals($indexMappings['_doc']['properties']['email']['type'], 'text');
+        $this->assertEquals($indexMappings['_doc']['properties']['username']['type'], 'text');
+        $this->assertEquals($indexMappings['_doc']['properties']['test']['type'], 'integer');
     }
 
     /**
@@ -577,7 +577,7 @@ class IndexTest extends BaseTest
         $docs[] = new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']);
         $docs[] = new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']);
 
-        $type = $index->getType('zeroType');
+        $type = $index->getType('_doc');
         $type->addDocuments($docs);
         $index->refresh();
 
@@ -656,9 +656,9 @@ class IndexTest extends BaseTest
         $this->assertTrue($search->hasIndex($index));
         $this->assertEquals([], $search->getTypes());
         $this->assertFalse($search->hasTypes());
-        $this->assertFalse($search->hasType('test_type'));
+        $this->assertFalse($search->hasType('_doc'));
 
-        $type = new Type($index, 'test_type2');
+        $type = new Type($index, '_doc');
         $this->assertFalse($search->hasType($type));
     }
 
@@ -669,7 +669,7 @@ class IndexTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $type = new Type($index, 'user');
+        $type = new Type($index, '_doc');
 
         $docs = [];
         $docs[] = new Document(1, ['username' => 'hans', 'test' => ['2', '3', '5']]);
@@ -701,7 +701,7 @@ class IndexTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $type = new Type($index, 'optimize');
+        $type = new Type($index, '_doc');
 
         $docs = [];
         $docs[] = new Document(1, ['foo' => 'bar']);

--- a/test/Elastica/Multi/SearchTest.php
+++ b/test/Elastica/Multi/SearchTest.php
@@ -35,7 +35,7 @@ class SearchTest extends BaseTest
         $docs[] = new Document(9, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
         $docs[] = new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
         $docs[] = new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
-        $type = $index->getType('zeroType');
+        $type = $index->getType('_doc');
         $type->addDocuments($docs);
         $index->refresh();
 

--- a/test/Elastica/PipelineTest.php
+++ b/test/Elastica/PipelineTest.php
@@ -88,7 +88,7 @@ class PipelineTest extends BasePipeline
         $this->assertContains('acknowledged', $result->getData());
 
         $index = $this->_createIndex('testpipelinecreation');
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => 'ruflin', 'type' => 'elastica', 'foo' => null]);

--- a/test/Elastica/Processor/AppendTest.php
+++ b/test/Elastica/Processor/AppendTest.php
@@ -54,7 +54,7 @@ class AppendTest extends BasePipelineTest
         $pipeline->addProcessor($append)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => 'ruflin', 'type' => 'elastica', 'foo' => null]);

--- a/test/Elastica/Processor/AttachmentTest.php
+++ b/test/Elastica/Processor/AttachmentTest.php
@@ -60,7 +60,7 @@ class AttachmentTest extends BasePipelineTest
         $pipeline->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         $bulk = new Bulk($index->getClient());
         $bulk->setIndex($index);
@@ -105,7 +105,7 @@ class AttachmentTest extends BasePipelineTest
         $pipeline->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         $bulk = new Bulk($index->getClient());
         $bulk->setIndex($index);
@@ -152,7 +152,7 @@ class AttachmentTest extends BasePipelineTest
         $pipeline->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         $bulk = new Bulk($index->getClient());
         $bulk->setIndex($index);
@@ -202,7 +202,7 @@ class AttachmentTest extends BasePipelineTest
         $indexParams = ['index' => ['number_of_shards' => 1, 'number_of_replicas' => 0]];
 
         $index = $this->_createIndex();
-        $type = new Type($index, 'content');
+        $type = new Type($index, '_doc');
 
         $mapping = Type\Mapping::create($indexMapping);
         $mapping->setSource(['excludes' => ['data']]);

--- a/test/Elastica/Processor/ConvertTest.php
+++ b/test/Elastica/Processor/ConvertTest.php
@@ -69,7 +69,7 @@ class ConvertTest extends BasePipelineTest
         $pipeline->addProcessor($append)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => 'ruflin', 'type' => 'elastica', 'foo' => '5.290']);

--- a/test/Elastica/Processor/DateTest.php
+++ b/test/Elastica/Processor/DateTest.php
@@ -74,7 +74,7 @@ class DateTest extends BasePipelineTest
         $pipeline->addProcessor($date)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['date_field' => '2010 12 06 11:05:15']);

--- a/test/Elastica/Processor/DotExpanderTest.php
+++ b/test/Elastica/Processor/DotExpanderTest.php
@@ -36,7 +36,7 @@ class DotExpanderTest extends BasePipelineTest
         $pipeline->addProcessor($dotExpander)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['foo.bar' => 'value']);

--- a/test/Elastica/Processor/FailTest.php
+++ b/test/Elastica/Processor/FailTest.php
@@ -39,7 +39,7 @@ class FailTest extends BasePipelineTest
             ->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => '']);

--- a/test/Elastica/Processor/JoinTest.php
+++ b/test/Elastica/Processor/JoinTest.php
@@ -37,7 +37,7 @@ class JoinTest extends BasePipelineTest
         $pipeline->addProcessor($join)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => ['abc', 'def', 'ghij']]);

--- a/test/Elastica/Processor/JsonTest.php
+++ b/test/Elastica/Processor/JsonTest.php
@@ -57,7 +57,7 @@ class JsonTest extends BasePipelineTest
         $pipeline->addProcessor($json)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => json_encode(['foo' => 2000])]);

--- a/test/Elastica/Processor/LowercaseTest.php
+++ b/test/Elastica/Processor/LowercaseTest.php
@@ -36,7 +36,7 @@ class LowercaseTest extends BasePipelineTest
         $pipeline->addProcessor($lcase)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => 'RUFLIN']);

--- a/test/Elastica/Processor/RemoveTest.php
+++ b/test/Elastica/Processor/RemoveTest.php
@@ -52,7 +52,7 @@ class RemoveTest extends BasePipelineTest
         $pipeline->addProcessor($remove)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => 'nicolas', 'es_version' => 6, 'package' => 'Elastica']);

--- a/test/Elastica/Processor/RenameTest.php
+++ b/test/Elastica/Processor/RenameTest.php
@@ -56,7 +56,7 @@ class RenameTest extends BasePipelineTest
         $pipeline->addProcessor($rename)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => 'nicolas', 'package' => 'Elastico']);

--- a/test/Elastica/Processor/SetTest.php
+++ b/test/Elastica/Processor/SetTest.php
@@ -56,7 +56,7 @@ class SetTest extends BasePipelineTest
         $pipeline->addProcessor($set)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => 'nicolas', 'package' => 'Elastico']);

--- a/test/Elastica/Processor/SortTest.php
+++ b/test/Elastica/Processor/SortTest.php
@@ -54,7 +54,7 @@ class SortTest extends BasePipelineTest
         $pipeline->addProcessor($sort)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]]);

--- a/test/Elastica/Processor/SplitTest.php
+++ b/test/Elastica/Processor/SplitTest.php
@@ -56,7 +56,7 @@ class SplitTest extends BasePipelineTest
         $pipeline->addProcessor($split)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => 'nicolas&ruflin']);

--- a/test/Elastica/Processor/TrimTest.php
+++ b/test/Elastica/Processor/TrimTest.php
@@ -36,7 +36,7 @@ class TrimTest extends BasePipelineTest
         $pipeline->addProcessor($trim)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => '   ruflin   ']);

--- a/test/Elastica/Processor/UppercaseTest.php
+++ b/test/Elastica/Processor/UppercaseTest.php
@@ -36,7 +36,7 @@ class UppercaseTest extends BasePipelineTest
         $pipeline->addProcessor($ucase)->create();
 
         $index = $this->_createIndex();
-        $type = $index->getType('bulk_test');
+        $type = $index->getType('_doc');
 
         // Add document to normal index
         $doc1 = new Document(null, ['name' => 'ruflin']);

--- a/test/Elastica/Query/BoolQueryTest.php
+++ b/test/Elastica/Query/BoolQueryTest.php
@@ -90,7 +90,7 @@ class BoolQueryTest extends BaseTest
         $index = new Index($client, 'test');
         $index->create([], true);
 
-        $type = new Type($index, 'helloworld');
+        $type = new Type($index, '_doc');
 
         $doc = new Document(1, ['id' => 1, 'email' => 'hans@test.com', 'username' => 'hans', 'test' => ['2', '4', '5']]);
         $type->addDocument($doc);
@@ -142,7 +142,7 @@ class BoolQueryTest extends BaseTest
     public function testEmptyBoolQuery()
     {
         $index = $this->_createIndex();
-        $type = new Type($index, 'test');
+        $type = new Type($index, '_doc');
 
         $docNumber = 3;
         for ($i = 0; $i < $docNumber; ++$i) {

--- a/test/Elastica/Query/CommonTest.php
+++ b/test/Elastica/Query/CommonTest.php
@@ -34,7 +34,7 @@ class CommonTest extends BaseTest
     public function testQuery()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $docs = [
             new Document(1, ['body' => 'foo baz']),

--- a/test/Elastica/Query/DisMaxTest.php
+++ b/test/Elastica/Query/DisMaxTest.php
@@ -55,7 +55,7 @@ class DisMaxTest extends BaseTest
     public function testQuery()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'Basel-Stadt']),

--- a/test/Elastica/Query/EscapeStringTest.php
+++ b/test/Elastica/Query/EscapeStringTest.php
@@ -18,7 +18,7 @@ class EscapeStringTest extends BaseTest
         $index = $this->_createIndex();
         $index->getSettings()->setNumberOfReplicas(0);
 
-        $type = new Type($index, 'helloworld');
+        $type = new Type($index, '_doc');
 
         $doc = new Document(1, [
             'email' => 'test@test.com', 'username' => 'test 7/6 123', 'test' => ['2', '3', '5'], ]

--- a/test/Elastica/Query/FunctionScoreTest.php
+++ b/test/Elastica/Query/FunctionScoreTest.php
@@ -15,7 +15,7 @@ class FunctionScoreTest extends BaseTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->setMapping([
             'name' => ['type' => 'text', 'index' => 'false'],

--- a/test/Elastica/Query/FuzzyTest.php
+++ b/test/Elastica/Query/FuzzyTest.php
@@ -86,7 +86,7 @@ class FuzzyTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'Basel-Stadt']),

--- a/test/Elastica/Query/GeoDistanceTest.php
+++ b/test/Elastica/Query/GeoDistanceTest.php
@@ -15,7 +15,7 @@ class GeoDistanceTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         // Set mapping
         $type->setMapping(['point' => ['type' => 'geo_point']]);

--- a/test/Elastica/Query/GeoPolygonTest.php
+++ b/test/Elastica/Query/GeoPolygonTest.php
@@ -16,7 +16,7 @@ class GeoPolygonTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         // Set mapping
         $type->setMapping(['location' => ['type' => 'geo_point']]);

--- a/test/Elastica/Query/GeoShapePreIndexedTest.php
+++ b/test/Elastica/Query/GeoShapePreIndexedTest.php
@@ -17,7 +17,7 @@ class GeoShapePreIndexedTest extends BaseTest
     {
         $index = $this->_createIndex();
         $indexName = $index->getName();
-        $otherType = $index->getType('other_type');
+        $otherType = $index->getType('_doc');
 
         // create other type mapping
         $otherMapping = new Mapping($otherType, [
@@ -42,7 +42,7 @@ class GeoShapePreIndexedTest extends BaseTest
         $index->refresh();
 
         $gsp = new GeoShapePreIndexed(
-            'location', '2', 'other_type', $indexName, 'location'
+            'location', '2', '_doc', $indexName, 'location'
         );
 
         $query = new BoolQuery();

--- a/test/Elastica/Query/GeoShapeProvidedTest.php
+++ b/test/Elastica/Query/GeoShapeProvidedTest.php
@@ -16,7 +16,7 @@ class GeoShapeProvidedTest extends BaseTest
     public function testSearch()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         // create mapping
         $mapping = new Mapping($type, [

--- a/test/Elastica/Query/HasChildTest.php
+++ b/test/Elastica/Query/HasChildTest.php
@@ -65,7 +65,7 @@ class HasChildTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('testhaschild');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping();
         $mapping->setType($type);
@@ -89,14 +89,14 @@ class HasChildTest extends BaseTest
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], '_doc');
 
         $doc2 = new Document(2, [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], '_doc');
 
         $index->addDocuments([$doc1, $doc2]);
 
@@ -107,7 +107,7 @@ class HasChildTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 1,
             ],
-        ], 'test', 'testhaschild');
+        ], '_doc', 'testhaschild');
 
         $doc4 = new Document(4, [
             'text' => 'this is an answer, the 2nd',
@@ -116,7 +116,7 @@ class HasChildTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test', 'testhaschild');
+        ], '_doc', 'testhaschild');
 
         $doc5 = new Document(5, [
             'text' => 'this is an answer, the 3rd',
@@ -125,7 +125,7 @@ class HasChildTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test', 'testhaschild');
+        ], '_doc', 'testhaschild');
 
         $this->_getClient()->addDocuments([$doc3, $doc4, $doc5], ['routing' => 1]);
         $index->refresh();

--- a/test/Elastica/Query/HasParentTest.php
+++ b/test/Elastica/Query/HasParentTest.php
@@ -64,7 +64,7 @@ class HasParentTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('testhasparentjoin');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping();
         $mapping->setType($type);
@@ -88,14 +88,14 @@ class HasParentTest extends BaseTest
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], '_doc');
 
         $doc2 = new Document(2, [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], '_doc');
 
         $index->addDocuments([$doc1, $doc2]);
 
@@ -106,7 +106,7 @@ class HasParentTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 1,
             ],
-        ], 'test', 'testhasparentjoin');
+        ], '_doc', 'testhasparentjoin');
 
         $doc4 = new Document(4, [
             'text' => 'this is an answer, the 2nd',
@@ -115,7 +115,7 @@ class HasParentTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test', 'testhasparentjoin');
+        ], '_doc', 'testhasparentjoin');
 
         $doc5 = new Document(5, [
             'text' => 'this is an answer, the 3rd',
@@ -124,7 +124,7 @@ class HasParentTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test', 'testhasparentjoin');
+        ], '_doc', 'testhasparentjoin');
 
         $this->_getClient()->addDocuments([$doc3, $doc4, $doc5], ['routing' => 1]);
         $index->refresh();

--- a/test/Elastica/Query/HighlightTest.php
+++ b/test/Elastica/Query/HighlightTest.php
@@ -14,7 +14,7 @@ class HighlightTest extends BaseTest
     public function testHightlightSearch()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('helloworld');
+        $type = $index->getType('_doc');
 
         $phrase = 'My name is ruflin';
 

--- a/test/Elastica/Query/IdsTest.php
+++ b/test/Elastica/Query/IdsTest.php
@@ -17,7 +17,7 @@ class IdsTest extends BaseTest
 
         $index = $this->_createIndex();
 
-        $type1 = $index->getType('helloworld1');
+        $type1 = $index->getType('_doc');
 
         $doc = new Document(1, ['name' => 'hello world']);
         $type1->addDocument($doc);

--- a/test/Elastica/Query/InnerHitsTest.php
+++ b/test/Elastica/Query/InnerHitsTest.php
@@ -18,7 +18,7 @@ class InnerHitsTest extends BaseTest
     private function _getIndexForNestedTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('questions');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping();
         $mapping->setType($type);
@@ -91,7 +91,7 @@ class InnerHitsTest extends BaseTest
     private function _getIndexForParentChildrenTest()
     {
         $index = $this->_createIndex();
-        $questionType = $index->getType('questions');
+        $questionType = $index->getType('_doc');
 
         // Parent
         $mappingQuestion = new Mapping();
@@ -119,35 +119,35 @@ class InnerHitsTest extends BaseTest
                 'my_join_field' => [
                     'name' => 'questions',
                 ],
-            ], 'questions'),
+            ], '_doc'),
             new Document(2, [
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about linux #2',
                 'my_join_field' => [
                     'name' => 'questions',
                 ],
-            ], 'questions'),
+            ], '_doc'),
             new Document(3, [
                 'last_activity_date' => '2015-01-05',
                 'title' => 'Question about windows #1',
                 'my_join_field' => [
                     'name' => 'questions',
                 ],
-            ], 'questions'),
+            ], '_doc'),
             new Document(4, [
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about windows #2',
                 'my_join_field' => [
                     'name' => 'questions',
                 ],
-            ], 'questions'),
+            ], '_doc'),
             new Document(5, [
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about osx',
                 'my_join_field' => [
                     'name' => 'questions',
                 ],
-            ], 'questions'),
+            ], '_doc'),
         ]);
 
         $documentResponse1 = new Document(6, [
@@ -157,7 +157,7 @@ class InnerHitsTest extends BaseTest
                 'name' => 'answers',
                 'parent' => 1,
             ],
-        ], 'questions', $index->getName());
+        ], '_doc', $index->getName());
 
         $documentResponse2 = new Document(7, [
             'answer' => 'linux is bad',
@@ -166,7 +166,7 @@ class InnerHitsTest extends BaseTest
                 'name' => 'answers',
                 'parent' => 1,
             ],
-        ], 'questions', $index->getName());
+        ], '_doc', $index->getName());
 
         $documentResponse3 = new Document(8, [
             'answer' => 'windows was cool',
@@ -175,7 +175,7 @@ class InnerHitsTest extends BaseTest
                 'name' => 'answers',
                 'parent' => 2,
             ],
-        ], 'questions', $index->getName());
+        ], '_doc', $index->getName());
 
         $this->_getClient()->addDocuments([$documentResponse1, $documentResponse2, $documentResponse3], ['routing' => 1]);
 
@@ -326,7 +326,10 @@ class InnerHitsTest extends BaseTest
     {
         $child = (new HasChild($query, 'answers'))->setInnerHits($innerHits);
 
-        return $this->_getIndexForParentChildrenTest()->getType('questions')->search($child);
+        $ind = $this->_getIndexForParentChildrenTest();
+        $t = $ind->getType('_doc');
+        $r = $t->search($child);
+        return $this->_getIndexForParentChildrenTest()->getType('_doc')->search($child);
     }
 
     /**

--- a/test/Elastica/Query/MatchAllTest.php
+++ b/test/Elastica/Query/MatchAllTest.php
@@ -34,7 +34,7 @@ class MatchAllTest extends BaseTest
 
         $doc1 = new Document(1, ['name' => 'kimchy']);
         $doc2 = new Document(2, ['name' => 'ruflin']);
-        $index1->getType('test')->addDocuments([$doc1, $doc2]);
+        $index1->getType('_doc')->addDocuments([$doc1, $doc2]);
 
         $index1->refresh();
 

--- a/test/Elastica/Query/MatchNoneTest.php
+++ b/test/Elastica/Query/MatchNoneTest.php
@@ -29,7 +29,7 @@ class MatchNoneTest extends BaseTest
         $client = $index->getClient();
 
         $doc = new Document(1, ['name' => 'ruflin']);
-        $index->getType('test')->addDocument($doc);
+        $index->getType('_doc')->addDocument($doc);
 
         $index->refresh();
 

--- a/test/Elastica/Query/MatchPhrasePrefixTest.php
+++ b/test/Elastica/Query/MatchPhrasePrefixTest.php
@@ -46,7 +46,7 @@ class MatchPhrasePrefixTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'Basel-Stadt']),

--- a/test/Elastica/Query/MatchPhraseTest.php
+++ b/test/Elastica/Query/MatchPhraseTest.php
@@ -43,7 +43,7 @@ class MatchPhraseTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'Basel-Stadt']),

--- a/test/Elastica/Query/MatchTest.php
+++ b/test/Elastica/Query/MatchTest.php
@@ -63,7 +63,7 @@ class MatchTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'Basel-Stadt']),
@@ -94,7 +94,7 @@ class MatchTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'Basel-Stadt']),
@@ -126,7 +126,7 @@ class MatchTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'Basel-Stadt']),
@@ -158,7 +158,7 @@ class MatchTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'Basel-Stadt']),

--- a/test/Elastica/Query/MoreLikeThisTest.php
+++ b/test/Elastica/Query/MoreLikeThisTest.php
@@ -24,7 +24,7 @@ class MoreLikeThisTest extends BaseTest
         $index->getSettings()->setNumberOfReplicas(0);
         //$index->getSettings()->setNumberOfShards(1);
 
-        $type = new Type($index, 'helloworldmlt');
+        $type = new Type($index, '_doc');
         $mapping = new Mapping($type, [
             'email' => ['store' => true, 'type' => 'text', 'index' => true],
             'content' => ['store' => true, 'type' => 'text',  'index' => true],
@@ -66,7 +66,7 @@ class MoreLikeThisTest extends BaseTest
         $index = $client->getIndex('elastica_test');
         $index->create(['index' => ['number_of_shards' => 1, 'number_of_replicas' => 0]], true);
 
-        $type = new Type($index, 'mlt_test');
+        $type = new Type($index, '_doc');
 
         $type->addDocuments([
             new Document(1, ['visible' => true, 'name' => 'bruce wayne batman']),
@@ -278,7 +278,7 @@ class MoreLikeThisTest extends BaseTest
     public function testToArrayForId()
     {
         $query = new MoreLikeThis();
-        $query->setLike(new Document(1, [], 'type', 'index'));
+        $query->setLike(new Document(1, [], '_doc', 'index'));
 
         $data = $query->toArray();
 
@@ -286,7 +286,7 @@ class MoreLikeThisTest extends BaseTest
             ['more_like_this' => [
                 'like' => [
                     '_id' => 1,
-                    '_type' => 'type',
+                    '_type' => '_doc',
                     '_index' => 'index',
                 ],
             ],
@@ -301,14 +301,14 @@ class MoreLikeThisTest extends BaseTest
     public function testToArrayForSource()
     {
         $query = new MoreLikeThis();
-        $query->setLike(new Document('', ['Foo' => 'Bar'], 'type', 'index'));
+        $query->setLike(new Document('', ['Foo' => 'Bar'], '_doc', 'index'));
 
         $data = $query->toArray();
 
         $this->assertEquals(
             ['more_like_this' => [
                 'like' => [
-                    '_type' => 'type',
+                    '_type' => '_doc',
                     '_index' => 'index',
                     'doc' => [
                         'Foo' => 'Bar',

--- a/test/Elastica/Query/MultiMatchTest.php
+++ b/test/Elastica/Query/MultiMatchTest.php
@@ -200,7 +200,7 @@ class MultiMatchTest extends BaseTest
             ],
         ], true);
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping($type, [
             'name' => ['type' => 'text', 'analyzer' => 'noStops'],

--- a/test/Elastica/Query/ParentIdTest.php
+++ b/test/Elastica/Query/ParentIdTest.php
@@ -14,13 +14,13 @@ class ParentIdTest extends BaseTest
      */
     public function testToArray()
     {
-        $type = 'test';
+        $type = '_doc';
 
         $query = new ParentId($type, 1);
 
         $expectedArray = [
             'parent_id' => [
-                'type' => 'test',
+                'type' => '_doc',
                 'id' => 1,
                 'ignore_unmapped' => false,
             ],
@@ -37,7 +37,7 @@ class ParentIdTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('testparentid');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping();
         $mapping->setType($type);
@@ -56,7 +56,7 @@ class ParentIdTest extends BaseTest
         $type->setMapping($mapping);
 
         $expected = [
-            'test' => [
+            '_doc' => [
                 'properties' => [
                     'firstname' => ['type' => 'text', 'store' => true],
                     'lastname' => ['type' => 'text'],
@@ -78,14 +78,14 @@ class ParentIdTest extends BaseTest
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], '_doc');
 
         $doc2 = new Document(2, [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], '_doc');
 
         $index->addDocuments([$doc1, $doc2]);
 
@@ -95,7 +95,7 @@ class ParentIdTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 1,
             ],
-        ], 'test', 'testparentid');
+        ], '_doc', 'testparentid');
 
         $doc4 = new Document(4, [
             'text' => 'this is an answer, the 2nd',
@@ -103,7 +103,7 @@ class ParentIdTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test', 'testparentid');
+        ], '_doc', 'testparentid');
 
         $doc5 = new Document(5, [
             'text' => 'this is an answer, the 3rd',
@@ -111,7 +111,7 @@ class ParentIdTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test', 'testparentid');
+        ], '_doc', 'testparentid');
 
         $this->_getClient()->addDocuments([$doc3, $doc4, $doc5], ['routing' => 1]);
         $index->refresh();

--- a/test/Elastica/Query/PercolateTest.php
+++ b/test/Elastica/Query/PercolateTest.php
@@ -99,7 +99,7 @@ class PercolateTest extends BaseTest
         $this->index->getSettings()->setNumberOfReplicas(0);
         //The doctype mapping is the mapping used to preprocess the document
         // defined in the percolator query before it gets indexed into a temporary index.
-        $this->documentType = $this->index->getType('doctype');
+        $this->documentType = $this->index->getType('_doc');
         //The queries mapping is the mapping used for indexing the query documents.
         $this->documentType->setMapping(['message' => ['type' => 'text'], 'query' => ['type' => 'percolator']]);
     }

--- a/test/Elastica/Query/PostFilterTest.php
+++ b/test/Elastica/Query/PostFilterTest.php
@@ -18,7 +18,7 @@ class PostFilterTest extends BaseTest
             new Document(3, ['color' => 'red', 'make' => 'ford']),
             new Document(4, ['color' => 'green', 'make' => 'renault']),
         ];
-        $index->getType('test')->addDocuments($docs);
+        $index->getType('_doc')->addDocuments($docs);
         $index->refresh();
 
         return $index;

--- a/test/Elastica/Query/QueryStringTest.php
+++ b/test/Elastica/Query/QueryStringTest.php
@@ -47,7 +47,7 @@ class QueryStringTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->getSettings()->setNumberOfReplicas(0);
-        $type = $index->getType('helloworld');
+        $type = $index->getType('_doc');
 
         $doc = new Document(1, ['email' => 'test@test.com', 'username' => 'hanswurst', 'test' => ['2', '3', '5']]);
         $type->addDocument($doc);
@@ -67,7 +67,7 @@ class QueryStringTest extends BaseTest
     public function testSearchFields()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $doc = new Document(1, ['title' => 'hello world', 'firstname' => 'nicolas', 'lastname' => 'ruflin', 'price' => '102', 'year' => '2012']);
         $type->addDocument($doc);
@@ -89,7 +89,7 @@ class QueryStringTest extends BaseTest
     public function testSearchFieldsValidationException()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $doc = new Document(1, ['title' => 'hello world', 'firstname' => 'nicolas', 'lastname' => 'ruflin', 'price' => '102', 'year' => '2012']);
         $type->addDocument($doc);
@@ -309,7 +309,7 @@ class QueryStringTest extends BaseTest
         $query->setBoost(9.3);
 
         $doc = new Document('', ['name' => 'test']);
-        $index->getType('test')->addDocument($doc);
+        $index->getType('_doc')->addDocument($doc);
         $index->refresh();
 
         $resultSet = $index->search($query);

--- a/test/Elastica/Query/RangeTest.php
+++ b/test/Elastica/Query/RangeTest.php
@@ -15,7 +15,7 @@ class RangeTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['age' => 16, 'height' => 140]),

--- a/test/Elastica/Query/SimpleQueryStringTest.php
+++ b/test/Elastica/Query/SimpleQueryStringTest.php
@@ -43,7 +43,7 @@ class SimpleQueryStringTest extends Base
             new Document(4, ['make' => 'Gibson', 'model' => 'SG Faded']),
             new Document(5, ['make' => 'Fender', 'model' => 'Stratocaster']),
         ];
-        $index->getType('guitars')->addDocuments($docs);
+        $index->getType('_doc')->addDocuments($docs);
         $index->refresh();
 
         $query = new SimpleQueryString('gibson +sg +-faded', ['make', 'model']);
@@ -85,7 +85,7 @@ class SimpleQueryStringTest extends Base
         $this->_checkVersion('1.5');
 
         $index = $this->_createIndex();
-        $type = $index->getType('foobars');
+        $type = $index->getType('_doc');
         $type->addDocuments([
             new Document(1, ['body' => 'foo']),
             new Document(2, ['body' => 'bar']),

--- a/test/Elastica/Query/SpanContainingTest.php
+++ b/test/Elastica/Query/SpanContainingTest.php
@@ -65,7 +65,7 @@ class SpanContainingTest extends BaseTest
         $value = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse odio lacus, aliquam nec nulla quis, aliquam eleifend eros.';
 
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $docHitData = [$field => $value];
         $doc = new Document(1, $docHitData);

--- a/test/Elastica/Query/SpanFirstTest.php
+++ b/test/Elastica/Query/SpanFirstTest.php
@@ -38,7 +38,7 @@ class SpanFirstTest extends BaseTest
         $value = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse odio lacus, aliquam nec nulla quis, aliquam eleifend eros.';
 
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $docHitData = [$field => $value];
         $doc = new Document(1, $docHitData);

--- a/test/Elastica/Query/SpanMultiTest.php
+++ b/test/Elastica/Query/SpanMultiTest.php
@@ -65,7 +65,7 @@ class SpanMultiTest extends BaseTest
         $text5 = 'Nullam pharetra mi vitae sollicitudin fermentum. Proin sed enim consequat, consectetur eros vitae, egestas metus';
 
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, [$field => $text1]),

--- a/test/Elastica/Query/SpanNearTest.php
+++ b/test/Elastica/Query/SpanNearTest.php
@@ -66,7 +66,7 @@ class SpanNearTest extends BaseTest
         $value = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse odio lacus, aliquam nec nulla quis, aliquam eleifend eros.';
 
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $docHitData = [$field => $value];
         $doc = new Document(1, $docHitData);

--- a/test/Elastica/Query/SpanNotTest.php
+++ b/test/Elastica/Query/SpanNotTest.php
@@ -65,7 +65,7 @@ class SpanNotTest extends BaseTest
         $value = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse odio lacus, aliquam nec nulla quis, aliquam eleifend eros.';
 
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $docHitData = [$field => $value];
         $doc = new Document(1, $docHitData);

--- a/test/Elastica/Query/SpanOrTest.php
+++ b/test/Elastica/Query/SpanOrTest.php
@@ -66,7 +66,7 @@ class SpanOrTest extends BaseTest
         $text3 = 'Vivamus vitae mi nec tortor iaculis pellentesque at nec ipsum.';
 
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, [$field => $text1]),

--- a/test/Elastica/Query/SpanTermTest.php
+++ b/test/Elastica/Query/SpanTermTest.php
@@ -34,7 +34,7 @@ class SpanTermTest extends BaseTest
         $value = 'match';
 
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $docMisData = [$field => 'mismatch', 'email' => 'test2@test.com'];
         $docHitData = [$field => $value, 'email' => 'test@test.com'];

--- a/test/Elastica/Query/SpanWithinTest.php
+++ b/test/Elastica/Query/SpanWithinTest.php
@@ -65,7 +65,7 @@ class SpanWithinTest extends BaseTest
         $value = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse odio lacus, aliquam nec nulla quis, aliquam eleifend eros.';
 
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $docHitData = [$field => $value];
         $doc = new Document(1, $docHitData);

--- a/test/Elastica/Query/TermsTest.php
+++ b/test/Elastica/Query/TermsTest.php
@@ -13,7 +13,7 @@ class TermsTest extends BaseTest
     public function testFilteredSearch()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('helloworld');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'hello world']),
@@ -42,10 +42,10 @@ class TermsTest extends BaseTest
     public function testFilteredSearchWithLookup()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('helloworld');
+        $type = $index->getType('_doc');
 
         $lookupIndex = $this->_createIndex('lookup_index');
-        $lookupType = $lookupIndex->getType('user');
+        $lookupType = $lookupIndex->getType('_doc');
 
         $lookupType->addDocuments([
             new Document(1, ['terms' => ['ruflin', 'nicolas']]),

--- a/test/Elastica/Query/WildcardTest.php
+++ b/test/Elastica/Query/WildcardTest.php
@@ -61,7 +61,7 @@ class WildcardTest extends BaseTest
         ];
 
         $index->create($indexParams, true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping($type, [
                 'name' => ['type' => 'text', 'analyzer' => 'lw'],

--- a/test/Elastica/QueryTest.php
+++ b/test/Elastica/QueryTest.php
@@ -90,7 +90,7 @@ class QueryTest extends BaseTest
     public function testSetSort()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping($type,
             [
@@ -411,7 +411,7 @@ class QueryTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $type = new Type($index, 'user');
+        $type = new Type($index, '_doc');
 
         // Adds 1 document to the index
         $doc1 = new Document(1,

--- a/test/Elastica/ReindexTest.php
+++ b/test/Elastica/ReindexTest.php
@@ -17,7 +17,7 @@ class ReindexTest extends Base
     public function testReindex()
     {
         $oldIndex = $this->_createIndex('idx1', true, 2);
-        $this->_addDocs($oldIndex->getType('resetTest'), 10);
+        $this->_addDocs($oldIndex->getType('_doc'), 10);
 
         $newIndex = $this->_createIndex('idx2', true, 2);
 
@@ -53,14 +53,14 @@ class ReindexTest extends Base
     public function testReindexTypeOption()
     {
         $oldIndex = $this->_createIndex('', true, 2);
-        $type1 = $oldIndex->getType('crossIndexTest_1');
+        $type1 = $oldIndex->getType('_doc');
 
         $this->_addDocs($type1, 10);
 
         $newIndex = $this->_createIndex(null, true, 2);
 
         $reindex = new Reindex($oldIndex, $newIndex, [
-            Reindex::TYPE => 'crossIndexTest_1',
+            Reindex::TYPE => '_doc',
         ]);
         $reindex->run();
 
@@ -73,7 +73,7 @@ class ReindexTest extends Base
     public function testReindexOpTypeOptionWithProceedSetOnConflicts()
     {
         $oldIndex = $this->_createIndex('idx1', true, 2);
-        $type1 = $oldIndex->getType('crossIndexTest_1');
+        $type1 = $oldIndex->getType('_doc');
 
         $docs1 = $this->_addDocs($type1, 10);
 
@@ -101,7 +101,7 @@ class ReindexTest extends Base
     public function testReindexWithQueryOption()
     {
         $oldIndex = $this->_createIndex('idx1', true, 2);
-        $type1 = $oldIndex->getType('crossIndexTest_1');
+        $type1 = $oldIndex->getType('_doc');
         $docs1 = $this->_addDocs($type1, 10);
 
         $newIndex = $this->_createIndex('idx2', true, 2);
@@ -126,7 +126,7 @@ class ReindexTest extends Base
     public function testReindexWithSizeOption()
     {
         $oldIndex = $this->_createIndex('idx1', true, 2);
-        $type1 = $oldIndex->getType('crossIndexTest_1');
+        $type1 = $oldIndex->getType('_doc');
         $this->_addDocs($type1, 10);
 
         $newIndex = $this->_createIndex('idx2', true, 2);

--- a/test/Elastica/ResponseTest.php
+++ b/test/Elastica/ResponseTest.php
@@ -18,7 +18,7 @@ class ResponseTest extends BaseTest
     public function testResponse()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('helloworld');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping($type, [
             'name' => ['type' => 'text'],
@@ -54,7 +54,7 @@ class ResponseTest extends BaseTest
     public function testIsOk()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $doc = new Document(1, ['name' => 'ruflin']);
         $response = $type->addDocument($doc);
@@ -68,7 +68,7 @@ class ResponseTest extends BaseTest
     public function testIsOkMultiple()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $docs = [
             new Document(1, ['name' => 'ruflin']),

--- a/test/Elastica/ResultSetTest.php
+++ b/test/Elastica/ResultSetTest.php
@@ -14,7 +14,7 @@ class ResultSetTest extends BaseTest
     public function testGetters()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'elastica search']),
@@ -41,7 +41,7 @@ class ResultSetTest extends BaseTest
     public function testArrayAccess()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'elastica search']),
@@ -66,7 +66,7 @@ class ResultSetTest extends BaseTest
     public function testDocumentsAccess()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $type->addDocuments([
             new Document(1, ['name' => 'elastica search']),
@@ -97,7 +97,7 @@ class ResultSetTest extends BaseTest
     public function testInvalidOffsetCreation()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $doc = new Document(1, ['name' => 'elastica search']);
         $type->addDocument($doc);
@@ -116,7 +116,7 @@ class ResultSetTest extends BaseTest
     public function testInvalidOffsetGet()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $doc = new Document(1, ['name' => 'elastica search']);
         $type->addDocument($doc);

--- a/test/Elastica/ResultTest.php
+++ b/test/Elastica/ResultTest.php
@@ -13,8 +13,8 @@ class ResultTest extends BaseTest
      */
     public function testGetters()
     {
-        // Creates a new index 'xodoa' and a type 'user' inside this index
-        $typeName = 'user';
+        // Creates a new index 'xodoa' and a type '_doc' inside this index
+        $typeName = '_doc';
 
         $index = $this->_createIndex();
         $type = $index->getType($typeName);
@@ -49,9 +49,9 @@ class ResultTest extends BaseTest
      */
     public function testGetIdNoSource()
     {
-        // Creates a new index 'xodoa' and a type 'user' inside this index
+        // Creates a new index 'xodoa' and a type '_doc' inside this index
         $indexName = 'xodoa';
-        $typeName = 'user';
+        $typeName = '_doc';
 
         $client = $this->_getClient();
         $index = $client->getIndex($indexName);
@@ -90,7 +90,7 @@ class ResultTest extends BaseTest
      */
     public function testGetTotalTimeReturnsExpectedResults()
     {
-        $typeName = 'user';
+        $typeName = '_doc';
         $index = $this->_createIndex();
         $type = $index->getType($typeName);
 

--- a/test/Elastica/Script/ScriptFieldsTest.php
+++ b/test/Elastica/Script/ScriptFieldsTest.php
@@ -73,7 +73,7 @@ class ScriptFieldsTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $doc = new Document(1, ['firstname' => 'guschti', 'lastname' => 'ruflin']);
         $type->addDocument($doc);
@@ -101,7 +101,7 @@ class ScriptFieldsTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('testscriptfieldwithjoin');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping();
         $mapping->setType($type);
@@ -125,14 +125,14 @@ class ScriptFieldsTest extends BaseTest
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], '_doc');
 
         $doc2 = new Document(2, [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], '_doc');
 
         $index->addDocuments([$doc1, $doc2]);
 
@@ -143,7 +143,7 @@ class ScriptFieldsTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 1,
             ],
-        ], 'test', 'testparentid');
+        ], '_doc', 'testparentid');
 
         $doc4 = new Document(4, [
             'text' => 'this is an answer, the 2nd',
@@ -152,7 +152,7 @@ class ScriptFieldsTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test', 'testparentid');
+        ], '_doc', 'testparentid');
 
         $doc5 = new Document(5, [
             'text' => 'this is an answer, the 3rd',
@@ -161,7 +161,7 @@ class ScriptFieldsTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test', 'testparentid');
+        ], '_doc', 'testparentid');
 
         $this->_getClient()->addDocuments([$doc3, $doc4, $doc5], ['routing' => 1]);
         $index->refresh();

--- a/test/Elastica/ScrollTest.php
+++ b/test/Elastica/ScrollTest.php
@@ -108,7 +108,7 @@ class ScrollTest extends Base
     {
         $index = $this->_createIndex();
         $index->refresh();
-        $type = $index->getType('scrollTest');
+        $type = $index->getType('_doc');
 
         if ($indexSize > 0) {
             $docs = [];

--- a/test/Elastica/SearchTest.php
+++ b/test/Elastica/SearchTest.php
@@ -88,8 +88,8 @@ class SearchTest extends BaseTest
 
         $index = $this->_createIndex();
 
-        $type1 = $index->getType('type1');
-        $type2 = $index->getType('type2');
+        $type1 = $index->getType('_doc');
+        $type2 = $index->getType('_doc');
 
         $this->assertEquals([], $search->getTypes());
 
@@ -125,8 +125,8 @@ class SearchTest extends BaseTest
         $index = $client->getIndex('foo');
 
         $types = [];
-        $types[] = $index->getType('type1');
-        $types[] = $index->getType('type2');
+        $types[] = $index->getType('_doc');
+        $types[] = $index->getType('_doc');
 
         $search->addTypes($types);
 
@@ -182,8 +182,8 @@ class SearchTest extends BaseTest
         $index1 = $this->_createIndex();
         $index2 = $this->_createIndex();
 
-        $type1 = $index1->getType('type1');
-        $type2 = $index1->getType('type2');
+        $type1 = $index1->getType('_doc');
+        $type2 = $index1->getType('_doc');
 
         // No index
         $this->assertEquals('/_search', $search1->getPath());
@@ -217,7 +217,7 @@ class SearchTest extends BaseTest
         $client = $this->_getClient();
         $search1 = new Search($client);
         $index1 = $this->_createIndex();
-        $type1 = $index1->getType('hello1');
+        $type1 = $index1->getType('_doc');
 
         $result = $search1->search([]);
         $this->assertFalse($result->getResponse()->hasError());
@@ -244,7 +244,7 @@ class SearchTest extends BaseTest
         $client = $this->_getClient();
 
         $index = $this->_createIndex();
-        $type = $index->getType('scrolltest');
+        $type = $index->getType('_doc');
 
         $docs = [];
         for ($x = 1; $x <= 10; ++$x) {
@@ -303,7 +303,7 @@ class SearchTest extends BaseTest
         $index = $client->getIndex('zero');
         $index->create(['index' => ['number_of_shards' => 1, 'number_of_replicas' => 0]], true);
 
-        $type = $index->getType('zeroType');
+        $type = $index->getType('_doc');
         $type->addDocuments([
             new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
             new Document(2, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
@@ -346,7 +346,7 @@ class SearchTest extends BaseTest
             $docs[] = new Document($i, ['id' => 1, 'email' => 'test@test.com', 'username' => 'test']);
         }
 
-        $type = $index->getType('zeroType');
+        $type = $index->getType('_doc');
         $type->addDocuments($docs);
         $index->refresh();
 
@@ -425,7 +425,7 @@ class SearchTest extends BaseTest
     {
         $index = $this->_createIndex();
         $doc = new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'ruflin']);
-        $index->getType('test')->addDocument($doc);
+        $index->getType('_doc')->addDocument($doc);
         $index->refresh();
 
         $search = new Search($index->getClient());
@@ -453,7 +453,7 @@ class SearchTest extends BaseTest
         $index = $client->getIndex('zero');
         $index->create(['index' => ['number_of_shards' => 1, 'number_of_replicas' => 0]], true);
 
-        $type = $index->getType('zeroType');
+        $type = $index->getType('_doc');
         $type->addDocuments([
             new Document(1,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
             new Document(2,  ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
@@ -497,7 +497,7 @@ class SearchTest extends BaseTest
 
         $index = $client->getIndex('zero');
         $index->create(['index' => ['number_of_shards' => 1, 'number_of_replicas' => 0]], true);
-        $type = $index->getType('zeroType');
+        $type = $index->getType('_doc');
         $type->addDocuments([
             new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
             new Document(2, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
@@ -537,7 +537,7 @@ class SearchTest extends BaseTest
     {
         $index = $this->_createIndex();
         $search = new Search($index->getClient());
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $doc = new Document(1, ['id' => 1, 'username' => 'ruflin']);
 

--- a/test/Elastica/SnapshotTest.php
+++ b/test/Elastica/SnapshotTest.php
@@ -36,7 +36,7 @@ class SnapshotTest extends Base
             new Document('2', ['city' => 'San Luis Obispo']),
             new Document('3', ['city' => 'San Francisco']),
         ];
-        $this->_index->getType('test')->addDocuments($this->_docs);
+        $this->_index->getType('_doc')->addDocuments($this->_docs);
         $this->_index->refresh();
     }
 
@@ -98,7 +98,7 @@ class SnapshotTest extends Base
         $this->_index->forcemerge();
 
         // ensure that the index has been restored
-        $count = $this->_index->getType('test')->count();
+        $count = $this->_index->getType('_doc')->count();
         $this->assertEquals(sizeof($this->_docs), $count);
 
         // delete the snapshot

--- a/test/Elastica/Suggest/CompletionTest.php
+++ b/test/Elastica/Suggest/CompletionTest.php
@@ -16,7 +16,7 @@ class CompletionTest extends BaseTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('song');
+        $type = $index->getType('_doc');
 
         $type->setMapping([
             'fieldName' => [

--- a/test/Elastica/Suggest/PhraseTest.php
+++ b/test/Elastica/Suggest/PhraseTest.php
@@ -16,7 +16,7 @@ class PhraseTest extends BaseTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('testSuggestType');
+        $type = $index->getType('_doc');
         $type->addDocuments([
             new Document(1, ['text' => 'Github is pretty cool']),
             new Document(2, ['text' => 'Elasticsearch is bonsai cool']),

--- a/test/Elastica/Suggest/TermTest.php
+++ b/test/Elastica/Suggest/TermTest.php
@@ -15,7 +15,7 @@ class TermTest extends BaseTest
     protected function _getIndexForTest()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('testSuggestType');
+        $type = $index->getType('_doc');
         $type->addDocuments([
             new Document(1, ['id' => 1, 'text' => 'GitHub']),
             new Document(2, ['id' => 1, 'text' => 'Elastic']),

--- a/test/Elastica/TaskTest.php
+++ b/test/Elastica/TaskTest.php
@@ -108,7 +108,7 @@ class TaskTest extends Base
     protected function _createIndexWithDocument(): \Elastica\Index
     {
         $index = $this->_createIndex();
-        $type1 = new Type($index, 'test');
+        $type1 = new Type($index, '_doc');
         $type1->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $index->refresh();
 

--- a/test/Elastica/Transport/AbstractTransportTest.php
+++ b/test/Elastica/Transport/AbstractTransportTest.php
@@ -114,7 +114,7 @@ class AbstractTransportTest extends BaseTest
         $index = $client->getIndex('elastica_testbooleanstringvalues');
 
         $doc = new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'ruflin']);
-        $index->getType('test')->addDocument($doc);
+        $index->getType('_doc')->addDocument($doc);
         $index->refresh();
 
         $search = new Search($index->getClient());

--- a/test/Elastica/Transport/GuzzleTest.php
+++ b/test/Elastica/Transport/GuzzleTest.php
@@ -48,7 +48,7 @@ class GuzzleTest extends BaseTest
 
         $index = $client->getIndex('dynamic_http_method_test');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->addDocument(new Document(1, ['test' => 'test']));
         $index->refresh();
         $resultSet = $index->search('test');
@@ -143,7 +143,7 @@ class GuzzleTest extends BaseTest
         $index->create([], true);
         $this->_waitForAllocation($index);
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->addDocument(new Document(1, ['test' => 'test']));
 
         $index->refresh();

--- a/test/Elastica/Transport/HttpTest.php
+++ b/test/Elastica/Transport/HttpTest.php
@@ -43,7 +43,7 @@ class HttpTest extends BaseTest
         $index->create([], true);
         $this->_waitForAllocation($index);
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->addDocument(new Document(1, ['test' => 'test']));
 
         $index->refresh();
@@ -77,7 +77,7 @@ class HttpTest extends BaseTest
         $index->create([], true);
         $this->_waitForAllocation($index);
 
-        $type = $index->getType('item');
+        $type = $index->getType('_doc');
         // Force HEAD request to set CURLOPT_NOBODY = true
         $index->exists();
 
@@ -106,7 +106,7 @@ class HttpTest extends BaseTest
         $index->create([], true);
         $this->_waitForAllocation($index);
 
-        $type = $index->getType('item');
+        $type = $index->getType('_doc');
 
         // Force HEAD request to set CURLOPT_NOBODY = true
         $index->exists();
@@ -203,7 +203,7 @@ class HttpTest extends BaseTest
         $index->create([], true);
         $this->_waitForAllocation($index);
 
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $type->addDocument(new Document(1, ['test' => 'test']));
 
         $index->refresh();

--- a/test/Elastica/Transport/TransportBenchmarkTest.php
+++ b/test/Elastica/Transport/TransportBenchmarkTest.php
@@ -39,7 +39,7 @@ class TransportBenchmarkTest extends BaseTest
         $index = $client->getIndex('benchmark'.uniqid());
         $index->create(['index' => ['number_of_shards' => 1, 'number_of_replicas' => 0]], true);
 
-        return $index->getType('benchmark');
+        return $index->getType('_doc');
     }
 
     /**
@@ -131,7 +131,7 @@ class TransportBenchmarkTest extends BaseTest
         $client = $this->_getClient($config);
         $index = $client->getIndex('benchmark');
         $index->create([], true);
-        $type = $index->getType('mappingTest');
+        $type = $index->getType('_doc');
 
         // Define mapping
         $mapping = new Mapping();

--- a/test/Elastica/Type/MappingTest.php
+++ b/test/Elastica/Type/MappingTest.php
@@ -19,7 +19,7 @@ class MappingTest extends BaseTest
         $index = $client->getIndex('test');
 
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping($type,
             [
@@ -72,7 +72,7 @@ class MappingTest extends BaseTest
         $index = $client->getIndex('test');
 
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping($type,
             [
@@ -118,7 +118,7 @@ class MappingTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('testjoinparentid');
         $index->create([], true);
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping();
         $mapping->setType($type);
@@ -135,7 +135,7 @@ class MappingTest extends BaseTest
         ]);
 
         $expected = [
-            'test' => [
+            '_doc' => [
                 'properties' => [
                     'firstname' => ['type' => 'text', 'store' => true],
                     'lastname' => ['type' => 'text'],
@@ -157,14 +157,14 @@ class MappingTest extends BaseTest
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], '_doc');
 
         $doc2 = new Document(2, [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
             ],
-        ], 'test');
+        ], '_doc');
 
         $index->addDocuments([$doc1, $doc2]);
 
@@ -174,7 +174,7 @@ class MappingTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 1,
             ],
-        ], 'test');
+        ], '_doc');
 
         $doc4 = new Document(4, [
             'text' => 'this is an answer, the 2nd',
@@ -182,7 +182,7 @@ class MappingTest extends BaseTest
                 'name' => 'answer',
                 'parent' => 2,
             ],
-        ], 'test');
+        ], '_doc');
 
         $index->addDocuments([$doc3, $doc4]);
         $index->refresh();
@@ -201,7 +201,7 @@ class MappingTest extends BaseTest
     public function testMappingExample()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('notes');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping($type,
             [
@@ -247,7 +247,7 @@ class MappingTest extends BaseTest
     public function testDynamicTemplate()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('person');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping($type);
         $mapping->setParam('dynamic_templates', [
@@ -275,7 +275,7 @@ class MappingTest extends BaseTest
         $newMapping = $type->getMapping();
         $this->assertArraySubset(
             [
-                'person' => [
+                '_doc' => [
                     'properties' => [
                         'multiname' => [
                             'type' => 'text',
@@ -302,7 +302,7 @@ class MappingTest extends BaseTest
     public function testSetMeta()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $mapping = new Mapping($type, [
             'firstname' => ['type' => 'text', 'store' => true],
             'lastname' => ['type' => 'text'],
@@ -311,7 +311,7 @@ class MappingTest extends BaseTest
         $type->setMapping($mapping);
 
         $mappingData = $type->getMapping();
-        $this->assertEquals('test', $mappingData['test']['_meta']['class']);
+        $this->assertEquals('test', $mappingData['_doc']['_meta']['class']);
 
         $index->delete();
     }
@@ -322,7 +322,7 @@ class MappingTest extends BaseTest
     public function testGetters()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test');
+        $type = $index->getType('_doc');
         $properties = [
             'firstname' => ['type' => 'text', 'store' => true],
             'lastname' => ['type' => 'text'],

--- a/test/Elastica/TypeTest.php
+++ b/test/Elastica/TypeTest.php
@@ -24,7 +24,7 @@ class TypeTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $type = new Type($index, 'user');
+        $type = new Type($index, '_doc');
 
         // Adds 1 document to the index
         $doc1 = new Document(1,
@@ -63,7 +63,7 @@ class TypeTest extends BaseTest
     {
         $client = $this->_getClient();
         $index = new Index($client, 'test_index');
-        $type = new Type($index, 'test_type');
+        $type = new Type($index, '_doc');
 
         $query = new QueryString('test');
         $options = [
@@ -88,10 +88,10 @@ class TypeTest extends BaseTest
         $this->assertTrue($search->hasIndex($index));
         $this->assertTrue($search->hasIndex('test_index'));
         $this->assertFalse($search->hasIndex('test'));
-        $this->assertEquals(['test_type'], $search->getTypes());
+        $this->assertEquals(['_doc'], $search->getTypes());
         $this->assertTrue($search->hasTypes());
         $this->assertTrue($search->hasType($type));
-        $this->assertTrue($search->hasType('test_type'));
+        $this->assertTrue($search->hasType('_doc'));
         $this->assertFalse($search->hasType('test_type2'));
     }
 
@@ -102,7 +102,7 @@ class TypeTest extends BaseTest
     {
         $client = $this->_getClient();
         $index = new Index($client, 'test_index');
-        $type = new Type($index, 'test_type');
+        $type = new Type($index, '_doc');
 
         $query = [
             'query' => [
@@ -134,10 +134,10 @@ class TypeTest extends BaseTest
         $this->assertTrue($search->hasIndex($index));
         $this->assertTrue($search->hasIndex('test_index'));
         $this->assertFalse($search->hasIndex('test'));
-        $this->assertEquals(['test_type'], $search->getTypes());
+        $this->assertEquals(['_doc'], $search->getTypes());
         $this->assertTrue($search->hasTypes());
         $this->assertTrue($search->hasType($type));
-        $this->assertTrue($search->hasType('test_type'));
+        $this->assertTrue($search->hasType('_doc'));
         $this->assertFalse($search->hasType('test_type2'));
     }
 
@@ -148,7 +148,7 @@ class TypeTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $type = new Type($index, 'user');
+        $type = new Type($index, '_doc');
         $mapping = new Mapping($type, [
             'id' => ['type' => 'integer', 'store' => 'true'],
             'username' => ['type' => 'text'],
@@ -158,11 +158,11 @@ class TypeTest extends BaseTest
 
         $mapping = $type->getMapping();
 
-        $this->assertArrayHasKey('user', $mapping);
-        $this->assertArrayHasKey('properties', $mapping['user']);
-        $this->assertArrayHasKey('id', $mapping['user']['properties']);
-        $this->assertArrayHasKey('type', $mapping['user']['properties']['id']);
-        $this->assertEquals('integer', $mapping['user']['properties']['id']['type']);
+        $this->assertArrayHasKey('_doc', $mapping);
+        $this->assertArrayHasKey('properties', $mapping['_doc']);
+        $this->assertArrayHasKey('id', $mapping['_doc']['properties']);
+        $this->assertArrayHasKey('type', $mapping['_doc']['properties']['id']);
+        $this->assertEquals('integer', $mapping['_doc']['properties']['id']['type']);
 
         // Adds 1 document to the index
         $doc1 = new Document(1,
@@ -199,7 +199,7 @@ class TypeTest extends BaseTest
     public function testDeleteById()
     {
         $index = $this->_createIndex();
-        $type = new Type($index, 'user');
+        $type = new Type($index, '_doc');
 
         // Adds hans, john and rolf to the index
         $docs = [
@@ -300,7 +300,7 @@ class TypeTest extends BaseTest
     public function testDeleteDocument()
     {
         $index = $this->_createIndex();
-        $type = new Type($index, 'user');
+        $type = new Type($index, '_doc');
 
         // Adds hans, john and rolf to the index
         $docs = [
@@ -336,7 +336,7 @@ class TypeTest extends BaseTest
     public function testGetDocumentNotExist()
     {
         $index = $this->_createIndex();
-        $type = new Type($index, 'test');
+        $type = new Type($index, '_doc');
         $type->addDocument(new Document(1, ['name' => 'ruflin']));
         $index->refresh();
 
@@ -353,7 +353,7 @@ class TypeTest extends BaseTest
     {
         $client = $this->_getClient();
         $index = new Index($client, 'index');
-        $type = new Type($index, 'type');
+        $type = new Type($index, '_doc');
 
         $type->getDocument(1);
     }
@@ -364,7 +364,7 @@ class TypeTest extends BaseTest
     public function testDeleteByQueryWithQueryString()
     {
         $index = $this->_createIndex();
-        $type = new Type($index, 'test');
+        $type = new Type($index, '_doc');
         $type->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
@@ -395,7 +395,7 @@ class TypeTest extends BaseTest
     public function testDeleteByQueryWithQuery()
     {
         $index = $this->_createIndex();
-        $type = new Type($index, 'test');
+        $type = new Type($index, '_doc');
         $type->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
@@ -426,7 +426,7 @@ class TypeTest extends BaseTest
     public function testDeleteByQueryWithArrayQuery()
     {
         $index = $this->_createIndex();
-        $type = new Type($index, 'test');
+        $type = new Type($index, '_doc');
         $type->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
         $type->addDocument(new Document(2, ['name' => 'ruflin']));
         $index->refresh();
@@ -456,7 +456,7 @@ class TypeTest extends BaseTest
     public function testDeleteByQueryWithQueryAndOptions()
     {
         $index = $this->_createIndex(null, true, 2);
-        $type = new Type($index, 'test');
+        $type = new Type($index, '_doc');
         $doc = new Document(1, ['name' => 'ruflin nicolas']);
         $doc->setRouting('first_routing');
         $type->addDocument($doc);
@@ -510,7 +510,7 @@ class TypeTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $type = new Type($index, 'test');
+        $type = new Type($index, '_doc');
         $mapping = new Mapping();
         $mapping->setProperties([
             'name' => [
@@ -562,7 +562,7 @@ class TypeTest extends BaseTest
         $docs[] = new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']);
         $docs[] = new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']);
 
-        $type = $index->getType('zeroType');
+        $type = $index->getType('_doc');
         $type->addDocuments($docs);
         $index->refresh();
 
@@ -582,7 +582,7 @@ class TypeTest extends BaseTest
     {
         $client = $this->_getClient();
         $index = $client->getIndex('elastica_test');
-        $type = $index->getType('update_type');
+        $type = $index->getType('_doc');
         $id = 1;
         $type->addDocument(new Document($id, ['name' => 'bruce wayne batman', 'counter' => 1]));
         $newName = 'batman';
@@ -612,7 +612,7 @@ class TypeTest extends BaseTest
     {
         $client = $this->_getClient();
         $index = $client->getIndex('elastica_test');
-        $type = $index->getType('update_type');
+        $type = $index->getType('_doc');
         $id = '/id/with/forward/slashes';
         $type->addDocument(new Document($id, ['name' => 'bruce wayne batman', 'counter' => 1]));
         $newName = 'batman';
@@ -642,7 +642,7 @@ class TypeTest extends BaseTest
     {
         $client = $this->_getClient();
         $index = $client->getIndex('elastica_test');
-        $type = $index->getType('update_type');
+        $type = $index->getType('_doc');
         $id = 1;
         $type->addDocument(new Document($id, ['name' => 'bruce wayne batman', 'counter' => 1]));
         $newName = 'batman';
@@ -681,7 +681,7 @@ class TypeTest extends BaseTest
     {
         $client = $this->_getClient();
         $index = $client->getIndex('elastica_test');
-        $type = $index->getType('update_type');
+        $type = $index->getType('_doc');
 
         $client->setConfigValue('document', ['autoPopulate' => true]);
 
@@ -731,7 +731,7 @@ class TypeTest extends BaseTest
     {
         $index = $this->_createIndex();
         $this->_waitForAllocation($index);
-        $type = $index->getType('elastica_type');
+        $type = $index->getType('_doc');
 
         $document = new Document();
 
@@ -744,7 +744,7 @@ class TypeTest extends BaseTest
     public function testUpdateDocumentWithoutSource()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('elastica_type');
+        $type = $index->getType('_doc');
 
         $mapping = new Mapping();
         $mapping->setProperties([
@@ -797,7 +797,7 @@ class TypeTest extends BaseTest
     public function testAddDocumentHashId()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('test2');
+        $type = $index->getType('_doc');
 
         $hashId = '#1';
 
@@ -821,7 +821,7 @@ class TypeTest extends BaseTest
     public function testAddDocumentAutoGeneratedId()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('elastica_type');
+        $type = $index->getType('_doc');
 
         $document = new Document();
         $document->setAutoPopulate();
@@ -848,7 +848,7 @@ class TypeTest extends BaseTest
     public function testAddDocumentPipeline()
     {
         $index = $this->_createIndex();
-        $type = $index->getType('elastica_type');
+        $type = $index->getType('_doc');
         $this->_createRenamePipeline();
 
         $document = new Document();
@@ -875,7 +875,7 @@ class TypeTest extends BaseTest
         $index = $this->_createIndex();
         $this->_waitForAllocation($index);
 
-        $type = new Type($index, 'user');
+        $type = new Type($index, '_doc');
 
         $type->addObject(new \stdClass());
     }
@@ -887,7 +887,7 @@ class TypeTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $type = new Type($index, 'user');
+        $type = new Type($index, '_doc');
         $type->setSerializer('get_object_vars');
 
         $userObject = new \stdClass();
@@ -913,7 +913,7 @@ class TypeTest extends BaseTest
     public function testSetSerializer()
     {
         $index = $this->_getClient()->getIndex('foo');
-        $type = $index->getType('user');
+        $type = $index->getType('_doc');
         $ret = $type->setSerializer('get_object_vars');
         $this->assertInstanceOf(Type::class, $ret);
     }
@@ -926,7 +926,7 @@ class TypeTest extends BaseTest
         $index = $this->_createIndex();
         $this->assertTrue($index->exists());
 
-        $type = new Type($index, 'user');
+        $type = new Type($index, '_doc');
         $this->assertFalse($type->exists());
 
         $type->addDocument(new Document(1, ['name' => 'test name']));
@@ -995,7 +995,7 @@ class TypeTest extends BaseTest
     public function testRequestEndpoint()
     {
         $index = $this->_createIndex();
-        $type = new Type($index, 'foo');
+        $type = new Type($index, '_doc');
 
         $mapping = new Mapping($type, $expect = [
             'id' => ['type' => 'integer', 'store' => true],
@@ -1011,7 +1011,7 @@ class TypeTest extends BaseTest
         $mapping = array_shift($data);
 
         $this->assertEquals(
-            ['foo' => ['properties' => $expect]],
+            ['_doc' => ['properties' => $expect]],
             $mapping['mappings']
         );
     }
@@ -1022,8 +1022,8 @@ class TypeTest extends BaseTest
     public function testExceptionWithTwoMappingType()
     {
         $index = $this->_createIndex();
-        $type1 = new Type($index, 'foo');
-        $type2 = new Type($index, 'bar');
+        $type1 = new Type($index, '_doc');
+        $type2 = new Type($index, '_doc');
 
         $mapping = new Mapping(null, $expect = [
             'text' => ['type' => 'text', 'analyzer' => 'standard'],


### PR DESCRIPTION
The preferred type name is [_doc](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/removal-of-types.html), so that index APIs have the same path as they will have in 7.0.

As agreed in #1563 I extracted the ```_doc``` commit as we can merge it into 6.x branch.