### PR TITLE
Implement an ErrorTransport (#1529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 * Added a transport class for mocking a HTTP 403 error codes, useful for testing response failures in inheriting clients
-* [Field](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-random) param for `Elastica\Query\FunctionScore::addRandomScoreFunction`
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file based on the
 
 ### Added
 
+* Added a transport class for mocking a HTTP 403 error codes, useful for testing response failures in inheriting clients
+* [Field](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-random) param for `Elastica\Query\FunctionScore::addRandomScoreFunction`
+
 ### Improvements
 
 - [Backported] Reduced memory footprint of response by not keeping the raw JSON data when JSON after JSON has been parsed. [#1588](https://github.com/ruflin/Elastica/pull/1588)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 * Added a transport class for mocking a HTTP 403 error codes, useful for testing response failures in inheriting clients
+[#1529](https://github.com/ruflin/Elastica/pull/1529)
+* [Backported] Added a transport class for mocking a HTTP 403 error codes, useful for testing response failures in inheriting clients
+[#1592](https://github.com/ruflin/Elastica/pull/1592)
 
 ### Improvements
 

--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -83,7 +83,8 @@ class Guzzle extends AbstractTransport
             throw new GuzzleException($ex, $request, new Response($ex->getMessage()));
         }
 
-        $response = new Response((string) $res->getBody(), $res->getStatusCode());
+        $responseBody = (string) $res->getBody();
+        $response = new Response($responseBody, $res->getStatusCode());
         $response->setQueryTime($end - $start);
         if ($connection->hasConfig('bigintConversion')) {
             $response->setJsonBigintConversion($connection->getConfig('bigintConversion'));
@@ -93,6 +94,7 @@ class Guzzle extends AbstractTransport
             [
                 'request_header' => $request->getMethod(),
                 'http_code' => $res->getStatusCode(),
+                'body' => $responseBody,
             ]
         );
 

--- a/lib/Elastica/Transport/NullTransport.php
+++ b/lib/Elastica/Transport/NullTransport.php
@@ -12,18 +12,50 @@ use Elastica\Response;
  * host but still returns a valid response object
  *
  * @author James Boehmer <james.boehmer@jamesboehmer.com>
+ * @author Jan Domanski <jandom@gmail.com>
  */
 class NullTransport extends AbstractTransport
 {
     /**
-     * Null transport.
+     * Response you want to get from the transport
      *
-     * @param \Elastica\Request $request
+     * @var Response Response
+     */
+    protected $_response = null;
+
+    /**
+     * Set response object the transport returns
+     *
+     * @param \Elastica\Response $response
+     *
+     * @return $this
+     */
+    public function getResponse()
+    {
+        return $this->_response;
+    }
+
+    /**
+     * Set response object the transport returns
+     *
+     * @param \Elastica\Response $response
+     *
+     * @return $this
+     */
+    public function setResponse(Response $response)
+    {
+        $this->_response = $response;
+        return $this->_response;
+    }
+
+    /**
+     * Generate an example response object
+     *
      * @param array             $params  Hostname, port, path, ...
      *
-     * @return \Elastica\Response Response empty object
+     * @return \Elastica\Response $response
      */
-    public function exec(Request $request, array $params)
+    public function generateDefaultResponse(array $params)
     {
         $response = [
             'took' => 0,
@@ -40,7 +72,25 @@ class NullTransport extends AbstractTransport
             ],
             'params' => $params,
         ];
-
         return new Response(JSON::stringify($response));
+    }
+
+    /**
+     * Null transport.
+     *
+     * @param \Elastica\Request $request
+     * @param array             $params  Hostname, port, path, ...
+     *
+     * @return \Elastica\Response Response empty object
+     */
+    public function exec(Request $request, array $params)
+    {
+        $response = $this->getResponse();
+
+        if (!$response) {
+            $response = $this->generateDefaultResponse($params);
+        }
+
+        return $response;
     }
 }

--- a/test/Elastica/Transport/NullTransportTest.php
+++ b/test/Elastica/Transport/NullTransportTest.php
@@ -12,9 +12,20 @@ use Elastica\Transport\NullTransport;
  * Elastica Null Transport Test.
  *
  * @author James Boehmer <james.boehmer@jamesboehmer.com>
+ * @author Jan Domanski <jandom@gmail.com>
  */
 class NullTransportTest extends BaseTest
 {
+
+    /** @var NullTransport NullTransport */
+    protected $transport;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->transport = new NullTransport();
+    }
+
     /**
      * @group functional
      */
@@ -95,5 +106,30 @@ class NullTransportTest extends BaseTest
 
         $data = $response->getData();
         $this->assertEquals($params, $data['params']);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testResponse()
+    {
+        $resposeString = '';
+        $response = new Response($resposeString);
+        $this->transport->setResponse($response);
+        $this->assertEquals($response, $this->transport->getResponse());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testGenerateDefaultResponse()
+    {
+        $params = [ 'blah' => 123 ];
+        $response = $this->transport->generateDefaultResponse($params);
+        $this->assertEquals([], $response->getTransferInfo());
+
+        $responseData = $response->getData();
+        $this->assertContains('params', $responseData);
+        $this->assertEquals($params, $responseData['params']);
     }
 }


### PR DESCRIPTION
This is backport of ErrorTransport onto the 5.x branch, all tests pass for me locally

Need this PR merged to close another one https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1465

Also requesting a version bump on 5.x otherwise I won't be able to configure composer.json correctly in FOSElasticaBundle

```
When using AwsAuthV4 transport, it is possible that the user provides incorrect credentials.

This means that the Guzzle client will get a 403 from AWS.

By default Guzzle silently ignores all exceptions and stores them in `$response->setTransferInfo()`

This feature allows a downstream client/library to handle them however.

Currently, FOSElastica does nothing to process 403 or other errors that come back from ruflin/Elastica (transferInfo is never used).

This causes a problem because 403 are silently ignored and the progress bar appears to be moving unhindered ;-)

This PR is a pre-requisite for unit tests that will accompany this fix on FOSElastica
# Conflicts:
#	test/Elastica/Transport/NullTransportTest.php
```