### PR TITLE
Remove duplicated "timeout" comment.

### DIFF
--- a/lib/Elastica/ClientConfiguration.php
+++ b/lib/Elastica/ClientConfiguration.php
@@ -28,7 +28,7 @@ class ClientConfiguration
         'transport' => null,
         'persistent' => true,
         'timeout' => null,
-        'connections' => [], // host, port, path, timeout, transport, compression, persistent, timeout, username, password, config -> (curl, headers, url)
+        'connections' => [], // host, port, path, transport, compression, persistent, timeout, username, password, config -> (curl, headers, url)
         'roundRobin' => false,
         'retryOnConflict' => 0,
         'bigintConversion' => false,


### PR DESCRIPTION
I think the `timeout` term is duplicated. I just removed one form comment.