### PR TITLE
Deprecate bool and null for 2nd argument of Index::create()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 * Deprecated Match query class and introduced MatchQuery instead for PHP 8.0 compatibility reason [#1799](https://github.com/ruflin/Elastica/pull/1799)
 * Deprecated `version`/`version_type` options [(deprecated in `6.7.0`)](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html) and added `if_seq_no` / `if_primary_term` that replaced it
+* Deprecated passing `bool` or `null` as 2nd argument to `Elastica\Index::create()` [#1828](https://github.com/ruflin/Elastica/pull/1828)
 ### Removed
 * Removed HHVM proxy detection [#1818](https://github.com/ruflin/Elastica/pull/1818)
 ### Fixed

--- a/src/Index.php
+++ b/src/Index.php
@@ -381,12 +381,16 @@ class Index implements SearchableInterface
      */
     public function create(array $args = [], $options = null): Response
     {
-        $options = $options ?? [];
-
-        if (\is_bool($options)) {
+        if (null === $options) {
+            if (\func_num_args() >= 2) {
+                @\trigger_error(\sprintf('Passing null as 2nd argument to "%s()" is deprecated since Elastica 7.0.1, avoid passing this argument or pass an array instead.', __METHOD__), \E_USER_DEPRECATED);
+            }
+            $options = [];
+        } elseif (\is_bool($options)) {
+            @\trigger_error(\sprintf('Passing a bool as 2nd argument to "%s()" is deprecated since Elastica 7.0.1, pass an array with the key "recreate" instead.', __METHOD__), \E_USER_DEPRECATED);
             $options = ['recreate' => $options];
         } elseif (!\is_array($options)) {
-            throw new \TypeError(\sprintf('Argument 2 passed to %s::create() must be of type array|bool|null, %s given.', self::class, \is_object($options) ? \get_class($options) : \gettype($options)));
+            throw new \TypeError(\sprintf('Argument 2 passed to "%s()" must be of type array|bool|null, %s given.', __METHOD__, \is_object($options) ? \get_class($options) : \gettype($options)));
         }
 
         $invalidOptions = \array_diff(\array_keys($options), $allowedOptions = [


### PR DESCRIPTION
A code sample result better resumes the changes

- `create()`

- `create([])`

- `create([], [])`

- `create([], null)`
**Deprecated: Passing null as 2nd argument to "Elastica\Index::create()" is deprecated since Elastica 7.0.1, avoid passing this argument or pass an array instead.**

- `create([], false)`
**Deprecated: Passing a bool as 2nd argument to "Elastica\Index::create()" is deprecated since Elastica 7.0.1, pass an array with the key "recreate" instead.**

See https://3v4l.org/CHRCv for real execution result