### PR TITLE
Fix minimal value for connect timeout

### DIFF
--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -89,7 +89,7 @@ class Http extends AbstractTransport
 
         // Let's only apply this value if the number of ms is greater than or equal to "1".
         // In case "0" is passed as an argument, the value is reset to its default (300 s)
-        if ($connectTimeoutMs > 1) {
+        if ($connectTimeoutMs >= 1) {
             \curl_setopt($conn, \CURLOPT_CONNECTTIMEOUT_MS, $connectTimeoutMs);
         }
 


### PR DESCRIPTION
An error remained in my last merged commit.
The check on the `$connectTimeoutMs` was invalid: the value must be greater than or equal to 1 (as mentioned in the comment above). This commit fixes this.