### PR TITLE
Field Collapsing Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file based on the
 * Elastica\Reindex missing options (script, remote, wait_for_completion, scroll...)
 * Added `AdjacencyMatrix` aggregation [#1642](https://github.com/ruflin/Elastica/pull/1642)
 * Added request method parameter to `Elastica\SearchableInterface->search()` and `Elastica\SearchableInterface->count()`. Same for `Elastica\Search`[#1441](https://github.com/ruflin/Elastica/issues/1441)
+* Added support for Field Collapsing (Issue: [#1392](https://github.com/ruflin/Elastica/issues/1392); PR: [#1653](https://github.com/ruflin/Elastica/pull/1653))
 
 ### Improvements
 * Added `native_function_invocation` CS rule [#1606](https://github.com/ruflin/Elastica/pull/1606)

--- a/lib/Elastica/Collapse.php
+++ b/lib/Elastica/Collapse.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Elastica;
+
+use Elastica\Collapse\InnerHits;
+
+/**
+ * Class Collapse
+ *
+ * Implementation of Collapse
+ *
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-collapse.html
+ *
+ * @package Elastica
+ */
+class Collapse extends Param
+{
+    /**
+     * Set field to collapse
+     *
+     * @param $fieldName
+     *
+     * @return $this
+     */
+    public function setFieldname($fieldName): self
+    {
+        return $this->setParam('field', $fieldName);
+    }
+
+    /**
+     * Set inner hits for collapsed field.
+     *
+     * @param InnerHits $innerHits
+     *
+     * @return $this
+     */
+    public function setInnerHits(InnerHits $innerHits): self
+    {
+        return $this->setParam('inner_hits', $innerHits);
+    }
+
+    /**
+     * @param InnerHits $innerHits
+     *
+     * @return Collapse
+     */
+    public function addInnerHits(InnerHits $innerHits): self
+    {
+        $hits = [];
+
+        if ($this->hasParam('inner_hits')) {
+            $existingInnerHits = $this->getParam('inner_hits');
+
+            $hits = $existingInnerHits instanceof InnerHits ? [$existingInnerHits] : $existingInnerHits;
+        }
+
+        $hits[] = $innerHits;
+
+        return $this->setParam('inner_hits', $hits);
+    }
+
+    /**
+     * @param int $groupSearches
+     *
+     * @return $this
+     */
+    public function setMaxConcurrentGroupSearches(int $groupSearches): self
+    {
+        return $this->setParam('max_concurrent_group_searches', $groupSearches);
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $data = $this->getParams();
+
+        if (!empty($this->_rawParams)) {
+            $data = array_merge($data, $this->_rawParams);
+        }
+
+        return $this->_convertArrayable($data);
+    }
+}

--- a/lib/Elastica/Collapse.php
+++ b/lib/Elastica/Collapse.php
@@ -5,18 +5,16 @@ namespace Elastica;
 use Elastica\Collapse\InnerHits;
 
 /**
- * Class Collapse
+ * Class Collapse.
  *
  * Implementation of Collapse
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-collapse.html
- *
- * @package Elastica
  */
 class Collapse extends Param
 {
     /**
-     * Set field to collapse
+     * Set field to collapse.
      *
      * @param $fieldName
      *
@@ -77,7 +75,7 @@ class Collapse extends Param
         $data = $this->getParams();
 
         if (!empty($this->_rawParams)) {
-            $data = array_merge($data, $this->_rawParams);
+            $data = \array_merge($data, $this->_rawParams);
         }
 
         return $this->_convertArrayable($data);

--- a/lib/Elastica/Collapse/InnerHits.php
+++ b/lib/Elastica/Collapse/InnerHits.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Elastica\Collapse;
+
+use Elastica\Collapse;
+use Elastica\Query\InnerHits as BaseInnerHits;
+
+/**
+ * Class InnerHits
+ *
+ * Basically identical to inner_hits on query level, but has support for a second level collapse as per
+ * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#_second_level_of_collapsing
+ *
+ * Collapse is part of the inner_hits construct in this case, which should be explicitly supported and not only
+ * via calling InnerHits::setParam('collapse', $collapse).
+ *
+ * On the other hand, collapse cannot be used on query level invocations of inner_hits, which is why it may not be part
+ * of Query\InnerHits.
+ *
+ * @package Elastica\Collapse
+ */
+class InnerHits extends BaseInnerHits
+{
+    /**
+     * @param Collapse $collapse
+     *
+     * @return $this
+     */
+    public function setCollapse(Collapse $collapse): self
+    {
+        return $this->setParam('collapse', $collapse);
+    }
+}

--- a/lib/Elastica/Collapse/InnerHits.php
+++ b/lib/Elastica/Collapse/InnerHits.php
@@ -6,7 +6,7 @@ use Elastica\Collapse;
 use Elastica\Query\InnerHits as BaseInnerHits;
 
 /**
- * Class InnerHits
+ * Class InnerHits.
  *
  * Basically identical to inner_hits on query level, but has support for a second level collapse as per
  * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#_second_level_of_collapsing
@@ -16,8 +16,6 @@ use Elastica\Query\InnerHits as BaseInnerHits;
  *
  * On the other hand, collapse cannot be used on query level invocations of inner_hits, which is why it may not be part
  * of Query\InnerHits.
- *
- * @package Elastica\Collapse
  */
 class InnerHits extends BaseInnerHits
 {

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -58,7 +58,7 @@ class Query extends Param
      *
      * @return self
      */
-    public static function create($query): self
+    public static function create($query)
     {
         switch (true) {
             case $query instanceof self:
@@ -91,7 +91,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setRawQuery(array $query): self
+    public function setRawQuery(array $query)
     {
         $this->_params = $query;
 
@@ -105,7 +105,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setQuery(AbstractQuery $query): self
+    public function setQuery(AbstractQuery $query)
     {
         return $this->setParam('query', $query);
     }
@@ -127,7 +127,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setFrom($from): self
+    public function setFrom($from)
     {
         return $this->setParam('from', $from);
     }
@@ -142,7 +142,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
      */
-    public function setSort(array $sortArgs): self
+    public function setSort(array $sortArgs)
     {
         return $this->setParam('sort', $sortArgs);
     }
@@ -156,7 +156,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
      */
-    public function addSort($sort): self
+    public function addSort($sort)
     {
         return $this->addParam('sort', $sort);
     }
@@ -184,7 +184,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
      */
-    public function setHighlight(array $highlightArgs): self
+    public function setHighlight(array $highlightArgs)
     {
         return $this->setParam('highlight', $highlightArgs);
     }
@@ -198,7 +198,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
      */
-    public function addHighlight($highlight): self
+    public function addHighlight($highlight)
     {
         return $this->addParam('highlight', $highlight);
     }
@@ -210,7 +210,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setSize($size = 10): self
+    public function setSize($size = 10)
     {
         return $this->setParam('size', $size);
     }
@@ -224,7 +224,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-explain.html
      */
-    public function setExplain($explain = true): self
+    public function setExplain($explain = true)
     {
         return $this->setParam('explain', $explain);
     }
@@ -238,7 +238,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
      */
-    public function setVersion($version = true): self
+    public function setVersion($version = true)
     {
         return $this->setParam('version', $version);
     }
@@ -254,7 +254,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fields.html
      */
-    public function setStoredFields(array $fields): self
+    public function setStoredFields(array $fields)
     {
         return $this->setParam('stored_fields', $fields);
     }
@@ -268,7 +268,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fielddata-fields.html
      */
-    public function setFieldDataFields(array $fieldDataFields): self
+    public function setFieldDataFields(array $fieldDataFields)
     {
         return $this->setParam('docvalue_fields', $fieldDataFields);
     }
@@ -282,7 +282,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
      */
-    public function setScriptFields($scriptFields): self
+    public function setScriptFields($scriptFields)
     {
         if (\is_array($scriptFields)) {
             $scriptFields = new ScriptFields($scriptFields);
@@ -299,7 +299,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function addScriptField($name, AbstractScript $script): self
+    public function addScriptField($name, AbstractScript $script)
     {
         if (isset($this->_params['script_fields'])) {
             $this->_params['script_fields']->addScript($name, $script);
@@ -317,7 +317,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function addAggregation(AbstractAggregation $agg): self
+    public function addAggregation(AbstractAggregation $agg)
     {
         $this->_params['aggs'][] = $agg;
 
@@ -329,7 +329,7 @@ class Query extends Param
      *
      * @return array Query array
      */
-    public function toArray(): array
+    public function toArray()
     {
         if (!isset($this->_params['query']) && (0 == $this->_suggest)) {
             $this->setQuery(new MatchAll());
@@ -357,7 +357,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setMinScore($minScore): self
+    public function setMinScore($minScore)
     {
         if (!\is_numeric($minScore)) {
             throw new InvalidException('has to be numeric param');
@@ -373,7 +373,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setSuggest(Suggest $suggest): self
+    public function setSuggest(Suggest $suggest)
     {
         $this->setParam('suggest', $suggest);
 
@@ -389,7 +389,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setRescore($rescore): self
+    public function setRescore($rescore)
     {
         if (\is_array($rescore)) {
             $buffer = [];
@@ -413,7 +413,7 @@ class Query extends Param
      *
      * @see   https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
      */
-    public function setSource($params): self
+    public function setSource($params)
     {
         return $this->setParam('_source', $params);
     }
@@ -427,7 +427,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-post-filter.html
      */
-    public function setPostFilter(AbstractQuery $filter): self
+    public function setPostFilter(AbstractQuery $filter)
     {
         return $this->setParam('post_filter', $filter);
     }

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -42,6 +42,8 @@ class Query extends Param
             $this->setQuery($query);
         } elseif ($query instanceof Suggest) {
             $this->setSuggest($query);
+        } elseif ($query instanceof Collapse) {
+            $this->setCollapse($query);
         }
     }
 
@@ -56,7 +58,7 @@ class Query extends Param
      *
      * @return self
      */
-    public static function create($query)
+    public static function create($query): self
     {
         switch (true) {
             case $query instanceof self:
@@ -74,6 +76,9 @@ class Query extends Param
 
             case $query instanceof Suggest:
                 return new self($query);
+
+            case $query instanceof Collapse:
+                return new self($query);
         }
 
         throw new InvalidException('Unexpected argument to create a query for.');
@@ -86,7 +91,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setRawQuery(array $query)
+    public function setRawQuery(array $query): self
     {
         $this->_params = $query;
 
@@ -100,7 +105,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setQuery(AbstractQuery $query)
+    public function setQuery(AbstractQuery $query): self
     {
         return $this->setParam('query', $query);
     }
@@ -108,7 +113,7 @@ class Query extends Param
     /**
      * Gets the query object.
      *
-     * @return \Elastica\Query\AbstractQuery
+     * @return array|\Elastica\Query\AbstractQuery
      **/
     public function getQuery()
     {
@@ -122,7 +127,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setFrom($from)
+    public function setFrom($from): self
     {
         return $this->setParam('from', $from);
     }
@@ -137,7 +142,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
      */
-    public function setSort(array $sortArgs)
+    public function setSort(array $sortArgs): self
     {
         return $this->setParam('sort', $sortArgs);
     }
@@ -151,7 +156,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
      */
-    public function addSort($sort)
+    public function addSort($sort): self
     {
         return $this->addParam('sort', $sort);
     }
@@ -165,7 +170,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html#_track_scores
      */
-    public function setTrackScores($trackScores = true)
+    public function setTrackScores($trackScores = true): self
     {
         return $this->setParam('track_scores', (bool) $trackScores);
     }
@@ -179,7 +184,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
      */
-    public function setHighlight(array $highlightArgs)
+    public function setHighlight(array $highlightArgs): self
     {
         return $this->setParam('highlight', $highlightArgs);
     }
@@ -193,7 +198,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
      */
-    public function addHighlight($highlight)
+    public function addHighlight($highlight): self
     {
         return $this->addParam('highlight', $highlight);
     }
@@ -205,7 +210,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setSize($size = 10)
+    public function setSize($size = 10): self
     {
         return $this->setParam('size', $size);
     }
@@ -219,7 +224,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-explain.html
      */
-    public function setExplain($explain = true)
+    public function setExplain($explain = true): self
     {
         return $this->setParam('explain', $explain);
     }
@@ -233,7 +238,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
      */
-    public function setVersion($version = true)
+    public function setVersion($version = true): self
     {
         return $this->setParam('version', $version);
     }
@@ -249,7 +254,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fields.html
      */
-    public function setStoredFields(array $fields)
+    public function setStoredFields(array $fields): self
     {
         return $this->setParam('stored_fields', $fields);
     }
@@ -263,7 +268,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-fielddata-fields.html
      */
-    public function setFieldDataFields(array $fieldDataFields)
+    public function setFieldDataFields(array $fieldDataFields): self
     {
         return $this->setParam('docvalue_fields', $fieldDataFields);
     }
@@ -277,7 +282,7 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html
      */
-    public function setScriptFields($scriptFields)
+    public function setScriptFields($scriptFields): self
     {
         if (\is_array($scriptFields)) {
             $scriptFields = new ScriptFields($scriptFields);
@@ -294,7 +299,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function addScriptField($name, AbstractScript $script)
+    public function addScriptField($name, AbstractScript $script): self
     {
         if (isset($this->_params['script_fields'])) {
             $this->_params['script_fields']->addScript($name, $script);
@@ -312,7 +317,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function addAggregation(AbstractAggregation $agg)
+    public function addAggregation(AbstractAggregation $agg): self
     {
         $this->_params['aggs'][] = $agg;
 
@@ -324,7 +329,7 @@ class Query extends Param
      *
      * @return array Query array
      */
-    public function toArray()
+    public function toArray(): array
     {
         if (!isset($this->_params['query']) && (0 == $this->_suggest)) {
             $this->setQuery(new MatchAll());
@@ -352,7 +357,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setMinScore($minScore)
+    public function setMinScore($minScore): self
     {
         if (!\is_numeric($minScore)) {
             throw new InvalidException('has to be numeric param');
@@ -368,7 +373,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setSuggest(Suggest $suggest)
+    public function setSuggest(Suggest $suggest): self
     {
         $this->setParam('suggest', $suggest);
 
@@ -384,7 +389,7 @@ class Query extends Param
      *
      * @return $this
      */
-    public function setRescore($rescore)
+    public function setRescore($rescore): self
     {
         if (\is_array($rescore)) {
             $buffer = [];
@@ -408,7 +413,7 @@ class Query extends Param
      *
      * @see   https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html
      */
-    public function setSource($params)
+    public function setSource($params): self
     {
         return $this->setParam('_source', $params);
     }
@@ -422,8 +427,18 @@ class Query extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-post-filter.html
      */
-    public function setPostFilter(AbstractQuery $filter)
+    public function setPostFilter(AbstractQuery $filter): self
     {
         return $this->setParam('post_filter', $filter);
+    }
+
+    /**
+     * @param Collapse $collapse
+     *
+     * @return $this
+     */
+    public function setCollapse(Collapse $collapse): self
+    {
+        return $this->setParam('collapse', $collapse);
     }
 }

--- a/lib/Elastica/QueryBuilder/DSL.php
+++ b/lib/Elastica/QueryBuilder/DSL.php
@@ -12,6 +12,7 @@ interface DSL
     const TYPE_QUERY = 'query';
     const TYPE_AGGREGATION = 'aggregation';
     const TYPE_SUGGEST = 'suggest';
+    const TYPE_COLLAPSE = 'collapse';
 
     /**
      * must return type for QueryBuilder usage.

--- a/lib/Elastica/QueryBuilder/DSL/Collapse.php
+++ b/lib/Elastica/QueryBuilder/DSL/Collapse.php
@@ -6,11 +6,8 @@ use Elastica\Query\InnerHits;
 use Elastica\QueryBuilder\DSL;
 
 /**
- * Class Collapse
+ * Class Collapse.
  *
- * @package Elastica\QueryBuilder\DSL
- *
- * Elasticsearch Collapse DSL
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.7/search-request-collapse.html
  */

--- a/lib/Elastica/QueryBuilder/DSL/Collapse.php
+++ b/lib/Elastica/QueryBuilder/DSL/Collapse.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Elastica\QueryBuilder\DSL;
+
+use Elastica\Query\InnerHits;
+use Elastica\QueryBuilder\DSL;
+
+/**
+ * Class Collapse
+ *
+ * @package Elastica\QueryBuilder\DSL
+ *
+ * Elasticsearch Collapse DSL
+ *
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.7/search-request-collapse.html
+ */
+class Collapse implements DSL
+{
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return self::TYPE_COLLAPSE;
+    }
+
+    /**
+     * @return InnerHits
+     */
+    public function inner_hits(): InnerHits
+    {
+        return new InnerHits();
+    }
+}

--- a/test/Elastica/Collapse/CollapseTest.php
+++ b/test/Elastica/Collapse/CollapseTest.php
@@ -3,9 +3,9 @@
 namespace Elastica\Test\Collapse;
 
 use Elastica\Collapse;
+use Elastica\Collapse\InnerHits;
 use Elastica\Document;
 use Elastica\Query;
-use Elastica\Collapse\InnerHits;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Type\Mapping;
 
@@ -20,57 +20,57 @@ class CollapseTest extends BaseTest
         $mapping->setType($type);
 
         $mapping->setProperties([
-            'user'    => ['type' => 'keyword'],
+            'user' => ['type' => 'keyword'],
             'message' => ['type' => 'text'],
-            'date'    => ['type' => 'date'],
-            'likes'   => ['type' => 'integer'],
-            'zip'     => ['type' => 'keyword']
+            'date' => ['type' => 'date'],
+            'likes' => ['type' => 'integer'],
+            'zip' => ['type' => 'keyword'],
         ]);
 
         $mapping->send();
 
         $type->addDocuments([
             new Document(1, [
-                'user'    => 'Veronica',
+                'user' => 'Veronica',
                 'message' => 'Always keeping an eye on elasticsearch.',
-                'date'    => '2019-08-15',
-                'likes'   => 10,
-                'zip'     => '07'
+                'date' => '2019-08-15',
+                'likes' => 10,
+                'zip' => '07',
             ]),
             new Document(2, [
-                'user'    => 'Wallace',
+                'user' => 'Wallace',
                 'message' => 'Elasticsearch DevOps is awesome!',
-                'date'    => '2019-08-05',
-                'likes'   => 50,
-                'zip'     => '06'
+                'date' => '2019-08-05',
+                'likes' => 50,
+                'zip' => '06',
             ]),
             new Document(3, [
-                'user'    => 'Logan',
+                'user' => 'Logan',
                 'message' => 'Can I find my lost stuff on elasticsearch?',
-                'date'    => '2019-08-02',
-                'likes'   => 1,
-                'zip'     => '09'
+                'date' => '2019-08-02',
+                'likes' => 1,
+                'zip' => '09',
             ]),
             new Document(4, [
-                'user'    => 'Keith',
+                'user' => 'Keith',
                 'message' => 'Investigating again.',
-                'date'    => '2019-08-10',
-                'likes'   => 30,
-                'zip'     => '07'
+                'date' => '2019-08-10',
+                'likes' => 30,
+                'zip' => '07',
             ]),
             new Document(5, [
-                'user'    => 'Veronica',
+                'user' => 'Veronica',
                 'message' => 'Finding out new stuff.',
-                'date'    => '2019-08-01',
-                'likes'   => 20,
-                'zip'     => '07'
+                'date' => '2019-08-01',
+                'likes' => 20,
+                'zip' => '07',
             ]),
             new Document(6, [
-                'user'    => 'Wallace',
+                'user' => 'Wallace',
                 'message' => 'Baller.',
-                'date'    => '2019-08-15',
-                'likes'   => 20,
-                'zip'     => '06'
+                'date' => '2019-08-15',
+                'likes' => 20,
+                'zip' => '06',
             ]),
         ]);
 

--- a/test/Elastica/Collapse/CollapseTest.php
+++ b/test/Elastica/Collapse/CollapseTest.php
@@ -1,0 +1,342 @@
+<?php
+
+namespace Elastica\Test\Collapse;
+
+use Elastica\Collapse;
+use Elastica\Document;
+use Elastica\Query;
+use Elastica\Collapse\InnerHits;
+use Elastica\Test\Base as BaseTest;
+use Elastica\Type\Mapping;
+
+class CollapseTest extends BaseTest
+{
+    private function _getIndexForCollapseTest()
+    {
+        $index = $this->_createIndex();
+        $type = $index->getType('_doc');
+
+        $mapping = new Mapping();
+        $mapping->setType($type);
+
+        $mapping->setProperties([
+            'user'    => ['type' => 'keyword'],
+            'message' => ['type' => 'text'],
+            'date'    => ['type' => 'date'],
+            'likes'   => ['type' => 'integer'],
+            'zip'     => ['type' => 'keyword']
+        ]);
+
+        $mapping->send();
+
+        $type->addDocuments([
+            new Document(1, [
+                'user'    => 'Veronica',
+                'message' => 'Always keeping an eye on elasticsearch.',
+                'date'    => '2019-08-15',
+                'likes'   => 10,
+                'zip'     => '07'
+            ]),
+            new Document(2, [
+                'user'    => 'Wallace',
+                'message' => 'Elasticsearch DevOps is awesome!',
+                'date'    => '2019-08-05',
+                'likes'   => 50,
+                'zip'     => '06'
+            ]),
+            new Document(3, [
+                'user'    => 'Logan',
+                'message' => 'Can I find my lost stuff on elasticsearch?',
+                'date'    => '2019-08-02',
+                'likes'   => 1,
+                'zip'     => '09'
+            ]),
+            new Document(4, [
+                'user'    => 'Keith',
+                'message' => 'Investigating again.',
+                'date'    => '2019-08-10',
+                'likes'   => 30,
+                'zip'     => '07'
+            ]),
+            new Document(5, [
+                'user'    => 'Veronica',
+                'message' => 'Finding out new stuff.',
+                'date'    => '2019-08-01',
+                'likes'   => 20,
+                'zip'     => '07'
+            ]),
+            new Document(6, [
+                'user'    => 'Wallace',
+                'message' => 'Baller.',
+                'date'    => '2019-08-15',
+                'likes'   => 20,
+                'zip'     => '06'
+            ]),
+        ]);
+
+        $index->refresh();
+
+        return $index;
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetFieldName()
+    {
+        $collapse = new Collapse();
+        $returnValue = $collapse->setFieldname('some_name');
+        $this->assertEquals('some_name', $collapse->getParam('field'));
+        $this->assertInstanceOf(Collapse::class, $returnValue);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetInnerHits()
+    {
+        $collapse = new Collapse();
+        $innerHits = new InnerHits();
+        $returnValue = $collapse->setInnerHits($innerHits);
+        $this->assertEquals($innerHits, $collapse->getParam('inner_hits'));
+        $this->assertInstanceOf(Collapse::class, $returnValue);
+        $this->assertInstanceOf(InnerHits::class, $collapse->getParam('inner_hits'));
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetMaxConcurrentGroupSearches()
+    {
+        $collapse = new Collapse();
+        $returnValue = $collapse->setMaxConcurrentGroupSearches(5);
+        $this->assertEquals(5, $collapse->getParam('max_concurrent_group_searches'));
+        $this->assertInstanceOf(Collapse::class, $returnValue);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testAddInnerHits()
+    {
+        $collapse = new Collapse();
+
+        $innerHits1 = new InnerHits();
+        $innerHits1->setName('most_liked');
+
+        $innerHits2 = new InnerHits();
+        $innerHits2->setName('most_recent');
+
+        $collapse->addInnerHits($innerHits1);
+        $collapse->addInnerHits($innerHits2);
+
+        $this->assertCount(2, $collapse->getParam('inner_hits'));
+        $this->assertInternalType('array', $collapse->getParam('inner_hits'));
+        $this->assertEquals($innerHits1, $collapse->getParam('inner_hits')[0]);
+        $this->assertEquals($innerHits2, $collapse->getParam('inner_hits')[1]);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetThenAddInnerHits()
+    {
+        $collapse = new Collapse();
+
+        $innerHits1 = new InnerHits();
+        $innerHits1->setName('most_liked');
+
+        $innerHits2 = new InnerHits();
+        $innerHits2->setName('most_recent');
+
+        $collapse->setInnerHits($innerHits1);
+        $collapse->addInnerHits($innerHits2);
+
+        $this->assertCount(2, $collapse->getParam('inner_hits'));
+        $this->assertInternalType('array', $collapse->getParam('inner_hits'));
+        $this->assertEquals($innerHits1, $collapse->getParam('inner_hits')[0]);
+        $this->assertEquals($innerHits2, $collapse->getParam('inner_hits')[1]);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetInnerHitsOverridesExistingValue()
+    {
+        $collapse = new Collapse();
+
+        $innerHits1 = new InnerHits();
+        $innerHits1->setName('most_liked');
+
+        $innerHits2 = new InnerHits();
+        $innerHits2->setName('most_recent');
+
+        $collapse->setInnerHits($innerHits1);
+        $collapse->addInnerHits($innerHits2);
+
+        $this->assertCount(2, $collapse->getParam('inner_hits'));
+        $this->assertInternalType('array', $collapse->getParam('inner_hits'));
+        $this->assertEquals($innerHits1, $collapse->getParam('inner_hits')[0]);
+        $this->assertEquals($innerHits2, $collapse->getParam('inner_hits')[1]);
+
+        $innerHitsOverride = new InnerHits();
+        $innerHitsOverride->setName('override');
+
+        $collapse->setInnerHits($innerHitsOverride);
+
+        $this->assertInstanceOf(InnerHits::class, $collapse->getParam('inner_hits'));
+        $this->assertEquals($innerHitsOverride, $collapse->getParam('inner_hits'));
+    }
+
+    /**
+     * @group functional
+     */
+    public function testCollapseField()
+    {
+        $query = new Query();
+        $query->setSource(false);
+        $collapse = new Collapse();
+        $query->setCollapse($collapse);
+
+        $collapse->setFieldname('user');
+
+        $results = $this->search($query);
+
+        // $results->getTotalHits() isn't correct when using field collapsing, as total hits report the number of
+        // documents matching a query, not the number of remaining documents after collapsing
+        $this->assertCount(4, $results->getResults());
+
+        $this->assertEquals('1', $results->getResults()[0]->getId());
+        $this->assertEquals('Veronica', $results->getResults()[0]->getData()['user'][0]);
+
+        $this->assertEquals('2', $results->getResults()[1]->getId());
+        $this->assertEquals('Wallace', $results->getResults()[1]->getData()['user'][0]);
+
+        $this->assertEquals('3', $results->getResults()[2]->getId());
+        $this->assertEquals('Logan', $results->getResults()[2]->getData()['user'][0]);
+
+        $this->assertEquals('4', $results->getResults()[3]->getId());
+        $this->assertEquals('Keith', $results->getResults()[3]->getData()['user'][0]);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testCollapseWithInnerHits()
+    {
+        $query = new Query();
+        $query->setSource(false);
+
+        $innerHits = new InnerHits();
+        $innerHits->setName('last_tweets');
+        $innerHits->setSize(5);
+        $innerHits->setSort(['date' => 'asc']);
+
+        $collapse = new Collapse();
+        $collapse->setFieldname('user');
+        $collapse->setInnerHits($innerHits);
+
+        $query->setCollapse($collapse);
+
+        $results = $this->search($query);
+
+        $this->assertCount(4, $results->getResults());
+
+        $this->assertEquals('1', $results->getResults()[0]->getId());
+        $this->assertEquals('Veronica', $results->getResults()[0]->getData()['user'][0]);
+        $this->assertEquals('2', $results->getResults()[0]->getInnerHits()['last_tweets']['hits']['total']['value']);
+        $this->assertEquals('Finding out new stuff.',
+            $results->getResults()[0]->getInnerHits()['last_tweets']['hits']['hits'][0]['_source']['message']);
+        $this->assertEquals('Always keeping an eye on elasticsearch.',
+            $results->getResults()[0]->getInnerHits()['last_tweets']['hits']['hits'][1]['_source']['message']);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testCollapseWithMultipleInnerHits()
+    {
+        $query = new Query();
+        $query->setSource(false);
+
+        $innerHitsLiked = new InnerHits();
+        $innerHitsLiked->setName('most_liked');
+        $innerHitsLiked->setSize(5);
+        $innerHitsLiked->setSort(['likes']);
+
+        $innerHitsRecent = new InnerHits();
+        $innerHitsRecent->setName('most_recent');
+        $innerHitsRecent->setSize(5);
+        $innerHitsRecent->setSort(['date' => 'asc']);
+
+        $collapse = new Collapse();
+        $collapse->setFieldname('user');
+        $collapse->addInnerHits($innerHitsLiked);
+        $collapse->addInnerHits($innerHitsRecent);
+
+        $query->setCollapse($collapse);
+
+        $results = $this->search($query);
+
+        $this->assertCount(4, $results->getResults());
+
+        $this->assertEquals('1', $results->getResults()[0]->getId());
+        $this->assertEquals('Veronica', $results->getResults()[0]->getData()['user'][0]);
+
+        $this->assertEquals('2', $results->getResults()[0]->getInnerHits()['most_liked']['hits']['total']['value']);
+        $this->assertEquals('Always keeping an eye on elasticsearch.',
+            $results->getResults()[0]->getInnerHits()['most_liked']['hits']['hits'][0]['_source']['message']);
+        $this->assertEquals('Finding out new stuff.',
+            $results->getResults()[0]->getInnerHits()['most_liked']['hits']['hits'][1]['_source']['message']);
+
+        $this->assertEquals('2', $results->getResults()[0]->getInnerHits()['most_recent']['hits']['total']['value']);
+        $this->assertEquals('Finding out new stuff.',
+            $results->getResults()[0]->getInnerHits()['most_recent']['hits']['hits'][0]['_source']['message']);
+        $this->assertEquals('Always keeping an eye on elasticsearch.',
+            $results->getResults()[0]->getInnerHits()['most_recent']['hits']['hits'][1]['_source']['message']);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testSecondLevelCollapsing()
+    {
+        $query = new Query();
+        $query->setSource(false);
+
+        $innerHitsByZip = new InnerHits();
+        $innerHitsByZip->setName('by_zip');
+        $innerHitsByZip->setSize(5);
+        $innerHitsByZip->setSource(false);
+
+        $collapse = new Collapse();
+        $collapse->setFieldname('zip');
+        $collapse->setInnerHits($innerHitsByZip);
+
+        $nestedCollapse = new Collapse();
+        $nestedCollapse->setFieldname('user');
+
+        $innerHitsByZip->setCollapse($nestedCollapse);
+
+        $query->setCollapse($collapse);
+
+        $results = $this->search($query);
+
+        $this->assertCount(3, $results->getResults());
+
+        $this->assertEquals('07', $results->getResults()[0]->getData()['zip'][0]);
+        $this->assertCount(2, $results->getResults()[0]->getInnerHits()['by_zip']['hits']['hits']);
+        $this->assertEquals('Veronica', $results->getResults()[0]->getInnerHits()['by_zip']['hits']['hits'][0]['fields']['user'][0]);
+        $this->assertEquals('Keith', $results->getResults()[0]->getInnerHits()['by_zip']['hits']['hits'][1]['fields']['user'][0]);
+    }
+
+    /**
+     * @param Query $query
+     *
+     * @return \Elastica\ResultSet
+     */
+    private function search(Query $query)
+    {
+        return $this->_getIndexForCollapseTest()->getType('_doc')->search($query);
+    }
+}

--- a/test/Elastica/QueryTest.php
+++ b/test/Elastica/QueryTest.php
@@ -486,18 +486,18 @@ class QueryTest extends BaseTest
         $query->setCollapse($collapse);
 
         $expected = [
-            'field'      => 'user',
+            'field' => 'user',
             'inner_hits' => [
                 'name' => 'last_tweets',
                 'size' => 5,
-                'sort' => ['date' => 'asc']
+                'sort' => ['date' => 'asc'],
             ],
-            'max_concurrent_group_searches' => 4
+            'max_concurrent_group_searches' => 4,
         ];
 
         $actual = $query->toArray();
 
-        $this->assertTrue(\array_key_exists('collapse', $actual));
+        $this->assertArrayHasKey('collapse', $actual);
         $this->assertEquals($expected, $actual['collapse']);
     }
 
@@ -526,21 +526,21 @@ class QueryTest extends BaseTest
         $query->setCollapse($collapse);
 
         $expected = [
-            'field'      => 'user',
+            'field' => 'user',
             'inner_hits' => [
                 'name' => 'last_tweets',
                 'size' => 5,
                 'sort' => ['date' => 'asc'],
                 'collapse' => [
-                    'field' => 'date'
-                ]
+                    'field' => 'date',
+                ],
             ],
-            'max_concurrent_group_searches' => 4
+            'max_concurrent_group_searches' => 4,
         ];
 
         $actual = $query->toArray();
 
-        $this->assertTrue(\array_key_exists('collapse', $actual));
+        $this->assertArrayHasKey('collapse', $actual);
         $this->assertEquals($expected, $actual['collapse']);
     }
 }

--- a/test/Elastica/QueryTest.php
+++ b/test/Elastica/QueryTest.php
@@ -3,6 +3,8 @@
 namespace Elastica\Test;
 
 use Elastica\Aggregation\Terms as TermsAggregation;
+use Elastica\Collapse;
+use Elastica\Collapse\InnerHits;
 use Elastica\Document;
 use Elastica\Exception\InvalidException;
 use Elastica\Query;
@@ -442,5 +444,103 @@ class QueryTest extends BaseTest
         $result = $resultSet->current();
         $this->assertEquals(1, $result->getId());
         $this->assertNotEmpty($result->getData());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testSetCollapseToArrayCast()
+    {
+        $query = new Query();
+        $collapse = new Collapse();
+        $collapse->setFieldname('some_field');
+
+        $query->setCollapse($collapse);
+
+        $collapse->setFieldname('another_field');
+
+        $anotherQuery = new Query();
+        $anotherQuery->setCollapse($collapse);
+
+        $this->assertEquals($query->toArray(), $anotherQuery->toArray());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testCollapseArrayStructure()
+    {
+        $query = new Query();
+        $collapse = new Collapse();
+        $collapse
+            ->setFieldname('user')
+            ->setInnerHits(
+                (new InnerHits())
+                    ->setName('last_tweets')
+                    ->setSize(5)
+                    ->setSort(['date' => 'asc'])
+            )
+            ->setMaxConcurrentGroupSearches(4)
+        ;
+
+        $query->setCollapse($collapse);
+
+        $expected = [
+            'field'      => 'user',
+            'inner_hits' => [
+                'name' => 'last_tweets',
+                'size' => 5,
+                'sort' => ['date' => 'asc']
+            ],
+            'max_concurrent_group_searches' => 4
+        ];
+
+        $actual = $query->toArray();
+
+        $this->assertTrue(\array_key_exists('collapse', $actual));
+        $this->assertEquals($expected, $actual['collapse']);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testCollapseSecondLevelArrayStructure()
+    {
+        $query = new Query();
+        $collapse = new Collapse();
+        $collapse
+            ->setFieldname('user')
+            ->setInnerHits(
+                (new InnerHits())
+                    ->setName('last_tweets')
+                    ->setSize(5)
+                    ->setSort(['date' => 'asc'])
+                    ->setCollapse(
+                        (new Collapse())
+                        ->setFieldname('date')
+                    )
+            )
+            ->setMaxConcurrentGroupSearches(4)
+        ;
+
+        $query->setCollapse($collapse);
+
+        $expected = [
+            'field'      => 'user',
+            'inner_hits' => [
+                'name' => 'last_tweets',
+                'size' => 5,
+                'sort' => ['date' => 'asc'],
+                'collapse' => [
+                    'field' => 'date'
+                ]
+            ],
+            'max_concurrent_group_searches' => 4
+        ];
+
+        $actual = $query->toArray();
+
+        $this->assertTrue(\array_key_exists('collapse', $actual));
+        $this->assertEquals($expected, $actual['collapse']);
     }
 }


### PR DESCRIPTION
Added support for Field Collapsing as requested in #1392.
ES documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-collapse

Note: Inheriting `Query\InnerHits` in `Collapse\InnerHits` was something I've been debating with myself over and over again. As far as I'm concerned it makes sense to have different classes, especially as the collapse one has to have support for the second level collapse, but I didn't want to duplicate the entire code for InnerHits.
Downside is that right now there's no `AbstractCollapse` base-class as there is for the other concepts. Still feel like that's okay, because field collapsing is a quite simple concept right now.