### PR TITLE
add Composite aggregation support

### DIFF
--- a/src/Aggregation/Composite.php
+++ b/src/Aggregation/Composite.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Elastica\Aggregation;
+
+class Composite extends AbstractAggregation
+{
+    /**
+     * @param int $size
+     * @return $this
+     */
+    public function setSize(int $size): self
+    {
+        return $this->setParam('size', $size);
+    }
+
+    /**
+     * @param AbstractAggregation $aggregation
+     * @return $this
+     */
+    public function addSource(AbstractAggregation $aggregation): self
+    {
+        return $this->addParam('sources', [$aggregation]);
+    }
+
+    /**
+     * @param array|null $checkpoint
+     * @return $this
+     */
+    public function addAfter(?array $checkpoint): self
+    {
+        return $this->setParam('after', $checkpoint);
+    }
+}


### PR DESCRIPTION
https://github.com/ruflin/Elastica/issues/1612

I needed it in my local project and it works for me. Should I add it to 6.x to?

Usage example:
```php
        $query = new Query();
        $query->setSize(0);

        $boolQuery = new Query\BoolQuery();
        $boolQuery
            ->addMust(new Query\Match('doctype', 'product_availability'))
        ;
        $query->setQuery($boolQuery);

        $compositeAggregation = new Composite('products');
        $compositeAggregation
            ->setSize(2000)
            ->addSource((new Terms('product_id'))->setField('product_id'))
            ->addAggregation((new Sum('amount'))->setField('amount'))
            ->addAfter($after);

        $query->addAggregation($compositeAggregation);

        $documentManager->getSearcher()->search($query)
```