### PR TITLE
Remove useless var annotations

### DIFF
--- a/tests/Connection/Strategy/RoundRobinTest.php
+++ b/tests/Connection/Strategy/RoundRobinTest.php
@@ -31,7 +31,6 @@ class RoundRobinTest extends Base
         $config = ['connectionStrategy' => 'RoundRobin'];
         $client = $this->_getClient($config);
         $response = $client->request('_aliases');
-        /* @var $response Response */
 
         $this->_checkResponse($response);
 
@@ -83,7 +82,6 @@ class RoundRobinTest extends Base
         $client->setConnections($connections);
 
         $response = $client->request('_aliases');
-        /* @var $response Response */
 
         $this->_checkResponse($response);
 

--- a/tests/Connection/Strategy/SimpleTest.php
+++ b/tests/Connection/Strategy/SimpleTest.php
@@ -70,7 +70,6 @@ class SimpleTest extends Base
         $client->setConnections($connections);
 
         $response = $client->request('_aliases');
-        /* @var $response Response */
 
         $this->_checkResponse($response);
 

--- a/tests/Processor/AppendTest.php
+++ b/tests/Processor/AppendTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Append;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -70,7 +69,6 @@ class AppendTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(2, $result->getResults());

--- a/tests/Processor/ConvertTest.php
+++ b/tests/Processor/ConvertTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Convert;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -85,7 +84,6 @@ class ConvertTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('elastica');
 
         $this->assertCount(2, $result->getResults());

--- a/tests/Processor/DateTest.php
+++ b/tests/Processor/DateTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Date;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -91,7 +90,6 @@ class DateTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(1, $result->getResults());

--- a/tests/Processor/DotExpanderTest.php
+++ b/tests/Processor/DotExpanderTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\DotExpander;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -53,7 +52,6 @@ class DotExpanderTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(1, $result->getResults());

--- a/tests/Processor/JoinTest.php
+++ b/tests/Processor/JoinTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Join;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -50,7 +49,6 @@ class JoinTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(1, $result->getResults());

--- a/tests/Processor/JsonTest.php
+++ b/tests/Processor/JsonTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Json;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -70,7 +69,6 @@ class JsonTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(1, $result->getResults());

--- a/tests/Processor/LowercaseTest.php
+++ b/tests/Processor/LowercaseTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Lowercase;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -52,7 +51,6 @@ class LowercaseTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(2, $result->getResults());

--- a/tests/Processor/RemoveTest.php
+++ b/tests/Processor/RemoveTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Remove;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -68,7 +67,6 @@ class RemoveTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(2, $result->getResults());

--- a/tests/Processor/RenameTest.php
+++ b/tests/Processor/RenameTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Rename;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -71,7 +70,6 @@ class RenameTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(1, $result->getResults());

--- a/tests/Processor/SetTest.php
+++ b/tests/Processor/SetTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Set;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -72,7 +71,6 @@ class SetTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(2, $result->getResults());

--- a/tests/Processor/SortTest.php
+++ b/tests/Processor/SortTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Sort;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -67,7 +66,6 @@ class SortTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(1, $result->getResults());

--- a/tests/Processor/SplitTest.php
+++ b/tests/Processor/SplitTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Split;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -71,7 +70,6 @@ class SplitTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(1, $result->getResults());

--- a/tests/Processor/TrimTest.php
+++ b/tests/Processor/TrimTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Trim;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -52,7 +51,6 @@ class TrimTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(2, $result->getResults());

--- a/tests/Processor/UppercaseTest.php
+++ b/tests/Processor/UppercaseTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test\Processor;
 use Elastica\Bulk;
 use Elastica\Document;
 use Elastica\Processor\Uppercase;
-use Elastica\ResultSet;
 use Elastica\Test\BasePipeline as BasePipelineTest;
 
 /**
@@ -52,7 +51,6 @@ class UppercaseTest extends BasePipelineTest
         $bulk->send();
         $index->refresh();
 
-        /** @var ResultSet $result */
         $result = $index->search('*');
 
         $this->assertCount(2, $result->getResults());

--- a/tests/ScrollTest.php
+++ b/tests/ScrollTest.php
@@ -4,7 +4,6 @@ namespace Elastica\Test;
 
 use Elastica\Client;
 use Elastica\Document;
-use Elastica\ResultSet;
 use Elastica\Scroll;
 use Elastica\Search;
 
@@ -26,7 +25,6 @@ class ScrollTest extends Base
 
         $this->_assertOpenSearchContexts($search->getClient(), 0);
 
-        /** @var ResultSet $resultSet */
         foreach ($scroll as $scrollId => $resultSet) {
             $this->assertNotEmpty($scrollId);
             $this->_assertOpenSearchContexts($search->getClient(), 1);
@@ -117,7 +115,6 @@ class ScrollTest extends Base
 
         $this->_assertOpenSearchContexts($search->getClient(), 0);
 
-        /** @var ResultSet $resultSet */
         foreach ($scroll as $scrollId => $resultSet) {
             $this->assertNotEmpty($scrollId);
             $this->_assertOpenSearchContexts($search->getClient(), 1);


### PR DESCRIPTION
Remove some var annotations as they are directly inferred from method returns.