### PR TITLE
[PHP 8.0] Allow PHPUnit 9.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "aws/aws-sdk-php": "^3.155",
         "guzzlehttp/guzzle": "^6.3",
-        "phpunit/phpunit": "^8.5.8"
+        "phpunit/phpunit": "^8.5.8 || ^9.4"
     },
     "suggest": {
         "aws/aws-sdk-php": "Allow using IAM authentication with Amazon ElasticSearch Service",

--- a/tests/Aggregation/TopHitsTest.php
+++ b/tests/Aggregation/TopHitsTest.php
@@ -324,7 +324,11 @@ class TopHitsTest extends BaseAggregationTest
 
         foreach ($aggrResult['hits']['hits'] as $doc) {
             $this->assertArrayHasKey('highlight', $doc);
-            $this->assertRegExp('#<em>linux</em>#', $doc['highlight']['title'][0]);
+            if (\method_exists($this, 'assertMatchesRegularExpression')) {
+                $this->assertMatchesRegularExpression('#<em>linux</em>#', $doc['highlight']['title'][0]);
+            } else {
+                $this->assertRegExp('#<em>linux</em>#', $doc['highlight']['title'][0]);
+            }
         }
     }
 

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -66,7 +66,8 @@ class PipelineTest extends BasePipeline
 
         $result = $pipeline->create();
 
-        $this->assertContains('acknowledged', $result->getData());
+        $this->assertArrayHasKey('acknowledged', $result->getData());
+        $this->assertTrue($result->getData()['acknowledged']);
 
         $pipeGet = $pipeline->getPipeline('my_custom_pipeline');
         $result = $pipeGet->getData();
@@ -89,7 +90,8 @@ class PipelineTest extends BasePipeline
 
         $result = $pipeline->create();
 
-        $this->assertContains('acknowledged', $result->getData());
+        $this->assertArrayHasKey('acknowledged', $result->getData());
+        $this->assertTrue($result->getData()['acknowledged']);
 
         $index = $this->_createIndex('testpipelinecreation');
 

--- a/tests/Processor/KvTest.php
+++ b/tests/Processor/KvTest.php
@@ -67,7 +67,8 @@ class KvTest extends BasePipelineTest
 
         $result = $pipeline->create();
 
-        $this->assertContains('acknowledged', $result->getData());
+        $this->assertArrayHasKey('acknowledged', $result->getData());
+        $this->assertTrue($result->getData()['acknowledged']);
 
         $pipelineGet = $pipeline->getPipeline('my_custom_pipeline');
         $result = $pipelineGet->getData();

--- a/tests/Query/InnerHitsTest.php
+++ b/tests/Query/InnerHitsTest.php
@@ -330,7 +330,11 @@ class InnerHitsTest extends BaseTest
             $innerHitsResult = $row->getInnerHits();
             foreach ($innerHitsResult['users']['hits']['hits'] as $doc) {
                 $this->assertArrayHasKey('highlight', $doc);
-                $this->assertRegExp('#<em>Simon</em>#', $doc['highlight']['users.name'][0]);
+                if (\method_exists($this, 'assertMatchesRegularExpression')) {
+                    $this->assertMatchesRegularExpression('#<em>Simon</em>#', $doc['highlight']['users.name'][0]);
+                } else {
+                    $this->assertRegExp('#<em>Simon</em>#', $doc['highlight']['users.name'][0]);
+                }
             }
         }
     }

--- a/tests/Query/QueryStringTest.php
+++ b/tests/Query/QueryStringTest.php
@@ -108,8 +108,6 @@ class QueryStringTest extends BaseTest
 
             $this->assertSame('query_shard_exception', $error['root_cause'][0]['type']);
             $this->assertStringContainsString('failed to create query', $error['root_cause'][0]['reason']);
-
-            $this->assertContains('query_validation_exception', $error);
             $this->assertStringContainsString('[fields] parameter in conjunction with [default_field]', $error['failed_shards'][0]['reason']['caused_by']['reason']);
 
             $this->assertEquals(400, $ex->getResponse()->getStatus());

--- a/tests/Transport/HttpTest.php
+++ b/tests/Transport/HttpTest.php
@@ -185,7 +185,11 @@ class HttpTest extends BaseTest
         $createIndexResponse = $index->create([], true);
 
         $createIndexResponseTransferInfo = $createIndexResponse->getTransferInfo();
-        $this->assertRegExp('/Accept-Encoding:\ (gzip|deflate)/', $createIndexResponseTransferInfo['request_header']);
+        if (\method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression('/Accept-Encoding:\ (gzip|deflate)/', $createIndexResponseTransferInfo['request_header']);
+        } else {
+            $this->assertRegExp('/Accept-Encoding:\ (gzip|deflate)/', $createIndexResponseTransferInfo['request_header']);
+        }
         $this->assertArrayHasKey('acknowledged', $createIndexResponse->getData());
     }
 
@@ -201,7 +205,11 @@ class HttpTest extends BaseTest
         $createIndexResponse = $index->create([], true);
 
         $createIndexResponseTransferInfo = $createIndexResponse->getTransferInfo();
-        $this->assertRegExp('/Accept-Encoding:\ (gzip|deflate)/', $createIndexResponseTransferInfo['request_header']);
+        if (\method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression('/Accept-Encoding:\ (gzip|deflate)/', $createIndexResponseTransferInfo['request_header']);
+        } else {
+            $this->assertRegExp('/Accept-Encoding:\ (gzip|deflate)/', $createIndexResponseTransferInfo['request_header']);
+        }
         $this->assertArrayHasKey('acknowledged', $createIndexResponse->getData());
     }
 

--- a/tests/Transport/NullTransportTest.php
+++ b/tests/Transport/NullTransportTest.php
@@ -52,7 +52,7 @@ class NullTransportTest extends BaseTest
 
         $this->assertArrayHasKey('took', $responseData);
         $this->assertEquals(0, $responseData['took']);
-        $this->assertContains('_shards', $responseData);
+        $this->assertArrayHasKey('_shards', $responseData);
         $this->assertArrayHasKey('hits', $responseData);
         $this->assertArrayHasKey('total', $responseData['hits']);
         $this->assertEquals(0, $responseData['hits']['total']['value']);
@@ -110,7 +110,7 @@ class NullTransportTest extends BaseTest
         $this->assertEquals([], $response->getTransferInfo());
 
         $responseData = $response->getData();
-        $this->assertContains('params', $responseData);
+        $this->assertArrayHasKey('params', $responseData);
         $this->assertEquals($params, $responseData['params']);
     }
 }


### PR DESCRIPTION
This PR will allow to support PHP 8.0 in #1794 

It allows to run PHPUnit **8.5** for PHP **7.2** support, but also to run PHPUnit **9.4** for versions supporting it (7.3, 7.4, 8.0) as PHP **8.0** is not supported in PHPUnit **8.5**.
