### PR TITLE
Add request method parameter for search and count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file based on the
 * hits.total is now an object in the search response [hits.total](https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-7.0.html#_literal_hits_total_literal_is_now_an_object_in_the_search_response) 
 * Elastica\Reindex does not return an Index anymore but a Response.
 * Elastica\Reindex->run() does not refresh the new Index after completion anymore. Use `$reindex->setParam(Reindex::REFRESH, 'wait_for')` instead.
+* `Elastica\Search->search()` and `Elastica\Search->count()` use request method `POST` by default. Same for `Elastica\Index`, `Elastica\Type\AbstractType`, `Elastica\Type`.
 
 ### Bugfixes
 * Always set the Guzzle `base_uri` to support connecting to multiple ES hosts. [#1618](https://github.com/ruflin/Elastica/pull/1618)
@@ -26,6 +27,7 @@ All notable changes to this project will be documented in this file based on the
 * Added `ParentAggregation` [#1616](https://github.com/ruflin/Elastica/pull/1616)
 * Elastica\Reindex missing options (script, remote, wait_for_completion, scroll...)
 * Added `AdjacencyMatrix` aggregation [#1642](https://github.com/ruflin/Elastica/pull/1642)
+* Added request method parameter to `Elastica\SearchableInterface->search()` and `Elastica\SearchableInterface->count()`. Same for `Elastica\Search`[#1441](https://github.com/ruflin/Elastica/issues/1441)
 
 ### Improvements
 * Added `native_function_invocation` CS rule [#1606](https://github.com/ruflin/Elastica/pull/1606)

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -353,32 +353,34 @@ class Index implements SearchableInterface
      *
      * @param string|array|\Elastica\Query $query   Array with all query data inside or a Elastica\Query object
      * @param int|array                    $options OPTIONAL Limit or associative array of options (option=>value)
+     * @param string                       $method  OPTIONAL Request method (use const's) (default = Request::POST)
      *
      * @return \Elastica\ResultSet with all results inside
      *
      * @see \Elastica\SearchableInterface::search
      */
-    public function search($query = '', $options = null)
+    public function search($query = '', $options = null, $method = Request::POST)
     {
         $search = $this->createSearch($query, $options);
 
-        return $search->search();
+        return $search->search('', null, $method);
     }
 
     /**
      * Counts results of query.
      *
-     * @param string|array|\Elastica\Query $query Array with all query data inside or a Elastica\Query object
+     * @param string|array|\Elastica\Query $query  Array with all query data inside or a Elastica\Query object
+     * @param string                       $method OPTIONAL Request method (use const's) (default = Request::POST)
      *
      * @return int number of documents matching the query
      *
      * @see \Elastica\SearchableInterface::count
      */
-    public function count($query = '')
+    public function count($query = '', $method = Request::POST)
     {
         $search = $this->createSearch($query);
 
-        return $search->count();
+        return $search->count('', false, $method);
     }
 
     /**

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -436,12 +436,13 @@ class Search
      *
      * @param mixed     $query
      * @param int|array $options OPTIONAL Limit or associative array of options (option=>value)
+     * @param string    $method  OPTIONAL Request method (use const's) (default = Request::POST)
      *
      * @throws \Elastica\Exception\InvalidException
      *
      * @return \Elastica\ResultSet
      */
-    public function search($query = '', $options = null)
+    public function search($query = '', $options = null, $method = Request::POST)
     {
         $this->setOptionsAndQuery($options, $query);
 
@@ -460,7 +461,7 @@ class Search
 
         $response = $this->getClient()->request(
             $path,
-            Request::GET,
+            $method,
             $data,
             $params
         );
@@ -471,10 +472,11 @@ class Search
     /**
      * @param mixed $query
      * @param $fullResult (default = false) By default only the total hit count is returned. If set to true, the full ResultSet including aggregations is returned
+     * @param string $method OPTIONAL Request method (use const's) (default = Request::POST)
      *
      * @return int|ResultSet
      */
-    public function count($query = '', $fullResult = false)
+    public function count($query = '', $fullResult = false, $method = Request::POST)
     {
         $this->setOptionsAndQuery(null, $query);
 
@@ -485,7 +487,7 @@ class Search
 
         $response = $this->getClient()->request(
             $path,
-            Request::GET,
+            $method,
             $query->toArray(),
             [self::OPTION_SEARCH_TYPE => self::OPTION_SEARCH_TYPE_QUERY_THEN_FETCH]
         );

--- a/lib/Elastica/SearchableInterface.php
+++ b/lib/Elastica/SearchableInterface.php
@@ -27,21 +27,23 @@ interface SearchableInterface
      *
      * @param string|array|\Elastica\Query $query   Array with all query data inside or a Elastica\Query object
      * @param null                         $options
+     * @param string                       $method  OPTIONAL Request method (use const's) (default = Request::POST)
      *
      * @return \Elastica\ResultSet with all results inside
      */
-    public function search($query = '', $options = null);
+    public function search($query = '', $options = null, $method = Request::POST);
 
     /**
      * Counts results for a query.
      *
      * If no query is set, matchall query is created
      *
-     * @param string|array|\Elastica\Query $query Array with all query data inside or a Elastica\Query object
+     * @param string|array|\Elastica\Query $query  Array with all query data inside or a Elastica\Query object
+     * @param string                       $method OPTIONAL Request method (use const's) (default = Request::POST)
      *
      * @return int number of documents matching the query
      */
-    public function count($query = '');
+    public function count($query = '', $method = Request::POST);
 
     /**
      * @param \Elastica\Query|string $query

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -349,32 +349,34 @@ class Type implements SearchableInterface
      *
      * @param string|array|\Elastica\Query $query   Array with all query data inside or a Elastica\Query object
      * @param int|array                    $options OPTIONAL Limit or associative array of options (option=>value)
+     * @param string                       $method  OPTIONAL Request method (use const's) (default = Request::POST)
      *
      * @return \Elastica\ResultSet with all results inside
      *
      * @see \Elastica\SearchableInterface::search
      */
-    public function search($query = '', $options = null)
+    public function search($query = '', $options = null, $method = Request::POST)
     {
         $search = $this->createSearch($query, $options);
 
-        return $search->search();
+        return $search->search('', null, $method);
     }
 
     /**
      * Count docs by query.
      *
-     * @param string|array|\Elastica\Query $query Array with all query data inside or a Elastica\Query object
+     * @param string|array|\Elastica\Query $query  Array with all query data inside or a Elastica\Query object
+     * @param string                       $method OPTIONAL Request method (use const's) (default = Request::POST)
      *
      * @return int number of documents matching the query
      *
      * @see \Elastica\SearchableInterface::count
      */
-    public function count($query = '')
+    public function count($query = '', $method = Request::POST)
     {
         $search = $this->createSearch($query);
 
-        return $search->count();
+        return $search->count('', false, $method);
     }
 
     /**

--- a/lib/Elastica/Type/AbstractType.php
+++ b/lib/Elastica/Type/AbstractType.php
@@ -6,6 +6,7 @@ use Elastica\Client;
 use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
+use Elastica\Request;
 use Elastica\ResultSet;
 use Elastica\Search;
 use Elastica\SearchableInterface;
@@ -151,28 +152,30 @@ abstract class AbstractType implements SearchableInterface
      *
      * @param string|array|Query $query   Array with all query data inside or a Elastica\Query object
      * @param int|array          $options
+     * @param string             $method  OPTIONAL Request method (use const's) (default = Request::POST)
      *
      * @return ResultSet with all results inside
      *
      * @see \Elastica\SearchableInterface::search
      */
-    public function search($query = '', $options = null): ResultSet
+    public function search($query = '', $options = null, $method = Request::POST): ResultSet
     {
-        return $this->getType()->search($query, $options = null);
+        return $this->getType()->search($query, $options = null, $method);
     }
 
     /**
      * Count docs in the type based on query.
      *
-     * @param string|array|Query $query Array with all query data inside or a Elastica\Query object
+     * @param string|array|Query $query  Array with all query data inside or a Elastica\Query object
+     * @param string             $method OPTIONAL Request method (use const's) (default = Request::POST)
      *
      * @return int number of documents matching the query
      *
      * @see \Elastica\SearchableInterface::count
      */
-    public function count($query = ''): int
+    public function count($query = '', $method = Request::POST): int
     {
-        return $this->getType()->count($query);
+        return $this->getType()->count($query, $method);
     }
 
     /**

--- a/test/Elastica/IndexTest.php
+++ b/test/Elastica/IndexTest.php
@@ -143,6 +143,33 @@ class IndexTest extends BaseTest
     /**
      * @group functional
      */
+    public function testCountGet()
+    {
+        $index = $this->_createIndex();
+
+        // Add document to normal index
+        $doc1 = new Document(null, ['name' => 'ruflin']);
+        $doc2 = new Document(null, ['name' => 'nicolas']);
+
+        $type = $index->getType('_doc');
+        $type->addDocument($doc1);
+        $type->addDocument($doc2);
+
+        $index->refresh();
+
+        $this->assertEquals(2, $index->count('', Request::GET));
+
+        $query = new Term();
+        $key = 'name';
+        $value = 'nicolas';
+        $query->setTerm($key, $value);
+
+        $this->assertEquals(1, $index->count($query, Request::GET));
+    }
+
+    /**
+     * @group functional
+     */
     public function testDeleteByQueryWithQueryString()
     {
         $index = $this->_createIndex();
@@ -694,6 +721,27 @@ class IndexTest extends BaseTest
 
         $count = $index->count();
         $this->assertEquals(3, $count);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testSearchGet()
+    {
+        $index = $this->_createIndex();
+
+        $type = new Type($index, '_doc');
+
+        $docs = [];
+        $docs[] = new Document(1, ['username' => 'hans']);
+        $type->addDocuments($docs);
+        $index->refresh();
+
+        $resultSet = $index->search('hans', null, Request::GET);
+        $this->assertEquals(1, $resultSet->count());
+
+        $count = $index->count('hans', Request::GET);
+        $this->assertEquals(1, $count);
     }
 
     /**

--- a/test/Elastica/Transport/GuzzleTest.php
+++ b/test/Elastica/Transport/GuzzleTest.php
@@ -17,60 +17,6 @@ class GuzzleTest extends BaseTest
     }
 
     /**
-     * Return transport configuration and the expected HTTP method.
-     *
-     * @return array[]
-     */
-    public function getConfig()
-    {
-        return [
-            [
-                ['persistent' => false, 'transport' => 'Guzzle'],
-                'GET',
-            ],
-            [
-                ['persistent' => false, 'transport' => ['type' => 'Guzzle', 'postWithRequestBody' => false]],
-                'GET',
-            ],
-            [
-                ['persistent' => false, 'transport' => ['type' => 'Guzzle', 'postWithRequestBody' => true]],
-                'POST',
-            ],
-        ];
-    }
-
-    /**
-     * @group functional
-     * @dataProvider getConfig
-     */
-    public function testDynamicHttpMethodBasedOnConfigParameter(array $config, $httpMethod)
-    {
-        $client = $this->_getClient($config);
-
-        $index = $client->getIndex('dynamic_http_method_test');
-        $index->create([], true);
-        $type = $index->getType('_doc');
-        $type->addDocument(new Document(1, ['test' => 'test']));
-        $index->refresh();
-        $resultSet = $index->search('test');
-        $info = $resultSet->getResponse()->getTransferInfo();
-        $this->assertStringStartsWith($httpMethod, $info['request_header']);
-    }
-
-    /**
-     * @group functional
-     * @dataProvider getConfig
-     */
-    public function testDynamicHttpMethodOnlyAffectsRequestsWithBody(array $config, $httpMethod)
-    {
-        $client = $this->_getClient($config);
-
-        $status = $client->getStatus();
-        $info = $status->getResponse()->getTransferInfo();
-        $this->assertStringStartsWith('GET', $info['request_header']);
-    }
-
-    /**
      * @group functional
      */
     public function testWithEnvironmentalProxy()

--- a/test/Elastica/Transport/HttpTest.php
+++ b/test/Elastica/Transport/HttpTest.php
@@ -10,65 +10,6 @@ use Elastica\Test\Base as BaseTest;
 class HttpTest extends BaseTest
 {
     /**
-     * Return transport configuration and the expected HTTP method.
-     *
-     * @return array[]
-     */
-    public function getConfig()
-    {
-        return [
-            [
-                ['transport' => 'Http', 'curl' => [CURLINFO_HEADER_OUT => true]],
-                'GET',
-            ],
-            [
-                ['transport' => ['type' => 'Http', 'postWithRequestBody' => false, 'curl' => [CURLINFO_HEADER_OUT => true]]],
-                'GET',
-            ],
-            [
-                ['transport' => ['type' => 'Http', 'postWithRequestBody' => true, 'curl' => [CURLINFO_HEADER_OUT => true]]],
-                'POST',
-            ],
-        ];
-    }
-
-    /**
-     * @group functional
-     * @dataProvider getConfig
-     */
-    public function testDynamicHttpMethodBasedOnConfigParameter(array $config, $httpMethod)
-    {
-        $client = $this->_getClient($config);
-
-        $index = $client->getIndex('dynamic_http_method_test');
-        $index->create([], true);
-        $this->_waitForAllocation($index);
-
-        $type = $index->getType('_doc');
-        $type->addDocument(new Document(1, ['test' => 'test']));
-
-        $index->refresh();
-
-        $resultSet = $index->search('test');
-
-        $info = $resultSet->getResponse()->getTransferInfo();
-        $this->assertStringStartsWith($httpMethod, $info['request_header']);
-    }
-
-    /**
-     * @group functional
-     * @dataProvider getConfig
-     */
-    public function testDynamicHttpMethodOnlyAffectsRequestsWithBody(array $config, $httpMethod)
-    {
-        $client = $this->_getClient($config);
-
-        $status = $client->getStatus();
-        $info = $status->getResponse()->getTransferInfo();
-        $this->assertStringStartsWith('GET', $info['request_header']);
-    }
-
-    /**
      * @group functional
      */
     public function testCurlNobodyOptionIsResetAfterHeadRequest()

--- a/test/Elastica/TypeTest.php
+++ b/test/Elastica/TypeTest.php
@@ -9,6 +9,7 @@ use Elastica\Index;
 use Elastica\Query\MatchAll;
 use Elastica\Query\QueryString;
 use Elastica\Query\SimpleQueryString;
+use Elastica\Request;
 use Elastica\Script\Script;
 use Elastica\Search;
 use Elastica\Test\Base as BaseTest;
@@ -48,6 +49,45 @@ class TypeTest extends BaseTest
         $this->assertEquals(1, $resultSet->count());
 
         $count = $type->count('rolf');
+        $this->assertEquals(1, $count);
+
+        // Test if source is returned
+        $result = $resultSet->current();
+        $this->assertEquals(3, $result->getId());
+        $data = $result->getData();
+        $this->assertEquals('rolf', $data['username']);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testSearchGet()
+    {
+        $index = $this->_createIndex();
+
+        $type = new Type($index, '_doc');
+
+        // Adds 1 document to the index
+        $doc1 = new Document(1,
+            ['username' => 'hans', 'test' => ['2', '3', '5']]
+        );
+        $type->addDocument($doc1);
+
+        // Adds a list of documents with _bulk upload to the index
+        $docs = [];
+        $docs[] = new Document(2,
+            ['username' => 'john', 'test' => ['1', '3', '6']]
+        );
+        $docs[] = new Document(3,
+            ['username' => 'rolf', 'test' => ['2', '3', '7']]
+        );
+        $type->addDocuments($docs);
+        $index->refresh();
+
+        $resultSet = $type->search('rolf', null, Request::GET);
+        $this->assertEquals(1, $resultSet->count());
+
+        $count = $type->count('rolf', Request::GET);
         $this->assertEquals(1, $count);
 
         // Test if source is returned


### PR DESCRIPTION
This PR allow to change request method for search and count as discussed in #1441.

### BC BREAK

I also moved default request method from `GET` to `POST` as suggested by @ruflin in [his comment](https://github.com/ruflin/Elastica/issues/1441#issuecomment-363285144).