### PR TITLE
Add support for returning the aggregation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file based on the
 * Added `DerivativeAggregation` [#1553](https://github.com/ruflin/Elastica/pull/1553)
 * The preferred type name is [_doc](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/removal-of-types.html), so that index APIs have the same path as they will have in 7.0
 * Introduced new version of PHP-CS-Fixer and new Lint travis step. [#1555](https://github.com/ruflin/Elastica/pull/1555)
+* Added `typed_keys` support for Search queries [#1603](https://github.com/ruflin/Elastica/pull/1603)
 
 ### Improvements
 

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -29,6 +29,7 @@ class Search
     const OPTION_TERMINATE_AFTER = 'terminate_after';
     const OPTION_SHARD_REQUEST_CACHE = 'request_cache';
     const OPTION_FILTER_PATH = 'filter_path';
+    const OPTION_TYPED_KEYS = 'typed_keys';
 
     /*
      * Search types
@@ -293,6 +294,7 @@ class Search
             case self::OPTION_TERMINATE_AFTER:
             case self::OPTION_SHARD_REQUEST_CACHE:
             case self::OPTION_FILTER_PATH:
+            case self::OPTION_TYPED_KEYS:
                 return true;
         }
 

--- a/test/Elastica/SearchTest.php
+++ b/test/Elastica/SearchTest.php
@@ -2,6 +2,7 @@
 
 namespace Elastica\Test;
 
+use Elastica\Aggregation\Cardinality;
 use Elastica\Client;
 use Elastica\Document;
 use Elastica\Exception\ResponseException;
@@ -395,6 +396,11 @@ class SearchTest extends BaseTest
         $filteredData = $resultSet->getResponse()->getData();
         $this->assertArrayNotHasKey('took', $filteredData);
         $this->assertArrayNotHasKey('max_score', $filteredData['hits']);
+
+        //test with typed_keys
+        $countIds = (new Cardinality('count_ids'))->setField('id');
+        $resultSet = $search->search((new Query())->addAggregation($countIds), [Search::OPTION_TYPED_KEYS => true]);
+        $this->assertNotEmpty($resultSet->getAggregation('cardinality#count_ids'));
 
         //Timeout - this one is a bit more tricky to test
         $mockResponse = new Response(json_encode(['timed_out' => true]));


### PR DESCRIPTION
As specified in: https://www.elastic.co/guide/en/elasticsearch/reference/6.x/returning-aggregation-type.html

The `typed_keys` option can be useful to know the type of the aggregation when parsing the results