### PR TITLE
Allow for string interval in Histogram aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Bugfixes
 
+- Corrected Histogram aggregations to allow for string interval [#1655](https://github.com/ruflin/Elastica/pull/1655)
+
 ### Added
 
 ### Improvements

--- a/lib/Elastica/Aggregation/Histogram.php
+++ b/lib/Elastica/Aggregation/Histogram.php
@@ -9,9 +9,9 @@ namespace Elastica\Aggregation;
 class Histogram extends AbstractSimpleAggregation
 {
     /**
-     * @param string $name     the name of this aggregation
-     * @param string $field    the name of the field on which to perform the aggregation
-     * @param int    $interval the interval by which documents will be bucketed
+     * @param string     $name     the name of this aggregation
+     * @param string     $field    the name of the field on which to perform the aggregation
+     * @param int|string $interval the interval by which documents will be bucketed
      */
     public function __construct($name, $field, $interval)
     {
@@ -23,7 +23,7 @@ class Histogram extends AbstractSimpleAggregation
     /**
      * Set the interval by which documents will be bucketed.
      *
-     * @param int $interval
+     * @param int|string $interval
      *
      * @return $this
      */


### PR DESCRIPTION
I found this issue today and thought I could contribute a bug fix.

I can see its already fixed for newer releases, but 5.x still has it wrong. :)