### PR TITLE
Deprecate global_agg() DSL, replace it by global()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Replaced deprecated `exceptions` request option by `http_errors` request option in Guzzle transport [#1817](https://github.com/ruflin/Elastica/pull/1817)
 * Used `GuzzleHttp\RequestOptions` constants for configuring request options [#1820](https://github.com/ruflin/Elastica/pull/1820)
 ### Deprecated
+* Deprecated `Elastica\QueryBuilder\DSL\Aggregation::global_agg()`, use `global()` instead [#1826](https://github.com/ruflin/Elastica/pull/1826)
 * Deprecated Match query class and introduced MatchQuery instead for PHP 8.0 compatibility reason [#1799](https://github.com/ruflin/Elastica/pull/1799)
 * Deprecated `version`/`version_type` options [(deprecated in `6.7.0`)](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html) and added `if_seq_no` / `if_primary_term` that replaced it
 ### Removed

--- a/src/QueryBuilder/DSL/Aggregation.php
+++ b/src/QueryBuilder/DSL/Aggregation.php
@@ -227,9 +227,19 @@ class Aggregation implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-global-aggregation.html
      */
-    public function global_agg(string $name): GlobalAggregation
+    public function global(string $name): GlobalAggregation
     {
         return new GlobalAggregation($name);
+    }
+
+    /**
+     * @deprecated since Elastica 7.0.1, use the "global()" method instead.
+     */
+    public function global_agg(string $name): GlobalAggregation
+    {
+        @\trigger_error(\sprintf('The "%s()" method is deprecated since Elastica 7.0.1, use global() instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->global($name);
     }
 
     /**

--- a/src/QueryBuilder/Version/Version700.php
+++ b/src/QueryBuilder/Version/Version700.php
@@ -73,7 +73,8 @@ class Version700 extends Version
         'geo_bounds',
         'top_hits',
         'scripted_metric',
-        'global_agg', // original: global
+        'global',
+        'global_agg', // Deprecated
         'filter',
         'filters',
         'missing',

--- a/tests/QueryBuilder/DSL/AggregationTest.php
+++ b/tests/QueryBuilder/DSL/AggregationTest.php
@@ -38,6 +38,7 @@ class AggregationTest extends AbstractDSLTest
         $this->_assertImplemented($aggregationDSL, 'filters', Aggregation\Filters::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'geo_distance', Aggregation\GeoDistance::class, ['name', 'field', 'origin']);
         $this->_assertImplemented($aggregationDSL, 'geohash_grid', Aggregation\GeohashGrid::class, ['name', 'field']);
+        $this->_assertImplemented($aggregationDSL, 'global', Aggregation\GlobalAggregation::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'global_agg', Aggregation\GlobalAggregation::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'histogram', Aggregation\Histogram::class, ['name', 'field', 1]);
         $this->_assertImplemented($aggregationDSL, 'ipv4_range', Aggregation\IpRange::class, ['name', 'field']);


### PR DESCRIPTION
Since PHP 7.0, there's no more reason to not use reserved keyword as class method name.

See original [RFC](https://wiki.php.net/rfc/context_sensitive_lexer).
See [code sample](https://3v4l.org/JPLmc)