### PR TITLE
Add list_syntax CS rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,6 +14,7 @@ return PhpCsFixer\Config::create()
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
         'is_null' => true,
+        'list_syntax' => ['syntax' => 'short'],
         'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
         'native_constant_invocation' => true,
         'native_function_invocation' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for defining a connection pool with DSN. Example: `pool(http://127.0.0.1 http://127.0.0.2/bar?timeout=4)` [#1808](https://github.com/ruflin/Elastica/pull/1808)
 * Added `Elastica\Aggregation\Composite` aggregation [#1804](https://github.com/ruflin/Elastica/pull/1804)
 * Added `symfony/deprecation-contracts` package to handle deprecations [#1823](https://github.com/ruflin/Elastica/pull/1823)
+* Added `list_syntax` CS rule [#1854](https://github.com/ruflin/Elastica/pull/1854)
 * Added `native_constant_invocation` CS rule [#1833](https://github.com/ruflin/Elastica/pull/1833)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)

--- a/tests/Bulk/ResponseSetTest.php
+++ b/tests/Bulk/ResponseSetTest.php
@@ -21,7 +21,7 @@ class ResponseSetTest extends BaseTest
      */
     public function testConstructor(): void
     {
-        list($responseData, $actions) = $this->_getFixture();
+        [$responseData, $actions] = $this->_getFixture();
 
         $responseSet = $this->_createResponseSet($responseData, $actions);
 
@@ -48,7 +48,7 @@ class ResponseSetTest extends BaseTest
      */
     public function testGetError(): void
     {
-        list($responseData, $actions) = $this->_getFixture();
+        [$responseData, $actions] = $this->_getFixture();
         $responseData['items'][1]['index']['ok'] = false;
         $responseData['items'][1]['index']['error'] = 'SomeExceptionMessage';
         $responseData['items'][2]['index']['ok'] = false;
@@ -84,7 +84,7 @@ class ResponseSetTest extends BaseTest
      */
     public function testGetBulkResponses(): void
     {
-        list($responseData, $actions) = $this->_getFixture();
+        [$responseData, $actions] = $this->_getFixture();
 
         $responseSet = $this->_createResponseSet($responseData, $actions);
 
@@ -108,7 +108,7 @@ class ResponseSetTest extends BaseTest
      */
     public function testIterator(): void
     {
-        list($responseData, $actions) = $this->_getFixture();
+        [$responseData, $actions] = $this->_getFixture();
 
         $responseSet = $this->_createResponseSet($responseData, $actions);
 
@@ -135,7 +135,7 @@ class ResponseSetTest extends BaseTest
 
     public function isOkDataProvider(): \Generator
     {
-        list($responseData, $actions) = $this->_getFixture();
+        [$responseData, $actions] = $this->_getFixture();
 
         yield [$responseData, $actions, true];
         $responseData['items'][2]['index']['ok'] = false;


### PR DESCRIPTION
Available since PHP 7.1: https://wiki.php.net/rfc/short_list_syntax