### PR TITLE
Support PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,11 @@ matrix:
   fast_finish: true
   include:
     - php: 7.3
-      env: RUN_TEST=true  ES_VERSION=73
+      env: RUN_TEST=true ES_VERSION=73
     - php: 7.4
-      env: RUN_TEST=true  ES_VERSION=73
+      env: RUN_TEST=true ES_VERSION=73
+    - php: nightly
+      env: RUN_TEST=true ES_VERSION=73 COMPOSER_FLAGS="--ignore-platform-reqs"
     # Testing the library with different ES versions
     - php: 7.2
       env: RUN_TEST=true ES_VERSION=72

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ability to specify the type of authentication manually by the `auth_type` parameter (in the client class config) was added (allowed values are `basic, digest, gssnegotiate, ntlm`)
 * Added `if_seq_no` / `if_primary_term` to replace `version` for [optimistic concurrency control](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/optimistic-concurrency-control.html)
 * Added `Elastica\Aggregation\PercentilesBucket` aggregation [#1806](https://github.com/ruflin/Elastica/pull/1806)
+* Supported PHP 8.0 [#1794](https://github.com/ruflin/Elastica/pull/1794)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "psr/log": "^1.0",
         "elasticsearch/elasticsearch": "^7.1.1 !=7.4.0"

--- a/tests/ClientConfigurationTest.php
+++ b/tests/ClientConfigurationTest.php
@@ -15,9 +15,9 @@ class ClientConfigurationTest extends TestCase
     public function testInvalidDsn(): void
     {
         $this->expectException(\Elastica\Exception\InvalidException::class);
-        $this->expectExceptionMessage("DSN 'test:0' is invalid.");
+        $this->expectExceptionMessage("DSN ':0' is invalid.");
 
-        ClientConfiguration::fromDsn('test:0');
+        ClientConfiguration::fromDsn(':0');
     }
 
     public function testFromSimpleDsn(): void


### PR DESCRIPTION
#### Done in this PR:

- [x] Update composer constraint to allow PHP 8.0.
- [x] Update travis configuration in order to run tests on PHP 8.0 (nightly).
- [x] Update changelog

#### Done in previous PRs:
- [x] Deprecate `Elastica\Query\Match` class and add a new `Elastica\Query\MatchQuery` class as match is now a reserved keyword. [#1799]
- [x] Update phpunit version in order to be compatible with PHP 8.0. [#1811]
- [x] Bump `aws/aws-sdk-php` package version to fix a bug with PHP 8.0. [#1798]

#### Done in external PRs:
- [x] Wait for `aws/aws-sdk-php` to be compatible with PHP 8. [https://github.com/aws/aws-sdk-php/pull/2079]
- [ ] Wait for `elasticsearch/elasticsearch` to be compatible with PHP 8.0 and remove `--ignore-platform-reqs` composer option.