### PR TITLE
Ensure the search::count() is counting all results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 
+* Fix Search::count() not counting all results [#1746](https://github.com/ruflin/Elastica/pull/1746)
 * Fixed handling of Search::OPTION_SEARCH_IGNORE_UNAVAILABLE inside Scroll object
 
 ### Added

--- a/lib/Elastica/Query.php
+++ b/lib/Elastica/Query.php
@@ -391,12 +391,16 @@ class Query extends Param
     /**
      * Adds a track_total_hits argument.
      *
-     * @param bool|int $trackTotalHits Track total hits parameter (default = true)
+     * @param bool|int $trackTotalHits Track total hits parameter
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-track-total-hits
      */
     public function setTrackTotalHits($trackTotalHits = true): self
     {
+        if (!\is_bool($trackTotalHits) && !\is_int($trackTotalHits)) {
+            throw new InvalidException('TrackTotalHits must be either a boolean, or an integer value');
+        }
+
         return $this->setParam('track_total_hits', $trackTotalHits);
     }
 }

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -324,6 +324,8 @@ class Search
         // Clone the object as we do not want to modify the original query.
         $query = clone $this->getQuery();
         $query->setSize(0);
+        $query->setTrackTotalHits(true);
+
         $path = $this->getPath();
 
         $response = $this->getClient()->request(

--- a/test/Elastica/QueryTest.php
+++ b/test/Elastica/QueryTest.php
@@ -535,21 +535,39 @@ class QueryTest extends BaseTest
     }
 
     /**
-     * @group unit
+     * @group functional
      */
-    public function testSetTrackTotalHitsIsInParams()
+    public function testSetTrackTotalHitsIsInParams(): void
     {
         $query = new Query();
-        $param = false;
-        $query->setTrackTotalHits($param);
+        $query->setTrackTotalHits(false);
 
-        $this->assertEquals($param, $query->getParam('track_total_hits'));
+        $this->assertFalse($query->getParam('track_total_hits'));
+    }
+
+    public function provideSetTrackTotalHitsInvalidValue(): iterable
+    {
+        yield 'string' => ['string string'];
+        yield 'null' => [null];
+        yield 'object' => [new \stdClass()];
+        yield 'array' => [[]];
+    }
+
+    /**
+     * @group functional
+     * @dataProvider provideSetTrackTotalHitsInvalidValue
+     */
+    public function testSetTrackTotalHitsInvalidValue($value): void
+    {
+        $this->expectException(InvalidException::class);
+
+        (new Query())->setTrackTotalHits($value);
     }
 
     /**
      * @group functional
      */
-    public function testSetTrackTotalHits()
+    public function testSetTrackTotalHits(): void
     {
         $index = $this->_createIndex();
         $index->setMapping(new Mapping([


### PR DESCRIPTION
The current Search::count() implementation is not taking into consideration the [track-total-hits](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-track-total-hits) setting in ES, fhus only returning the count for the first 10000 results.

This PR makes sure that the track-total-hits is set to `true`, allowing all results to be counted.