### PR TITLE
Allow the Terms query to accept arrays of strings, ints and floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.0.0...master)
 ### Backward Compatibility Breaks
+* Allow the Terms query to accept arrays of strings, ints and floats [#1872](https://github.com/ruflin/Elastica/pull/1872)
 ### Added
 * Ability to specify the type of authentication manually by the `auth_type` parameter (in the client class config) was added (allowed values are `basic, digest, gssnegotiate, ntlm`)
 * Added `if_seq_no` / `if_primary_term` to replace `version` for [optimistic concurrency control](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/optimistic-concurrency-control.html)

--- a/src/Query/Terms.php
+++ b/src/Query/Terms.php
@@ -61,6 +61,10 @@ class Terms extends AbstractQuery
      */
     public function addTerm($term): self
     {
+        if (!\is_string($term) && !\is_int($term) && !\is_float($term)) {
+            throw new \TypeError(\sprintf('Argument 1 passed to "%s()" must be of type float|int|string, %s given.', __METHOD__, \is_object($term) ? \get_class($term) : \gettype($term)));
+        }
+
         $this->terms[] = $term;
 
         return $this;

--- a/src/Query/Terms.php
+++ b/src/Query/Terms.php
@@ -20,7 +20,7 @@ class Terms extends AbstractQuery
     private $field;
 
     /**
-     * @var string[]
+     * @var float[]|int[]|string[]
      */
     private $terms;
 
@@ -30,7 +30,7 @@ class Terms extends AbstractQuery
     private $lookup;
 
     /**
-     * @param string[] $terms Terms list, leave empty if building a terms-lookup query
+     * @param float[]|int[]|string[] $terms Terms list, leave empty if building a terms-lookup query
      */
     public function __construct(string $field, array $terms = [])
     {
@@ -45,7 +45,7 @@ class Terms extends AbstractQuery
     /**
      * Sets terms for the query.
      *
-     * @param string[]
+     * @param float[]|int[]|string[]
      */
     public function setTerms(array $terms): self
     {
@@ -56,8 +56,10 @@ class Terms extends AbstractQuery
 
     /**
      * Adds a single term to the list.
+     *
+     * @param float|int|string $term
      */
-    public function addTerm(string $term): self
+    public function addTerm($term): self
     {
         $this->terms[] = $term;
 

--- a/src/Query/Terms.php
+++ b/src/Query/Terms.php
@@ -20,7 +20,7 @@ class Terms extends AbstractQuery
     private $field;
 
     /**
-     * @var float[]|int[]|string[]
+     * @var array<float|int|string>
      */
     private $terms;
 
@@ -30,7 +30,7 @@ class Terms extends AbstractQuery
     private $lookup;
 
     /**
-     * @param float[]|int[]|string[] $terms Terms list, leave empty if building a terms-lookup query
+     * @param array<float|int|string> $terms Terms list, leave empty if building a terms-lookup query
      */
     public function __construct(string $field, array $terms = [])
     {
@@ -45,7 +45,7 @@ class Terms extends AbstractQuery
     /**
      * Sets terms for the query.
      *
-     * @param float[]|int[]|string[]
+     * @param array<float|int|string>
      */
     public function setTerms(array $terms): self
     {

--- a/tests/Query/TermsTest.php
+++ b/tests/Query/TermsTest.php
@@ -96,4 +96,83 @@ class TermsTest extends BaseTest
 
         $this->assertEquals(2, $resultSet->count());
     }
+
+    /**
+     * @group functional
+     */
+    public function testVariousDataTypesViaConstructor(): void
+    {
+        $index = $this->_createIndex();
+
+        $index->addDocuments([
+            new Document(1, ['some_numeric_field' => 9876]),
+        ]);
+        $index->refresh();
+
+        // string
+        $query = new Terms('some_numeric_field', ['9876']);
+        $resultSet = $index->search($query);
+        $this->assertEquals(1, $resultSet->count());
+
+        // int
+        $query = new Terms('some_numeric_field', [9876]);
+        $resultSet = $index->search($query);
+        $this->assertEquals(1, $resultSet->count());
+
+        // float
+        $query = new Terms('some_numeric_field', [9876.0]);
+        $resultSet = $index->search($query);
+        $this->assertEquals(1, $resultSet->count());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testVariousMixedDataTypesViaConstructor(): void
+    {
+        $index = $this->_createIndex();
+
+        $index->addDocuments([
+            new Document(1, ['some_numeric_field' => 9876]),
+            new Document(2, ['some_numeric_field' => 5678]),
+            new Document(3, ['some_numeric_field' => 1234]),
+            new Document(4, ['some_numeric_field' => 8899]),
+        ]);
+        $index->refresh();
+
+        $query = new Terms('some_numeric_field', ['9876', 1234, 5678.0]);
+        $resultSet = $index->search($query);
+        $this->assertEquals(3, $resultSet->count());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testVariousDataTypesViaAddTerm(): void
+    {
+        $index = $this->_createIndex();
+
+        $index->addDocuments([
+            new Document(1, ['some_numeric_field' => 9876]),
+        ]);
+        $index->refresh();
+
+        // string
+        $query = new Terms('some_numeric_field');
+        $query->addTerm('9876');
+        $resultSet = $index->search($query);
+        $this->assertEquals(1, $resultSet->count());
+
+        // int
+        $query = new Terms('some_numeric_field');
+        $query->addTerm(9876);
+        $resultSet = $index->search($query);
+        $this->assertEquals(1, $resultSet->count());
+
+        // float
+        $query = new Terms('some_numeric_field');
+        $query->addTerm(9876.0);
+        $resultSet = $index->search($query);
+        $this->assertEquals(1, $resultSet->count());
+    }
 }

--- a/tests/Query/TermsTest.php
+++ b/tests/Query/TermsTest.php
@@ -175,4 +175,13 @@ class TermsTest extends BaseTest
         $resultSet = $index->search($query);
         $this->assertEquals(1, $resultSet->count());
     }
+
+    public function testAddTermTypeError(): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument 1 passed to "Elastica\Query\Terms::addTerm()" must be of type float|int|string, stdClass given.');
+
+        $query = new Terms('some_numeric_field');
+        $query->addTerm(new \stdClass());
+    }
 }


### PR DESCRIPTION
As shown in https://github.com/ruflin/Elastica/pull/1765#discussion_r525927129 , ElasticSearch accepts all of them

Note: the change of `public function addTerm` was not previously discussed, but is made for consistency, however poses a breaking change if someone extended this class previously => https://3v4l.org/Ws5bM

### TODO
- [x] Add changelog
- [ ] Discuss breaking change outcome
- [x] Provide a functional test