### PR TITLE
empty the raw response string after parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 
+* Reduced memory footprint of response by not keeping the raw JSON data when JSON after JSON has been parsed. [#1588](https://github.com/ruflin/Elastica/pull/1588)
+
 ### Deprecated
 
 ## [6.1.0](https://github.com/ruflin/Elastica/compare/6.0.2...6.1.0)

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -235,6 +235,7 @@ class Response
             }
 
             $this->_response = $response;
+            $this->_responseString = '';
         }
 
         return $this->_response;


### PR DESCRIPTION
when a query yields a large response, duplicating the data between string and parsed array duplicates the memory consumption.
once $this->_response is set, $this->_responseString is not accessed anywhere in the code anymore.