### PR TITLE
Add missing Response infos to Bulk/ResponseSet (#1737)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Elastica\Aggregation\WeightedAvg` aggregation [#1770](https://github.com/ruflin/Elastica/pull/1770)
 
 ### Changed
+* Added missing Response information to Bulk/ResponseSet [#1776](https://github.com/ruflin/Elastica/pull/1776)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/Bulk/ResponseSet.php
+++ b/src/Bulk/ResponseSet.php
@@ -21,7 +21,10 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
      */
     public function __construct(BaseResponse $response, array $bulkResponses)
     {
-        parent::__construct($response->getData());
+        parent::__construct($response->getData(), $response->getStatus());
+
+        $this->setQueryTime($response->getQueryTime());
+        $this->setTransferInfo($response->getTransferInfo());
 
         $this->_bulkResponses = $bulkResponses;
     }

--- a/tests/Bulk/ResponseSetTest.php
+++ b/tests/Bulk/ResponseSetTest.php
@@ -18,6 +18,23 @@ class ResponseSetTest extends BaseTest
 {
     /**
      * @group unit
+     */
+    public function testConstructor(): void
+    {
+        list($responseData, $actions) = $this->_getFixture();
+
+        $responseSet = $this->_createResponseSet($responseData, $actions);
+
+        $this->assertEquals(200, $responseSet->getStatus());
+        $this->assertEquals(12.3, $responseSet->getQueryTime());
+        $this->assertEquals([
+            'url' => 'http://127.0.0.1:9200/_bulk',
+            'http_code' => 200,
+        ], $responseSet->getTransferInfo());
+    }
+
+    /**
+     * @group unit
      * @dataProvider isOkDataProvider
      */
     public function testIsOk(array $responseData, array $actions, bool $expected): void
@@ -129,10 +146,17 @@ class ResponseSetTest extends BaseTest
     {
         $client = $this->createMock(Client::class);
 
+        $response = new Response($responseData, 200);
+        $response->setQueryTime(12.3);
+        $response->setTransferInfo([
+            'url' => 'http://127.0.0.1:9200/_bulk',
+            'http_code' => 200,
+        ]);
+
         $client->expects($this->once())
             ->method('request')
             ->withAnyParameters()
-            ->willReturn(new Response($responseData))
+            ->willReturn($response)
         ;
 
         $bulk = new Bulk($client);


### PR DESCRIPTION
I'm using the Bulk API and the response transfer info & status code get erased by the method `_processResponse`.

Here's the `Response` I get from the `Client`:
```
Elastica\Response {
  #_queryTime: 0.00088000297546387
  #_responseString: ""
  #_transferInfo: array:26 [
    "url" => "http://127.0.0.1:9200/_bulk?filter_path=-took%2C-items"
    "content_type" => null
    "http_code" => 413
    "header_size" => 60
    "request_size" => 201
    "filetime" => -1
    "ssl_verify_result" => 0
    "redirect_count" => 0
    "total_time" => 0.000824
    "namelookup_time" => 5.3E-5
    "connect_time" => 0.000235
    "pretransfer_time" => 0.000276
    "size_upload" => 0.0
    "size_download" => 0.0
    "speed_download" => 0.0
    "speed_upload" => 0.0
    "download_content_length" => 0.0
    "upload_content_length" => 3462417.0
    "starttransfer_time" => 0.000815
    "redirect_time" => 0.0
    "redirect_url" => ""
    "primary_ip" => "127.0.0.1"
    "certinfo" => []
    "primary_port" => 9200
    "local_ip" => "127.0.0.1"
    "local_port" => 55295
  ]
  #_response: []
  #_status: 413
  #_jsonBigintConversion: false
}
```

And the ResponseSet I get from the `Bulk->send()->_processResponse()`:
```
Elastica\Bulk\ResponseSet {
  #_bulkResponses: []
  #_position: 0
  #_queryTime: null
  #_responseString: ""
  #_transferInfo: []
  #_response: []
  #_status: null
  #_jsonBigintConversion: false
}
```

We're losing all the `_transferInfo` data along with the `status` which in my case is what I'd really need to prevent my code from running on error.

Here's the `ResponseSet` from the changes I made:
```
Elastica\Bulk\ResponseSet {
  #_bulkResponses: []
  #_position: 0
  #_queryTime: 0.0019330978393555
  #_responseString: ""
  #_transferInfo: array:26 [
    "url" => "http://127.0.0.1:9200/_bulk"
    "content_type" => null
    "http_code" => 413
    "header_size" => 60
    "request_size" => 174
    "filetime" => -1
    "ssl_verify_result" => 0
    "redirect_count" => 0
    "total_time" => 0.001874
    "namelookup_time" => 5.0E-5
    "connect_time" => 0.000387
    "pretransfer_time" => 0.000426
    "size_upload" => 0.0
    "size_download" => 0.0
    "speed_download" => 0.0
    "speed_upload" => 0.0
    "download_content_length" => 0.0
    "upload_content_length" => 3743468.0
    "starttransfer_time" => 0.001863
    "redirect_time" => 0.0
    "redirect_url" => ""
    "primary_ip" => "127.0.0.1"
    "certinfo" => []
    "primary_port" => 9200
    "local_ip" => "127.0.0.1"
    "local_port" => 56270
  ]
  #_response: []
  #_status: 413
  #_jsonBigintConversion: false
}
```

I opened a PR on `6.x` (https://github.com/ruflin/Elastica/pull/1775), but I just read PR should be on `master` so here it is.