### PR TITLE
Deprecate Util::getParamName()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Used `GuzzleHttp\RequestOptions` constants for configuring request options [#1820](https://github.com/ruflin/Elastica/pull/1820)
 ### Deprecated
 * Deprecated `Elastica\QueryBuilder\DSL\Aggregation::global_agg()`, use `global()` instead [#1826](https://github.com/ruflin/Elastica/pull/1826)
+* Deprecated `Elastica\Util::getParamName()` [#1832](https://github.com/ruflin/Elastica/pull/1832)
 * Deprecated Match query class and introduced MatchQuery instead for PHP 8.0 compatibility reason [#1799](https://github.com/ruflin/Elastica/pull/1799)
 * Deprecated `version`/`version_type` options [(deprecated in `6.7.0`)](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html) and added `if_seq_no` / `if_primary_term` that replaced it
 * Deprecated passing `bool` or `null` as 2nd argument to `Elastica\Index::create()` [#1828](https://github.com/ruflin/Elastica/pull/1828)

--- a/src/Param.php
+++ b/src/Param.php
@@ -172,7 +172,7 @@ class Param implements ArrayableInterface, \Countable
      */
     protected function _getBaseName()
     {
-        return Util::getParamName($this);
+        return Util::toSnakeCase((new \ReflectionClass($this))->getShortName());
     }
 
     /**

--- a/src/Query/AbstractQuery.php
+++ b/src/Query/AbstractQuery.php
@@ -3,6 +3,7 @@
 namespace Elastica\Query;
 
 use Elastica\Param;
+use Elastica\Util;
 
 /**
  * Abstract query object. Should be extended by all query types.
@@ -11,4 +12,11 @@ use Elastica\Param;
  */
 abstract class AbstractQuery extends Param
 {
+    protected function _getBaseName()
+    {
+        $shortName = (new \ReflectionClass($this))->getShortName();
+        $shortName = \preg_replace('/Query$/', '', $shortName);
+
+        return Util::toSnakeCase($shortName);
+    }
 }

--- a/src/Util.php
+++ b/src/Util.php
@@ -215,6 +215,8 @@ class Util
      */
     public static function getParamName($class)
     {
+        trigger_deprecation('ruflin/elastica', '7.1.0', 'The "%s()" method is deprecated. It will be removed in 8.0.', __METHOD__);
+
         if (\is_object($class)) {
             $class = \get_class($class);
         }

--- a/tests/ParamTest.php
+++ b/tests/ParamTest.php
@@ -4,7 +4,6 @@ namespace Elastica\Test;
 
 use Elastica\Param;
 use Elastica\Test\Base as BaseTest;
-use Elastica\Util;
 
 /**
  * @internal
@@ -18,7 +17,7 @@ class ParamTest extends BaseTest
     {
         $param = new Param();
         $this->assertInstanceOf(Param::class, $param);
-        $this->assertEquals([$this->_getFilterName($param) => []], $param->toArray());
+        $this->assertEquals(['param' => []], $param->toArray());
     }
 
     /**
@@ -31,7 +30,7 @@ class ParamTest extends BaseTest
         $param->setParams($params);
 
         $this->assertInstanceOf(Param::class, $param);
-        $this->assertEquals([$this->_getFilterName($param) => $params], $param->toArray());
+        $this->assertEquals(['param' => $params], $param->toArray());
     }
 
     /**
@@ -111,10 +110,5 @@ class ParamTest extends BaseTest
 
         $param->setParam($key, $value);
         $this->assertTrue($param->hasParam($key));
-    }
-
-    protected function _getFilterName($filter)
-    {
-        return Util::getParamName($filter);
     }
 }


### PR DESCRIPTION
See comment: https://github.com/ruflin/Elastica/pull/1813#discussion_r509259083
I'm proposing to deprecate `Elastica\Util::getParamName()` as it's too generic and used in context of multiple classes with different naming conventions like `Query`, `Aggregation` and `Processor` (it checks for example `Query` suffix for every class, even when the class is not related to a Query). Instead I moved logic to `Query` suffix in the base Query class. This can be replicated for base classes `Aggregation` and `Processor` later to handle their suffix in an unified way.