### PR TITLE
Fix docblock for Index:analyze

### DIFF
--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -563,12 +563,12 @@ class Index implements SearchableInterface
     }
 
     /**
-     * Analyzes a string.
+     * Analyzes a string, or a list of strings.
      *
      * Detailed arguments can be found here in the link
      *
-     * @param string $text String to be analyzed
-     * @param array  $args OPTIONAL Additional arguments
+     * @param string[]|string $text String or list of strings to be analyzed
+     * @param array           $args OPTIONAL Additional arguments
      *
      * @return array Server response
      *

--- a/test/Elastica/IndexTest.php
+++ b/test/Elastica/IndexTest.php
@@ -893,24 +893,51 @@ class IndexTest extends BaseTest
         $this->assertEquals(0, $stats['_all']['primaries']['docs']['deleted']);
     }
 
+
+    public function analyzeDataProvider()
+    {
+        return [
+            'single-keyword' => [
+                'foo',
+                [[
+                    'token' => 'foo',
+                    'start_offset' => 0,
+                    'end_offset' => 3,
+                    'type' => '<ALPHANUM>',
+                    'position' => 0,
+                ]],
+            ],
+            'multi-keyword' => [
+                ['foo', 'bar'],
+                [
+                    [
+                        'token' => 'foo',
+                        'start_offset' => 0,
+                        'end_offset' => 3,
+                        'type' => '<ALPHANUM>',
+                        'position' => 0,
+                    ],                    [
+                        'token' => 'bar',
+                        'start_offset' => 4,
+                        'end_offset' => 7,
+                        'type' => '<ALPHANUM>',
+                        'position' => 101,
+                    ],
+                ],
+            ]
+        ];
+
+    }
+
     /**
      * @group functional
+     * @dataProvider analyzeDataProvider
      */
-    public function testAnalyze()
+    public function testAnalyze($text, $tokens)
     {
         $index = $this->_createIndex();
         $index->refresh();
-        $returnedTokens = $index->analyze('foo');
-
-        $tokens = [
-            [
-                'token' => 'foo',
-                'start_offset' => 0,
-                'end_offset' => 3,
-                'type' => '<ALPHANUM>',
-                'position' => 0,
-            ],
-        ];
+        $returnedTokens = $index->analyze($text);
 
         $this->assertEquals($tokens, $returnedTokens);
     }


### PR DESCRIPTION
The Analyze API call allows the `text` to be passed as an array of strings: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html#indices-analyze (second example)