### PR TITLE
Remove specific hack for global aggregation

### DIFF
--- a/src/Aggregation/AbstractAggregation.php
+++ b/src/Aggregation/AbstractAggregation.php
@@ -128,10 +128,6 @@ abstract class AbstractAggregation extends Param implements NameableInterface
     {
         $array = parent::toArray();
 
-        if (\array_key_exists('global_aggregation', $array)) {
-            // compensate for class name GlobalAggregation
-            $array = ['global' => new \stdClass()];
-        }
         if (\count($this->_aggs)) {
             $array['aggs'] = $this->_convertArrayable($this->_aggs);
         }

--- a/src/Aggregation/GlobalAggregation.php
+++ b/src/Aggregation/GlobalAggregation.php
@@ -9,4 +9,8 @@ namespace Elastica\Aggregation;
  */
 class GlobalAggregation extends AbstractAggregation
 {
+    protected function _getBaseName()
+    {
+        return 'global';
+    }
 }

--- a/tests/Aggregation/GlobalAggregationTest.php
+++ b/tests/Aggregation/GlobalAggregationTest.php
@@ -16,7 +16,7 @@ class GlobalAggregationTest extends BaseAggregationTest
     public function testToArray(): void
     {
         $expected = [
-            'global' => new \stdClass(),
+            'global' => [],
             'aggs' => [
                 'avg_price' => ['avg' => ['field' => 'price']],
             ],


### PR DESCRIPTION
There is a specific hack for `global_aggregation`.
`ParentAggregation` which has the same issue does it by overriding `_getBasename()`, so let's do it the same way.