### PR TITLE
Allow Terms aggregations to define exact excludes and includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `Wildcard` Query's constructor now requires the `name` and `value` properties.
 
 ### Added
+* Added `AbstractTermsAggregation::setIncludeAsExactMatch()` [#1766](https://github.com/ruflin/Elastica/pull/1766) 
+* Added `AbstractTermsAggregation::setExcludeAsExactMatch()` [#1766](https://github.com/ruflin/Elastica/pull/1766)
+* Added `AbstractTermsAggregation::setIncludeWithPartitions()` [#1766](https://github.com/ruflin/Elastica/pull/1766)
 * Added `Elastica\Reindex->setPipeline(Elastica\Pipeline $pipeline): void`. The link between the reindex and the pipeline is solved when `run()` is called, and thus the pipeline given doesn't need to be created before calling `setPipeline()` [#1752](https://github.com/ruflin/Elastica/pull/1752)
 * Added `Elastica\Reindex->setRefresh(string $value): void`. It accepts `REFRESH_*` constants from its class [#1752](https://github.com/ruflin/Elastica/pull/1752) and [#1758](https://github.com/ruflin/Elastica/pull/1758)
 * Added `Elastica\Reindex->setQuery(Elastica\Query\AbstractQuery $query): void` [#1752](https://github.com/ruflin/Elastica/pull/1752)
@@ -31,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 ### Removed
+- Removed unsupported `flags` from `AbstractTermsAggregation::setInclude()` [#1766](https://github.com/ruflin/Elastica/pull/1766) 
+- Removed unsupported `flags` from `AbstractTermsAggregation::setExclude()` [#1766](https://github.com/ruflin/Elastica/pull/1766) 
 ### Fixed
 ### Security
 

--- a/src/Aggregation/AbstractTermsAggregation.php
+++ b/src/Aggregation/AbstractTermsAggregation.php
@@ -7,10 +7,11 @@ namespace Elastica\Aggregation;
  */
 abstract class AbstractTermsAggregation extends AbstractSimpleAggregation
 {
+    public const EXECUTION_HINT_MAP = 'map';
+    public const EXECUTION_HINT_GLOBAL_ORDINALS = 'global_ordinals';
+
     /**
      * Set the minimum number of documents in which a term must appear in order to be returned in a bucket.
-     *
-     * @return $this
      */
     public function setMinimumDocumentCount(int $count): self
     {
@@ -20,20 +21,37 @@ abstract class AbstractTermsAggregation extends AbstractSimpleAggregation
     /**
      * Filter documents to include based on a regular expression.
      *
-     * @param string $pattern a regular expression
-     * @param string $flags   Java Pattern flags
+     * @See https://www.elastic.co/guide/en/elasticsearch/reference/current/regexp-syntax.html for syntax
      *
-     * @return $this
+     * @param string $pattern a regular expression, following the Regexp syntax
      */
-    public function setInclude(string $pattern, ?string $flags = null): self
+    public function setInclude(string $pattern): self
     {
-        if (null === $flags) {
-            return $this->setParam('include', $pattern);
-        }
+        return $this->setParam('include', $pattern);
+    }
 
+    /**
+     * Filter documents to include based on a list of exact values.
+     *
+     * @param string[] $values
+     *
+     * @See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_filtering_values_with_exact_values_2
+     */
+    public function setIncludeAsExactMatch(array $values): self
+    {
+        return $this->setParam('include', $values);
+    }
+
+    /**
+     * Set the aggregation filter to use partitions.
+     *
+     * @See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_filtering_values_with_partitions
+     */
+    public function setIncludeWithPartitions(int $partition, int $numPartitions): self
+    {
         return $this->setParam('include', [
-            'pattern' => $pattern,
-            'flags' => $flags,
+            'partition' => $partition,
+            'num_partitions' => $numPartitions,
         ]);
     }
 
@@ -41,28 +59,26 @@ abstract class AbstractTermsAggregation extends AbstractSimpleAggregation
      * Filter documents to exclude based on a regular expression.
      *
      * @param string $pattern a regular expression
-     * @param string $flags   Java Pattern flags
-     *
-     * @return $this
      */
-    public function setExclude(string $pattern, ?string $flags = null): self
+    public function setExclude(string $pattern): self
     {
-        if (null === $flags) {
-            return $this->setParam('exclude', $pattern);
-        }
+        return $this->setParam('exclude', $pattern);
+    }
 
-        return $this->setParam('exclude', [
-            'pattern' => $pattern,
-            'flags' => $flags,
-        ]);
+    /**
+     * Filter documents to exclude based on a list of exact values.
+     *
+     * @param string[] $values
+     *
+     * @See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_filtering_values_with_exact_values_2
+     */
+    public function setExcludeAsExactMatch(array $values): self
+    {
+        return $this->setParam('exclude', $values);
     }
 
     /**
      * Sets the amount of terms to be returned.
-     *
-     * @param int $size the amount of terms to be returned
-     *
-     * @return $this
      */
     public function setSize(int $size): self
     {
@@ -71,10 +87,6 @@ abstract class AbstractTermsAggregation extends AbstractSimpleAggregation
 
     /**
      * Sets how many terms the coordinating node will request from each shard.
-     *
-     * @param int $shardSize the amount of terms to be returned
-     *
-     * @return $this
      */
     public function setShardSize(int $shardSize): self
     {
@@ -85,9 +97,9 @@ abstract class AbstractTermsAggregation extends AbstractSimpleAggregation
      * Instruct Elasticsearch to use direct field data or ordinals of the field values to execute this aggregation.
      * The execution hint will be ignored if it is not applicable.
      *
-     * @param string $hint map or ordinals
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-execution-hint
      *
-     * @return $this
+     * @param string $hint Execution hint, use one of self::EXECUTION_HINT_MAP or self::EXECUTION_HINT_GLOBAL_ORDINALS
      */
     public function setExecutionHint(string $hint): self
     {

--- a/tests/Aggregation/TermsTest.php
+++ b/tests/Aggregation/TermsTest.php
@@ -9,13 +9,70 @@ use Elastica\Mapping;
 use Elastica\Query;
 
 /**
+ * @group functional
+ *
  * @internal
  */
 class TermsTest extends BaseAggregationTest
 {
     /**
-     * @group functional
+     * @group unit
      */
+    public function testIncludePattern(): void
+    {
+        $agg = new Terms('terms');
+        $agg->setInclude('pattern*');
+
+        $this->assertSame($agg->getParam('include'), 'pattern*');
+    }
+
+    /**
+     * @group unit
+     */
+    public function testIncludeExactMatch(): void
+    {
+        $agg = new Terms('terms');
+        $agg->setIncludeAsExactMatch(['first', 'second']);
+
+        $this->assertSame($agg->getParam('include'), ['first', 'second']);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testIncludeWithPartitions(): void
+    {
+        $agg = new Terms('terms');
+        $agg->setIncludeWithPartitions(1, 23);
+
+        $this->assertSame($agg->getParam('include'), [
+            'partition' => 1,
+            'num_partitions' => 23,
+        ]);
+    }
+
+    /**
+     * @group unit
+     */
+    public function testExcludePattern(): void
+    {
+        $agg = new Terms('terms');
+        $agg->setExclude('pattern*');
+
+        $this->assertSame($agg->getParam('exclude'), 'pattern*');
+    }
+
+    /**
+     * @group unit
+     */
+    public function testExcludeExactMatch(): void
+    {
+        $agg = new Terms('terms');
+        $agg->setExcludeAsExactMatch(['first', 'second']);
+
+        $this->assertSame($agg->getParam('exclude'), ['first', 'second']);
+    }
+
     public function testTermsAggregation(): void
     {
         $agg = new Terms('terms');
@@ -23,15 +80,12 @@ class TermsTest extends BaseAggregationTest
 
         $query = new Query();
         $query->addAggregation($agg);
-        $results = $this->_getIndexForTest()->search($query)->getAggregation('terms');
+        $results = $this->getIndex()->search($query)->getAggregation('terms');
 
         $this->assertEquals(2, $results['buckets'][0]['doc_count']);
         $this->assertEquals('blue', $results['buckets'][0]['key']);
     }
 
-    /**
-     * @group functional
-     */
     public function testTermsSetOrder(): void
     {
         $agg = new Terms('terms');
@@ -40,14 +94,11 @@ class TermsTest extends BaseAggregationTest
 
         $query = new Query();
         $query->addAggregation($agg);
-        $results = $this->_getIndexForTest()->search($query)->getAggregation('terms');
+        $results = $this->getIndex()->search($query)->getAggregation('terms');
 
         $this->assertEquals('blue', $results['buckets'][2]['key']);
     }
 
-    /**
-     * @group functional
-     */
     public function testTermsSetOrders(): void
     {
         $agg = new Terms('terms');
@@ -59,14 +110,14 @@ class TermsTest extends BaseAggregationTest
 
         $query = new Query();
         $query->addAggregation($agg);
-        $results = $this->_getIndexForTest()->search($query)->getAggregation('terms');
+        $results = $this->getIndex()->search($query)->getAggregation('terms');
 
         $this->assertSame('green', $results['buckets'][0]['key']);
         $this->assertSame('red', $results['buckets'][1]['key']);
         $this->assertSame('blue', $results['buckets'][2]['key']);
     }
 
-    protected function _getIndexForTest(): Index
+    private function getIndex(): Index
     {
         $index = $this->_createIndex();
 


### PR DESCRIPTION
Allow Terms aggregations to define:
- exact excludes
- exact includes
- include-partitions

Removed the `$flags` from the `setInclude()` as not supported by ES anymore

Closes #1764

