### PR TITLE
Add common processor fields

### DIFF
--- a/src/Processor/AbstractProcessor.php
+++ b/src/Processor/AbstractProcessor.php
@@ -13,4 +13,32 @@ use Elastica\Param;
  */
 abstract class AbstractProcessor extends Param
 {
+    public function setTag(string $tag): self
+    {
+        return $this->setParam('tag', $tag);
+    }
+
+    /**
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/handling-failure-in-pipelines.html
+     */
+    public function setOnFailure(AbstractProcessor $processor): self
+    {
+        return $this->setParam('on_failure', $processor);
+    }
+
+    /**
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/handling-failure-in-pipelines.html
+     */
+    public function setIgnoreFailure(bool $ignoreFailure): self
+    {
+        return $this->setParam('ignore_failure', $ignoreFailure ? 'true' : 'false');
+    }
+
+    /**
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-conditionals.html
+     */
+    public function setIf(string $script): self
+    {
+        return $this->setParam('if', $script);
+    }
 }

--- a/tests/Processor/AppendTest.php
+++ b/tests/Processor/AppendTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Append;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class AppendTest extends BasePipelineTest
+class AppendTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -83,5 +82,12 @@ class AppendTest extends BasePipelineTest
             $this->assertEquals('item3', $value['foo'][2]);
             $this->assertEquals('item4', $value['foo'][3]);
         }
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Append('field', 'value')],
+        ];
     }
 }

--- a/tests/Processor/AttachmentTest.php
+++ b/tests/Processor/AttachmentTest.php
@@ -6,14 +6,13 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Mapping;
 use Elastica\Processor\Attachment;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @group functional
  *
  * @internal
  */
-class AttachmentTest extends BasePipelineTest
+class AttachmentTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -216,5 +215,12 @@ class AttachmentTest extends BasePipelineTest
         $this->assertEquals($data['title'], $title);
         $this->assertEquals($data['text'], $text);
         $this->assertArrayNotHasKey('file', $data);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Attachment('field')],
+        ];
     }
 }

--- a/tests/Processor/BaseProcessorTestCase.php
+++ b/tests/Processor/BaseProcessorTestCase.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Elastica\Test\Processor;
+
+use Elastica\Processor\AbstractProcessor;
+use Elastica\Processor\Set;
+use Elastica\Test\BasePipeline;
+
+/**
+ * @internal
+ */
+abstract class BaseProcessorTestCase extends BasePipeline
+{
+    /**
+     * @dataProvider validProcessorProvider
+     * @group unit
+     */
+    public function testBaseFields(AbstractProcessor $processor): void
+    {
+        $onFailureProcessor = new Set('error', "there's a problem");
+
+        $processor
+            ->setTag('mytag')
+            ->setOnFailure($onFailureProcessor)
+            ->setIgnoreFailure(true)
+            ->setIf("ctx.my == 'if'")
+        ;
+
+        $asArray = $processor->toArray();
+        $body = \reset($asArray);
+
+        $this->assertArrayHasKey('if', $body);
+        $this->assertEquals("ctx.my == 'if'", $body['if']);
+
+        $this->assertArrayHasKey('on_failure', $body);
+        $this->assertEquals($onFailureProcessor->toArray(), $body['on_failure']);
+
+        $this->assertArrayHasKey('ignore_failure', $body);
+        $this->assertEquals('true', $body['ignore_failure']);
+
+        $this->assertArrayHasKey('if', $body);
+        $this->assertEquals("ctx.my == 'if'", $body['if']);
+    }
+
+    abstract public function validProcessorProvider(): array;
+}

--- a/tests/Processor/ConvertTest.php
+++ b/tests/Processor/ConvertTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Convert;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class ConvertTest extends BasePipelineTest
+class ConvertTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -98,5 +97,12 @@ class ConvertTest extends BasePipelineTest
 
         $this->assertSame(5.290, ($results[0]->getHit())['_source']['foo']);
         $this->assertSame(6.908, ($results[1]->getHit())['_source']['foo']);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Convert('field', 'type')],
+        ];
     }
 }

--- a/tests/Processor/DateIndexNameTest.php
+++ b/tests/Processor/DateIndexNameTest.php
@@ -3,12 +3,11 @@
 namespace Elastica\Test\Processor;
 
 use Elastica\Processor\DateIndexName;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class DateIndexNameTest extends BasePipelineTest
+class DateIndexNameTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -50,5 +49,12 @@ class DateIndexNameTest extends BasePipelineTest
         ];
 
         $this->assertEquals($expected, $processor->toArray());
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new DateIndexName('field', 'd')],
+        ];
     }
 }

--- a/tests/Processor/DateTest.php
+++ b/tests/Processor/DateTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Date;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class DateTest extends BasePipelineTest
+class DateTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -99,5 +98,12 @@ class DateTest extends BasePipelineTest
         $results = $result->getResults();
 
         $this->assertEquals('2010-06-12T00:00:00.000+02:00', ($results[0]->getHit())['_source']['date_parsed']);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Date('field', ['dd/MM/yyyy hh:mm:ss'])],
+        ];
     }
 }

--- a/tests/Processor/DotExpanderTest.php
+++ b/tests/Processor/DotExpanderTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\DotExpander;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class DotExpanderTest extends BasePipelineTest
+class DotExpanderTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -65,5 +64,12 @@ class DotExpanderTest extends BasePipelineTest
         ];
         $results = $result->getResults();
         $this->assertEquals($expect, ($results[0]->getHit())['_source']);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new DotExpander('field')],
+        ];
     }
 }

--- a/tests/Processor/FailTest.php
+++ b/tests/Processor/FailTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Fail;
 use Elastica\Processor\Json;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class FailTest extends BasePipelineTest
+class FailTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -58,5 +57,12 @@ class FailTest extends BasePipelineTest
         } catch (\Exception $e) {
             $this->assertStringContainsString('custom error fail message', $e->getMessage());
         }
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Fail('message')],
+        ];
     }
 }

--- a/tests/Processor/JoinTest.php
+++ b/tests/Processor/JoinTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Join;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class JoinTest extends BasePipelineTest
+class JoinTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -57,5 +56,12 @@ class JoinTest extends BasePipelineTest
 
         $results = $result->getResults();
         $this->assertSame('abc-def-ghij', ($results[0]->getHit())['_source']['name']);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Join('field', 'separator')],
+        ];
     }
 }

--- a/tests/Processor/JsonTest.php
+++ b/tests/Processor/JsonTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Json;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class JsonTest extends BasePipelineTest
+class JsonTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -83,5 +82,12 @@ class JsonTest extends BasePipelineTest
             $value = $rx->getData();
             $this->assertEquals($resultExpected, $value['realname']);
         }
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Json('field')],
+        ];
     }
 }

--- a/tests/Processor/KvTest.php
+++ b/tests/Processor/KvTest.php
@@ -3,12 +3,11 @@
 namespace Elastica\Test\Processor;
 
 use Elastica\Processor\Kv;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class KvTest extends BasePipelineTest
+class KvTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -75,5 +74,12 @@ class KvTest extends BasePipelineTest
         $this->assertSame($result['my_custom_pipeline']['processors'][0]['kv']['field'], 'field1');
         $this->assertSame($result['my_custom_pipeline']['processors'][0]['kv']['field_split'], '&');
         $this->assertSame($result['my_custom_pipeline']['processors'][0]['kv']['value_split'], '=');
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Kv('field', 'field_split', 'value_split')],
+        ];
     }
 }

--- a/tests/Processor/LowercaseTest.php
+++ b/tests/Processor/LowercaseTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Lowercase;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class LowercaseTest extends BasePipelineTest
+class LowercaseTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -60,5 +59,12 @@ class LowercaseTest extends BasePipelineTest
         $results = $result->getResults();
         $this->assertSame('ruflin', ($results[0]->getHit())['_source']['name']);
         $this->assertSame('nicolas', ($results[1]->getHit())['_source']['name']);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Lowercase('field')],
+        ];
     }
 }

--- a/tests/Processor/RemoveTest.php
+++ b/tests/Processor/RemoveTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Remove;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class RemoveTest extends BasePipelineTest
+class RemoveTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -78,5 +77,12 @@ class RemoveTest extends BasePipelineTest
             $this->assertArrayNotHasKey('package', $value);
             $this->assertArrayNotHasKey('es_version', $value);
         }
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Remove('field')],
+        ];
     }
 }

--- a/tests/Processor/RenameTest.php
+++ b/tests/Processor/RenameTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Rename;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class RenameTest extends BasePipelineTest
+class RenameTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -78,5 +77,12 @@ class RenameTest extends BasePipelineTest
 
         $results = $result->getResults();
         $this->assertArrayHasKey('packages', ($results[0]->getHit())['_source']);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Rename('field', 'target_field')],
+        ];
     }
 }

--- a/tests/Processor/SetTest.php
+++ b/tests/Processor/SetTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Set;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class SetTest extends BasePipelineTest
+class SetTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -81,5 +80,12 @@ class SetTest extends BasePipelineTest
             $value = $rx->getData();
             $this->assertSame('Elastica', $value['package']);
         }
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Set('field', 'value')],
+        ];
     }
 }

--- a/tests/Processor/SortTest.php
+++ b/tests/Processor/SortTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Sort;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class SortTest extends BasePipelineTest
+class SortTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -74,5 +73,12 @@ class SortTest extends BasePipelineTest
 
         $results = $result->getResults();
         $this->assertSame([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], ($results[0]->getHit())['_source']['name']);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Sort('field')],
+        ];
     }
 }

--- a/tests/Processor/SplitTest.php
+++ b/tests/Processor/SplitTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Split;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class SplitTest extends BasePipelineTest
+class SplitTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -78,5 +77,12 @@ class SplitTest extends BasePipelineTest
 
         $results = $result->getResults();
         $this->assertSame(['nicolas', 'ruflin'], ($results[0]->getHit())['_source']['name']);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Split('field', 'separator')],
+        ];
     }
 }

--- a/tests/Processor/TrimTest.php
+++ b/tests/Processor/TrimTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Trim;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class TrimTest extends BasePipelineTest
+class TrimTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -60,5 +59,12 @@ class TrimTest extends BasePipelineTest
         $results = $result->getResults();
         $this->assertSame('ruflin', ($results[0]->getHit())['_source']['name']);
         $this->assertSame('nicolas', ($results[1]->getHit())['_source']['name']);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Trim('field')],
+        ];
     }
 }

--- a/tests/Processor/UppercaseTest.php
+++ b/tests/Processor/UppercaseTest.php
@@ -6,12 +6,11 @@ use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Uppercase;
 use Elastica\ResultSet;
-use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
  * @internal
  */
-class UppercaseTest extends BasePipelineTest
+class UppercaseTest extends BaseProcessorTestCase
 {
     /**
      * @group unit
@@ -60,5 +59,12 @@ class UppercaseTest extends BasePipelineTest
         $results = $result->getResults();
         $this->assertSame('RUFLIN', ($results[0]->getHit())['_source']['name']);
         $this->assertSame('NICOLAS', ($results[1]->getHit())['_source']['name']);
+    }
+
+    public function validProcessorProvider(): array
+    {
+        return [
+            [new Uppercase('field')],
+        ];
     }
 }


### PR DESCRIPTION
Add common fields<sup>1,2</sup> to all processors:

- `tag`
- `on_failure`
- `ignore_failure`
- `if`

<sup>1</sup> https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-processors.html
<sup>2</sup> https://www.elastic.co/guide/en/elasticsearch/reference/current/handling-failure-in-pipelines.html