### PR TITLE
Fix regression introduced in #1872

### DIFF
--- a/src/Query/Terms.php
+++ b/src/Query/Terms.php
@@ -30,7 +30,7 @@ class Terms extends AbstractQuery
     private $lookup;
 
     /**
-     * @param array<float|int|string> $terms Terms list, leave empty if building a terms-lookup query
+     * @param array<bool|float|int|string> $terms Terms list, leave empty if building a terms-lookup query
      */
     public function __construct(string $field, array $terms = [])
     {
@@ -45,7 +45,7 @@ class Terms extends AbstractQuery
     /**
      * Sets terms for the query.
      *
-     * @param array<float|int|string>
+     * @param array<bool|float|int|string>
      */
     public function setTerms(array $terms): self
     {
@@ -57,12 +57,12 @@ class Terms extends AbstractQuery
     /**
      * Adds a single term to the list.
      *
-     * @param float|int|string $term
+     * @param bool|float|int|string $term
      */
     public function addTerm($term): self
     {
-        if (!\is_string($term) && !\is_int($term) && !\is_float($term)) {
-            throw new \TypeError(\sprintf('Argument 1 passed to "%s()" must be of type float|int|string, %s given.', __METHOD__, \is_object($term) ? \get_class($term) : \gettype($term)));
+        if (!\is_scalar($term)) {
+            throw new \TypeError(\sprintf('Argument 1 passed to "%s()" must be a scalar, %s given.', __METHOD__, \is_object($term) ? \get_class($term) : \gettype($term)));
         }
 
         $this->terms[] = $term;

--- a/tests/Query/TermsTest.php
+++ b/tests/Query/TermsTest.php
@@ -179,7 +179,7 @@ class TermsTest extends BaseTest
     public function testAddTermTypeError(): void
     {
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Argument 1 passed to "Elastica\Query\Terms::addTerm()" must be of type float|int|string, stdClass given.');
+        $this->expectExceptionMessage('Argument 1 passed to "Elastica\Query\Terms::addTerm()" must be a scalar, stdClass given.');
 
         $query = new Terms('some_numeric_field');
         $query->addTerm(new \stdClass());


### PR DESCRIPTION
Since the merge of #1872, boolean values are not accepted anymore in the Terms aggregation whereas they're legal values.
This PR fixes this issue