### PR TITLE
empty the raw response string after parsing (backport #1588 to 5.x branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/ruflin/Elastica/compare/5.3.2...master)
+
+## [Unreleased](https://github.com/ruflin/Elastica/compare/5.3.3...master)
 
 ### Backward Compatibility Breaks
 
@@ -10,6 +11,15 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 ### Improvements
+
+- [Backported] Reduced memory footprint of response by not keeping the raw JSON data when JSON after JSON has been parsed. [#1588](https://github.com/ruflin/Elastica/pull/1588)
+
+
+## [5.3.3](https://github.com/ruflin/Elastica/compare/5.3.2...5.3.3)
+
+### Bugfixes
+
+- [Backported] Corrected phpdoc types to avoid warnings from code quality tools. [#1525](https://github.com/ruflin/Elastica/pull/1525)
 
 
 ## [5.3.2](https://github.com/ruflin/Elastica/compare/5.3.1...5.3.2)

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -234,6 +234,7 @@ class Response
             }
 
             $this->_response = $response;
+            $this->_responseString = '';
         }
 
         return $this->_response;


### PR DESCRIPTION
found out we are still on elasticsearch 5 and can't easily upgrade that. can we get this fix in a 5.x release please?