### PR TITLE
Add the Sampler aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 
 ### Added
+* Added `Sampler` aggregation [#1688](https://github.com/ruflin/Elastica/pull/1688)
 
 ### Improvements
 

--- a/lib/Elastica/Aggregation/Sampler.php
+++ b/lib/Elastica/Aggregation/Sampler.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Elastica\Aggregation;
+
+/**
+ * Class Sampler.
+ *
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-sampler-aggregation.html
+ */
+class Sampler extends AbstractAggregation
+{
+    /**
+     * Set the number of top-scoring documents to be returned from each shard.
+     *
+     * @param int $shardSize
+     *
+     * @return $this
+     */
+    public function setShardSize(int $shardSize): self
+    {
+        return $this->setParam('shard_size', $shardSize);
+    }
+}

--- a/lib/Elastica/QueryBuilder/DSL/Aggregation.php
+++ b/lib/Elastica/QueryBuilder/DSL/Aggregation.php
@@ -24,6 +24,7 @@ use Elastica\Aggregation\Nested;
 use Elastica\Aggregation\Percentiles;
 use Elastica\Aggregation\Range;
 use Elastica\Aggregation\ReverseNested;
+use Elastica\Aggregation\Sampler;
 use Elastica\Aggregation\ScriptedMetric;
 use Elastica\Aggregation\SerialDiff;
 use Elastica\Aggregation\SignificantTerms;
@@ -552,5 +553,18 @@ class Aggregation implements DSL
     public function adjacency_matrix(string $name): AdjacencyMatrix
     {
         return new AdjacencyMatrix($name);
+    }
+
+    /** sampler aggregation.
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-sampler-aggregation.html
+     *
+     * @param string $name
+     *
+     * @return Sampler
+     */
+    public function sampler($name): Sampler
+    {
+        return new Sampler($name);
     }
 }

--- a/test/Elastica/Aggregation/SamplerTest.php
+++ b/test/Elastica/Aggregation/SamplerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Elastica\Test\Aggregation;
+
+use Elastica\Aggregation\Sampler;
+use Elastica\Aggregation\Sum;
+use Elastica\Document;
+use Elastica\Index;
+use Elastica\Query;
+
+class SamplerTest extends BaseAggregationTest
+{
+    protected function _getIndexForTest(): Index
+    {
+        $index = $this->_createIndex(null, true, 2);
+
+        $routing1 = 'first_routing';
+        $routing2 = 'second_routing';
+
+        $index->addDocuments([
+            (new Document(1, ['price' => 5]))->setRouting($routing1),
+            (new Document(2, ['price' => 8]))->setRouting($routing1),
+            (new Document(3, ['price' => 1]))->setRouting($routing1),
+            (new Document(4, ['price' => 3]))->setRouting($routing2),
+            (new Document(5, ['price' => 1.5]))->setRouting($routing2),
+        ]);
+
+        $index->refresh();
+
+        return $index;
+    }
+
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $expected = [
+            'sampler' => [
+                'shard_size' => 1,
+            ],
+            'aggs' => [
+                'price_sum' => [
+                    'sum' => [
+                        'field' => 'price',
+                    ],
+                ],
+            ],
+        ];
+
+        $agg = new Sampler('price_sampler');
+        $agg->setShardSize(1);
+
+        $childAgg = new Sum('price_sum');
+        $childAgg->setField('price');
+
+        $agg->addAggregation($childAgg);
+
+        $this->assertEquals($expected, $agg->toArray());
+    }
+
+    /**
+     * @dataProvider shardSizeProvider
+     * @group functional
+     *
+     * @param int $shardSize
+     * @param int $docCount
+     */
+    public function testSamplerAggregation(int $shardSize, int $docCount)
+    {
+        $agg = new Sampler('price_sampler');
+        $agg->setShardSize($shardSize);
+
+        $childAgg = new Sum('price_sum');
+        $childAgg->setField('price');
+
+        $agg->addAggregation($childAgg);
+
+        $query = new Query();
+        $query->addAggregation($agg);
+        $results = $this->_getIndexForTest()->search($query)->getAggregation('price_sampler');
+
+        $this->assertEquals($docCount, $results['doc_count']);
+    }
+
+    public function shardSizeProvider()
+    {
+        return [
+            [1, 2],
+            [2, 4],
+            [3, 5],
+        ];
+    }
+}

--- a/test/Elastica/QueryBuilder/DSL/AggregationTest.php
+++ b/test/Elastica/QueryBuilder/DSL/AggregationTest.php
@@ -57,6 +57,7 @@ class AggregationTest extends AbstractDSLTest
         $this->_assertImplemented($aggregationDSL, 'avg_bucket', Aggregation\AvgBucket::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'sum_bucket', Aggregation\SumBucket::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'adjacency_matrix', Aggregation\AdjacencyMatrix::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'sampler', Aggregation\Sampler::class, ['name']);
 
         $this->_assertNotImplemented($aggregationDSL, 'children', ['name']);
         $this->_assertNotImplemented($aggregationDSL, 'geo_bounds', ['name']);


### PR DESCRIPTION
This patch adds the [Sampler](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-sampler-aggregation.html) aggregation.