### PR TITLE
Mark Elastica 5.x as unmaintained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.0.0-beta2...master)
+* Marked Elastica 5.x as unmaintained
 
 ### Backward Compatibility Breaks
 
@@ -13,7 +14,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Deprecated
 
-## [Unreleased](https://github.com/ruflin/Elastica/compare/7.0.0-beta1...7.0.0-beta2)
+## [7.0.0-beta2](https://github.com/ruflin/Elastica/compare/7.0.0-beta1...7.0.0-beta2)
 
 ### Backward Compatibility Breaks
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This project tries to follow Elasticsearch in terms of [End of Life](https://www
 | --------------------------------------------------------------------------------------- | ------------- | ----------------- | -------- |
 | [7.x](https://github.com/ruflin/Elastica/tree/master)                                   | 7.x           | ^7.0              | ^7.2     |
 | [6.x](https://github.com/ruflin/Elastica/tree/6.x)                                      | 6.x           | ^6.0              | ^7.0     |
-| [5.x](https://github.com/ruflin/Elastica/tree/5.x)                                      | 5.x           | ^5.0              | \>=5.6   |
+| [5.x](https://github.com/ruflin/Elastica/tree/5.x) (unmaintained)                       | 5.x           | ^5.0              | \>=5.6   |
 | [3.2.3](https://github.com/ruflin/Elastica/tree/3.2.3) (unmaintained)                   | 2.4.0         | no                | \>=5.4   |
 | [2.x](https://github.com/ruflin/Elastica/tree/2.x) (unmaintained)                       | 1.7.2         | no                | \>=5.3.3 |
 ------------


### PR DESCRIPTION
ES v5.6.x EOL was on 2019-03-11