### PR TITLE
Fix transient test

### DIFF
--- a/tests/Base.php
+++ b/tests/Base.php
@@ -168,9 +168,11 @@ class Base extends TestCase
             $indexState = $state['routing_table']['indices'][$index->getName()];
 
             $allocated = true;
-            foreach ($indexState['shards'] as $shard) {
-                if ('STARTED' !== $shard[0]['state']) {
-                    $allocated = false;
+            foreach ($indexState['shards'] as $shards) {
+                foreach ($shards as $shard) {
+                    if ('STARTED' !== $shard['state']) {
+                        $allocated = false;
+                    }
                 }
             }
         } while (!$allocated);

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -937,6 +937,7 @@ class ClientFunctionalTest extends BaseTest
     public function testEndpointParamsRequest(): void
     {
         $index = $this->_createIndex();
+        $this->_waitForAllocation($index);
         $client = $index->getClient();
         $doc = new Document(null, ['foo' => 'bar']);
         $doc->setRouting('first_routing');
@@ -952,7 +953,7 @@ class ClientFunctionalTest extends BaseTest
         $this->assertArrayHasKey('index_total', $response->getData()['indices'][$index->getName()]['total']['indexing']);
 
         $this->assertSame(
-            1,
+            2,
             $response->getData()['indices'][$index->getName()]['total']['indexing']['index_total']
         );
     }


### PR DESCRIPTION
This should fix this failing test which occurs regularly:
```
There was 1 failure:

1) Elastica\Test\ClientFunctionalTest::testEndpointParamsRequest
Failed asserting that 2 is identical to 1.
```

This was occurring when replica(s) shard(s) was/were not started before adding a document.
There also a `wait_for_active_shards` options that could be passed to query when creating an index, but would require to adapt `Index::create()` method (I will probably propose another PR for this).

To better understand the change here the json part Elasticsearch returns when calling `GET /_cluster/state`:
```json
{
   "routing_table":{
      "indices":{
         "elasticatestclientfunctionaltestffbf":{
            "shards":{
               "0":[
                  {
                     "state":"STARTED",
                     "primary":true,
                     "node":"4uHcxqlPRVKRZw9Ay8MerQ",
                     "relocating_node":null,
                     "shard":0,
                     "index":"elasticatestclientfunctionaltestffbf",
                     "allocation_id":{
                        "id":"1GMyYkpQRTq4IHsy_YwKmg"
                     }
                  },
                  {
                     "state":"STARTED",
                     "primary":false,
                     "node":"FB_0fAuzSEuj9pS5FUF_Rw",
                     "relocating_node":null,
                     "shard":0,
                     "index":"elasticatestclientfunctionaltestffbf",
                     "allocation_id":{
                        "id":"sqc10Z0gQ-K3ipZef6YiFQ"
                     }
                  }
               ]
            }
         }
      }
   }
}
```