### PR TITLE
Restore request data in debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 
 * The `\Elastica\Query\GeoPolygon::count()` method now returns the count of points passed to the filter [#1696](https://github.com/ruflin/Elastica/pull/1696)
+* Fix issue in `\Elastica\Client::request()` which causes request data to not be sent to the logger [#1682](https://github.com/ruflin/Elastica/pull/1682)
 
 ### Added
 

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -641,7 +641,7 @@ class Client
         }
 
         $this->_logger->debug('Elastica Request', [
-            'request' => $request,
+            'request' => $request->toArray(),
             'response' => $this->_lastResponse ? $this->_lastResponse->getData() : null,
             'responseStatus' => $this->_lastResponse ? $this->_lastResponse->getStatus() : null,
         ]);


### PR DESCRIPTION
After the merge of #1661 I've not been getting the request body in my debug logs. The issue seems to be due to the the fact that it's not being converted into an array like it used to be.

I've not added to the CHANGELOG.md as this is fixing an issue that is already in that change log.