### PR TITLE
Update `elasticsearch-php` to 5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Improvements
 
+- Update `elasticsearch-php` dependency to 5.4 [#1648](https://github.com/ruflin/Elastica/pull/1648)
+
 
 ## [5.3.5](https://github.com/ruflin/Elastica/compare/5.3.4...5.3.5)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Contributions are always welcome. For details on how to contribute, check the [C
 
 Dependencies
 ------------
-| Project | Version | Required |
-|---------|---------|----------|
-|[Elasticsearch](https://github.com/elasticsearch/elasticsearch/tree/5.3)|5.3|yes|
+
+| Elastica                                                                                | ElasticSearch | elasticsearch-php | PHP      |
+| --------------------------------------------------------------------------------------- | ------------- | ----------------- | -------- |
+| [5.x](https://github.com/ruflin/Elastica/tree/5.x)                                      | 5.x           | ^5.0              | \>=5.6   |
+| [3.2.3](https://github.com/ruflin/Elastica/tree/3.2.3) (unmaintained)                   | 2.4.0         | no                | \>=5.4   |
+| [2.x](https://github.com/ruflin/Elastica/tree/2.x) (unmaintained)                       | 1.7.2         | no                | \>=5.3.3 |
+
+------------
+

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.6.0",
         "psr/log": "~1.0",
-        "elasticsearch/elasticsearch": "5.3.*"
+        "elasticsearch/elasticsearch": "5.4.*"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",


### PR DESCRIPTION
Updates `elasticsearch/elasticsearch` to the latest `v5` version.

Changelog: https://github.com/elastic/elasticsearch-php/blob/5.0/CHANGELOG.md#release-540
Changes: https://github.com/elastic/elasticsearch-php/compare/v5.3.2...v5.4.0