### PR TITLE
Cleanup gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,8 @@
-.DS_Store
-.idea
-*.iml
-.vagrant
 .php_cs
 .php_cs.cache
 
-cache.properties
-/nbproject
-build
-atlassian-ide-plugin.xml
-.settings
 /vendor
+/build
+
 composer.lock
 composer.phar
-/test/nginx/logs/access.log
-/test/nginx/logs/error.log


### PR DESCRIPTION
A .gitignore in a project should only cover artifacts caused by the contained source code, not those caused by the person