### PR TITLE
Allow to pass native endpoint options to index creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `list_syntax` CS rule [#1854](https://github.com/ruflin/Elastica/pull/1854)
 * Added `native_constant_invocation` CS rule [#1833](https://github.com/ruflin/Elastica/pull/1833)
 * Added `Elastica\Aggregation\DateRange::setTimezone()` [#1847](https://github.com/ruflin/Elastica/pull/1847)
+* Added endpoint options support to `Elastica\Index::create()` [#1859](https://github.com/ruflin/Elastica/pull/1859)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)

--- a/src/Index.php
+++ b/src/Index.php
@@ -402,9 +402,10 @@ class Index implements SearchableInterface
             throw new \TypeError(\sprintf('Argument 2 passed to "%s()" must be of type array|bool|null, %s given.', __METHOD__, \is_object($options) ? \get_class($options) : \gettype($options)));
         }
 
-        $invalidOptions = \array_diff(\array_keys($options), $allowedOptions = [
+        $endpoint = new Create();
+        $invalidOptions = \array_diff(\array_keys($options), $allowedOptions = \array_merge($endpoint->getParamWhitelist(), [
             'recreate',
-        ]);
+        ]));
 
         if (1 === $invalidOptionCount = \count($invalidOptions)) {
             throw new InvalidException(\sprintf('"%s" is not a valid option. Allowed options are "%s".', \implode('", "', $invalidOptions), \implode('", "', $allowedOptions)));
@@ -422,7 +423,9 @@ class Index implements SearchableInterface
             }
         }
 
-        $endpoint = new Create();
+        unset($options['recreate']);
+
+        $endpoint->setParams($options);
         $endpoint->setBody($args);
 
         return $this->requestEndpoint($endpoint);

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -582,16 +582,17 @@ class IndexTest extends BaseTest
         $indexName = 'test';
 
         $index = $client->getIndex($indexName);
-        $index->create([]);
-        $this->_waitForAllocation($index);
+        $index->create([], [
+            'wait_for_active_shards' => 'all',
+        ]);
         $status = new Status($client);
         $this->assertTrue($status->indexExists($indexName));
 
         $index = $client->getIndex($indexName);
         $index->create([], [
             'recreate' => true,
+            'wait_for_active_shards' => 'all',
         ]);
-        $this->_waitForAllocation($index);
         $status = new Status($client);
         $this->assertTrue($status->indexExists($indexName));
     }
@@ -608,13 +609,11 @@ class IndexTest extends BaseTest
 
         $this->expectDeprecation('Since ruflin/elastica 7.1.0: Passing null as 2nd argument to "Elastica\Index::create()" is deprecated, avoid passing this argument or pass an array instead. It will be removed in 8.0.');
         $index->create([], null);
-        $this->_waitForAllocation($index);
         $status = new Status($client);
         $this->assertTrue($status->indexExists($indexName));
 
         $this->expectDeprecation('Since ruflin/elastica 7.1.0: Passing a bool as 2nd argument to "Elastica\Index::create()" is deprecated, pass an array with the key "recreate" instead. It will be removed in 8.0.');
         $index->create([], true);
-        $this->_waitForAllocation($index);
         $status = new Status($client);
         $this->assertTrue($status->indexExists($indexName));
     }
@@ -625,7 +624,7 @@ class IndexTest extends BaseTest
     public function testCreateWithInvalidOption(): void
     {
         $this->expectException(InvalidException::class);
-        $this->expectExceptionMessage('"testing_invalid_option" is not a valid option. Allowed options are "recreate".');
+        $this->expectExceptionMessageMatches('/"testing_invalid_option" is not a valid option\. Allowed options are ((("[a-z_]+")(, )?)+)\./');
 
         $client = $this->_getClient();
         $indexName = 'test';


### PR DESCRIPTION
This PR will allow to pass endpoint query parameters to index creation: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-query-params

The list of available options is retrieved from the corresponding elasticsearch endpoint class to avoid maintaining it here.