### PR TITLE
Changed default test target to PHP 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 
 * Launch tests with PHP 7.4
-* local tests launch with PHP 7.2 by default
+* local tests launch with PHP 7.2 by default [#1725](https://github.com/ruflin/Elastica/pull/1725)
 * Added `nullable_type_declaration_for_default_null_value`, `no_alias_functions` CS rules [#1706](https://github.com/ruflin/Elastica/pull/1706)
 * Configured `visibility_required` CS rule for constants [#1723](https://github.com/ruflin/Elastica/pull/1723)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 
 * Launch tests with PHP 7.4
+* local tests launch with PHP 7.2 by default
 * Added `nullable_type_declaration_for_default_null_value`, `no_alias_functions` CS rules [#1706](https://github.com/ruflin/Elastica/pull/1706)
 * Configured `visibility_required` CS rule for constants [#1723](https://github.com/ruflin/Elastica/pull/1723)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #/bin/bash
 
 SOURCE = "./lib"
-TARGET?=71
+TARGET?=72
 
 # By default docker environment is used to run commands. To run without the predefined environment, set RUN_ENV=" " either as parameter or as environment variable
 ifndef RUN_ENV


### PR DESCRIPTION
Just a minor change: following up on dropping support for PHP 7.1, the default test target for local tests (using the `make tests` target) should be set to 7.2.