### PR TITLE
Added support for pools using DSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Elastica\Aggregation\PercentilesBucket` aggregation [#1806](https://github.com/ruflin/Elastica/pull/1806)
 * Added `weighted_avg` to aggregations DSL [#1814](https://github.com/ruflin/Elastica/pull/1814)
 * Supported PHP 8.0 [#1794](https://github.com/ruflin/Elastica/pull/1794)
+* Added support for defining a connection pool with DSN. Example `pool(http://127.0.0.1 http://127.0.0.2/bar?timeout=4)` [#1808](https://github.com/ruflin/Elastica/pull/1808)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Elastica\Aggregation\PercentilesBucket` aggregation [#1806](https://github.com/ruflin/Elastica/pull/1806)
 * Added `weighted_avg` to aggregations DSL [#1814](https://github.com/ruflin/Elastica/pull/1814)
 * Supported PHP 8.0 [#1794](https://github.com/ruflin/Elastica/pull/1794)
-* Added support for defining a connection pool with DSN. Example `pool(http://127.0.0.1 http://127.0.0.2/bar?timeout=4)` [#1808](https://github.com/ruflin/Elastica/pull/1808)
+* Added support for defining a connection pool with DSN. Example: `pool(http://127.0.0.1 http://127.0.0.2/bar?timeout=4)` [#1808](https://github.com/ruflin/Elastica/pull/1808)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "psr/log": "^1.0",
-        "elasticsearch/elasticsearch": "^7.1.1 !=7.4.0"
+        "elasticsearch/elasticsearch": "^7.1.1 !=7.4.0",
+        "nyholm/dsn": "2.0.0-beta1"
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.155",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-json": "*",
         "psr/log": "^1.0",
         "elasticsearch/elasticsearch": "^7.1.1 !=7.4.0",
-        "nyholm/dsn": "2.0.0-beta1"
+        "nyholm/dsn": "^2.0.0"
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.155",

--- a/src/ClientConfiguration.php
+++ b/src/ClientConfiguration.php
@@ -62,7 +62,7 @@ class ClientConfiguration
      * Create configuration from Dsn string. Example of valid DSN strings:
      * - http://localhost
      * - http://foo:bar@localhost:1234?timeout=4&persistant=false
-     * - pool(http://127.0.0.1 http://127.0.0.2/bar?timeout=4)
+     * - pool(http://127.0.0.1 http://127.0.0.2/bar?timeout=4).
      *
      * @return ClientConfiguration
      */
@@ -71,14 +71,14 @@ class ClientConfiguration
         try {
             $func = DsnParser::parseFunc($dsnString);
         } catch (DsnException $e) {
-            throw new InvalidException(sprintf('DSN "%s" is invalid.', $dsnString), 0, $e);
+            throw new InvalidException(\sprintf('DSN "%s" is invalid.', $dsnString), 0, $e);
         }
 
-        if ($func->getName() == 'dsn') {
+        if ('dsn' == $func->getName()) {
             /** @var Url $dsn */
             $dsn = $func->first();
             $clientConfiguration = self::fromArray(self::parseDsn($dsn));
-        } elseif ($func->getName() == 'pool') {
+        } elseif ('pool' == $func->getName()) {
             $connections = [];
             $clientConfiguration = new static();
             foreach ($func->getArguments() as $arg) {
@@ -95,56 +95,13 @@ class ClientConfiguration
             } elseif ('true' === $optionValue) {
                 $optionValue = true;
             } elseif (\is_numeric($optionValue)) {
-                $optionValue = (int)$optionValue;
+                $optionValue = (int) $optionValue;
             }
 
             $clientConfiguration->set($optionName, $optionValue);
         }
 
         return $clientConfiguration;
-    }
-
-    private static function parseDsn(Url $dsn): array
-    {
-        $data = ['host' => $dsn->getHost(),];
-
-        if (null !== $dsn->getScheme()) {
-            $data['transport'] = $dsn->getScheme();
-        }
-
-        if (null !== $dsn->getUser()) {
-            $data['username'] = $dsn->getUser();
-        }
-
-        if (null !== $dsn->getPassword()) {
-            $data['password'] = $dsn->getPassword();
-        }
-
-        if (null !== $dsn->getUser() && null !== $dsn->getPassword()) {
-            $data['auth_type'] = 'basic';
-        }
-
-        if (null !== $dsn->getPort()) {
-            $data['port'] = $dsn->getPort();
-        }
-
-        if (null !== $dsn->getPath()) {
-            $data['path'] = $dsn->getPath();
-        }
-
-        foreach ($dsn->getParameters() as $optionName => $optionValue) {
-            if ('false' === $optionValue) {
-                $optionValue = false;
-            } elseif ('true' === $optionValue) {
-                $optionValue = true;
-            } elseif (\is_numeric($optionValue)) {
-                $optionValue = (int) $optionValue;
-            }
-
-            $data[$optionName] = $optionValue;
-        }
-
-        return $data;
     }
 
     /**
@@ -209,5 +166,48 @@ class ClientConfiguration
                 $this->configuration[$key] = [$this->configuration[$key], $value];
             }
         }
+    }
+
+    private static function parseDsn(Url $dsn): array
+    {
+        $data = ['host' => $dsn->getHost()];
+
+        if (null !== $dsn->getScheme()) {
+            $data['transport'] = $dsn->getScheme();
+        }
+
+        if (null !== $dsn->getUser()) {
+            $data['username'] = $dsn->getUser();
+        }
+
+        if (null !== $dsn->getPassword()) {
+            $data['password'] = $dsn->getPassword();
+        }
+
+        if (null !== $dsn->getUser() && null !== $dsn->getPassword()) {
+            $data['auth_type'] = 'basic';
+        }
+
+        if (null !== $dsn->getPort()) {
+            $data['port'] = $dsn->getPort();
+        }
+
+        if (null !== $dsn->getPath()) {
+            $data['path'] = $dsn->getPath();
+        }
+
+        foreach ($dsn->getParameters() as $optionName => $optionValue) {
+            if ('false' === $optionValue) {
+                $optionValue = false;
+            } elseif ('true' === $optionValue) {
+                $optionValue = true;
+            } elseif (\is_numeric($optionValue)) {
+                $optionValue = (int) $optionValue;
+            }
+
+            $data[$optionName] = $optionValue;
+        }
+
+        return $data;
     }
 }

--- a/tests/ClientConfigurationTest.php
+++ b/tests/ClientConfigurationTest.php
@@ -15,9 +15,9 @@ class ClientConfigurationTest extends TestCase
     public function testInvalidDsn(): void
     {
         $this->expectException(\Elastica\Exception\InvalidException::class);
-        $this->expectExceptionMessage('DSN "test:foo" is invalid.');
+        $this->expectExceptionMessage('DSN "test foo" is invalid.');
 
-        ClientConfiguration::fromDsn('test:foo');
+        ClientConfiguration::fromDsn('test foo');
     }
 
     public function testInvalidDsnPortOnly(): void

--- a/tests/ClientConfigurationTest.php
+++ b/tests/ClientConfigurationTest.php
@@ -77,11 +77,12 @@ class ClientConfigurationTest extends TestCase
 
         $this->assertEquals($expected, $configuration->getAll());
     }
+
     public function testFromDsnWithPool(): void
     {
         $configuration = ClientConfiguration::fromDsn('pool(http://nicolas@127.0.0.1 http://127.0.0.2/bar?timeout=4)?extra=abc&username=tobias');
         $expected = [
-             'host' => null,
+            'host' => null,
             'port' => null,
             'path' => null,
             'url' => null,
@@ -90,8 +91,8 @@ class ClientConfigurationTest extends TestCase
             'persistent' => true,
             'timeout' => null,
             'connections' => [
-                ['host'=>'127.0.0.1', 'transport'=>'http', 'username'=>'nicolas'],
-                ['host'=>'127.0.0.2', 'path'=>'/bar', 'transport'=>'http', 'timeout'=>4],
+                ['host' => '127.0.0.1', 'transport' => 'http', 'username' => 'nicolas'],
+                ['host' => '127.0.0.2', 'path' => '/bar', 'transport' => 'http', 'timeout' => 4],
             ],
             'roundRobin' => false,
             'retryOnConflict' => 0,

--- a/tests/ClientConfigurationTest.php
+++ b/tests/ClientConfigurationTest.php
@@ -15,7 +15,15 @@ class ClientConfigurationTest extends TestCase
     public function testInvalidDsn(): void
     {
         $this->expectException(\Elastica\Exception\InvalidException::class);
-        $this->expectExceptionMessage("DSN ':0' is invalid.");
+        $this->expectExceptionMessage('DSN "test:0" is invalid.');
+
+        ClientConfiguration::fromDsn('test:0');
+    }
+
+    public function testInvalidDsnPortOnly(): void
+    {
+        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectExceptionMessage('DSN ":0" is invalid.');
 
         ClientConfiguration::fromDsn(':0');
     }
@@ -50,7 +58,7 @@ class ClientConfigurationTest extends TestCase
         $configuration = ClientConfiguration::fromDsn('https://user:p4ss@foo.com:9201/my-path?proxy=https://proxy.com&persistent=false&timeout=45&roundRobin=true&retryOnConflict=2&bigintConversion=true&extra=abc');
         $expected = [
             'host' => 'foo.com',
-            'port' => '9201',
+            'port' => 9201,
             'path' => '/my-path',
             'url' => null,
             'proxy' => 'https://proxy.com',
@@ -64,6 +72,33 @@ class ClientConfigurationTest extends TestCase
             'username' => 'user',
             'password' => 'p4ss',
             'auth_type' => 'basic',
+            'extra' => 'abc',
+        ];
+
+        $this->assertEquals($expected, $configuration->getAll());
+    }
+    public function testFromDsnWithPool(): void
+    {
+        $configuration = ClientConfiguration::fromDsn('pool(http://nicolas@127.0.0.1 http://127.0.0.2/bar?timeout=4)?extra=abc&username=tobias');
+        $expected = [
+             'host' => null,
+            'port' => null,
+            'path' => null,
+            'url' => null,
+            'proxy' => null,
+            'transport' => null,
+            'persistent' => true,
+            'timeout' => null,
+            'connections' => [
+                ['host'=>'127.0.0.1', 'transport'=>'http', 'username'=>'nicolas'],
+                ['host'=>'127.0.0.2', 'path'=>'/bar', 'transport'=>'http', 'timeout'=>4],
+            ],
+            'roundRobin' => false,
+            'retryOnConflict' => 0,
+            'bigintConversion' => false,
+            'username' => 'tobias',
+            'password' => null,
+            'auth_type' => null,
             'extra' => 'abc',
         ];
 

--- a/tests/ClientConfigurationTest.php
+++ b/tests/ClientConfigurationTest.php
@@ -15,9 +15,9 @@ class ClientConfigurationTest extends TestCase
     public function testInvalidDsn(): void
     {
         $this->expectException(\Elastica\Exception\InvalidException::class);
-        $this->expectExceptionMessage('DSN "test:0" is invalid.');
+        $this->expectExceptionMessage('DSN "test:foo" is invalid.');
 
-        ClientConfiguration::fromDsn('test:0');
+        ClientConfiguration::fromDsn('test:foo');
     }
 
     public function testInvalidDsnPortOnly(): void


### PR DESCRIPTION
I was about to update https://github.com/Happyr/elastica-dsn which basically adds DSN support to 6.x. But then I saw that 7.x will have support for DNS but not for multiple hosts. 

Im sorry that I introduce a new dependency like this for such a small feature. I do need this feature in my app and I really wanted to try out nyholm/dsn:2.0 before I tag a stable release.

This will support any crazy DSN you may think of. See the full specification here: https://github.com/nyholm/dsn

Let me know what you think.

---

The PR is in draft as it should not be merged before nyholm/dsn:2.0 is released.
