### PR TITLE
Use Guzzle RequestOptions constants for configuring requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Reviewed options handling in `Elastica\Index::create()` [#1822](https://github.com/ruflin/Elastica/pull/1822)
 * Replaced deprecated `exceptions` request option by `http_errors` request option in Guzzle transport [#1817](https://github.com/ruflin/Elastica/pull/1817)
+* Used `GuzzleHttp\RequestOptions` constants for configuring request options [#1820](https://github.com/ruflin/Elastica/pull/1820)
 ### Deprecated
 * Deprecated Match query class and introduced MatchQuery instead for PHP 8.0 compatibility reason [#1799](https://github.com/ruflin/Elastica/pull/1799)
 * Deprecated `version`/`version_type` options [(deprecated in `6.7.0`)](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html) and added `if_seq_no` / `if_primary_term` that replaced it

--- a/src/Transport/Guzzle.php
+++ b/src/Transport/Guzzle.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\RequestOptions;
 
 /**
  * Elastica Guzzle Transport object.
@@ -57,17 +58,18 @@ class Guzzle extends AbstractTransport
 
         $options = [
             'base_uri' => $this->_getBaseUrl($connection),
-            'headers' => [
+            RequestOptions::HEADERS => [
                 'Content-Type' => $request->getContentType(),
             ],
-            'http_errors' => false, // 4xx and 5xx is expected and NOT an exceptions in this context
+            RequestOptions::HTTP_ERRORS => false, // 4xx and 5xx is expected and NOT an exceptions in this context
         ];
+
         if ($connection->getTimeout()) {
-            $options['timeout'] = $connection->getTimeout();
+            $options[RequestOptions::TIMEOUT] = $connection->getTimeout();
         }
 
         if (null !== $proxy = $connection->getProxy()) {
-            $options['proxy'] = $proxy;
+            $options[RequestOptions::PROXY] = $proxy;
         }
 
         $req = $this->_createPsr7Request($request, $connection);


### PR DESCRIPTION
Use RequestOptions constants.
The main advantage I see is that it will be easier to spot removed options ;)