### PR TITLE
Make classes with factory methods extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/6.1.1...master)
+* Changed all factory methods to make use of [late static bindings](http://docs.php.net/manual/en/language.oop5.late-static-bindings.php) by using `static` instead of `self` keyword. This is to increase extendability for classes with factory methods.
 
 ### Backward Compatibility Breaks
 * Dropped support for PHP 7.0

--- a/lib/Elastica/ClientConfiguration.php
+++ b/lib/Elastica/ClientConfiguration.php
@@ -45,7 +45,7 @@ class ClientConfiguration
      */
     public static function fromArray(array $config): self
     {
-        $clientConfiguration = new self();
+        $clientConfiguration = new static();
         foreach ($config as $key => $value) {
             $clientConfiguration->set($key, $value);
         }
@@ -66,7 +66,7 @@ class ClientConfiguration
             throw new InvalidException(\sprintf("DSN '%s' is invalid.", $dsn));
         }
 
-        $clientConfiguration = new self();
+        $clientConfiguration = new static();
 
         if (isset($parsedDsn['scheme'])) {
             $clientConfiguration->set('transport', $parsedDsn['scheme']);

--- a/lib/Elastica/Connection.php
+++ b/lib/Elastica/Connection.php
@@ -332,7 +332,7 @@ class Connection extends Param
     public static function create($params = [])
     {
         if (\is_array($params)) {
-            return new self($params);
+            return new static($params);
         }
 
         if ($params instanceof self) {

--- a/lib/Elastica/Document.php
+++ b/lib/Elastica/Document.php
@@ -331,7 +331,7 @@ class Document extends AbstractUpdateAction
         }
 
         if (\is_array($data)) {
-            return new self('', $data);
+            return new static('', $data);
         }
 
         throw new InvalidException('Failed to create document. Invalid data passed.');

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -64,21 +64,16 @@ class Query extends Param
             case $query instanceof self:
                 return $query;
             case $query instanceof AbstractQuery:
+            case \is_array($query):
+            case $query instanceof Suggest:
+            case $query instanceof Collapse:
                 return new static($query);
             case empty($query):
                 return new static(new MatchAll());
-            case \is_array($query):
-                return new static($query);
             case \is_string($query):
                 return new static(new QueryString($query));
             case $query instanceof AbstractSuggest:
                 return new static(new Suggest($query));
-
-            case $query instanceof Suggest:
-                return new static($query);
-
-            case $query instanceof Collapse:
-                return new static($query);
         }
 
         throw new InvalidException('Unexpected argument to create a query for.');

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -64,16 +64,21 @@ class Query extends Param
             case $query instanceof self:
                 return $query;
             case $query instanceof AbstractQuery:
-            case \is_array($query):
-            case $query instanceof Suggest:
-            case $query instanceof Collapse:
                 return new static($query);
             case empty($query):
                 return new static(new MatchAll());
+            case \is_array($query):
+                return new static($query);
             case \is_string($query):
                 return new static(new QueryString($query));
             case $query instanceof AbstractSuggest:
                 return new static(new Suggest($query));
+
+            case $query instanceof Suggest:
+                return new static($query);
+
+            case $query instanceof Collapse:
+                return new static($query);
         }
 
         throw new InvalidException('Unexpected argument to create a query for.');

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -64,21 +64,21 @@ class Query extends Param
             case $query instanceof self:
                 return $query;
             case $query instanceof AbstractQuery:
-                return new self($query);
+                return new static($query);
             case empty($query):
-                return new self(new MatchAll());
+                return new static(new MatchAll());
             case \is_array($query):
-                return new self($query);
+                return new static($query);
             case \is_string($query):
-                return new self(new QueryString($query));
+                return new static(new QueryString($query));
             case $query instanceof AbstractSuggest:
-                return new self(new Suggest($query));
+                return new static(new Suggest($query));
 
             case $query instanceof Suggest:
-                return new self($query);
+                return new static($query);
 
             case $query instanceof Collapse:
-                return new self($query);
+                return new static($query);
         }
 
         throw new InvalidException('Unexpected argument to create a query for.');

--- a/lib/Elastica/Suggest.php
+++ b/lib/Elastica/Suggest.php
@@ -59,7 +59,7 @@ class Suggest extends Param
             case $suggestion instanceof self:
                 return $suggestion;
             case $suggestion instanceof AbstractSuggest:
-                return new self($suggestion);
+                return new static($suggestion);
         }
         throw new NotImplementedException();
     }

--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -226,7 +226,7 @@ class Mapping
     public static function create($mapping): Mapping
     {
         if (\is_array($mapping)) {
-            $mappingObject = new self();
+            $mappingObject = new static();
             $mappingObject->setProperties($mapping);
 
             return $mappingObject;


### PR DESCRIPTION
# What this is changing
Use `static` instead of `self` in all factory methods in Elastica.

# What is my motivation/problem
I am working on a ES persistence layer library for my company.
My goal is to write it in a way that users can combine various query implementations with various ES clients (i.e. elasticsearch-php and elastica at the moment), Elastica queries being among the options. For this i wrote a thin wrapper for the `Elastica\Query` class and struggled with the factory method since it was using `self` instead of `static`. This is violating the open-closed principle in my opinion, hence i created this PR :)