### PR TITLE
Improvements on the Reindex API to support more options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file based on the
 * The parameter [fields](https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html#_the_parameter_literal_fields_literal_deprecated_in_6_x_has_been_removed_from_bulk_request) deprecated in 6.x has been removed from Bulk requestedit and Update request.
 * The [_parent](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-parent-field.html) field has been removed in favour of the join field.
 * hits.total is now an object in the search response [hits.total](https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html#_literal_hits_total_literal_is_now_an_object_in_the_search_response) 
+* Elastica\Reindex does not return an Index anymore but a Response.
+* Elastica\Reindex->run() does not refresh the new Index after completion anymore. Use `$reindex->setParam(Reindex::REFRESH, 'wait_for')` instead.
 
 ### Bugfixes
 * Always set the Guzzle `base_uri` to support connecting to multiple ES hosts. [#1618](https://github.com/ruflin/Elastica/pull/1618)
@@ -21,6 +23,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 * Added `ParentAggregation` [#1616](https://github.com/ruflin/Elastica/pull/1616)
+* Elastica\Reindex missing options (script, remote, wait_for_completion, scroll...)
 
 ### Improvements
 * Added `native_function_invocation` CS rule [#1606](https://github.com/ruflin/Elastica/pull/1606)
@@ -28,7 +31,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Deprecated
 
-## [Unreleased](https://github.com/ruflin/Elastica/compare/6.1.0...6.1.1)
+## [6.1.1](https://github.com/ruflin/Elastica/compare/6.1.0...6.1.1)
 
 ### Added
 

--- a/lib/Elastica/Reindex.php
+++ b/lib/Elastica/Reindex.php
@@ -16,8 +16,13 @@ class Reindex extends Param
     const TYPE = 'type';
     const SIZE = 'size';
     const QUERY = 'query';
+    const REFRESH = 'refresh';
     const WAIT_FOR_COMPLETION = 'wait_for_completion';
     const WAIT_FOR_COMPLETION_FALSE = 'false';
+    const WAIT_FOR_ACTIVE_SHARDS = 'wait_for_active_shards';
+    const TIMEOUT = 'timeout';
+    const SCROLL = 'scroll';
+    const REQUESTS_PER_SECOND = 'requests_per_second';
 
     /**
      * @var Index
@@ -70,7 +75,7 @@ class Reindex extends Param
 
         $body = array_merge_recursive($body, [
             'source' => ['index' => $oldIndex->getName()],
-            'dest'   => ['index' => $newIndex->getName()],
+            'dest' => ['index' => $newIndex->getName()],
         ]);
 
         return $body;
@@ -80,7 +85,7 @@ class Reindex extends Param
     {
         $params = array_merge([
             'source' => $this->_getSourcePartBody($options),
-            'dest'   => $this->_getDestPartBody($options),
+            'dest' => $this->_getDestPartBody($options),
         ], $this->_resolveBodyOptions($options));
 
         return $params;
@@ -162,8 +167,49 @@ class Reindex extends Param
     private function _getEndpointParams(array $params)
     {
         return array_intersect_key($params, [
+            self::REFRESH => null,
             self::WAIT_FOR_COMPLETION => null,
+            self::WAIT_FOR_ACTIVE_SHARDS => null,
+            self::TIMEOUT => null,
+            self::SCROLL => null,
+            self::REQUESTS_PER_SECOND => null,
         ]);
+    }
+
+    public function setWaitForCompletion($value)
+    {
+        is_bool($value) && $value = $value ? 'true' : 'false';
+        $this->setParam(self::WAIT_FOR_COMPLETION, $value);
+    }
+
+    public function setWaitForActiveShards($value)
+    {
+        $this->setParam(self::WAIT_FOR_ACTIVE_SHARDS, $value);
+    }
+
+    public function setTimeout($value)
+    {
+        $this->setParam(self::TIMEOUT, $value);
+    }
+
+    public function setScroll($value)
+    {
+        $this->setParam(self::SCROLL, $value);
+    }
+
+    public function setRequestsPerSecond($value)
+    {
+        $this->setParam(self::REQUESTS_PER_SECOND, $value);
+    }
+
+    public function setSourceParam(string $key, $value)
+    {
+        $this->_params['source'][$key] = $value;
+    }
+
+    public function setDestParam(string $key, $value)
+    {
+        $this->_params['dest'][$key] = $value;
     }
 
     public function getTaskId()
@@ -174,10 +220,5 @@ class Reindex extends Param
         }
 
         return $taskId;
-    }
-
-    public function setWaitForCompletion($value)
-    {
-        $this->setParam(self::WAIT_FOR_COMPLETION, $value);
     }
 }

--- a/lib/Elastica/Reindex.php
+++ b/lib/Elastica/Reindex.php
@@ -59,7 +59,7 @@ class Reindex extends Param
         $this->setParams($params);
     }
 
-    public function run()
+    public function run(): Response
     {
         $body = $this->_getBody($this->_oldIndex, $this->_newIndex, $this->getParams());
 
@@ -73,7 +73,7 @@ class Reindex extends Param
         return $this->_lastResponse;
     }
 
-    protected function _getBody($oldIndex, $newIndex, $params)
+    protected function _getBody(Index $oldIndex, Index $newIndex, array $params): array
     {
         $body = \array_merge([
             'source' => $this->_getSourcePartBody($oldIndex, $params),
@@ -85,7 +85,7 @@ class Reindex extends Param
         return $body;
     }
 
-    protected function _getSourcePartBody(Index $index, array $params)
+    protected function _getSourcePartBody(Index $index, array $params): array
     {
         $sourceBody = \array_merge([
             'index' => $index->getName(),
@@ -97,7 +97,7 @@ class Reindex extends Param
         return $sourceBody;
     }
 
-    protected function _getDestPartBody(Index $index, array $params)
+    protected function _getDestPartBody(Index $index, array $params): array
     {
         $destBody = \array_merge([
             'index' => $index->getName(),
@@ -106,7 +106,7 @@ class Reindex extends Param
         return $destBody;
     }
 
-    private function _resolveSourceOptions(array $params)
+    private function _resolveSourceOptions(array $params): array
     {
         return \array_intersect_key($params, [
             self::TYPE => null,
@@ -118,7 +118,7 @@ class Reindex extends Param
         ]);
     }
 
-    private function _resolveDestOptions(array $params)
+    private function _resolveDestOptions(array $params): array
     {
         return \array_intersect_key($params, [
             self::VERSION_TYPE => null,
@@ -126,7 +126,7 @@ class Reindex extends Param
         ]);
     }
 
-    private function _resolveBodyOptions(array $params)
+    private function _resolveBodyOptions(array $params): array
     {
         return \array_intersect_key($params, [
             self::SIZE => null,
@@ -134,7 +134,7 @@ class Reindex extends Param
         ]);
     }
 
-    private function _setSourceQuery(array $sourceBody)
+    private function _setSourceQuery(array $sourceBody): array
     {
         if (isset($sourceBody[self::QUERY]) && $sourceBody[self::QUERY] instanceof AbstractQuery) {
             $sourceBody[self::QUERY] = $sourceBody[self::QUERY]->toArray();
@@ -143,7 +143,7 @@ class Reindex extends Param
         return $sourceBody;
     }
 
-    private function _setSourceType(array $sourceBody)
+    private function _setSourceType(array $sourceBody): array
     {
         if (isset($sourceBody[self::TYPE]) && !\is_array($sourceBody[self::TYPE])) {
             $sourceBody[self::TYPE] = [$sourceBody[self::TYPE]];
@@ -159,7 +159,7 @@ class Reindex extends Param
         return $sourceBody;
     }
 
-    private function _setBodyScript(array $body)
+    private function _setBodyScript(array $body): array
     {
         if (!$this->hasParam(self::SCRIPT)) {
             return $body;

--- a/lib/Elastica/Reindex.php
+++ b/lib/Elastica/Reindex.php
@@ -63,7 +63,7 @@ class Reindex extends Param
         $reindexEndpoint->setParams($params);
         $reindexEndpoint->setBody($body);
 
-        $this->lastResponse = $this->_oldIndex->getClient()->requestEndpoint($reindexEndpoint);
+        $this->_lastResponse = $this->_oldIndex->getClient()->requestEndpoint($reindexEndpoint);
         $this->_newIndex->refresh();
 
         return $this->_newIndex;
@@ -215,8 +215,8 @@ class Reindex extends Param
     public function getTaskId()
     {
         $taskId = null;
-        if ($this->lastResponse instanceof Response) {
-            $taskId = $this->lastResponse->getData()['task'] ?? null;
+        if ($this->_lastResponse instanceof Response) {
+            $taskId = $this->_lastResponse->getData()['task'] ? $this->_lastResponse->getData()['task'] : null;
         }
 
         return $taskId;

--- a/test/Elastica/ReindexTest.php
+++ b/test/Elastica/ReindexTest.php
@@ -141,6 +141,23 @@ class ReindexTest extends Base
     }
 
     /**
+     * @group functional
+     */
+    public function testReindexWithFalseSetOnWaitForCompletion()
+    {
+        $oldIndex = $this->_createIndex('idx1', true, 2);
+        $this->_addDocs($oldIndex->getType('reindexTest'), 10);
+
+        $newIndex = $this->_createIndex('idx2', true, 2);
+
+        $reindex = new Reindex($oldIndex, $newIndex);
+        $reindex->setWaitForCompletion(Reindex::WAIT_FOR_COMPLETION_FALSE);
+        $reindex->run();
+
+        $this->assertNotEmpty($reindex->getTaskId());
+    }
+
+    /**
      * @param Type $type
      * @param int  $docs
      *


### PR DESCRIPTION
This PR replace #1494 and add some missing options and tests. Thanks to @daviscaics for the initial contribution.

The Reindex API now supports all the options listed on the documentation https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html - tests are added too for Script, remote, etc.

## BC Break

I chose to introduce some BC Breaks and I hope that's ok.

- the `run` method was also calling `refresh()` on the new Index. So it's impossible to reindex an Index and make sure it's not yet refreshed _for some reason, like doing other indexation in that index after the reindex_. It does not make sense to force a refresh on the users. If that's really an issue, I can use the REFRESH Param value with a default value to "true", to keep the current behavior, but still allow to disable it;
- the `run` method was returning the new Index object, that's not consistent with other API and that does not allow to read the response content (is there any conflict, how long does it took...). So I changed the returned value.

## Still not supported

- the ability to set multiple index as the source index