### PR TITLE
Review options handling for index creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)
+* Reviewed options handling in `Elastica\Index::create()` [#1822](https://github.com/ruflin/Elastica/pull/1822)
 ### Deprecated
 * Deprecated Match query class and introduced MatchQuery instead for PHP 8.0 compatibility reason [#1799](https://github.com/ruflin/Elastica/pull/1799)
 * Deprecated `version`/`version_type` options [(deprecated in `6.7.0`)](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html) and added `if_seq_no` / `if_primary_term` that replaced it

--- a/src/Index.php
+++ b/src/Index.php
@@ -405,7 +405,7 @@ class Index implements SearchableInterface
             try {
                 $this->delete();
             } catch (ResponseException $e) {
-                // Table can't be deleted, because doesn't exist
+                // Index can't be deleted, because it doesn't exist
             }
         }
 

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -96,7 +96,9 @@ class Base extends TestCase
         $client = $this->_getClient();
         $index = $client->getIndex($name);
 
-        $index->create(['settings' => ['index' => ['number_of_shards' => $shards, 'number_of_replicas' => 1]]], $delete);
+        $index->create(['settings' => ['index' => ['number_of_shards' => $shards, 'number_of_replicas' => 1]]], [
+            'recreate' => $delete,
+        ]);
 
         return $index;
     }

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -577,6 +577,7 @@ class IndexTest extends BaseTest
     public function testCreateWithInvalidOption(): void
     {
         $this->expectException(InvalidException::class);
+        $this->expectExceptionMessage('"testing_invalid_option" is not a valid option. Allowed options are "recreate".');
 
         $client = $this->_getClient();
         $indexName = 'test';


### PR DESCRIPTION
There are multiple changes. Maybe I should split the PR.

- Better check for options parameters by throwing a `TypeError` if not an expected type.
- Ensure `$options` is always converted to an array (I was planning to add deprecations with `\trigger_error('xxx', E_USER_DEPRECATED)` for other types in a following PR)
- Avoid duplicating the delete call when handling boolean or array (now it's unified and treat only the array option, as boolean option filled the array appropriatly).
- More user friendly messages when option(s) is/are invalid.