### PR TITLE
[ES-7] Fix tests

### DIFF
--- a/lib/Elastica/Query/ParentId.php
+++ b/lib/Elastica/Query/ParentId.php
@@ -13,13 +13,13 @@ class ParentId extends AbstractQuery
      * ParentId constructor.
      *
      * @param string $type           Name of the child relationship mapped for the join field
-     * @param string $parentDocId    ID of the parent document. The query will return child documents of this parent document.
+     * @param string $id             ID of the parent document. The query will return child documents of this parent document.
      * @param bool   $ignoreUnmapped Indicates whether to ignore an unmapped type and not return any documents instead of an error. Defaults to false.
      */
-    public function __construct(string $type, string $parentDocId, bool $ignoreUnmapped = false)
+    public function __construct(string $type, string $id, bool $ignoreUnmapped = false)
     {
         $this->setRelationshipType($type);
-        $this->setId($parentDocId);
+        $this->setId($id);
         $this->setIgnoreUnmapped($ignoreUnmapped);
     }
 

--- a/lib/Elastica/Query/Percolate.php
+++ b/lib/Elastica/Query/Percolate.php
@@ -9,7 +9,7 @@ use Elastica\Document;
  *
  * @author Boris Popovschi <zyqsempai@mail.ru>
  *
- * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.0/query-dsl-percolate-query.html
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-percolate-query.html
  */
 /**
  * Class Percolate.
@@ -50,18 +50,6 @@ class Percolate extends AbstractQuery
     public function setDocumentIndex(string $index): self
     {
         return $this->setParam('index', $index);
-    }
-
-    /**
-     * The type of the document to fetch.
-     *
-     * @param string $type
-     *
-     * @return $this
-     */
-    public function setExistingDocumentType(string $type): self
-    {
-        return $this->setParam('type', $type);
     }
 
     /**

--- a/lib/Elastica/QueryBuilder/Version/Version240.php
+++ b/lib/Elastica/QueryBuilder/Version/Version240.php
@@ -47,7 +47,6 @@ class Version240 extends Version
         'wildcard',
         'geo_distance',
         'exists',
-        'type',
         'percolate',
     ];
 

--- a/test/Elastica/BulkTest.php
+++ b/test/Elastica/BulkTest.php
@@ -77,11 +77,11 @@ class BulkTest extends BaseTest
         ];
         $this->assertEquals($expected, $data);
 
-        $expected = '{"index":{"_id":1,"_index":"'.$indexName.'"}}
+        $expected = '{"index":{"_id":"1","_index":"'.$indexName.'"}}
 {"name":"Mister Fantastic"}
-{"index":{"_id":2}}
+{"index":{"_id":"2"}}
 {"name":"Invisible Woman"}
-{"create":{"_id":3,"_index":"'.$indexName.'"}}
+{"create":{"_id":"3","_index":"'.$indexName.'"}}
 {"name":"The Human Torch"}
 {"index":{"_index":"'.$indexName.'"}}
 {"name":"The Thing"}

--- a/test/Elastica/MappingTest.php
+++ b/test/Elastica/MappingTest.php
@@ -255,14 +255,12 @@ class MappingTest extends BaseTest
         $newMapping = $index->getMapping();
         $this->assertArraySubset(
             [
-                Document::DEFAULT_TYPE => [
-                    'properties' => [
-                        'multiname' => [
-                            'type' => 'text',
-                            'fields' => [
-                                'raw' => [
-                                    'type' => 'keyword',
-                                ],
+                'properties' => [
+                    'multiname' => [
+                        'type' => 'text',
+                        'fields' => [
+                            'raw' => [
+                                'type' => 'keyword',
                             ],
                         ],
                     ],

--- a/test/Elastica/Processor/AttachmentTest.php
+++ b/test/Elastica/Processor/AttachmentTest.php
@@ -198,7 +198,6 @@ class AttachmentTest extends BasePipelineTest
         ]);
         $mapping->setSource(['excludes' => ['data']]);
 
-        $index->create(['settings' => ['index' => ['number_of_shards' => 1, 'number_of_replicas' => 0]]]);
         $index->setMapping($mapping);
 
         $docId = 1;

--- a/test/Elastica/Query/PercolateTest.php
+++ b/test/Elastica/Query/PercolateTest.php
@@ -67,7 +67,6 @@ class PercolateTest extends BaseTest
 
         $percolateQuery = new Percolate();
         $percolateQuery->setField('query')
-            ->setExistingDocumentType($this->index->getName())
             ->setDocumentIndex($this->index->getName())
             ->setDocumentId($doc->getId());
         $resultSet = $this->index->search($percolateQuery);
@@ -85,7 +84,6 @@ class PercolateTest extends BaseTest
         $this->index->addDocument($doc2);
         $percolateQuery = new Percolate();
         $percolateQuery->setField('query')
-            ->setExistingDocumentType($this->index->getName())
             ->setDocumentIndex($this->index->getName())
             ->setDocumentId($doc2->getId());
         $resultSet = $this->index->search($percolateQuery);
@@ -143,20 +141,6 @@ class PercolateTest extends BaseTest
         $data = $query->toArray();
 
         $this->assertEquals($data['percolate']['index'], $index->getName());
-    }
-
-    /**
-     * @group unit
-     */
-    public function testSetExistingDocumentType()
-    {
-        $type = 'newType';
-        $query = new Percolate();
-        $query->setExistingDocumentType($type);
-
-        $data = $query->toArray();
-
-        $this->assertEquals($data['percolate']['type'], $type);
     }
 
     /**

--- a/test/Elastica/Query/TermsTest.php
+++ b/test/Elastica/Query/TermsTest.php
@@ -59,7 +59,6 @@ class TermsTest extends BaseTest
 
         $query->setTermsLookup('name', [
             'index' => $lookupIndex->getName(),
-            'type' => $lookupIndex->getName(),
             'id' => '1',
             'path' => 'terms',
         ]);


### PR DESCRIPTION
Here are some tests fixes.

I pushed individual commits to make easier you cheery-pick those you like, juste in case.

and, a question: Is there a reason to keep `Version240` class? Strangely, it has some queries that aren't avaiable in 2.4, such `parent_id`