### PR TITLE
[PHP 8.0] Fix \ReflectionParameter deprecations

### DIFF
--- a/tests/QueryBuilder/DSL/AbstractDSLTest.php
+++ b/tests/QueryBuilder/DSL/AbstractDSLTest.php
@@ -72,16 +72,14 @@ abstract class AbstractDSLTest extends BaseTest
      */
     protected function _getHintName(\ReflectionParameter $param)
     {
-        if ($param->isCallable()) {
-            return 'callable';
+        if (null === $type = $param->getType()) {
+            return null;
         }
 
-        if ($param->isArray()) {
-            return 'array';
-        }
-
-        if ($class = $param->getClass()) {
-            return $class->getName();
+        if (\in_array($type->getName(), ['array', 'callable'], true)
+            || !$param->getType()->isBuiltin()
+        ) {
+            return $type->getName();
         }
 
         return null;

--- a/tests/QueryBuilder/DSL/AbstractDSLTest.php
+++ b/tests/QueryBuilder/DSL/AbstractDSLTest.php
@@ -77,7 +77,7 @@ abstract class AbstractDSLTest extends BaseTest
         }
 
         if (\in_array($type->getName(), ['array', 'callable'], true)
-            || !$param->getType()->isBuiltin()
+            || !$type->isBuiltin()
         ) {
             return $type->getName();
         }

--- a/tests/QueryBuilder/DSL/AbstractDSLTest.php
+++ b/tests/QueryBuilder/DSL/AbstractDSLTest.php
@@ -67,10 +67,7 @@ abstract class AbstractDSLTest extends BaseTest
         return null;
     }
 
-    /**
-     * @return string|null
-     */
-    protected function _getHintName(\ReflectionParameter $param)
+    protected function _getHintName(\ReflectionParameter $param): ?string
     {
         if (null === $type = $param->getType()) {
             return null;


### PR DESCRIPTION
See https://php.watch/versions/8.0/deprecated-reflectionparameter-methods for details about the deprecations addressed here.