### PR TITLE
add auth_type param to fix issue 1789

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.0.0...master)
 ### Backward Compatibility Breaks
 ### Added
-Ability to specify the type of authentication manually by the `auth_type` parameter (in the client class config) was added (allowed values are `basic, digest, gssnegotiate, ntlm`)
+* Ability to specify the type of authentication manually by the `auth_type` parameter (in the client class config) was added (allowed values are `basic, digest, gssnegotiate, ntlm`)
 ### Changed
 
 ### Deprecated
 ### Removed
 ### Fixed
-fixed issue [1789](https://github.com/ruflin/Elastica/issues/1789)
+* fixed issue [1789](https://github.com/ruflin/Elastica/issues/1789)
 ### Security
 
 
@@ -33,7 +33,7 @@ fixed issue [1789](https://github.com/ruflin/Elastica/issues/1789)
 * The `Terms` Query's constructor now requires the `field` and `terms` properties.
 
 ### Added
-* Added `AbstractTermsAggregation::setIncludeAsExactMatch()` [#1766](https://github.com/ruflin/Elastica/pull/1766) 
+* Added `AbstractTermsAggregation::setIncludeAsExactMatch()` [#1766](https://github.com/ruflin/Elastica/pull/1766)
 * Added `AbstractTermsAggregation::setExcludeAsExactMatch()` [#1766](https://github.com/ruflin/Elastica/pull/1766)
 * Added `AbstractTermsAggregation::setIncludeWithPartitions()` [#1766](https://github.com/ruflin/Elastica/pull/1766)
 * Added `Elastica\Reindex->setPipeline(Elastica\Pipeline $pipeline): void`. The link between the reindex and the pipeline is solved when `run()` is called, and thus the pipeline given doesn't need to be created before calling `setPipeline()` [#1752](https://github.com/ruflin/Elastica/pull/1752)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.0.0...master)
 ### Backward Compatibility Breaks
 ### Added
-
+Ability to specify the type of authentication manually by the `auth_type` parameter (in the client class config) was added (allowed values are `basic, digest, gssnegotiate, ntlm`)
 ### Changed
 
 ### Deprecated
 ### Removed
 ### Fixed
+fixed issue [1789](https://github.com/ruflin/Elastica/issues/1789)
 ### Security
 
 

--- a/src/ClientConfiguration.php
+++ b/src/ClientConfiguration.php
@@ -28,12 +28,13 @@ class ClientConfiguration
         'transport' => null,
         'persistent' => true,
         'timeout' => null,
-        'connections' => [], // host, port, path, transport, compression, persistent, timeout, username, password, config -> (curl, headers, url)
+        'connections' => [], // host, port, path, transport, compression, persistent, timeout, username, password, auth_type, config -> (curl, headers, url)
         'roundRobin' => false,
         'retryOnConflict' => 0,
         'bigintConversion' => false,
         'username' => null,
         'password' => null,
+        'auth_type' => null //basic, digest, gssnegotiate, ntlm
     ];
 
     /**

--- a/src/ClientConfiguration.php
+++ b/src/ClientConfiguration.php
@@ -34,7 +34,7 @@ class ClientConfiguration
         'bigintConversion' => false,
         'username' => null,
         'password' => null,
-        'auth_type' => null //basic, digest, gssnegotiate, ntlm
+        'auth_type' => null, //basic, digest, gssnegotiate, ntlm
     ];
 
     /**
@@ -83,10 +83,9 @@ class ClientConfiguration
             $clientConfiguration->set('password', \urldecode($parsedDsn['pass']));
         }
 
-        if (isset($parsedDsn['pass']) && isset($parsedDsn['user'])) {
+        if (isset($parsedDsn['pass'], $parsedDsn['user'])) {
             $clientConfiguration->set('auth_type', 'basic');
         }
-
 
         if (isset($parsedDsn['port'])) {
             $clientConfiguration->set('port', $parsedDsn['port']);

--- a/src/ClientConfiguration.php
+++ b/src/ClientConfiguration.php
@@ -83,6 +83,11 @@ class ClientConfiguration
             $clientConfiguration->set('password', \urldecode($parsedDsn['pass']));
         }
 
+        if (isset($parsedDsn['pass']) && isset($parsedDsn['user'])) {
+            $clientConfiguration->set('auth_type', 'basic');
+        }
+
+
         if (isset($parsedDsn['port'])) {
             $clientConfiguration->set('port', $parsedDsn['port']);
         }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -361,6 +361,6 @@ class Connection extends Param
      */
     public function getAuthType()
     {
-        return $this->hasParam('auth_type') ? strtolower($this->getParam('auth_type')) : null;
+        return $this->hasParam('auth_type') ? \strtolower($this->getParam('auth_type')) : null;
     }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -355,4 +355,12 @@ class Connection extends Param
     {
         return $this->hasParam('password') ? $this->getParam('password') : null;
     }
+
+    /**
+     * @return string AuthType
+     */
+    public function getAuthType()
+    {
+        return $this->hasParam('auth_type') ? strtolower($this->getParam('auth_type')) : null;
+    }
 }

--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -36,7 +36,7 @@ class Http extends AbstractTransport
      * Makes calls to the elasticsearch server.
      *
      * All calls that are made to the server are done through this function
-     *
+     * @param Request $request
      * @param array $params Host, Port, ...
      *
      * @throws ConnectionException
@@ -104,7 +104,7 @@ class Http extends AbstractTransport
         $username = $connection->getUsername();
         $password = $connection->getPassword();
         if (null !== $username && null !== $password) {
-            \curl_setopt($conn, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+            \curl_setopt($conn, CURLOPT_HTTPAUTH, $this->_getAuthType());
             \curl_setopt($conn, CURLOPT_USERPWD, "{$username}:{$password}");
         }
 
@@ -221,5 +221,23 @@ class Http extends AbstractTransport
         }
 
         return self::$_curlConnection;
+    }
+
+    protected function _getAuthType()
+    {
+        switch ($this->_connection->getAuthType()) {
+            case "digest":
+                return CURLAUTH_DIGEST;
+                break;
+            case "gssnegotiate":
+                return CURLAUTH_GSSNEGOTIATE;
+                break;
+            case "ntlm":
+                return CURLAUTH_NTLM;
+                break;
+            case "basic":
+            default:
+                return CURLAUTH_BASIC;
+        }
     }
 }

--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -236,8 +236,10 @@ class Http extends AbstractTransport
                 return CURLAUTH_NTLM;
                 break;
             case "basic":
-            default:
                 return CURLAUTH_BASIC;
+                break;
+            default:
+                return CURLAUTH_ANY;
         }
     }
 }

--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -36,7 +36,7 @@ class Http extends AbstractTransport
      * Makes calls to the elasticsearch server.
      *
      * All calls that are made to the server are done through this function
-     * @param Request $request
+     *
      * @param array $params Host, Port, ...
      *
      * @throws ConnectionException
@@ -226,16 +226,16 @@ class Http extends AbstractTransport
     protected function _getAuthType()
     {
         switch ($this->_connection->getAuthType()) {
-            case "digest":
+            case 'digest':
                 return CURLAUTH_DIGEST;
                 break;
-            case "gssnegotiate":
+            case 'gssnegotiate':
                 return CURLAUTH_GSSNEGOTIATE;
                 break;
-            case "ntlm":
+            case 'ntlm':
                 return CURLAUTH_NTLM;
                 break;
-            case "basic":
+            case 'basic':
                 return CURLAUTH_BASIC;
                 break;
             default:

--- a/tests/ClientConfigurationTest.php
+++ b/tests/ClientConfigurationTest.php
@@ -89,7 +89,7 @@ class ClientConfigurationTest extends TestCase
             'bigintConversion' => false,
             'username' => null,
             'password' => null,
-            'auth_type' => null
+            'auth_type' => null,
         ];
 
         $this->assertEquals($expected, $configuration->getAll());

--- a/tests/ClientConfigurationTest.php
+++ b/tests/ClientConfigurationTest.php
@@ -39,6 +39,7 @@ class ClientConfigurationTest extends TestCase
             'bigintConversion' => false,
             'username' => null,
             'password' => null,
+            'auth_type' => null,
         ];
 
         $this->assertEquals($expected, $configuration->getAll());
@@ -62,6 +63,7 @@ class ClientConfigurationTest extends TestCase
             'bigintConversion' => true,
             'username' => 'user',
             'password' => 'p4ss',
+            'auth_type' => 'basic',
             'extra' => 'abc',
         ];
 
@@ -87,6 +89,7 @@ class ClientConfigurationTest extends TestCase
             'bigintConversion' => false,
             'username' => null,
             'password' => null,
+            'auth_type' => null
         ];
 
         $this->assertEquals($expected, $configuration->getAll());
@@ -114,6 +117,7 @@ class ClientConfigurationTest extends TestCase
             'bigintConversion' => false,
             'username' => 'Jdoe',
             'password' => null,
+            'auth_type' => null,
             'extra' => 'abc',
         ];
 
@@ -147,6 +151,7 @@ class ClientConfigurationTest extends TestCase
             'bigintConversion' => false,
             'username' => null,
             'password' => null,
+            'auth_type' => null,
         ];
 
         $this->assertEquals($expected, $configuration->get(''));

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -40,6 +40,7 @@ class ClientTest extends BaseTest
             'bigintConversion' => false,
             'username' => 'user',
             'password' => 'p4ss',
+            'auth_type' => 'basic',
             'connectionStrategy' => 'Simple',
         ];
 


### PR DESCRIPTION
I added   auth_type option to resolve the problem of duplicate requests in [1789 issue](https://github.com/ruflin/Elastica/issues/1789 "1789 issue")
```php
        'auth_type' => null //basic, digest, gssnegotiate, ntlm
```