### PR TITLE
Scroll memory improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 
-* Scroll releases previous ResultSet from memory before calling ES for next data batch
+* Scroll releases previous ResultSet from memory before calling ES for next data batch [#1740](https://github.com/ruflin/Elastica/pull/1740)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file based on the
 
 ### Improvements
 
+* Scroll releases previous ResultSet from memory before calling ES for next data batch
+
 ### Deprecated
 
 ## [7.0.0-beta2](https://github.com/ruflin/Elastica/compare/7.0.0-beta1...7.0.0-beta2)

--- a/lib/Elastica/Scroll.php
+++ b/lib/Elastica/Scroll.php
@@ -69,6 +69,7 @@ class Scroll implements \Iterator
      */
     public function next()
     {
+        $this->_currentResultSet = null;
         if ($this->currentPage < $this->totalPages) {
             $this->_saveOptions();
 
@@ -81,7 +82,6 @@ class Scroll implements \Iterator
         } else {
             // If there are no pages left, we do not need to query ES.
             $this->clear();
-            $this->_currentResultSet = null;
         }
     }
 
@@ -121,6 +121,7 @@ class Scroll implements \Iterator
 
         $this->_search->setOption(Search::OPTION_SCROLL, $this->expiryTime);
         $this->_search->setOption(Search::OPTION_SCROLL_ID, null);
+        $this->_currentResultSet = null;
         $this->_setScrollId($this->_search->search());
 
         $this->_revertOptions();


### PR DESCRIPTION
Remove reference to current result set before running another call to ES - without this it was effectively doubling memory requirement for data as json parsing and processing to ResultSet was done before previous ResultSet was released.

As i'm working with quite large dataset i hit memory limit and found i can fix it by just removing the reference before next search() call.