### PR TITLE
Fix PHPUnit expectations misorder

### DIFF
--- a/tests/Aggregation/TermsTest.php
+++ b/tests/Aggregation/TermsTest.php
@@ -23,7 +23,7 @@ class TermsTest extends BaseAggregationTest
         $agg = new Terms('terms');
         $agg->setInclude('pattern*');
 
-        $this->assertSame($agg->getParam('include'), 'pattern*');
+        $this->assertSame('pattern*', $agg->getParam('include'));
     }
 
     /**
@@ -34,7 +34,7 @@ class TermsTest extends BaseAggregationTest
         $agg = new Terms('terms');
         $agg->setIncludeAsExactMatch(['first', 'second']);
 
-        $this->assertSame($agg->getParam('include'), ['first', 'second']);
+        $this->assertSame(['first', 'second'], $agg->getParam('include'));
     }
 
     /**
@@ -45,10 +45,10 @@ class TermsTest extends BaseAggregationTest
         $agg = new Terms('terms');
         $agg->setIncludeWithPartitions(1, 23);
 
-        $this->assertSame($agg->getParam('include'), [
+        $this->assertSame([
             'partition' => 1,
             'num_partitions' => 23,
-        ]);
+        ], $agg->getParam('include'));
     }
 
     /**
@@ -59,7 +59,7 @@ class TermsTest extends BaseAggregationTest
         $agg = new Terms('terms');
         $agg->setExclude('pattern*');
 
-        $this->assertSame($agg->getParam('exclude'), 'pattern*');
+        $this->assertSame('pattern*', $agg->getParam('exclude'));
     }
 
     /**
@@ -70,7 +70,7 @@ class TermsTest extends BaseAggregationTest
         $agg = new Terms('terms');
         $agg->setExcludeAsExactMatch(['first', 'second']);
 
-        $this->assertSame($agg->getParam('exclude'), ['first', 'second']);
+        $this->assertSame(['first', 'second'], $agg->getParam('exclude'));
     }
 
     public function testTermsAggregation(): void

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -41,11 +41,11 @@ class IndexTest extends BaseTest
 
         $storedMapping = $index->getMapping();
 
-        $this->assertEquals($storedMapping['properties']['id']['type'], 'integer');
-        $this->assertEquals($storedMapping['properties']['id']['store'], true);
-        $this->assertEquals($storedMapping['properties']['email']['type'], 'text');
-        $this->assertEquals($storedMapping['properties']['username']['type'], 'text');
-        $this->assertEquals($storedMapping['properties']['test']['type'], 'integer');
+        $this->assertEquals('integer', $storedMapping['properties']['id']['type']);
+        $this->assertEquals(true, $storedMapping['properties']['id']['store']);
+        $this->assertEquals('text', $storedMapping['properties']['email']['type']);
+        $this->assertEquals('text', $storedMapping['properties']['username']['type']);
+        $this->assertEquals('integer', $storedMapping['properties']['test']['type']);
     }
 
     public function testGetMappingAlias(): void
@@ -503,11 +503,11 @@ class IndexTest extends BaseTest
         $index->refresh();
         $indexMappings = $index->getMapping();
 
-        $this->assertEquals($indexMappings['properties']['id']['type'], 'integer');
-        $this->assertEquals($indexMappings['properties']['id']['store'], true);
-        $this->assertEquals($indexMappings['properties']['email']['type'], 'text');
-        $this->assertEquals($indexMappings['properties']['username']['type'], 'text');
-        $this->assertEquals($indexMappings['properties']['test']['type'], 'integer');
+        $this->assertEquals('integer', $indexMappings['properties']['id']['type']);
+        $this->assertEquals(true, $indexMappings['properties']['id']['store']);
+        $this->assertEquals('text', $indexMappings['properties']['email']['type']);
+        $this->assertEquals('text', $indexMappings['properties']['username']['type']);
+        $this->assertEquals('integer', $indexMappings['properties']['test']['type']);
     }
 
     public function testEmptyIndexGetMapping(): void

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -99,7 +99,7 @@ class MappingTest extends BaseTest
 
         $index->refresh();
         $resultSet = $index->search('ruflin');
-        $this->assertEquals($resultSet->count(), 1);
+        $this->assertEquals(1, $resultSet->count());
 
         $index->delete();
     }

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -72,10 +72,10 @@ class PipelineTest extends BasePipeline
         $pipeGet = $pipeline->getPipeline('my_custom_pipeline');
         $result = $pipeGet->getData();
 
-        $this->assertSame($result['my_custom_pipeline']['description'], 'pipeline for Set');
-        $this->assertSame($result['my_custom_pipeline']['processors'][0]['set']['field'], 'field4');
-        $this->assertSame($result['my_custom_pipeline']['processors'][0]['set']['value'], '333');
-        $this->assertSame($result['my_custom_pipeline']['processors'][0]['trim']['field'], 'field1');
+        $this->assertSame('pipeline for Set', $result['my_custom_pipeline']['description']);
+        $this->assertSame('field4', $result['my_custom_pipeline']['processors'][0]['set']['field']);
+        $this->assertSame('333', $result['my_custom_pipeline']['processors'][0]['set']['value']);
+        $this->assertSame('field1', $result['my_custom_pipeline']['processors'][0]['trim']['field']);
     }
 
     /**

--- a/tests/Processor/KvTest.php
+++ b/tests/Processor/KvTest.php
@@ -73,8 +73,8 @@ class KvTest extends BasePipelineTest
         $pipelineGet = $pipeline->getPipeline('my_custom_pipeline');
         $result = $pipelineGet->getData();
 
-        $this->assertSame($result['my_custom_pipeline']['processors'][0]['kv']['field'], 'field1');
-        $this->assertSame($result['my_custom_pipeline']['processors'][0]['kv']['field_split'], '&');
-        $this->assertSame($result['my_custom_pipeline']['processors'][0]['kv']['value_split'], '=');
+        $this->assertSame('field1', $result['my_custom_pipeline']['processors'][0]['kv']['field']);
+        $this->assertSame('&', $result['my_custom_pipeline']['processors'][0]['kv']['field_split']);
+        $this->assertSame('=', $result['my_custom_pipeline']['processors'][0]['kv']['value_split']);
     }
 }

--- a/tests/Query/BoostingTest.php
+++ b/tests/Query/BoostingTest.php
@@ -55,9 +55,9 @@ class BoostingTest extends BaseTest
         $query->setParam('boost', 42.0);
 
         $queryToCheck = $query->toArray();
-        $this->assertEquals($queryToCheck['boosting']['boost'], 42.0);
-        $this->assertEquals($queryToCheck['boosting']['positive']['term']['name']['boost'], 5.0);
-        $this->assertEquals($queryToCheck['boosting']['negative']['term']['name']['boost'], 8.0);
-        $this->assertEquals($queryToCheck['boosting']['negative_boost'], 23.0);
+        $this->assertEquals(42.0, $queryToCheck['boosting']['boost']);
+        $this->assertEquals(5.0, $queryToCheck['boosting']['positive']['term']['name']['boost']);
+        $this->assertEquals(8.0, $queryToCheck['boosting']['negative']['term']['name']['boost']);
+        $this->assertEquals(23.0, $queryToCheck['boosting']['negative_boost']);
     }
 }

--- a/tests/Query/InnerHitsTest.php
+++ b/tests/Query/InnerHitsTest.php
@@ -159,8 +159,8 @@ class InnerHitsTest extends BaseTest
 
         $innerHitsResults = $firstResult->getInnerHits();
 
-        $this->assertEquals($firstResult->getId(), 4);
-        $this->assertEquals($innerHitsResults['users']['hits']['hits'][0]['_source']['name'], 'Newton');
+        $this->assertEquals(4, $firstResult->getId());
+        $this->assertEquals('Newton', $innerHitsResults['users']['hits']['hits'][0]['_source']['name']);
     }
 
     /**
@@ -183,7 +183,7 @@ class InnerHitsTest extends BaseTest
             $responsesId[] = $response['_id'];
         }
 
-        $this->assertEquals($firstResult->getId(), 1);
+        $this->assertEquals(1, $firstResult->getId());
         $this->assertEquals([6, 7], $responsesId);
     }
 
@@ -224,7 +224,7 @@ class InnerHitsTest extends BaseTest
 
         $responses = $innerHits['answers']['hits']['hits'];
 
-        $this->assertEquals(\count($responses), 1);
+        $this->assertCount(1, $responses);
         $this->assertEquals(7, $responses[0]['_id']);
     }
 
@@ -249,7 +249,7 @@ class InnerHitsTest extends BaseTest
             $responsesId[] = $response['_id'];
         }
 
-        $this->assertEquals($firstResult->getId(), 1);
+        $this->assertEquals(1, $firstResult->getId());
         $this->assertEquals([7, 6], $responsesId);
     }
 

--- a/tests/Query/ParentIdTest.php
+++ b/tests/Query/ParentIdTest.php
@@ -113,7 +113,7 @@ class ParentIdTest extends BaseTest
 
         $result = $results->current();
         $data = $result->getData();
-        $this->assertEquals($data['text'], 'this is an answer, the 1st');
+        $this->assertEquals('this is an answer, the 1st', $data['text']);
 
         $parentQuery = new ParentId('answer', '2', true);
         $search = new Search($index->getClient());
@@ -192,7 +192,7 @@ class ParentIdTest extends BaseTest
 
         $result = $results->current();
         $data = $result->getData();
-        $this->assertEquals($data['text'], 'this is an answer, the 1st');
+        $this->assertEquals('this is an answer, the 1st', $data['text']);
 
         $parentId = $queryDSL->parent_id('answer', 2, true);
         $search = new Search($index->getClient());

--- a/tests/Script/ScriptFieldsTest.php
+++ b/tests/Script/ScriptFieldsTest.php
@@ -23,20 +23,20 @@ class ScriptFieldsTest extends BaseTest
         // addScript
         $scriptFields = new ScriptFields();
         $scriptFields->addScript('test', $script);
-        $this->assertSame($scriptFields->getParam('test'), $script);
+        $this->assertSame($script, $scriptFields->getParam('test'));
 
         // setScripts
         $scriptFields = new ScriptFields();
         $scriptFields->setScripts([
             'test' => $script,
         ]);
-        $this->assertSame($scriptFields->getParam('test'), $script);
+        $this->assertSame($script, $scriptFields->getParam('test'));
 
         // Constructor
         $scriptFields = new ScriptFields([
             'test' => $script,
         ]);
-        $this->assertSame($scriptFields->getParam('test'), $script);
+        $this->assertSame($script, $scriptFields->getParam('test'));
     }
 
     /**
@@ -51,12 +51,12 @@ class ScriptFieldsTest extends BaseTest
             'test' => $script,
         ]);
         $query->setScriptFields($scriptFields);
-        $this->assertSame($query->getParam('script_fields'), $scriptFields);
+        $this->assertSame($scriptFields, $query->getParam('script_fields'));
 
         $query->setScriptFields([
             'test' => $script,
         ]);
-        $this->assertSame($query->getParam('script_fields')->getParam('test'), $script);
+        $this->assertSame($script, $query->getParam('script_fields')->getParam('test'));
     }
 
     /**


### PR DESCRIPTION
PHPUnit methods like `assertEquals`, `assertSame` are waiting the expected result as first argument and the current result as second. Sometimes they're misordered in the tests.