### PR TITLE
Fix BC break in elasticsearch-php by excluding broken version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.2",
         "ext-json": "*",
         "psr/log": "~1.0",
-        "elasticsearch/elasticsearch": "^7.0 <7.4.0"
+        "elasticsearch/elasticsearch": "^7.0 !=7.4.0"
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",


### PR DESCRIPTION
Related to #1710 and elastic/elasticsearch-php#967
Should be merged once elastic/elasticsearch-php#968 is merged and version 7.4.1 of elastic/elasticsearch-php is released.