### PR TITLE
Allow string argument in AbstractUpdateAction::setRefresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Ability to specify the type of authentication manually by the `auth_type` parameter (in the client class config) was added (allowed values are `basic, digest, gssnegotiate, ntlm`)
 ### Changed
-
+* Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
+* Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -252,21 +252,29 @@ class AbstractUpdateAction extends Param
     }
 
     /**
-     * @param bool $refresh
+     * @param bool|string $refresh
      *
      * @return $this
      */
     public function setRefresh($refresh = true)
     {
-        return $this->setParam('refresh', (bool) $refresh ? 'true' : 'false');
+        \is_bool($refresh) && $refresh = $refresh
+            ? Reindex::REFRESH_TRUE
+            : Reindex::REFRESH_FALSE;
+
+        return $this->setParam(Reindex::REFRESH, $refresh);
     }
 
     /**
-     * @return bool
+     * @return bool|string
      */
     public function getRefresh()
     {
-        return 'true' === $this->getParam('refresh');
+        $refresh = $this->getParam('refresh');
+
+        return \in_array($refresh, [Reindex::REFRESH_TRUE, Reindex::REFRESH_FALSE])
+            ? $refresh === Reindex::REFRESH_TRUE
+            : $refresh;
     }
 
     /**

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -273,7 +273,7 @@ class AbstractUpdateAction extends Param
         $refresh = $this->getParam('refresh');
 
         return \in_array($refresh, [Reindex::REFRESH_TRUE, Reindex::REFRESH_FALSE])
-            ? $refresh === Reindex::REFRESH_TRUE
+            ? Reindex::REFRESH_TRUE === $refresh
             : $refresh;
     }
 

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -5,6 +5,7 @@ namespace Elastica\Test;
 use Elastica\Document;
 use Elastica\Exception\InvalidException;
 use Elastica\Index;
+use Elastica\Reindex;
 use Elastica\Test\Base as BaseTest;
 
 /**
@@ -118,6 +119,10 @@ class DocumentTest extends BaseTest
         $document->setRefresh(true);
         $this->assertTrue($document->hasRefresh());
         $this->assertTrue($document->getRefresh());
+
+        $document->setRefresh(Reindex::REFRESH_WAIT_FOR);
+        $this->assertTrue($document->hasRefresh());
+        $this->assertEquals(Reindex::REFRESH_WAIT_FOR, $document->getRefresh());
     }
 
     /**


### PR DESCRIPTION
Ref #1475 

Currently, `AbstractUpdateAction::setRefresh` only accepts boolean values: 
- `true` - to perform an immediate refresh
- `false` - to not refresh at all

The [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html), however, strongly suggests the usage of `wait_for` option to ensure a good cluster performance while doing the refresh operation. But the problem is that `wait_for` is of type `string`; thus, we cannot pass it as an argument to the method.

This modifies `AbstractUpdateAction::setRefresh` so that arguments of type `string` such as `wait_for` can also be passed to the method. Additionally, the return type of its getter counterpart, `AbstractUpdateAction::getRefresh`, has also been modified to mirror the accepted types of the setter.