### PR TITLE
Add callable type hinting to Connection callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file based on the
 * Added support for Field Collapsing (Issue: [#1392](https://github.com/ruflin/Elastica/issues/1392); PR: [#1653](https://github.com/ruflin/Elastica/pull/1653))
 * Support string DSN in `\Elastica\Client` constructor for config argument [#1640](https://github.com/ruflin/Elastica/issues/1640)
 * Move Client configuration in a dedicated class
+* Added `callable` type hinting to `$callback` in `Client` constructor. [#1659](https://github.com/ruflin/Elastica/pull/1659)
 
 ### Improvements
 * Added `native_function_invocation` CS rule [#1606](https://github.com/ruflin/Elastica/pull/1606)

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -59,12 +59,12 @@ class Client
      * Creates a new Elastica client.
      *
      * @param array|string    $config   OPTIONAL Additional config or DSN of options
-     * @param callback        $callback OPTIONAL Callback function which can be used to be notified about errors (for example connection down)
+     * @param callback|null   $callback OPTIONAL Callback function which can be used to be notified about errors (for example connection down)
      * @param LoggerInterface $logger
      *
      * @throws \Elastica\Exception\InvalidException
      */
-    public function __construct($config = [], $callback = null, LoggerInterface $logger = null)
+    public function __construct($config = [], callable $callback = null, LoggerInterface $logger = null)
     {
         if (\is_string($config)) {
             $configuration = ClientConfiguration::fromDsn($config);


### PR DESCRIPTION
The `$callback` parameter is only used in `ConnectionPool` which already has the type hint.