### PR TITLE
Remove HHVM proxy detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Deprecated Match query class and introduced MatchQuery instead for PHP 8.0 compatibility reason [#1799](https://github.com/ruflin/Elastica/pull/1799)
 * Deprecated `version`/`version_type` options [(deprecated in `6.7.0`)](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html) and added `if_seq_no` / `if_primary_term` that replaced it
 ### Removed
+* Removed HHVM proxy detection [#1818](https://github.com/ruflin/Elastica/pull/1818)
 ### Fixed
 * fixed issue [1789](https://github.com/ruflin/Elastica/issues/1789)
 * Replaced `_routing` and `_retry_on_conflict` by `routing` and `retry_on_conflict` in `AbstractUpdateAction` [#1807](https://github.com/ruflin/Elastica/issues/1807)

--- a/src/Transport/Guzzle.php
+++ b/src/Transport/Guzzle.php
@@ -66,14 +66,7 @@ class Guzzle extends AbstractTransport
             $options['timeout'] = $connection->getTimeout();
         }
 
-        $proxy = $connection->getProxy();
-
-        // See: https://github.com/facebook/hhvm/issues/4875
-        if (null === $proxy && \defined('HHVM_VERSION')) {
-            $proxy = \getenv('http_proxy') ?: null;
-        }
-
-        if (null !== $proxy) {
+        if (null !== $proxy = $connection->getProxy()) {
             $options['proxy'] = $proxy;
         }
 

--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -90,14 +90,7 @@ class Http extends AbstractTransport
             \curl_setopt($conn, CURLOPT_CONNECTTIMEOUT, $connectTimeout);
         }
 
-        $proxy = $connection->getProxy();
-
-        // See: https://github.com/facebook/hhvm/issues/4875
-        if (null === $proxy && \defined('HHVM_VERSION')) {
-            $proxy = \getenv('http_proxy') ?: null;
-        }
-
-        if (null !== $proxy) {
+        if (null !== $proxy = $connection->getProxy()) {
             \curl_setopt($conn, CURLOPT_PROXY, $proxy);
         }
 


### PR DESCRIPTION
HHVM is not compatible anymore with PHP (last version supporting PHP was v3.30 released on 17th december 2018).
I think it's time move forward as many packages already did and drop code related to HHVM.