### PR TITLE
[ES-7] Make Bulk classes Type free

### DIFF
--- a/lib/Elastica/Bulk.php
+++ b/lib/Elastica/Bulk.php
@@ -81,39 +81,6 @@ class Bulk
     }
 
     /**
-     * @param string|Type $type
-     *
-     * @return $this
-     */
-    public function setType($type): self
-    {
-        if ($type instanceof Type) {
-            $this->setIndex($type->getIndex()->getName());
-            $type = $type->getName();
-        }
-
-        $this->_type = (string) $type;
-
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getType()
-    {
-        return $this->_type;
-    }
-
-    /**
-     * @return bool
-     */
-    public function hasType(): bool
-    {
-        return null !== $this->getType() && '' !== $this->getType();
-    }
-
-    /**
      * @return string
      */
     public function getPath(): string
@@ -121,9 +88,6 @@ class Bulk
         $path = '';
         if ($this->hasIndex()) {
             $path .= $this->getIndex().'/';
-            if ($this->hasType()) {
-                $path .= $this->getType().'/';
-            }
         }
         $path .= '_bulk';
 

--- a/lib/Elastica/Bulk/Action.php
+++ b/lib/Elastica/Bulk/Action.php
@@ -5,7 +5,6 @@ namespace Elastica\Bulk;
 use Elastica\Bulk;
 use Elastica\Index;
 use Elastica\JSON;
-use Elastica\Type;
 
 class Action
 {
@@ -138,22 +137,6 @@ class Action
             $index = $index->getName();
         }
         $this->_metadata['_index'] = $index;
-
-        return $this;
-    }
-
-    /**
-     * @param string|Type $type
-     *
-     * @return $this
-     */
-    public function setType($type): self
-    {
-        if ($type instanceof Type) {
-            $this->setIndex($type->getIndex()->getName());
-            $type = $type->getName();
-        }
-        $this->_metadata['_type'] = $type;
 
         return $this;
     }

--- a/lib/Elastica/Bulk/Action/DeleteDocument.php
+++ b/lib/Elastica/Bulk/Action/DeleteDocument.php
@@ -18,7 +18,6 @@ class DeleteDocument extends AbstractDocument
     {
         return $action->getOptions([
             '_index',
-            '_type',
             '_id',
             'version',
             'version_type',

--- a/lib/Elastica/Bulk/Action/IndexDocument.php
+++ b/lib/Elastica/Bulk/Action/IndexDocument.php
@@ -31,7 +31,6 @@ class IndexDocument extends AbstractDocument
     {
         return $action->getOptions([
             '_index',
-            '_type',
             '_id',
             'version',
             'version_type',

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -12,6 +12,7 @@ use Elastica\ResultSet\BuilderInterface;
 use Elastica\Script\AbstractScript;
 use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Endpoints\DeleteByQuery;
+use Elasticsearch\Endpoints\Get as DocumentGet;
 use Elasticsearch\Endpoints\Indices\Aliases\Update;
 use Elasticsearch\Endpoints\Indices\Analyze;
 use Elasticsearch\Endpoints\Indices\Cache\Clear;
@@ -21,7 +22,6 @@ use Elasticsearch\Endpoints\Indices\Delete;
 use Elasticsearch\Endpoints\Indices\Exists;
 use Elasticsearch\Endpoints\Indices\Flush;
 use Elasticsearch\Endpoints\Indices\ForceMerge;
-use Elasticsearch\Endpoints\Indices\Get;
 use Elasticsearch\Endpoints\Indices\Mapping\Get as MappingGet;
 use Elasticsearch\Endpoints\Indices\Open;
 use Elasticsearch\Endpoints\Indices\Refresh;
@@ -202,7 +202,7 @@ class Index implements SearchableInterface
      */
     public function getDocument($id, array $options = []): Document
     {
-        $endpoint = new Get();
+        $endpoint = new DocumentGet();
         $endpoint->setID($id);
         $endpoint->setParams($options);
 

--- a/test/Elastica/Bulk/Action/UpdateDocumentTest.php
+++ b/test/Elastica/Bulk/Action/UpdateDocumentTest.php
@@ -6,7 +6,6 @@ use Elastica\Bulk\Action\UpdateDocument;
 use Elastica\Document;
 use Elastica\Index;
 use Elastica\Test\Base as BaseTest;
-use Elastica\Type;
 
 class UpdateDocumentTest extends BaseTest
 {
@@ -31,35 +30,22 @@ class UpdateDocumentTest extends BaseTest
         $expected .= $docExpected;
         $this->assertEquals($expected, $action->toString());
 
-        $action->setType('_doc');
-
-        $expected = '{"update":{"_index":"index","_type":"_doc"}}'."\n";
-        $expected .= $docExpected;
-        $this->assertEquals($expected, $action->toString());
-
         $action->setId(1);
-        $expected = '{"update":{"_index":"index","_type":"_doc","_id":1}}'."\n";
+        $expected = '{"update":{"_index":"index","_id":1}}'."\n";
         $expected .= $docExpected;
         $this->assertEquals($expected, $action->toString());
 
         $action->setRouting(1);
-        $expected = '{"update":{"_index":"index","_type":"_doc","_id":1,"routing":1}}'."\n";
+        $expected = '{"update":{"_index":"index","_id":1,"routing":1}}'."\n";
         $expected .= $docExpected;
         $this->assertEquals($expected, $action->toString());
 
         $client = $this->_getClient();
         $index = new Index($client, 'index2');
-        $type = new Type($index, '_doc');
 
         $action->setIndex($index);
 
-        $expected = '{"update":{"_index":"index2","_type":"_doc","_id":1,"routing":1}}'."\n";
-        $expected .= $docExpected;
-        $this->assertEquals($expected, $action->toString());
-
-        $action->setType($type);
-
-        $expected = '{"update":{"_index":"index2","_type":"_doc","_id":1,"routing":1}}'."\n";
+        $expected = '{"update":{"_index":"index2","_id":1,"routing":1}}'."\n";
         $expected .= $docExpected;
         $this->assertEquals($expected, $action->toString());
     }
@@ -69,14 +55,14 @@ class UpdateDocumentTest extends BaseTest
      */
     public function testUpdateDocumentAsUpsert()
     {
-        $document = new Document(1, ['foo' => 'bar'], '_doc', 'index');
+        $document = new Document(1, ['foo' => 'bar'], 'index');
         $document->setDocAsUpsert(true);
         $action = new UpdateDocument($document);
 
         $this->assertEquals('update', $action->getOpType());
         $this->assertTrue($action->hasSource());
 
-        $expected = '{"update":{"_id":1,"_type":"_doc","_index":"index"}}'."\n"
+        $expected = '{"update":{"_id":1,"_index":"index"}}'."\n"
                 .'{"doc":{"foo":"bar"},"doc_as_upsert":true}'."\n";
         $this->assertEquals($expected, $action->toString());
 
@@ -86,7 +72,7 @@ class UpdateDocumentTest extends BaseTest
 
         $document->setDocAsUpsert(false);
         $action->setDocument($document);
-        $expected = '{"update":{"_id":1,"_type":"_doc","_index":"index"}}'."\n"
+        $expected = '{"update":{"_id":1,"_index":"index"}}'."\n"
                 .'{"doc":{"foo":"bar"}}'."\n";
         $this->assertEquals($expected, $action->toString());
 

--- a/test/Elastica/Bulk/ActionTest.php
+++ b/test/Elastica/Bulk/ActionTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Bulk;
 use Elastica\Bulk\Action;
 use Elastica\Index;
 use Elastica\Test\Base as BaseTest;
-use Elastica\Type;
 
 class ActionTest extends BaseTest
 {
@@ -26,36 +25,25 @@ class ActionTest extends BaseTest
         $expected = '{"index":{"_index":"index"}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
-        $action->setType('_doc');
-
-        $expected = '{"index":{"_index":"index","_type":"_doc"}}'."\n";
-        $this->assertEquals($expected, $action->toString());
-
         $action->setId(1);
-        $expected = '{"index":{"_index":"index","_type":"_doc","_id":1}}'."\n";
+        $expected = '{"index":{"_index":"index","_id":1}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
         $action->setRouting(1);
-        $expected = '{"index":{"_index":"index","_type":"_doc","_id":1,"routing":1}}'."\n";
+        $expected = '{"index":{"_index":"index","_id":1,"routing":1}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
         $client = $this->_getClient();
         $index = new Index($client, 'index2');
-        $type = new Type($index, '_doc');
 
         $action->setIndex($index);
 
-        $expected = '{"index":{"_index":"index2","_type":"_doc","_id":1,"routing":1}}'."\n";
-        $this->assertEquals($expected, $action->toString());
-
-        $action->setType($type);
-
-        $expected = '{"index":{"_index":"index2","_type":"_doc","_id":1,"routing":1}}'."\n";
+        $expected = '{"index":{"_index":"index2","_id":1,"routing":1}}'."\n";
         $this->assertEquals($expected, $action->toString());
 
         $action->setSource(['user' => 'name']);
 
-        $expected = '{"index":{"_index":"index2","_type":"_doc","_id":1,"routing":1}}'."\n";
+        $expected = '{"index":{"_index":"index2","_id":1,"routing":1}}'."\n";
         $expected .= '{"user":"name"}'."\n";
 
         $this->assertEquals($expected, $action->toString());

--- a/test/Elastica/Bulk/ResponseSetTest.php
+++ b/test/Elastica/Bulk/ResponseSetTest.php
@@ -148,7 +148,6 @@ class ResponseSetTest extends BaseTest
                 [
                     'index' => [
                         '_index' => 'index',
-                        '_type' => 'type',
                         '_id' => '1',
                         '_version' => 1,
                         'ok' => true,
@@ -157,7 +156,6 @@ class ResponseSetTest extends BaseTest
                 [
                     'index' => [
                         '_index' => 'index',
-                        '_type' => 'type',
                         '_id' => '2',
                         '_version' => 1,
                         'ok' => true,
@@ -166,7 +164,6 @@ class ResponseSetTest extends BaseTest
                 [
                     'index' => [
                         '_index' => 'index',
-                        '_type' => 'type',
                         '_id' => '3',
                         '_version' => 1,
                         'ok' => true,


### PR DESCRIPTION
Attempt to:

- Remove `Type` usage in `Bulk` classes

Tests `make test TEST="test/Elastica/Bulk*"` are green.

Note:

- `Index->createDocument()` isn't yet available from parent commit, they use `new Document()` instead