### PR TITLE
[ES-7] Cleanup Search->addType() and Search->addTypes()

### DIFF
--- a/lib/Elastica/Multi/Search.php
+++ b/lib/Elastica/Multi/Search.php
@@ -206,10 +206,6 @@ class Search
             $header['index'] = $search->getIndices();
         }
 
-        if ($search->hasTypes()) {
-            $header['types'] = $search->getTypes();
-        }
-
         // Filter options accepted in the "header"
         return \array_intersect_key($header, \array_flip(self::$HEADER_OPTIONS));
     }

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -128,46 +128,6 @@ class Search
     }
 
     /**
-     * Adds a type to the current search.
-     *
-     * @param \Elastica\Type|string $type Type name or object
-     *
-     * @throws \Elastica\Exception\InvalidException
-     *
-     * @return $this
-     */
-    public function addType($type)
-    {
-        if ($type instanceof Type) {
-            $type = $type->getName();
-        }
-
-        if (!\is_string($type)) {
-            throw new InvalidException('Invalid type type');
-        }
-
-        $this->_types[] = $type;
-
-        return $this;
-    }
-
-    /**
-     * Add array of types.
-     *
-     * @param array $types
-     *
-     * @return $this
-     */
-    public function addTypes(array $types = [])
-    {
-        foreach ($types as $type) {
-            $this->addType($type);
-        }
-
-        return $this;
-    }
-
-    /**
      * @param string|array|\Elastica\Query|\Elastica\Suggest|\Elastica\Query\AbstractQuery $query
      *
      * @return $this
@@ -344,38 +304,6 @@ class Search
     }
 
     /**
-     * Return array of types.
-     *
-     * @return array List of types
-     */
-    public function getTypes()
-    {
-        return $this->_types;
-    }
-
-    /**
-     * @return bool
-     */
-    public function hasTypes()
-    {
-        return \count($this->_types) > 0;
-    }
-
-    /**
-     * @param \Elastica\Type|string $type
-     *
-     * @return bool
-     */
-    public function hasType($type)
-    {
-        if ($type instanceof Type) {
-            $type = $type->getName();
-        }
-
-        return \in_array($type, $this->_types);
-    }
-
-    /**
      * @return \Elastica\Query
      */
     public function getQuery()
@@ -410,25 +338,7 @@ class Search
             return '_search/scroll';
         }
 
-        $indices = $this->getIndices();
-
-        $path = '';
-        $types = $this->getTypes();
-
-        if (empty($indices)) {
-            if (!empty($types)) {
-                $path .= '_all';
-            }
-        } else {
-            $path .= \implode(',', $indices);
-        }
-
-        if (!empty($types)) {
-            $path .= '/'.\implode(',', $types);
-        }
-
-        // Add full path based on indices and types -> could be all
-        return $path.'/_search';
+        return \implode(',', $this->getIndices()).'/_search';
     }
 
     /**

--- a/test/Elastica/Multi/SearchTest.php
+++ b/test/Elastica/Multi/SearchTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test\Multi;
 
 use Elastica\Document;
+use Elastica\Index;
 use Elastica\Multi\ResultSet as MultiResultSet;
 use Elastica\Multi\Search as MultiSearch;
 use Elastica\Query;
@@ -11,14 +12,10 @@ use Elastica\Response;
 use Elastica\ResultSet;
 use Elastica\Search;
 use Elastica\Test\Base as BaseTest;
-use Elastica\Type;
 
 class SearchTest extends BaseTest
 {
-    /**
-     * @return Type
-     */
-    protected function _createType(): Type
+    protected function _createIndex(): Index
     {
         $client = $this->_getClient();
 
@@ -37,11 +34,10 @@ class SearchTest extends BaseTest
         $docs[] = new Document(9, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
         $docs[] = new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
         $docs[] = new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
-        $type = $index->getType('_doc');
-        $type->addDocuments($docs);
+        $index->addDocuments($docs);
         $index->refresh();
 
-        return $type;
+        return $index;
     }
 
     /**
@@ -124,14 +120,13 @@ class SearchTest extends BaseTest
      */
     public function testSearch()
     {
-        $type = $this->_createType();
-        $index = $type->getIndex();
+        $index = $this->_createIndex();
         $client = $index->getClient();
 
         $multiSearch = new MultiSearch($client);
 
         $search1 = new Search($client);
-        $search1->addIndex($index)->addType($type);
+        $search1->addIndex($index);
         $query1 = new Query();
         $termQuery1 = new Term();
         $termQuery1->setTerm('username', 'farrelley');
@@ -144,7 +139,7 @@ class SearchTest extends BaseTest
         $this->assertCount(1, $multiSearch->getSearches());
 
         $search2 = new Search($client);
-        $search2->addIndex($index)->addType($type);
+        $search2->addIndex($index);
         $query2 = new Query();
         $termQuery2 = new Term();
         $termQuery2->setTerm('username', 'bunny');
@@ -215,14 +210,13 @@ class SearchTest extends BaseTest
      */
     public function testSearchWithKeys()
     {
-        $type = $this->_createType();
-        $index = $type->getIndex();
+        $index = $this->_createIndex();
         $client = $index->getClient();
 
         $multiSearch = new MultiSearch($client);
 
         $search1 = new Search($client);
-        $search1->addIndex($index)->addType($type);
+        $search1->addIndex($index);
         $query1 = new Query();
         $termQuery1 = new Term();
         $termQuery1->setTerm('username', 'farrelley');
@@ -235,7 +229,7 @@ class SearchTest extends BaseTest
         $this->assertCount(1, $multiSearch->getSearches());
 
         $search2 = new Search($client);
-        $search2->addIndex($index)->addType($type);
+        $search2->addIndex($index);
         $query2 = new Query();
         $termQuery2 = new Term();
         $termQuery2->setTerm('username', 'bunny');
@@ -308,21 +302,20 @@ class SearchTest extends BaseTest
      */
     public function testSearchWithError()
     {
-        $type = $this->_createType();
-        $index = $type->getIndex();
+        $index = $this->_createIndex();
         $client = $index->getClient();
 
         $multiSearch = new MultiSearch($client);
 
         $searchGood = new Search($client);
         $searchGood->setQuery('bunny');
-        $searchGood->addIndex($index)->addType($type);
+        $searchGood->addIndex($index);
 
         $multiSearch->addSearch($searchGood);
 
         $searchBad = new Search($client);
         $searchBad->setOption(Search::OPTION_SIZE, -2);
-        $searchBad->addIndex($index)->addType($type);
+        $searchBad->addIndex($index);
 
         $multiSearch->addSearch($searchBad);
 
@@ -354,21 +347,20 @@ class SearchTest extends BaseTest
      */
     public function testSearchWithErrorWithKeys()
     {
-        $type = $this->_createType();
-        $index = $type->getIndex();
+        $index = $this->_createIndex();
         $client = $index->getClient();
 
         $multiSearch = new MultiSearch($client);
 
         $searchGood = new Search($client);
         $searchGood->setQuery('bunny');
-        $searchGood->addIndex($index)->addType($type);
+        $searchGood->addIndex($index);
 
         $multiSearch->addSearch($searchGood, 'search1');
 
         $searchBad = new Search($client);
         $searchBad->setOption(Search::OPTION_SIZE, -2);
-        $searchBad->addIndex($index)->addType($type);
+        $searchBad->addIndex($index);
 
         $multiSearch->addSearch($searchBad);
 
@@ -400,14 +392,13 @@ class SearchTest extends BaseTest
      */
     public function testGlobalSearchTypeSearch()
     {
-        $type = $this->_createType();
-        $index = $type->getIndex();
+        $index = $this->_createIndex();
         $client = $index->getClient();
 
         $multiSearch = new MultiSearch($client);
 
         $search1 = new Search($client);
-        $search1->addIndex($index)->addType($type);
+        $search1->addIndex($index);
         $query1 = new Query();
         $termQuery1 = new Term();
         $termQuery1->setTerm('username', 'farrelley');
@@ -420,7 +411,7 @@ class SearchTest extends BaseTest
         $this->assertCount(1, $multiSearch->getSearches());
 
         $search2 = new Search($client);
-        $search2->addIndex($index)->addType($type);
+        $search2->addIndex($index);
         $query2 = new Query();
         $termQuery2 = new Term();
         $termQuery2->setTerm('username', 'bunny');
@@ -484,14 +475,13 @@ class SearchTest extends BaseTest
      */
     public function testGlobalSearchTypeSearchWithKeys()
     {
-        $type = $this->_createType();
-        $index = $type->getIndex();
+        $index = $this->_createIndex();
         $client = $index->getClient();
 
         $multiSearch = new MultiSearch($client);
 
         $search1 = new Search($client);
-        $search1->addIndex($index)->addType($type);
+        $search1->addIndex($index);
         $query1 = new Query();
         $termQuery1 = new Term();
         $termQuery1->setTerm('username', 'farrelley');
@@ -504,7 +494,7 @@ class SearchTest extends BaseTest
         $this->assertCount(1, $multiSearch->getSearches());
 
         $search2 = new Search($client);
-        $search2->addIndex($index)->addType($type);
+        $search2->addIndex($index);
         $query2 = new Query();
         $termQuery2 = new Term();
         $termQuery2->setTerm('username', 'bunny');
@@ -569,14 +559,13 @@ class SearchTest extends BaseTest
      */
     public function testSearchWithSearchOptions()
     {
-        $type = $this->_createType();
-        $index = $type->getIndex();
+        $index = $this->_createIndex();
         $client = $index->getClient();
 
         $multiSearch = new MultiSearch($client);
 
         $search1 = new Search($client);
-        $search1->addIndex($index)->addType($type);
+        $search1->addIndex($index);
         $search1->setOption('terminate_after', '1');
         $query1 = new Query();
         $termQuery1 = new Term();
@@ -590,7 +579,7 @@ class SearchTest extends BaseTest
         $this->assertCount(1, $multiSearch->getSearches());
 
         $search2 = new Search($client);
-        $search2->addIndex($index)->addType($type);
+        $search2->addIndex($index);
         $query2 = new Query();
         $termQuery2 = new Term();
         $termQuery2->setTerm('username', 'bunny');


### PR DESCRIPTION
Attempt to:

- Cleanup `Search->addType()`
- Cleanup `Search->addTypes()`

Tests are green (`make test TEST="test/Elastica/SearchTest.php"` and  `make test TEST="test/Elastica/Multi/SearchTest.php"`):
- `Index->addDocument()` isn't yet available from parent commit, they use `Index->addDocuments()` instead