### PR TITLE
Deprecate Range::setKeyedResponse() in favor of setKeyed()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Used new alias endpoints classes [#1839](https://github.com/ruflin/Elastica/pull/1839)
 * Used new ingest pipeline endpoints classes [#1834](https://github.com/ruflin/Elastica/pull/1834)
 ### Deprecated
+* Deprecated `Elastica\Aggregation\Range::setKeyedResponse()`, use `setKeyed()` instead [#1848](https://github.com/ruflin/Elastica/pull/1848)
 * Deprecated `Elastica\Exception\ResponseException::getElasticsearchException()`, use `getResponse()::getFullError()` instead [#1829](https://github.com/ruflin/Elastica/pull/1829)
 * Deprecated `Elastica\QueryBuilder\DSL\Aggregation::global_agg()`, use `global()` instead [#1826](https://github.com/ruflin/Elastica/pull/1826)
 * Deprecated Match query class and introduced MatchQuery instead for PHP 8.0 compatibility reason [#1799](https://github.com/ruflin/Elastica/pull/1799)

--- a/src/Aggregation/Range.php
+++ b/src/Aggregation/Range.php
@@ -50,8 +50,18 @@ class Range extends AbstractSimpleAggregation
      *
      * @return $this
      */
-    public function setKeyedResponse(bool $keyed = true): self
+    public function setKeyed(bool $keyed): self
     {
         return $this->setParam('keyed', $keyed);
+    }
+
+    /**
+     * @return $this
+     */
+    public function setKeyedResponse(bool $keyed = true): self
+    {
+        trigger_deprecation('ruflin/elastica', '7.1.0', 'The "%s()" method is deprecated, use setKeyed() instead. It will be removed in 8.0.', __METHOD__);
+
+        return $this->setKeyed($keyed);
     }
 }

--- a/src/Aggregation/Range.php
+++ b/src/Aggregation/Range.php
@@ -57,10 +57,12 @@ class Range extends AbstractSimpleAggregation
 
     /**
      * @return $this
+     *
+     * @deprecated singe version 7.1.0, use the "setKeyed()" method instead.
      */
     public function setKeyedResponse(bool $keyed = true): self
     {
-        trigger_deprecation('ruflin/elastica', '7.1.0', 'The "%s()" method is deprecated, use setKeyed() instead. It will be removed in 8.0.', __METHOD__);
+        trigger_deprecation('ruflin/elastica', '7.1.0', 'The "%s()" method is deprecated, use "setKeyed()" instead. It will be removed in 8.0.', __METHOD__);
 
         return $this->setKeyed($keyed);
     }


### PR DESCRIPTION
`setKeyed()` is used in:
- `Elastica\Aggregation\Percentiles`
- `Elastica\Aggregation\PercentilesBucket`

Let's use it there too. Feels more natural.