### PR TITLE
Fix PhpDocBlock current()

### DIFF
--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -236,7 +236,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     /**
      * Returns the current object of the set.
      *
-     * @return \Elastica\Result|bool Set object or false if not valid (no more entries)
+     * @return \Elastica\Result|false Set object or false if not valid (no more entries)
      */
     public function current()
     {


### PR DESCRIPTION
The `ResultSet::current()` returns `\Elastica\Resut` or` false`, never a "boolean"

The change is only needed for the `5.x` branch, in the latest `master` the PHP DocBlock is correct.