### PR TITLE
Support DSN in Client constructor for config argument (#1640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file based on the
 * Elastica\Reindex does not return an Index anymore but a Response.
 * Elastica\Reindex->run() does not refresh the new Index after completion anymore. Use `$reindex->setParam(Reindex::REFRESH, 'wait_for')` instead.
 * `Elastica\Search->search()` and `Elastica\Search->count()` use request method `POST` by default. Same for `Elastica\Index`, `Elastica\Type\AbstractType`, `Elastica\Type`.
+* Elastica\Client `$_config` field is now a `ClientConfiguration` instead of an array
 
 ### Bugfixes
 * Always set the Guzzle `base_uri` to support connecting to multiple ES hosts. [#1618](https://github.com/ruflin/Elastica/pull/1618)
@@ -29,6 +30,8 @@ All notable changes to this project will be documented in this file based on the
 * Added `AdjacencyMatrix` aggregation [#1642](https://github.com/ruflin/Elastica/pull/1642)
 * Added request method parameter to `Elastica\SearchableInterface->search()` and `Elastica\SearchableInterface->count()`. Same for `Elastica\Search`[#1441](https://github.com/ruflin/Elastica/issues/1441)
 * Added support for Field Collapsing (Issue: [#1392](https://github.com/ruflin/Elastica/issues/1392); PR: [#1653](https://github.com/ruflin/Elastica/pull/1653))
+* Support string DSN in `\Elastica\Client` constructor for config argument [#1640](https://github.com/ruflin/Elastica/issues/1640)
+* Move Client configuration in a dedicated class
 
 ### Improvements
 * Added `native_function_invocation` CS rule [#1606](https://github.com/ruflin/Elastica/pull/1606)

--- a/lib/Elastica/ClientConfiguration.php
+++ b/lib/Elastica/ClientConfiguration.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Elastica;
+
+use Elastica\Exception\InvalidException;
+
+/**
+ * Elastica client configuration.
+ *
+ * @author Antoine Lamirault <lamiraultantoine@gmail.com>
+ */
+class ClientConfiguration
+{
+    /**
+     * Config with defaults.
+     *
+     * log: Set to true, to enable logging, set a string to log to a specific file
+     * retryOnConflict: Use in \Elastica\Client::updateDocument
+     * bigintConversion: Set to true to enable the JSON bigint to string conversion option (see issue #717)
+     *
+     * @var array
+     */
+    protected $configuration = [
+        'host' => null,
+        'port' => null,
+        'path' => null,
+        'url' => null,
+        'proxy' => null,
+        'transport' => null,
+        'persistent' => true,
+        'timeout' => null,
+        'connections' => [], // host, port, path, timeout, transport, compression, persistent, timeout, username, password, config -> (curl, headers, url)
+        'roundRobin' => false,
+        'log' => false,
+        'retryOnConflict' => 0,
+        'bigintConversion' => false,
+        'username' => null,
+        'password' => null,
+    ];
+
+    /**
+     * Create configuration.
+     *
+     * @param array $config Additional config
+     *
+     * @return ClientConfiguration
+     */
+    public static function fromArray(array $config): self
+    {
+        $clientConfiguration = new self();
+        foreach ($config as $key => $value) {
+            $clientConfiguration->set($key, $value);
+        }
+
+        return $clientConfiguration;
+    }
+
+    /**
+     * Create configuration from Dsn string.
+     *
+     * @param string $dsn
+     *
+     * @return ClientConfiguration
+     */
+    public static function fromDsn(string $dsn): self
+    {
+        if (false === $parsedDsn = \parse_url($dsn)) {
+            throw new InvalidException(\sprintf("DSN '%s' is invalid.", $dsn));
+        }
+
+        $clientConfiguration = new self();
+
+        if (isset($parsedDsn['scheme'])) {
+            $clientConfiguration->set('transport', $parsedDsn['scheme']);
+        }
+
+        if (isset($parsedDsn['host'])) {
+            $clientConfiguration->set('host', $parsedDsn['host']);
+        }
+
+        if (isset($parsedDsn['user'])) {
+            $clientConfiguration->set('username', \urldecode($parsedDsn['user']));
+        }
+
+        if (isset($parsedDsn['pass'])) {
+            $clientConfiguration->set('password', \urldecode($parsedDsn['pass']));
+        }
+
+        if (isset($parsedDsn['port'])) {
+            $clientConfiguration->set('port', $parsedDsn['port']);
+        }
+
+        if (isset($parsedDsn['path'])) {
+            $clientConfiguration->set('path', $parsedDsn['path']);
+        }
+
+        $options = [];
+        if (isset($parsedDsn['query'])) {
+            \parse_str($parsedDsn['query'], $options);
+        }
+
+        foreach ($options as $optionName => $optionValue) {
+            if ('false' === $optionValue) {
+                $optionValue = false;
+            } elseif ('true' === $optionValue) {
+                $optionValue = true;
+            } elseif (\is_numeric($optionValue)) {
+                $optionValue = (int) $optionValue;
+            }
+
+            $clientConfiguration->set($optionName, $optionValue);
+        }
+
+        return $clientConfiguration;
+    }
+
+    /**
+     * Returns a specific config key or the whole
+     * config array if not set.
+     *
+     * @param string $key Config key
+     *
+     * @throws \Elastica\Exception\InvalidException
+     *
+     * @return mixed Config value
+     */
+    public function get(string $key)
+    {
+        if (empty($key)) {
+            return $this->configuration;
+        }
+
+        if (!$this->has($key)) {
+            throw new InvalidException('Config key is not set: '.$key);
+        }
+
+        return $this->configuration[$key];
+    }
+
+    /**
+     * Returns boolean indicates if configuration has key.
+     *
+     * @param string $key Key to check
+     *
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        return \array_key_exists($key, $this->configuration);
+    }
+
+    /**
+     * Return all configuration.
+     *
+     * @return array
+     */
+    public function getAll(): array
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * @param string $key   Key to set
+     * @param mixed  $value Value
+     */
+    public function set(string $key, $value): void
+    {
+        $this->configuration[$key] = $value;
+    }
+
+    /**
+     * Add value to a key. If original value is not an array, value is wrapped.
+     *
+     * @param string $key   Key to add
+     * @param mixed  $value Value
+     */
+    public function add(string $key, $value): void
+    {
+        if (!\array_key_exists($key, $this->configuration)) {
+            $this->configuration[$key] = [$value];
+        } else {
+            if (\is_array($this->configuration[$key])) {
+                $this->configuration[$key][] = $value;
+            } else {
+                $this->configuration[$key] = [$this->configuration[$key], $value];
+            }
+        }
+    }
+}

--- a/test/Elastica/ClientConfigurationTest.php
+++ b/test/Elastica/ClientConfigurationTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Elastica\Test;
+
+use Elastica\ClientConfiguration;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group unit
+ */
+class ClientConfigurationTest extends TestCase
+{
+    public function testInvalidDsn()
+    {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectExceptionMessage("DSN 'test:0' is invalid.");
+
+        ClientConfiguration::fromDsn('test:0');
+    }
+
+    public function testFromSimpleDsn()
+    {
+        $configuration = ClientConfiguration::fromDsn('192.168.1.1:9201');
+
+        $expected = [
+            'host' => '192.168.1.1',
+            'port' => '9201',
+            'path' => null,
+            'url' => null,
+            'proxy' => null,
+            'transport' => null,
+            'persistent' => true,
+            'timeout' => null,
+            'connections' => [],
+            'roundRobin' => false,
+            'log' => false,
+            'retryOnConflict' => 0,
+            'bigintConversion' => false,
+            'username' => null,
+            'password' => null,
+        ];
+
+        $this->assertEquals($expected, $configuration->getAll());
+    }
+
+    public function testFromDsnWithParameters()
+    {
+        $configuration = ClientConfiguration::fromDsn('https://user:p4ss@foo.com:9201/my-path?proxy=https://proxy.com&persistent=false&timeout=45&roundRobin=true&log=true&retryOnConflict=2&bigintConversion=true&extra=abc');
+        $expected = [
+            'host' => 'foo.com',
+            'port' => '9201',
+            'path' => '/my-path',
+            'url' => null,
+            'proxy' => 'https://proxy.com',
+            'transport' => 'https',
+            'persistent' => false,
+            'timeout' => 45,
+            'connections' => [],
+            'roundRobin' => true,
+            'log' => true,
+            'retryOnConflict' => 2,
+            'bigintConversion' => true,
+            'username' => 'user',
+            'password' => 'p4ss',
+            'extra' => 'abc',
+        ];
+
+        $this->assertEquals($expected, $configuration->getAll());
+    }
+
+    public function testFromEmptyArray()
+    {
+        $configuration = ClientConfiguration::fromArray([]);
+
+        $expected = [
+            'host' => null,
+            'port' => null,
+            'path' => null,
+            'url' => null,
+            'proxy' => null,
+            'transport' => null,
+            'persistent' => true,
+            'timeout' => null,
+            'connections' => [], // host, port, path, timeout, transport, compression, persistent, timeout, username, password, config -> (curl, headers, url)
+            'roundRobin' => false,
+            'log' => false,
+            'retryOnConflict' => 0,
+            'bigintConversion' => false,
+            'username' => null,
+            'password' => null,
+        ];
+
+        $this->assertEquals($expected, $configuration->getAll());
+    }
+
+    public function testFromArray()
+    {
+        $configuration = ClientConfiguration::fromArray([
+            'username' => 'Jdoe',
+            'extra' => 'abc',
+        ]);
+
+        $expected = [
+            'host' => null,
+            'port' => null,
+            'path' => null,
+            'url' => null,
+            'proxy' => null,
+            'transport' => null,
+            'persistent' => true,
+            'timeout' => null,
+            'connections' => [], // host, port, path, timeout, transport, compression, persistent, timeout, username, password, config -> (curl, headers, url)
+            'roundRobin' => false,
+            'log' => false,
+            'retryOnConflict' => 0,
+            'bigintConversion' => false,
+            'username' => 'Jdoe',
+            'password' => null,
+            'extra' => 'abc',
+        ];
+
+        $this->assertEquals($expected, $configuration->getAll());
+    }
+
+    public function testHas()
+    {
+        $configuration = new ClientConfiguration();
+        $this->assertTrue($configuration->has('host'));
+        $this->assertFalse($configuration->has('inexistantKey'));
+    }
+
+    public function testGet()
+    {
+        $configuration = new ClientConfiguration();
+        $this->assertTrue($configuration->get('persistent'));
+
+        $expected = [
+            'host' => null,
+            'port' => null,
+            'path' => null,
+            'url' => null,
+            'proxy' => null,
+            'transport' => null,
+            'persistent' => true,
+            'timeout' => null,
+            'connections' => [],
+            'roundRobin' => false,
+            'log' => false,
+            'retryOnConflict' => 0,
+            'bigintConversion' => false,
+            'username' => null,
+            'password' => null,
+        ];
+
+        $this->assertEquals($expected, $configuration->get(''));
+
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $configuration->get('invalidKey');
+    }
+
+    public function testAdd()
+    {
+        $keyName = 'myKey';
+
+        $configuration = new ClientConfiguration();
+        $this->assertFalse($configuration->has($keyName));
+
+        $configuration->add($keyName, 'FirstValue');
+        $this->assertEquals(['FirstValue'], $configuration->get($keyName));
+
+        $configuration->add($keyName, 'SecondValue');
+        $this->assertEquals(['FirstValue', 'SecondValue'], $configuration->get($keyName));
+
+        $configuration->set('otherKey', 'value');
+        $this->assertEquals('value', $configuration->get('otherKey'));
+        $configuration->add('otherKey', 'nextValue');
+        $this->assertEquals(['value', 'nextValue'], $configuration->get('otherKey'));
+    }
+}

--- a/test/Elastica/ClientTest.php
+++ b/test/Elastica/ClientTest.php
@@ -17,7 +17,6 @@ use Elastica\Response;
 use Elastica\Script\Script;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Type;
-use Elasticsearch\Endpoints\Get;
 use Elasticsearch\Endpoints\Indices\Stats;
 use Elasticsearch\Endpoints\Search;
 
@@ -30,6 +29,36 @@ class ClientTest extends BaseTest
     {
         $client = $this->_getClient();
         $this->assertCount(1, $client->getConnections());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testConstructWithDsn()
+    {
+        $client = new Client('https://user:p4ss@foo.com:9200?persistent=false&retryOnConflict=2');
+        $this->assertCount(1, $client->getConnections());
+
+        $expected = [
+            'host' => 'foo.com',
+            'port' => '9200',
+            'path' => null,
+            'url' => null,
+            'proxy' => null,
+            'transport' => 'https',
+            'persistent' => false,
+            'timeout' => null,
+            'connections' => [],
+            'roundRobin' => false,
+            'log' => false,
+            'retryOnConflict' => 2,
+            'bigintConversion' => false,
+            'username' => 'user',
+            'password' => 'p4ss',
+            'connectionStrategy' => 'Simple',
+        ];
+
+        $this->assertEquals($expected, $client->getConfig());
     }
 
     /**


### PR DESCRIPTION
This PR allow to pass DSN to the Elastica\Client constructor as discussed in #1640 .

For example: `$client = new Client('https://user:p4ss@foo.com:9200?persistent=false&retryOnConflict=2');`

I have just a doubt about `url` config parameter. Should I build it from `transport`, `host`, `port` and `path` ? Or it works when these args are filled ?

Another question: Is there a doc to update ? Elastica.io appears to be outdated.