### PR TITLE
Fix Scroll:current() annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Backward Compatibility Breaks
 ### Added
 ### Changed
+- Scroll is now throwing an exception when calling `current()` on an invalid iteration: always call `valid()` before 
+    accessing the current item, as documented in PHP's Iterator documentation [#1749](https://github.com/ruflin/Elastica/pull/1749)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/lib/Elastica/Scroll.php
+++ b/lib/Elastica/Scroll.php
@@ -2,6 +2,8 @@
 
 namespace Elastica;
 
+use Elastica\Exception\InvalidException;
+
 /**
  * Scroll Iterator.
  *
@@ -43,9 +45,6 @@ class Scroll implements \Iterator
     private $totalPages = 0;
     private $currentPage = 0;
 
-    /**
-     * Constructor.
-     */
     public function __construct(Search $search, string $expiryTime = '1m')
     {
         $this->_search = $search;
@@ -57,8 +56,12 @@ class Scroll implements \Iterator
      *
      * @see http://php.net/manual/en/iterator.current.php
      */
-    public function current(): ?ResultSet
+    public function current(): ResultSet
     {
+        if (!$this->_currentResultSet) {
+            throw new InvalidException('Could not fetch the current ResultSet from an invalid iterator. Did you forget to call "valid()"?');
+        }
+
         return $this->_currentResultSet;
     }
 
@@ -67,7 +70,7 @@ class Scroll implements \Iterator
      *
      * @see http://php.net/manual/en/iterator.next.php
      */
-    public function next()
+    public function next(): void
     {
         $this->_currentResultSet = null;
         if ($this->currentPage < $this->totalPages) {


### PR DESCRIPTION
When analyzing a code using the iterator in a `foreach($scroll as $resultSet)` with phpstan, the following error is reported:

```
Argument of an invalid type Elastica\ResultSet|null supplied for foreach, only iterables are supported.
```

There is quite a debate about the return type of an `Iterator::current()`, as it should always return the item in the collection.
Invoking the `current()` when "out of bounds" of the collection is expected not to happen, as the `Iterator::valid()` should be called first.