### PR TITLE
Fixing a usage bug with ltrim

### DIFF
--- a/lib/Elastica/Transport/Guzzle.php
+++ b/lib/Elastica/Transport/Guzzle.php
@@ -187,7 +187,7 @@ class Guzzle extends AbstractTransport
                 'scheme' => $this->_scheme,
                 'host' => $connection->getHost(),
                 'port' => $connection->getPort(),
-                'path' => ltrim('/', $connection->getPath()),
+                'path' => ltrim($connection->getPath(), '/'),
             ]);
         }
 


### PR DESCRIPTION
Pretty sure the intention of this was to remove the '/', not lose the path, which this would do.  So fixing it.  Looks like this has been in the code going back quite a while, so might want to port it back.