### PR TITLE
Allow guzzlehttp/guzzle 7.2 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `if_seq_no` / `if_primary_term` to replace `version` for [optimistic concurrency control](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/optimistic-concurrency-control.html)
 * Added `Elastica\Aggregation\PercentilesBucket` aggregation [#1806](https://github.com/ruflin/Elastica/pull/1806)
 * Added `weighted_avg` to aggregations DSL [#1814](https://github.com/ruflin/Elastica/pull/1814)
+* Supported `guzzlehttp/guzzle` 7.x [#1816](https://github.com/ruflin/Elastica/pull/1816)
 * Supported PHP 8.0 [#1794](https://github.com/ruflin/Elastica/pull/1794)
 * Added support for defining a connection pool with DSN. Example: `pool(http://127.0.0.1 http://127.0.0.2/bar?timeout=4)` [#1808](https://github.com/ruflin/Elastica/pull/1808)
 * Added `Elastica\Aggregation\Composite` aggregation [#1804](https://github.com/ruflin/Elastica/pull/1804)

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.155",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3 || ^7.2",
         "phpunit/phpunit": "^8.5.8 || ^9.4"
     },
     "suggest": {


### PR DESCRIPTION
Support `guzzlehttp/guzzle:7.2` as that's where PHP 8.0 support was added.
It requires some work:
- [x] Fix deprecated option not available anymore [#1817]
- [x] Fix `ConnectException` extending `TransferException` now instead of `RequestException` [#1825]