### PR TITLE
Version option deprecation fix and replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)
+* Removed deprecated `version` option [(deprecated in `6.7.0`)](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html) and added `if_seq_no` / `if_primary_term` that replaced it
 ### Deprecated
 * Deprecated Match query class and introduced MatchQuery instead for PHP 8.0 compatibility reason [#1799](https://github.com/ruflin/Elastica/pull/1799)
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Backward Compatibility Breaks
 ### Added
 * Ability to specify the type of authentication manually by the `auth_type` parameter (in the client class config) was added (allowed values are `basic, digest, gssnegotiate, ntlm`)
+* Added `if_seq_no` / `if_primary_term` to replace `version` for [optimistic concurrency control](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/optimistic-concurrency-control.html)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)
-* Removed deprecated `version` option [(deprecated in `6.7.0`)](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html) and added `if_seq_no` / `if_primary_term` that replaced it
 ### Deprecated
 * Deprecated Match query class and introduced MatchQuery instead for PHP 8.0 compatibility reason [#1799](https://github.com/ruflin/Elastica/pull/1799)
+* Deprecated `version`/`version_type` options [(deprecated in `6.7.0`)](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html) and added `if_seq_no` / `if_primary_term` that replaced it
 ### Removed
 ### Fixed
 * fixed issue [1789](https://github.com/ruflin/Elastica/issues/1789)

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -65,6 +65,71 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * Sets the sequence number of a document for use with optimistic concurrency control.
+     *
+     * @param int $number Sequence Number
+     *
+     * @return $this
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/optimistic-concurrency-control.html
+     */
+    public function setSequenceNumber($number)
+    {
+        return $this->setParam('if_seq_no', $number);
+    }
+
+    /**
+     * Returns document version.
+     *
+     * @return int|string Document version
+     */
+    public function getSequenceNumber()
+    {
+        return $this->getParam('if_seq_no');
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasSequenceNumber()
+    {
+        return $this->hasParam('if_seq_no');
+    }
+
+    /**
+     * Sets the prmary term of a document for use with optimistic concurrency control.
+     *
+     * @param int $term Primary Term
+     *
+     * @return $this
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/optimistic-concurrency-control.html
+     */
+    public function setPrimaryTerm($term)
+    {
+        return $this->setParam('if_primary_term', $term);
+    }
+
+    /**
+     * Returns document version.
+     *
+     * @return int|string Document version
+     */
+    public function getPrimaryTerm()
+    {
+        return $this->getParam('if_primary_term');
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPrimaryTerm()
+    {
+        return $this->hasParam('if_primary_term');
+    }
+
+    /**
+     * @deprecated
      * Sets the version of a document for use with optimistic concurrency control.
      *
      * @param int $version Document version
@@ -75,10 +140,13 @@ class AbstractUpdateAction extends Param
      */
     public function setVersion($version)
     {
-        return $this->setParam('version', (int) $version);
+        \trigger_error('Elastica\AbstractUpdateAction\setVersion is deprecated. Elastica\AbstractUpdateAction\setSequenceNumber and Elastica\AbstractUpdateAction\setPrimaryTerm instead.', E_USER_DEPRECATED);
+
+        return $this;
     }
 
     /**
+     * @deprecated
      * Returns document version.
      *
      * @return int|string Document version
@@ -89,6 +157,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * @deprecated
      * @return bool
      */
     public function hasVersion()
@@ -97,6 +166,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * @deprecated
      * Sets the version_type of a document
      * Default in ES is internal, but you can set to external to use custom versioning.
      *
@@ -106,10 +176,13 @@ class AbstractUpdateAction extends Param
      */
     public function setVersionType($versionType)
     {
-        return $this->setParam('version_type', $versionType);
+        \trigger_error('Elastica\AbstractUpdateAction\setVersionType is deprecated. Elastica\AbstractUpdateAction\setSequenceNumber and Elastica\AbstractUpdateAction\setPrimaryTerm instead.', E_USER_DEPRECATED);
+
+        return $this;
     }
 
     /**
+     * @deprecated
      * Returns document version type.
      *
      * @return int|string Document version type
@@ -120,6 +193,7 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * @deprecated
      * @return bool
      */
     public function hasVersionType()

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -438,4 +438,26 @@ class AbstractUpdateAction extends Param
 
         return \array_filter($this->getParams());
     }
+
+    /**
+     * @param array $responseData
+     *
+     * @return $this
+     */
+    public function setVersionParams(array $responseData) :self
+    {
+        if (isset($responseData['_version'])) {
+            $this->setVersion($responseData['_version']);
+        }
+
+        if (isset($data['_seq_no'])) {
+            $this->setSequenceNumber($responseData['_seq_no']);
+        }
+
+        if (isset($data['_primary_term'])) {
+            $this->setPrimaryTerm($responseData['_primary_term']);
+        }
+
+        return $this;
+    }
 }

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -59,7 +59,7 @@ class AbstractUpdateAction extends Param
      *
      * @return string Index name
      */
-    public function getIndex()
+    public function getIndex(): string
     {
         return $this->getParam('_index');
     }
@@ -73,31 +73,31 @@ class AbstractUpdateAction extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/optimistic-concurrency-control.html
      */
-    public function setSequenceNumber($number)
+    public function setSequenceNumber(int $number): self
     {
-        return $this->setParam('if_seq_no', $number);
+        return $this->setParam('_seq_no', $number);
     }
 
     /**
      * Returns document version.
      *
-     * @return int|string Document version
+     * @return int Document version
      */
-    public function getSequenceNumber()
+    public function getSequenceNumber(): int
     {
-        return $this->getParam('if_seq_no');
+        return $this->getParam('_seq_no');
     }
 
     /**
      * @return bool
      */
-    public function hasSequenceNumber()
+    public function hasSequenceNumber(): bool
     {
-        return $this->hasParam('if_seq_no');
+        return $this->hasParam('_seq_no');
     }
 
     /**
-     * Sets the prmary term of a document for use with optimistic concurrency control.
+     * Sets the primary term of a document for use with optimistic concurrency control.
      *
      * @param int $term Primary Term
      *
@@ -105,31 +105,30 @@ class AbstractUpdateAction extends Param
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/optimistic-concurrency-control.html
      */
-    public function setPrimaryTerm($term)
+    public function setPrimaryTerm(int $term): self
     {
-        return $this->setParam('if_primary_term', $term);
+        return $this->setParam('_primary_term', $term);
     }
 
     /**
      * Returns document version.
      *
-     * @return int|string Document version
+     * @return int Document version
      */
-    public function getPrimaryTerm()
+    public function getPrimaryTerm(): int
     {
-        return $this->getParam('if_primary_term');
+        return $this->getParam('_primary_term');
     }
 
     /**
      * @return bool
      */
-    public function hasPrimaryTerm()
+    public function hasPrimaryTerm(): bool
     {
-        return $this->hasParam('if_primary_term');
+        return $this->hasParam('_primary_term');
     }
 
     /**
-     * @deprecated
      * Sets the version of a document for use with optimistic concurrency control.
      *
      * @param int $version Document version
@@ -138,67 +137,27 @@ class AbstractUpdateAction extends Param
      *
      * @see https://www.elastic.co/blog/versioning
      */
-    public function setVersion($version)
+    public function setVersion(int $version): self
     {
-        \trigger_error('Elastica\AbstractUpdateAction::setVersion is deprecated. Use Elastica\AbstractUpdateAction::setSequenceNumber and Elastica\AbstractUpdateAction::setPrimaryTerm instead.', E_USER_DEPRECATED);
-
-        return $this;
+        return $this->setParam('_version', $version);
     }
 
     /**
-     * @deprecated
      * Returns document version.
      *
-     * @return int|string Document version
+     * @return int Document version
      */
-    public function getVersion()
+    public function getVersion(): int
     {
         return $this->getParam('version');
     }
 
     /**
-     * @deprecated
      * @return bool
      */
-    public function hasVersion()
+    public function hasVersion(): bool
     {
         return $this->hasParam('version');
-    }
-
-    /**
-     * @deprecated
-     * Sets the version_type of a document
-     * Default in ES is internal, but you can set to external to use custom versioning.
-     *
-     * @param string $versionType Document version type
-     *
-     * @return $this
-     */
-    public function setVersionType($versionType)
-    {
-        \trigger_error('Elastica\AbstractUpdateAction::setVersionType is deprecated. Use Elastica\AbstractUpdateAction::setSequenceNumber and Elastica\AbstractUpdateAction::setPrimaryTerm instead.', E_USER_DEPRECATED);
-
-        return $this;
-    }
-
-    /**
-     * @deprecated
-     * Returns document version type.
-     *
-     * @return int|string Document version type
-     */
-    public function getVersionType()
-    {
-        return $this->getParam('version_type');
-    }
-
-    /**
-     * @deprecated
-     * @return bool
-     */
-    public function hasVersionType()
-    {
-        return $this->hasParam('version_type');
     }
 
     /**
@@ -208,7 +167,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setOpType($opType)
+    public function setOpType(string $opType): self
     {
         return $this->setParam('op_type', $opType);
     }
@@ -218,7 +177,7 @@ class AbstractUpdateAction extends Param
      *
      * @return string
      */
-    public function getOpType()
+    public function getOpType(): string
     {
         return $this->getParam('op_type');
     }
@@ -226,7 +185,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return bool
      */
-    public function hasOpType()
+    public function hasOpType(): bool
     {
         return $this->hasParam('op_type');
     }
@@ -238,7 +197,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setRouting($value)
+    public function setRouting(string $value): self
     {
         return $this->setParam('routing', $value);
     }
@@ -248,7 +207,7 @@ class AbstractUpdateAction extends Param
      *
      * @return string
      */
-    public function getRouting()
+    public function getRouting(): string
     {
         return $this->getParam('_routing');
     }
@@ -256,7 +215,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return bool
      */
-    public function hasRouting()
+    public function hasRouting(): bool
     {
         return $this->hasParam('_routing');
     }
@@ -266,7 +225,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setFields($fields)
+    public function setFields($fields): self
     {
         if (\is_array($fields)) {
             $fields = \implode(',', $fields);
@@ -278,7 +237,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return $this
      */
-    public function setFieldsSource()
+    public function setFieldsSource(): self
     {
         return $this->setFields('_source');
     }
@@ -286,7 +245,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return string
      */
-    public function getFields()
+    public function getFields(): string
     {
         return $this->getParam('fields');
     }
@@ -294,7 +253,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return bool
      */
-    public function hasFields()
+    public function hasFields(): bool
     {
         return $this->hasParam('fields');
     }
@@ -304,7 +263,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setRetryOnConflict($num)
+    public function setRetryOnConflict(int $num): self
     {
         return $this->setParam('retry_on_conflict', (int) $num);
     }
@@ -312,7 +271,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return int
      */
-    public function getRetryOnConflict()
+    public function getRetryOnConflict(): int
     {
         return $this->getParam('retry_on_conflict');
     }
@@ -320,7 +279,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return bool
      */
-    public function hasRetryOnConflict()
+    public function hasRetryOnConflict(): bool
     {
         return $this->hasParam('_retry_on_conflict');
     }
@@ -354,7 +313,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return bool
      */
-    public function hasRefresh()
+    public function hasRefresh(): bool
     {
         return $this->hasParam('refresh');
     }
@@ -364,15 +323,15 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setTimeout($timeout)
+    public function setTimeout(string $timeout): self
     {
         return $this->setParam('timeout', $timeout);
     }
 
     /**
-     * @return bool
+     * @return string
      */
-    public function getTimeout()
+    public function getTimeout(): string
     {
         return $this->getParam('timeout');
     }
@@ -380,7 +339,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return bool
      */
-    public function hasTimeout()
+    public function hasTimeout(): bool
     {
         return $this->hasParam('timeout');
     }
@@ -390,7 +349,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setConsistency($timeout)
+    public function setConsistency(string $timeout): self
     {
         return $this->setParam('consistency', $timeout);
     }
@@ -398,7 +357,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return string
      */
-    public function getConsistency()
+    public function getConsistency(): string
     {
         return $this->getParam('consistency');
     }
@@ -406,7 +365,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return bool
      */
-    public function hasConsistency()
+    public function hasConsistency(): bool
     {
         return $this->hasParam('consistency');
     }
@@ -416,7 +375,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setReplication($timeout)
+    public function setReplication(string $timeout): self
     {
         return $this->setParam('replication', $timeout);
     }
@@ -424,7 +383,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return string
      */
-    public function getReplication()
+    public function getReplication(): string
     {
         return $this->getParam('replication');
     }
@@ -432,7 +391,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return bool
      */
-    public function hasReplication()
+    public function hasReplication(): bool
     {
         return $this->hasParam('replication');
     }
@@ -442,7 +401,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setUpsert($data)
+    public function setUpsert($data): self
     {
         $document = Document::create($data);
         $this->_upsert = $document;
@@ -453,7 +412,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return Document
      */
-    public function getUpsert()
+    public function getUpsert(): Document
     {
         return $this->_upsert;
     }
@@ -461,7 +420,7 @@ class AbstractUpdateAction extends Param
     /**
      * @return bool
      */
-    public function hasUpsert()
+    public function hasUpsert(): bool
     {
         return null !== $this->_upsert;
     }
@@ -471,7 +430,7 @@ class AbstractUpdateAction extends Param
      *
      * @return array
      */
-    public function getOptions(array $fields = [])
+    public function getOptions(array $fields = []): array
     {
         if (!empty($fields)) {
             return \array_filter(\array_intersect_key($this->getParams(), \array_flip($fields)));

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -75,7 +75,7 @@ class AbstractUpdateAction extends Param
      */
     public function setSequenceNumber(int $number): self
     {
-        return $this->setParam('_seq_no', $number);
+        return $this->setParam('if_seq_no', $number);
     }
 
     /**
@@ -85,7 +85,7 @@ class AbstractUpdateAction extends Param
      */
     public function getSequenceNumber(): int
     {
-        return $this->getParam('_seq_no');
+        return $this->getParam('if_seq_no');
     }
 
     /**
@@ -93,7 +93,7 @@ class AbstractUpdateAction extends Param
      */
     public function hasSequenceNumber(): bool
     {
-        return $this->hasParam('_seq_no');
+        return $this->hasParam('if_seq_no');
     }
 
     /**
@@ -107,7 +107,7 @@ class AbstractUpdateAction extends Param
      */
     public function setPrimaryTerm(int $term): self
     {
-        return $this->setParam('_primary_term', $term);
+        return $this->setParam('if_primary_term', $term);
     }
 
     /**
@@ -117,7 +117,7 @@ class AbstractUpdateAction extends Param
      */
     public function getPrimaryTerm(): int
     {
-        return $this->getParam('_primary_term');
+        return $this->getParam('if_primary_term');
     }
 
     /**
@@ -125,11 +125,11 @@ class AbstractUpdateAction extends Param
      */
     public function hasPrimaryTerm(): bool
     {
-        return $this->hasParam('_primary_term');
+        return $this->hasParam('if_primary_term');
     }
 
     /**
-     * Sets the version of a document for use with optimistic concurrency control.
+     * Sets the version of a document.
      *
      * @param int $version Document version
      *
@@ -149,7 +149,7 @@ class AbstractUpdateAction extends Param
      */
     public function getVersion(): int
     {
-        return $this->getParam('version');
+        return $this->getParam('_version');
     }
 
     /**
@@ -157,7 +157,7 @@ class AbstractUpdateAction extends Param
      */
     public function hasVersion(): bool
     {
-        return $this->hasParam('version');
+        return $this->hasParam('_version');
     }
 
     /**

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -65,6 +65,30 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * Sets the version parameters of a document for use with optimistic concurrency control.
+     *
+     * @param array $responseData
+     *
+     * @return $this
+     */
+    public function setVersionParams(array $responseData): self
+    {
+        if (isset($responseData['_version'])) {
+            $this->setVersion($responseData['_version']);
+        }
+
+        if (isset($data['_seq_no'])) {
+            $this->setSequenceNumber($responseData['_seq_no']);
+        }
+
+        if (isset($data['_primary_term'])) {
+            $this->setPrimaryTerm($responseData['_primary_term']);
+        }
+
+        return $this;
+    }
+
+    /**
      * Sets the sequence number of a document for use with optimistic concurrency control.
      *
      * @param int $number Sequence Number
@@ -437,27 +461,5 @@ class AbstractUpdateAction extends Param
         }
 
         return \array_filter($this->getParams());
-    }
-
-    /**
-     * @param array $responseData
-     *
-     * @return $this
-     */
-    public function setVersionParams(array $responseData) :self
-    {
-        if (isset($responseData['_version'])) {
-            $this->setVersion($responseData['_version']);
-        }
-
-        if (isset($data['_seq_no'])) {
-            $this->setSequenceNumber($responseData['_seq_no']);
-        }
-
-        if (isset($data['_primary_term'])) {
-            $this->setPrimaryTerm($responseData['_primary_term']);
-        }
-
-        return $this;
     }
 }

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -67,8 +67,6 @@ class AbstractUpdateAction extends Param
     /**
      * Sets the version parameters of a document for use with optimistic concurrency control.
      *
-     * @param array $responseData
-     *
      * @return $this
      */
     public function setVersionParams(array $responseData): self
@@ -112,9 +110,6 @@ class AbstractUpdateAction extends Param
         return $this->getParam('if_seq_no');
     }
 
-    /**
-     * @return bool
-     */
     public function hasSequenceNumber(): bool
     {
         return $this->hasParam('if_seq_no');
@@ -144,9 +139,6 @@ class AbstractUpdateAction extends Param
         return $this->getParam('if_primary_term');
     }
 
-    /**
-     * @return bool
-     */
     public function hasPrimaryTerm(): bool
     {
         return $this->hasParam('if_primary_term');
@@ -176,9 +168,6 @@ class AbstractUpdateAction extends Param
         return $this->getParam('_version');
     }
 
-    /**
-     * @return bool
-     */
     public function hasVersion(): bool
     {
         return $this->hasParam('_version');
@@ -198,17 +187,12 @@ class AbstractUpdateAction extends Param
 
     /**
      * Get operation type.
-     *
-     * @return string
      */
     public function getOpType(): string
     {
         return $this->getParam('op_type');
     }
 
-    /**
-     * @return bool
-     */
     public function hasOpType(): bool
     {
         return $this->hasParam('op_type');
@@ -228,17 +212,12 @@ class AbstractUpdateAction extends Param
 
     /**
      * Get routing parameter.
-     *
-     * @return string
      */
     public function getRouting(): string
     {
         return $this->getParam('_routing');
     }
 
-    /**
-     * @return bool
-     */
     public function hasRouting(): bool
     {
         return $this->hasParam('_routing');
@@ -266,25 +245,17 @@ class AbstractUpdateAction extends Param
         return $this->setFields('_source');
     }
 
-    /**
-     * @return string
-     */
     public function getFields(): string
     {
         return $this->getParam('fields');
     }
 
-    /**
-     * @return bool
-     */
     public function hasFields(): bool
     {
         return $this->hasParam('fields');
     }
 
     /**
-     * @param int $num
-     *
      * @return $this
      */
     public function setRetryOnConflict(int $num): self
@@ -292,17 +263,11 @@ class AbstractUpdateAction extends Param
         return $this->setParam('retry_on_conflict', (int) $num);
     }
 
-    /**
-     * @return int
-     */
     public function getRetryOnConflict(): int
     {
         return $this->getParam('retry_on_conflict');
     }
 
-    /**
-     * @return bool
-     */
     public function hasRetryOnConflict(): bool
     {
         return $this->hasParam('_retry_on_conflict');
@@ -334,17 +299,12 @@ class AbstractUpdateAction extends Param
             : $refresh;
     }
 
-    /**
-     * @return bool
-     */
     public function hasRefresh(): bool
     {
         return $this->hasParam('refresh');
     }
 
     /**
-     * @param string $timeout
-     *
      * @return $this
      */
     public function setTimeout(string $timeout): self
@@ -352,25 +312,17 @@ class AbstractUpdateAction extends Param
         return $this->setParam('timeout', $timeout);
     }
 
-    /**
-     * @return string
-     */
     public function getTimeout(): string
     {
         return $this->getParam('timeout');
     }
 
-    /**
-     * @return bool
-     */
     public function hasTimeout(): bool
     {
         return $this->hasParam('timeout');
     }
 
     /**
-     * @param string $timeout
-     *
      * @return $this
      */
     public function setConsistency(string $timeout): self
@@ -378,25 +330,17 @@ class AbstractUpdateAction extends Param
         return $this->setParam('consistency', $timeout);
     }
 
-    /**
-     * @return string
-     */
     public function getConsistency(): string
     {
         return $this->getParam('consistency');
     }
 
-    /**
-     * @return bool
-     */
     public function hasConsistency(): bool
     {
         return $this->hasParam('consistency');
     }
 
     /**
-     * @param string $timeout
-     *
      * @return $this
      */
     public function setReplication(string $timeout): self
@@ -404,17 +348,11 @@ class AbstractUpdateAction extends Param
         return $this->setParam('replication', $timeout);
     }
 
-    /**
-     * @return string
-     */
     public function getReplication(): string
     {
         return $this->getParam('replication');
     }
 
-    /**
-     * @return bool
-     */
     public function hasReplication(): bool
     {
         return $this->hasParam('replication');
@@ -433,17 +371,11 @@ class AbstractUpdateAction extends Param
         return $this;
     }
 
-    /**
-     * @return Document
-     */
     public function getUpsert(): Document
     {
         return $this->_upsert;
     }
 
-    /**
-     * @return bool
-     */
     public function hasUpsert(): bool
     {
         return null !== $this->_upsert;
@@ -451,8 +383,6 @@ class AbstractUpdateAction extends Param
 
     /**
      * @param array $fields if empty array all options will be returned
-     *
-     * @return array
      */
     public function getOptions(array $fields = []): array
     {

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -59,7 +59,7 @@ class AbstractUpdateAction extends Param
      *
      * @return string Index name
      */
-    public function getIndex(): string
+    public function getIndex()
     {
         return $this->getParam('_index');
     }
@@ -153,24 +153,27 @@ class AbstractUpdateAction extends Param
      *
      * @see https://www.elastic.co/blog/versioning
      */
-    public function setVersion(int $version): self
+    public function setVersion($version)
     {
-        return $this->setParam('_version', $version);
+        return $this->setParam('version', (int) $version);
     }
 
     /**
      * Returns document version.
      *
-     * @return int Document version
+     * @return int|string Document version
      */
-    public function getVersion(): int
+    public function getVersion()
     {
-        return $this->getParam('_version');
+        return $this->getParam('version');
     }
 
-    public function hasVersion(): bool
+    /**
+     * @return bool
+     */
+    public function hasVersion()
     {
-        return $this->hasParam('_version');
+        return $this->hasParam('version');
     }
 
     /**
@@ -180,20 +183,25 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setOpType(string $opType): self
+    public function setOpType($opType)
     {
         return $this->setParam('op_type', $opType);
     }
 
     /**
      * Get operation type.
+     *
+     * @return string
      */
-    public function getOpType(): string
+    public function getOpType()
     {
         return $this->getParam('op_type');
     }
 
-    public function hasOpType(): bool
+    /**
+     * @return bool
+     */
+    public function hasOpType()
     {
         return $this->hasParam('op_type');
     }
@@ -205,20 +213,25 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setRouting(string $value): self
+    public function setRouting($value)
     {
         return $this->setParam('routing', $value);
     }
 
     /**
      * Get routing parameter.
+     *
+     * @return string
      */
-    public function getRouting(): string
+    public function getRouting()
     {
         return $this->getParam('_routing');
     }
 
-    public function hasRouting(): bool
+    /**
+     * @return bool
+     */
+    public function hasRouting()
     {
         return $this->hasParam('_routing');
     }
@@ -228,7 +241,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setFields($fields): self
+    public function setFields($fields)
     {
         if (\is_array($fields)) {
             $fields = \implode(',', $fields);
@@ -240,35 +253,49 @@ class AbstractUpdateAction extends Param
     /**
      * @return $this
      */
-    public function setFieldsSource(): self
+    public function setFieldsSource()
     {
         return $this->setFields('_source');
     }
 
-    public function getFields(): string
+    /**
+     * @return string
+     */
+    public function getFields()
     {
         return $this->getParam('fields');
     }
 
-    public function hasFields(): bool
+    /**
+     * @return bool
+     */
+    public function hasFields()
     {
         return $this->hasParam('fields');
     }
 
     /**
+     * @param int $num
+     *
      * @return $this
      */
-    public function setRetryOnConflict(int $num): self
+    public function setRetryOnConflict($num)
     {
         return $this->setParam('retry_on_conflict', (int) $num);
     }
 
-    public function getRetryOnConflict(): int
+    /**
+     * @return int
+     */
+    public function getRetryOnConflict()
     {
         return $this->getParam('retry_on_conflict');
     }
 
-    public function hasRetryOnConflict(): bool
+    /**
+     * @return bool
+     */
+    public function hasRetryOnConflict()
     {
         return $this->hasParam('_retry_on_conflict');
     }
@@ -299,61 +326,88 @@ class AbstractUpdateAction extends Param
             : $refresh;
     }
 
-    public function hasRefresh(): bool
+    /**
+     * @return bool
+     */
+    public function hasRefresh()
     {
         return $this->hasParam('refresh');
     }
 
     /**
+     * @param string $timeout
+     *
      * @return $this
      */
-    public function setTimeout(string $timeout): self
+    public function setTimeout($timeout)
     {
         return $this->setParam('timeout', $timeout);
     }
 
-    public function getTimeout(): string
+    /**
+     * @return bool
+     */
+    public function getTimeout()
     {
         return $this->getParam('timeout');
     }
 
-    public function hasTimeout(): bool
+    /**
+     * @return bool
+     */
+    public function hasTimeout()
     {
         return $this->hasParam('timeout');
     }
 
     /**
+     * @param string $timeout
+     *
      * @return $this
      */
-    public function setConsistency(string $timeout): self
+    public function setConsistency($timeout)
     {
         return $this->setParam('consistency', $timeout);
     }
 
-    public function getConsistency(): string
+    /**
+     * @return string
+     */
+    public function getConsistency()
     {
         return $this->getParam('consistency');
     }
 
-    public function hasConsistency(): bool
+    /**
+     * @return bool
+     */
+    public function hasConsistency()
     {
         return $this->hasParam('consistency');
     }
 
     /**
+     * @param string $timeout
+     *
      * @return $this
      */
-    public function setReplication(string $timeout): self
+    public function setReplication($timeout)
     {
         return $this->setParam('replication', $timeout);
     }
 
-    public function getReplication(): string
+    /**
+     * @return string
+     */
+    public function getReplication()
     {
         return $this->getParam('replication');
     }
 
-    public function hasReplication(): bool
+    /**
+     * @return bool
+     */
+    public function hasReplication()
     {
         return $this->hasParam('replication');
     }
@@ -363,7 +417,7 @@ class AbstractUpdateAction extends Param
      *
      * @return $this
      */
-    public function setUpsert($data): self
+    public function setUpsert($data)
     {
         $document = Document::create($data);
         $this->_upsert = $document;
@@ -371,20 +425,28 @@ class AbstractUpdateAction extends Param
         return $this;
     }
 
-    public function getUpsert(): Document
+    /**
+     * @return Document
+     */
+    public function getUpsert()
     {
         return $this->_upsert;
     }
 
-    public function hasUpsert(): bool
+    /**
+     * @return bool
+     */
+    public function hasUpsert()
     {
         return null !== $this->_upsert;
     }
 
     /**
      * @param array $fields if empty array all options will be returned
+     *
+     * @return array
      */
-    public function getOptions(array $fields = []): array
+    public function getOptions(array $fields = [])
     {
         if (!empty($fields)) {
             return \array_filter(\array_intersect_key($this->getParams(), \array_flip($fields)));

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -140,7 +140,7 @@ class AbstractUpdateAction extends Param
      */
     public function setVersion($version)
     {
-        \trigger_error('Elastica\AbstractUpdateAction\setVersion is deprecated. Elastica\AbstractUpdateAction\setSequenceNumber and Elastica\AbstractUpdateAction\setPrimaryTerm instead.', E_USER_DEPRECATED);
+        \trigger_error('Elastica\AbstractUpdateAction::setVersion is deprecated. Use Elastica\AbstractUpdateAction::setSequenceNumber and Elastica\AbstractUpdateAction::setPrimaryTerm instead.', E_USER_DEPRECATED);
 
         return $this;
     }
@@ -176,7 +176,7 @@ class AbstractUpdateAction extends Param
      */
     public function setVersionType($versionType)
     {
-        \trigger_error('Elastica\AbstractUpdateAction\setVersionType is deprecated. Elastica\AbstractUpdateAction\setSequenceNumber and Elastica\AbstractUpdateAction\setPrimaryTerm instead.', E_USER_DEPRECATED);
+        \trigger_error('Elastica\AbstractUpdateAction::setVersionType is deprecated. Use Elastica\AbstractUpdateAction::setSequenceNumber and Elastica\AbstractUpdateAction::setPrimaryTerm instead.', E_USER_DEPRECATED);
 
         return $this;
     }

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -323,6 +323,9 @@ class Bulk
                         if (!$data->hasId() && isset($bulkResponseData['_id'])) {
                             $data->setId($bulkResponseData['_id']);
                         }
+                        if (isset($responseData['_version'])) {
+                            $data->setVersion($responseData['_version']);
+                        }
                         if (isset($responseData['_seq_no'])) {
                             $data->setSequenceNumber($responseData['_seq_no']);
                         }

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -323,15 +323,7 @@ class Bulk
                         if (!$data->hasId() && isset($bulkResponseData['_id'])) {
                             $data->setId($bulkResponseData['_id']);
                         }
-                        if (isset($bulkResponseData['_version'])) {
-                            $data->setVersion($bulkResponseData['_version']);
-                        }
-                        if (isset($bulkResponseData['_seq_no'])) {
-                            $data->setSequenceNumber($bulkResponseData['_seq_no']);
-                        }
-                        if (isset($bulkResponseData['_primary_term'])) {
-                            $data->setPrimaryTerm($bulkResponseData['_primary_term']);
-                        }
+                        $data->setVersionParams($bulkResponseData);
                     }
                 }
 

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -323,14 +323,14 @@ class Bulk
                         if (!$data->hasId() && isset($bulkResponseData['_id'])) {
                             $data->setId($bulkResponseData['_id']);
                         }
-                        if (isset($responseData['_version'])) {
-                            $data->setVersion($responseData['_version']);
+                        if (isset($bulkResponseData['_version'])) {
+                            $data->setVersion($bulkResponseData['_version']);
                         }
-                        if (isset($responseData['_seq_no'])) {
-                            $data->setSequenceNumber($responseData['_seq_no']);
+                        if (isset($bulkResponseData['_seq_no'])) {
+                            $data->setSequenceNumber($bulkResponseData['_seq_no']);
                         }
-                        if (isset($responseData['_primary_term'])) {
-                            $data->setPrimaryTerm($responseData['_primary_term']);
+                        if (isset($bulkResponseData['_primary_term'])) {
+                            $data->setPrimaryTerm($bulkResponseData['_primary_term']);
                         }
                     }
                 }

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -323,8 +323,11 @@ class Bulk
                         if (!$data->hasId() && isset($bulkResponseData['_id'])) {
                             $data->setId($bulkResponseData['_id']);
                         }
-                        if (isset($bulkResponseData['_version'])) {
-                            $data->setVersion($bulkResponseData['_version']);
+                        if (isset($responseData['_seq_no'])) {
+                            $data->setSequenceNumber($responseData['_seq_no']);
+                        }
+                        if (isset($responseData['_primary_term'])) {
+                            $data->setPrimaryTerm($responseData['_primary_term']);
                         }
                     }
                 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -310,13 +310,7 @@ class Client
             && $data instanceof Document
             && ($data->isAutoPopulate() || $this->getConfigValue(['document', 'autoPopulate'], false))
         ) {
-            $responseData = $response->getData();
-            if (isset($responseData['_seq_no'])) {
-                $data->setSequenceNumber($responseData['_seq_no']);
-            }
-            if (isset($responseData['_primary_term'])) {
-                $data->setPrimaryTerm($responseData['_primary_term']);
-            }
+            $data->setVersionParams($response->getData());
         }
 
         return $response;

--- a/src/Client.php
+++ b/src/Client.php
@@ -278,8 +278,6 @@ class Client
             $docOptions = $data->getOptions(
                 [
                     'consistency',
-                    'if_primary_term',
-                    'if_seq_no',
                     'parent',
                     'percolate',
                     'refresh',

--- a/src/Client.php
+++ b/src/Client.php
@@ -277,7 +277,8 @@ class Client
 
             $docOptions = $data->getOptions(
                 [
-                    'version',
+                    'if_seq_no',
+                    'if_primary_term',
                     'version_type',
                     'routing',
                     'percolate',

--- a/src/Client.php
+++ b/src/Client.php
@@ -279,7 +279,6 @@ class Client
                 [
                     'if_seq_no',
                     'if_primary_term',
-                    'version_type',
                     'routing',
                     'percolate',
                     'parent',
@@ -312,8 +311,11 @@ class Client
             && ($data->isAutoPopulate() || $this->getConfigValue(['document', 'autoPopulate'], false))
         ) {
             $responseData = $response->getData();
-            if (isset($responseData['_version'])) {
-                $data->setVersion($responseData['_version']);
+            if (isset($responseData['_seq_no'])) {
+                $data->setSequenceNumber($responseData['_seq_no']);
+            }
+            if (isset($responseData['_primary_term'])) {
+                $data->setPrimaryTerm($responseData['_primary_term']);
             }
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -277,15 +277,15 @@ class Client
 
             $docOptions = $data->getOptions(
                 [
-                    'if_seq_no',
-                    'if_primary_term',
-                    'routing',
-                    'percolate',
-                    'parent',
-                    'retry_on_conflict',
                     'consistency',
-                    'replication',
+                    'if_primary_term',
+                    'if_seq_no',
+                    'parent',
+                    'percolate',
                     'refresh',
+                    'replication',
+                    'retry_on_conflict',
+                    'routing',
                     'timeout',
                 ]
             );

--- a/src/Index.php
+++ b/src/Index.php
@@ -215,8 +215,11 @@ class Index implements SearchableInterface
             if (isset($data['_id']) && !$doc->hasId()) {
                 $doc->setId($data['_id']);
             }
-            if (isset($data['_version'])) {
-                $doc->setVersion($data['_version']);
+            if (isset($responseData['_seq_no'])) {
+                $doc->setSequenceNumber($responseData['_seq_no']);
+            }
+            if (isset($responseData['_primary_term'])) {
+                $doc->setPrimaryTerm($responseData['_primary_term']);
             }
         }
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -215,11 +215,14 @@ class Index implements SearchableInterface
             if (isset($data['_id']) && !$doc->hasId()) {
                 $doc->setId($data['_id']);
             }
-            if (isset($responseData['_seq_no'])) {
-                $doc->setSequenceNumber($responseData['_seq_no']);
+            if (isset($data['_version'])) {
+                $doc->setVersion($data['_version']);
             }
-            if (isset($responseData['_primary_term'])) {
-                $doc->setPrimaryTerm($responseData['_primary_term']);
+            if (isset($data['_seq_no'])) {
+                $doc->setSequenceNumber($data['_seq_no']);
+            }
+            if (isset($data['_primary_term'])) {
+                $doc->setPrimaryTerm($data['_primary_term']);
             }
         }
 
@@ -275,7 +278,18 @@ class Index implements SearchableInterface
             $data = [];
         }
 
-        return new Document($id, $data, $this->getName());
+        $doc = new Document($id, $data, $this->getName());
+        if (isset($data['_version'])) {
+            $doc->setVersion($data['_version']);
+        }
+        if (isset($data['_seq_no'])) {
+            $doc->setSequenceNumber($data['_seq_no']);
+        }
+        if (isset($data['_primary_term'])) {
+            $doc->setPrimaryTerm($data['_primary_term']);
+        }
+
+        return $doc;
     }
 
     /**

--- a/src/Index.php
+++ b/src/Index.php
@@ -275,10 +275,7 @@ class Index implements SearchableInterface
             $data = [];
         }
 
-        $document = new Document($id, $data, $this->getName());
-        $document->setVersion($result['_version']);
-
-        return $document;
+        return new Document($id, $data, $this->getName());
     }
 
     /**

--- a/src/Index.php
+++ b/src/Index.php
@@ -215,15 +215,7 @@ class Index implements SearchableInterface
             if (isset($data['_id']) && !$doc->hasId()) {
                 $doc->setId($data['_id']);
             }
-            if (isset($data['_version'])) {
-                $doc->setVersion($data['_version']);
-            }
-            if (isset($data['_seq_no'])) {
-                $doc->setSequenceNumber($data['_seq_no']);
-            }
-            if (isset($data['_primary_term'])) {
-                $doc->setPrimaryTerm($data['_primary_term']);
-            }
+            $doc->setVersionParams($data);
         }
 
         return $response;
@@ -279,15 +271,7 @@ class Index implements SearchableInterface
         }
 
         $doc = new Document($id, $data, $this->getName());
-        if (isset($data['_version'])) {
-            $doc->setVersion($data['_version']);
-        }
-        if (isset($data['_seq_no'])) {
-            $doc->setSequenceNumber($data['_seq_no']);
-        }
-        if (isset($data['_primary_term'])) {
-            $doc->setPrimaryTerm($data['_primary_term']);
-        }
+        $doc->setVersionParams($data);
 
         return $doc;
     }


### PR DESCRIPTION
As stated in https://github.com/ruflin/Elastica/pull/1796

* removed `version` and `version_type`
* added replacements `if_seq_no` and `if_primary_term`