### PR TITLE
uncommented version in _params on updateDocument() to support Elatica…

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -277,7 +277,7 @@ class Client
 
             $docOptions = $data->getOptions(
                 [
-                    'version',
+//                    'version',
                     'version_type',
                     'routing',
                     'percolate',


### PR DESCRIPTION
… 7.9.1

The version parameter is removed from elasticsearch, tested on Elasticsearch 7.9.1