### PR TITLE
Refactor Util::toSnakeCase()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * fixed issue [1789](https://github.com/ruflin/Elastica/issues/1789)
 * Fixed type-hint for `Elastica\QueryBuilder\DSL\Aggregation::sampler()` not consistent with the underlying constructor call [#1815](https://github.com/ruflin/Elastica/pull/1815)
 * Replaced `_routing` and `_retry_on_conflict` by `routing` and `retry_on_conflict` in `AbstractUpdateAction` [#1807](https://github.com/ruflin/Elastica/issues/1807)
+* Fixed `Elastica\Util::toSnakeCase()` with first letter being lower cased [#1831](https://github.com/ruflin/Elastica/pull/1831)
 ### Security
 
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -165,9 +165,7 @@ class Util
      */
     public static function toSnakeCase($string)
     {
-        $string = \preg_replace('/([A-Z])/', '_$1', $string);
-
-        return \strtolower(\substr($string, 1));
+        return \strtolower(\preg_replace('/[A-Z]/', '_\\0', \lcfirst($string)));
     }
 
     /**

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -147,11 +147,9 @@ class UtilTest extends BaseTest
      */
     public function testToSnakeCase(): void
     {
-        $string = 'HelloWorld';
-        $this->assertEquals('hello_world', Util::toSnakeCase($string));
-
-        $string = 'HowAreYouToday';
-        $this->assertEquals('how_are_you_today', Util::toSnakeCase($string));
+        $this->assertSame('foo_bar', Util::toSnakeCase('fooBar'));
+        $this->assertSame('hello_world', Util::toSnakeCase('HelloWorld'));
+        $this->assertSame('how_are_you_today', Util::toSnakeCase('HowAreYouToday'));
     }
 
     /**


### PR DESCRIPTION
Current implementation is buggy when string is not starting with an upper letter.
For fun I also benchmarked current implement vs new implementation: https://3v4l.org/a9EdW

Here's the previous result when testing snake casing with `fooBar`:
```
1) Elastica\Test\UtilTest::testToSnakeCase
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'foo_bar'
+'oo_bar'
```