### PR TITLE
Fix test performing no assertions

### DIFF
--- a/tests/Transport/AwsAuthV4Test.php
+++ b/tests/Transport/AwsAuthV4Test.php
@@ -150,12 +150,12 @@ class AwsAuthV4Test extends GuzzleTest
 
         try {
             $client->request('_status', 'GET');
-
-            $this->assertEquals(80, $client->getLastRequest()->toArray()['port']);
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
             if ($guzzleException instanceof RequestException) {
                 $request = $guzzleException->getRequest();
+
+                $this->assertSame('http', $request->getUri()->getScheme());
             }
         }
     }
@@ -180,7 +180,7 @@ class AwsAuthV4Test extends GuzzleTest
             if ($guzzleException instanceof RequestException) {
                 $request = $guzzleException->getRequest();
 
-                $this->assertEquals('https', $request->getUri()->getScheme());
+                $this->assertSame('https', $request->getUri()->getScheme());
             }
         }
     }


### PR DESCRIPTION
This will remove this warning in PHPUnit output:
```
There was 1 risky test:

1) Elastica\Test\Transport\AwsAuthV4Test::testUseHttpAsDefaultProtocol
This test did not perform any assertions

/home/travis/build/ruflin/Elastica/tests/Transport/AwsAuthV4Test.php:139
```