### PR TITLE
Update linting strategies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,20 +31,41 @@ To run all tests inside the docker environment, run the following command:
 make tests
 ```
 
-If you want to run just a specific test or a one specific file, run the following command by replacing your file with the existingpath:
+If you want to run just a specific test or a one specific file, run the following command by replacing your file with the existing path:
 
 ```
 make test TEST="test/lib/Elastica/Test/SearchTest.php"
 ```
 
 ## Check style of your code
-This command will call php-cs-fixer with the predefined settings for the elastica project. No local setup of the tools is needed as everything will happen directly in the container.
+This command will call php-cs-fixer (2.x) with the predefined settings for the elastica project.
+You need to execute it before open a Pull Request; Travis build will do check for style if they
+are not respected **build will fail**. 
+No local setup of the tools is needed as everything will happen directly in the container.
+
 ```
 make lint
 ```
 
+and
 
+```
+make check-style
+```
+will do a check executing php-cs-fixer in ```dry-run``` mode. It is usually executed during Travis build.
 
+  Exit codes
+  ----------
+
+  Exit code is built using following bit flags:
+
+  *  0 OK.
+  *  1 General error (or PHP minimal requirement not matched).
+  *  4 Some files have invalid syntax (only in dry-run mode).
+  *  8 Some files need fixing (only in dry-run mode).
+  * 16 Configuration error of the application.
+  * 32 Configuration error of a Fixer.
+  * 64 Exception raised within the application.
 
 Coding
 ------

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ TARGET?=70
 # By default docker environment is used to run commands. To run without the predefined environment, set RUN_ENV=" " either as parameter or as environment variable
 ifndef RUN_ENV
 	RUN_ENV = docker run --workdir="/elastica" -v $(shell pwd):/elastica ruflin/elastica-dev-base
+	RUN_ENV_LINT = docker run --workdir="/elastica" -v $(shell pwd):/elastica ruflin/elastica-dev-base-linter
 endif
 
 .PHONY: clean
@@ -79,16 +80,13 @@ doc:
 # Uses the preconfigured standards in .php_cs
 .PHONY: lint
 lint:
-	${RUN_ENV} php-cs-fixer fix --allow-risky=yes
+	docker build -t ruflin/elastica-dev-base-linter -f env/elastica/Lint env/elastica/
+	${RUN_ENV_LINT} php-cs-fixer fix --allow-risky=yes
 
 .PHONY: check-style
 check-style:
-	docker build -t ruflin/elastica-dev-base -f env/elastica/${TARGET} env/elastica/
-	docker build -t ruflin/elastica .
-	make start
-	mkdir -p build
-
-	${RUN_ENV} php-cs-fixer fix --allow-risky=yes --dry-run
+	docker build -t ruflin/elastica-dev-base-linter -f env/elastica/Lint env/elastica/
+	${RUN_ENV_LINT} php-cs-fixer fix --allow-risky=yes --dry-run
 
 .PHONY: loc
 loc:


### PR DESCRIPTION
In order to make ```check-style``` and linting ```quicker``` I removed from Make action
the whole stack build. To have code fixed we don't need an Elasticsearch Cluster up and running.
