### PR TITLE
Fixing bug in usage of ltrim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Deprecated `Elastica\Transport\HttpAdapter` class [#1940](https://github.com/ruflin/Elastica/pull/1940)
 ### Removed
 ### Fixed
+* Fixed wrong `ltrim` usage in guzzle transport [#1783](https://github.com/ruflin/Elastica/pull/1783)
 * Fixed `_seq_no` and `_primary_term` wrong initialization [#1920](https://github.com/ruflin/Elastica/pull/1920)
 * Fixed `Elastica\Connection\StrategyInterface` instance checks [#1921](https://github.com/ruflin/Elastica/pull/1921)
 * Fixed various PHPDoc annotations [#1922](https://github.com/ruflin/Elastica/pull/1922)

--- a/src/Transport/Guzzle.php
+++ b/src/Transport/Guzzle.php
@@ -168,7 +168,7 @@ class Guzzle extends AbstractTransport
                 'scheme' => $this->_scheme,
                 'host' => $connection->getHost(),
                 'port' => $connection->getPort(),
-                'path' => \ltrim('/', $connection->getPath()),
+                'path' => \ltrim($connection->getPath(), '/'),
             ]);
         }
 


### PR DESCRIPTION
Pretty sure the intention of this was to remove the '/', not lose the path, which this would do. So fixing it. Looks like this has been in the code going back quite a while, so might want to port it back.