### PR TITLE
Rename Suggest\Term prefix_len option to prefix_length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 
+* Renamed `\Elastica\Suggest\Term` deprecated option `prefix_len` to `prefix_length` [#1707](https://github.com/ruflin/Elastica/pull/1707)
 * The `\Elastica\Query\GeoPolygon::count()` method now returns the count of points passed to the filter [#1696](https://github.com/ruflin/Elastica/pull/1696)
 * Fix issue in `\Elastica\Client::request()` which causes request data to not be sent to the logger [#1682](https://github.com/ruflin/Elastica/pull/1682)
 

--- a/lib/Elastica/Suggest/Term.php
+++ b/lib/Elastica/Suggest/Term.php
@@ -75,7 +75,7 @@ class Term extends AbstractSuggest
      */
     public function setPrefixLength(int $length = 1): Term
     {
-        return $this->setParam('prefix_len', $length);
+        return $this->setParam('prefix_length', $length);
     }
 
     /**


### PR DESCRIPTION
Taken from https://github.com/ruflin/Elastica/pull/1438