### PR TITLE
Review deprecations triggering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Supported PHP 8.0 [#1794](https://github.com/ruflin/Elastica/pull/1794)
 * Added support for defining a connection pool with DSN. Example: `pool(http://127.0.0.1 http://127.0.0.2/bar?timeout=4)` [#1808](https://github.com/ruflin/Elastica/pull/1808)
 * Added `Elastica\Aggregation\Composite` aggregation [#1804](https://github.com/ruflin/Elastica/pull/1804)
+* Added `symfony/deprecation-contracts` package to handle deprecations [#1823](https://github.com/ruflin/Elastica/pull/1823)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "ext-json": "*",
         "psr/log": "^1.0",
         "elasticsearch/elasticsearch": "^7.1.1 !=7.4.0",
-        "nyholm/dsn": "^2.0.0"
+        "nyholm/dsn": "^2.0.0",
+        "symfony/deprecation-contracts": "^2.2"
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.155",

--- a/src/Exception/ElasticsearchException.php
+++ b/src/Exception/ElasticsearchException.php
@@ -2,7 +2,7 @@
 
 namespace Elastica\Exception;
 
-\trigger_error('Elastica\Exception\ElasticsearchException is deprecated. Use Elastica\Exception\ResponseException::getResponse::getFullError instead.', E_USER_DEPRECATED);
+trigger_deprecation('ruflin/elastica', '5.2.0', 'The "%s" class is deprecated, use "Elastica\Exception\ResponseException::getResponse()::getFullError()" instead. It will be removed in 8.0.', ElasticsearchException::class);
 
 /**
  * Elasticsearch exception.

--- a/src/Index.php
+++ b/src/Index.php
@@ -383,11 +383,11 @@ class Index implements SearchableInterface
     {
         if (null === $options) {
             if (\func_num_args() >= 2) {
-                @\trigger_error(\sprintf('Passing null as 2nd argument to "%s()" is deprecated since Elastica 7.0.1, avoid passing this argument or pass an array instead.', __METHOD__), \E_USER_DEPRECATED);
+                trigger_deprecation('ruflin/elastica', '7.1.0', 'Passing null as 2nd argument to "%s()" is deprecated, avoid passing this argument or pass an array instead. It will be removed in 8.0.', __METHOD__);
             }
             $options = [];
         } elseif (\is_bool($options)) {
-            @\trigger_error(\sprintf('Passing a bool as 2nd argument to "%s()" is deprecated since Elastica 7.0.1, pass an array with the key "recreate" instead.', __METHOD__), \E_USER_DEPRECATED);
+            trigger_deprecation('ruflin/elastica', '7.1.0', 'Passing a bool as 2nd argument to "%s()" is deprecated, pass an array with the key "recreate" instead. It will be removed in 8.0.', __METHOD__);
             $options = ['recreate' => $options];
         } elseif (!\is_array($options)) {
             throw new \TypeError(\sprintf('Argument 2 passed to "%s()" must be of type array|bool|null, %s given.', __METHOD__, \is_object($options) ? \get_class($options) : \gettype($options)));

--- a/src/Query/Match.php
+++ b/src/Query/Match.php
@@ -2,7 +2,7 @@
 
 namespace Elastica\Query;
 
-\trigger_error('Elastica\Query\Match is deprecated. Use Elastica\Query\MatchQuery instead. From PHP 8 match is reserved word and this class will be removed in further Elastica releases', \E_USER_DEPRECATED);
+trigger_deprecation('ruflin/elastica', '7.1.0', 'The "%s" class is deprecated, use "%s" instead. "match" is a reserved keyword starting from PHP 8.0. It will be removed in 8.0.', Match::class, MatchQuery::class);
 
 /**
  * Match query.

--- a/src/QueryBuilder/DSL/Aggregation.php
+++ b/src/QueryBuilder/DSL/Aggregation.php
@@ -237,7 +237,7 @@ class Aggregation implements DSL
      */
     public function global_agg(string $name): GlobalAggregation
     {
-        @\trigger_error(\sprintf('The "%s()" method is deprecated since Elastica 7.0.1, use global() instead.', __METHOD__), E_USER_DEPRECATED);
+        trigger_deprecation('ruflin/elastica', '7.1.0', 'The "%s()" method is deprecated, use global() instead. It will be removed in 8.0.', __METHOD__);
 
         return $this->global($name);
     }


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch-php/pull/973 for details about why unsilenced deprecations can cause issues.
Symfony link related in the elasticsearch issue is outdated as it points to current version which use `trigger_deprecation`, see [this link](https://symfony.com/doc/4.4/contributing/code/conventions.html#deprecating-code) instead.

Here what is stated in the symfony documentation:
```
Without the @-silencing operator, users would need to opt-out from deprecation notices. Silencing 
swaps this behavior and allows users to opt-in when they are ready to cope with them (by adding 
a custom error handler like the one used by the Web Debug Toolbar or by the PHPUnit bridge).
```
I added `symfony/deprecation-contracts` to better handle deprecations (they take care of silencing the deprecations).