### PR TITLE
Improve error to include caused_by reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 * Added `native_function_invocation` CS rule [#1606](https://github.com/ruflin/Elastica/pull/1606)
 * Elasticsearch test version changed from 6.5.2 to 6.6.1 [#1620](https://github.com/ruflin/Elastica/pull/1620)
+* Added `caused_by` to exception responses to clarify errors [#1623](https://github.com/ruflin/Elastica/pull/1623)
 
 ### Deprecated
 

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -94,6 +94,7 @@ class Response
 
         if (isset($error['root_cause'][0])) {
             $rootError = $error['root_cause'][0];
+            $message = $rootError['reason'];
 
             if (isset($error['caused_by'])) {
                 $message .= sprintf(

--- a/lib/Elastica/Response.php
+++ b/lib/Elastica/Response.php
@@ -90,11 +90,20 @@ class Response
         }
 
         $rootError = $error;
+        $message = $rootError['reason'];
+
         if (isset($error['root_cause'][0])) {
             $rootError = $error['root_cause'][0];
+
+            if (isset($error['caused_by'])) {
+                $message .= sprintf(
+                    ' [%s:%s]',
+                    $error['caused_by']['caused_by']['type'],
+                    $error['caused_by']['caused_by']['reason']
+                );
+            }
         }
 
-        $message = $rootError['reason'];
         if (isset($rootError['index'])) {
             $message .= ' [index: '.$rootError['index'].']';
         }


### PR DESCRIPTION
Instead of 

`[reason: failed to execute script]`

You will now get more details about the failure:

`[illegal_argument_exception:Variable [count] is not defined.] [reason: failed to execute script]`