### PR TITLE
Remove QueryString::setAutoGeneratePhraseQueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Backward Compatibility Breaks
 * \Elastica\AbstractUpdateAction::getOptions( $fields ) no longer supports the $underscore parameter, option names must match what elasticsearch expects.
+* Removed no longer supported \Elastica\Query\QueryString::setAutoGeneratePhraseQueries( $bool ) [#1622](https://github.com/ruflin/Elastica/pull/1622)
 
 ### Bugfixes
 * Always set the Guzzle `base_uri` to support connecting to multiple ES hosts. [#1618](https://github.com/ruflin/Elastica/pull/1618)

--- a/lib/Elastica/Query/QueryString.php
+++ b/lib/Elastica/Query/QueryString.php
@@ -181,20 +181,6 @@ class QueryString extends AbstractQuery
     }
 
     /**
-     * Sets the param to automatically generate phrase queries.
-     *
-     * If not set, defaults to true.
-     *
-     * @param bool $autoGenerate
-     *
-     * @return $this
-     */
-    public function setAutoGeneratePhraseQueries(bool $autoGenerate = true): self
-    {
-        return $this->setParam('auto_generate_phrase_queries', $autoGenerate);
-    }
-
-    /**
      * Sets the fields. If no fields are set, _all is chosen.
      * You cannot set fields and default_field.
      *

--- a/test/Elastica/Query/QueryStringTest.php
+++ b/test/Elastica/Query/QueryStringTest.php
@@ -219,18 +219,6 @@ class QueryStringTest extends BaseTest
     /**
      * @group unit
      */
-    public function testSetAutoGeneratePhraseQueries()
-    {
-        $value = true;
-        $query = new QueryString('test');
-        $query->setAutoGeneratePhraseQueries($value);
-
-        $this->assertEquals($value, $query->toArray()['query_string']['auto_generate_phrase_queries']);
-    }
-
-    /**
-     * @group unit
-     */
     public function testSetTieBreaker()
     {
         $value = 0.2;


### PR DESCRIPTION
Completely ignored since 6.x