### PR TITLE
Improvements on the Reindex API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.0.0-beta.3...master)
 ### Backward Compatibility Breaks
 ### Added
+* Added `Elastica\Reindex->setPipeline(Elastica\Pipeline $pipeline): void`. The link between the reindex and the pipeline is solved when `run()` is called, and thus the pipeline given doesn't need to be created before calling `setPipeline()`
+* Added `Elastica\Reindex->setRefresh(bool|string $value): void`. It accepts boolean and `REFRESH_*` constants from its class
+* Added `Elastica\Reindex->setQuery(Elastica\Query\AbstractQuery $query): void`
+* Added constants `PIPELINE`, `REFRESH_TRUE`, `REFRESH_FALSE`, `REFRESH_WAIT_FOR`, `SLICES` and `SLICES_AUTO` to `Elastica\Reindex`
+* Added `Elastica\Pipeline->getId(): ?string`
+
 ### Changed
 - Require elastica-php library >= v7.1.1, fixes an issue on Ingestion/Put() type-hinting
 - Require guzzle >= v6.3 as development library: fixes issues on PHP >= 7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.0.0-beta.3...master)
 ### Backward Compatibility Breaks
 ### Added
-* Added `Elastica\Reindex->setPipeline(Elastica\Pipeline $pipeline): void`. The link between the reindex and the pipeline is solved when `run()` is called, and thus the pipeline given doesn't need to be created before calling `setPipeline()`
-* Added `Elastica\Reindex->setRefresh(bool|string $value): void`. It accepts boolean and `REFRESH_*` constants from its class
-* Added `Elastica\Reindex->setQuery(Elastica\Query\AbstractQuery $query): void`
-* Added constants `PIPELINE`, `REFRESH_TRUE`, `REFRESH_FALSE`, `REFRESH_WAIT_FOR`, `SLICES` and `SLICES_AUTO` to `Elastica\Reindex`
-* Added `Elastica\Pipeline->getId(): ?string`
+* Added `Elastica\Reindex->setPipeline(Elastica\Pipeline $pipeline): void`. The link between the reindex and the pipeline is solved when `run()` is called, and thus the pipeline given doesn't need to be created before calling `setPipeline()` [#1752](https://github.com/ruflin/Elastica/pull/1752)
+* Added `Elastica\Reindex->setRefresh(bool|string $value): void`. It accepts boolean and `REFRESH_*` constants from its class [#1752](https://github.com/ruflin/Elastica/pull/1752)
+* Added `Elastica\Reindex->setQuery(Elastica\Query\AbstractQuery $query): void` [#1752](https://github.com/ruflin/Elastica/pull/1752)
+* Added constants `PIPELINE`, `REFRESH_TRUE`, `REFRESH_FALSE`, `REFRESH_WAIT_FOR`, `SLICES` and `SLICES_AUTO` to `Elastica\Reindex` [#1752](https://github.com/ruflin/Elastica/pull/1752)
+* Added `Elastica\Pipeline->getId(): ?string` [#1752](https://github.com/ruflin/Elastica/pull/1752)
 
 ### Changed
 - Require elastica-php library >= v7.1.1, fixes an issue on Ingestion/Put() type-hinting

--- a/lib/Elastica/Pipeline.php
+++ b/lib/Elastica/Pipeline.php
@@ -123,6 +123,11 @@ class Pipeline extends Param
         return $this;
     }
 
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
     /**
      * @param AbstractProcessor[]
      */

--- a/lib/Elastica/Reindex.php
+++ b/lib/Elastica/Reindex.php
@@ -30,6 +30,8 @@ class Reindex extends Param
     public const SCROLL = 'scroll';
     public const REQUESTS_PER_SECOND = 'requests_per_second';
     public const PIPELINE = 'pipeline';
+    public const SLICES = 'slices';
+    public const SLICES_AUTO = 'auto';
 
     /**
      * @var Index
@@ -190,6 +192,11 @@ class Reindex extends Param
     public function setScript(Script $script)
     {
         $this->setParam(self::SCRIPT, $script);
+    }
+
+    public function setQuery(AbstractQuery $query): void
+    {
+        $this->setParam(self::QUERY, $query);
     }
 
     public function setPipeline(Pipeline $pipeline): void

--- a/lib/Elastica/Reindex.php
+++ b/lib/Elastica/Reindex.php
@@ -29,6 +29,7 @@ class Reindex extends Param
     public const TIMEOUT = 'timeout';
     public const SCROLL = 'scroll';
     public const REQUESTS_PER_SECOND = 'requests_per_second';
+    public const PIPELINE = 'pipeline';
 
     /**
      * @var Index
@@ -96,6 +97,12 @@ class Reindex extends Param
             'index' => $index->getName(),
         ], $this->_resolveDestOptions($params));
 
+        // Resolves the pipeline name
+        $pipeline = $destBody[self::PIPELINE] ?? null;
+        if ($pipeline instanceof Pipeline) {
+            $destBody[self::PIPELINE] = $pipeline->getId();
+        }
+
         return $destBody;
     }
 
@@ -115,6 +122,7 @@ class Reindex extends Param
         return \array_intersect_key($params, [
             self::VERSION_TYPE => null,
             self::OPERATION_TYPE => null,
+            self::PIPELINE => null,
         ]);
     }
 
@@ -182,6 +190,18 @@ class Reindex extends Param
     public function setScript(Script $script)
     {
         $this->setParam(self::SCRIPT, $script);
+    }
+
+    public function setPipeline(Pipeline $pipeline): void
+    {
+        $this->setParam(self::PIPELINE, $pipeline);
+    }
+
+    public function setRefresh($value): void
+    {
+        \is_bool($value) && $value = $value ? 'true' : 'false';
+
+        $this->setParam(self::REFRESH, $value);
     }
 
     public function getTaskId()

--- a/lib/Elastica/Reindex.php
+++ b/lib/Elastica/Reindex.php
@@ -23,6 +23,9 @@ class Reindex extends Param
     public const REMOTE = 'remote';
     public const SLICE = 'slice';
     public const REFRESH = 'refresh';
+    public const REFRESH_TRUE = 'true';
+    public const REFRESH_FALSE = 'false';
+    public const REFRESH_WAIT_FOR = 'wait_for';
     public const WAIT_FOR_COMPLETION = 'wait_for_completion';
     public const WAIT_FOR_COMPLETION_FALSE = 'false';
     public const WAIT_FOR_ACTIVE_SHARDS = 'wait_for_active_shards';
@@ -204,9 +207,12 @@ class Reindex extends Param
         $this->setParam(self::PIPELINE, $pipeline);
     }
 
+    /**
+     * @param bool|string $value
+     */
     public function setRefresh($value): void
     {
-        \is_bool($value) && $value = $value ? 'true' : 'false';
+        \is_bool($value) && $value = $value ? self::REFRESH_TRUE : self::REFRESH_FALSE;
 
         $this->setParam(self::REFRESH, $value);
     }


### PR DESCRIPTION
Reindex improvements:

- Add pipeline support
    - Add `Reindex::PIPELINE`
    - Add `$reindex->setPipeline(Pipeline $pipeline)`
- Improve refresh support
    - Add `$reindex->setRefresh(bool|string $value)`
- Improve query support
    - Add `$reindex->setQuery(AbstractQuery $query)`
- Add slices support
    - Add `Reindex::SLICES`
    - Add `Reindex::SLICES_AUTO`

... and also:

- Add `$pipeline->getId()`


