### PR TITLE
Use microsecond precision instead of second for connection timeout and connect-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Used new mapping endpoints classes [#1845](https://github.com/ruflin/Elastica/pull/1845)
 * Used new nodes endpoints classes [#1863](https://github.com/ruflin/Elastica/pull/1863)
 * Used new settings endpoints classes [#1852](https://github.com/ruflin/Elastica/pull/1852)
+* Allow float values for connection timeout and connection connect-timeout, providing ms precision for those. Previous precision was second. [#1868](https://github.com/ruflin/Elastica/pull/1868)
 ### Deprecated
 * Deprecated `Elastica\Aggregation\Range::setKeyedResponse()`, use `setKeyed()` instead [#1848](https://github.com/ruflin/Elastica/pull/1848)
 * Deprecated `Elastica\Exception\ResponseException::getElasticsearchException()`, use `getResponse()::getFullError()` instead [#1829](https://github.com/ruflin/Elastica/pull/1829)

--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -76,7 +76,7 @@ class Http extends AbstractTransport
         }
 
         \curl_setopt($conn, \CURLOPT_URL, $baseUri);
-        \curl_setopt($conn, \CURLOPT_TIMEOUT, $connection->getTimeout());
+        \curl_setopt($conn, \CURLOPT_TIMEOUT_MS, $connection->getTimeout() * 1000);
         \curl_setopt($conn, \CURLOPT_FORBID_REUSE, 0);
 
         // Tell ES that we support the compressed responses
@@ -85,9 +85,12 @@ class Http extends AbstractTransport
         \curl_setopt($conn, \CURLOPT_ENCODING, '');
 
         /* @see Connection::setConnectTimeout() */
-        $connectTimeout = $connection->getConnectTimeout();
-        if ($connectTimeout > 0) {
-            \curl_setopt($conn, \CURLOPT_CONNECTTIMEOUT, $connectTimeout);
+        $connectTimeoutMs = $connection->getConnectTimeout() * 1000;
+
+        // Let's only apply this value if the number of ms is greater than or equal to "1".
+        // In case "0" is passed as an argument, the value is reset to its default (300 s)
+        if ($connectTimeoutMs > 1) {
+            \curl_setopt($conn, \CURLOPT_CONNECTTIMEOUT_MS, $connectTimeoutMs);
         }
 
         if (null !== $proxy = $connection->getProxy()) {


### PR DESCRIPTION
Current implementation only allows second precision for connection timeout and connect-timeout.
This PR provides millisecond precision by accepting float values, and using them if libcurl is compatible with this.