### PR TITLE
Deprecate using "interval" configuration for date histograms aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Allow the Terms query to accept arrays of strings, ints and floats [#1872](https://github.com/ruflin/Elastica/pull/1872)
 * Added a default value to `Elastica\Aggregation\Range::setKeyed()` and `Elastica\Aggregation\PercentilesBucket::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
 * Removed type-hint to `Elastica\Aggregation\Percentiles::setMissing()` argument [#1875](https://github.com/ruflin/Elastica/pull/1875)
+* Allow the Terms query to accept arrays of scalars [#1872](https://github.com/ruflin/Elastica/pull/1872)
+* `Elastica\Aggregation\DateHistogram` does not extends `Elastica\Aggregation\Histogram` anymore [#1874](https://github.com/ruflin/Elastica/pull/1874)
 ### Added
 * Ability to specify the type of authentication manually by the `auth_type` parameter (in the client class config) was added (allowed values are `basic, digest, gssnegotiate, ntlm`)
 * Added `if_seq_no` / `if_primary_term` to replace `version` for [optimistic concurrency control](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/optimistic-concurrency-control.html)
@@ -58,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Deprecated Match query class and introduced MatchQuery instead for PHP 8.0 compatibility reason [#1799](https://github.com/ruflin/Elastica/pull/1799)
 * Deprecated `version`/`version_type` options [(deprecated in `6.7.0`)](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html) and added `if_seq_no` / `if_primary_term` that replaced it
 * Deprecated passing `bool` or `null` as 2nd argument to `Elastica\Index::create()` [#1828](https://github.com/ruflin/Elastica/pull/1828)
+* Deprecated `Elastica\Aggregation\DateHistogram::__construct` third argument (`$interval`) and `Elastica\Aggregation\DateHistogram::setInterval` in favor of `setFixedInterval()` and `setCalendarInterval()` [#1874](https://github.com/ruflin/Elastica/pull/1874)
 ### Removed
 * Removed HHVM proxy detection [#1818](https://github.com/ruflin/Elastica/pull/1818)
 ### Fixed

--- a/src/Aggregation/DateHistogram.php
+++ b/src/Aggregation/DateHistogram.php
@@ -7,9 +7,69 @@ namespace Elastica\Aggregation;
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html
  */
-class DateHistogram extends Histogram
+class DateHistogram extends AbstractSimpleAggregation
 {
+    use Traits\KeyedTrait;
+    use Traits\MissingTrait;
+
     public const DEFAULT_TIMEZONE_VALUE = 'UTC';
+
+    /**
+     * @param string     $name     the name of this aggregation
+     * @param string     $field    the name of the field on which to perform the aggregation
+     * @param int|string $interval the interval by which documents will be bucketed
+     */
+    public function __construct(string $name, string $field, $interval = null)
+    {
+        parent::__construct($name, $field);
+        $this->setField($field);
+
+        if (null !== $interval) {
+            trigger_deprecation('ruflin/elastica', '7.1.0', 'Argument 3 passed to "%s()" is deprecated, use "setDateInterval()" or "setCalendarInterval()" instead. It will be removed in 8.0.', __METHOD__);
+
+            $this->setParam('interval', $interval);
+        }
+    }
+
+    /**
+     * Set the interval by which documents will be bucketed.
+     *
+     * @deprecated Deprecated since 7.1.0
+     *
+     * @param int|string $interval
+     *
+     * @return $this
+     */
+    public function setInterval($interval): self
+    {
+        trigger_deprecation('ruflin/elastica', '7.1.0', 'The "%s()" method is deprecated, use "setDateInterval()" or "setCalendarInterval()" instead. It will be removed in 8.0.', __METHOD__);
+
+        return $this->setParam('interval', $interval);
+    }
+
+    /**
+     * Set the fixed interval by which documents will be bucketed.
+     *
+     * @param int|string $interval
+     *
+     * @return $this
+     */
+    public function setFixedInterval($interval): self
+    {
+        return $this->setParam('fixed_interval', $interval);
+    }
+
+    /**
+     * Set the calendar interval by which documents will be bucketed.
+     *
+     * @param int|string $interval
+     *
+     * @return $this
+     */
+    public function setCalendarInterval($interval): self
+    {
+        return $this->setParam('calendar_interval', $interval);
+    }
 
     /**
      * Set time_zone option.
@@ -79,5 +139,30 @@ class DateHistogram extends Histogram
         }
 
         return $this->setParam('extended_bounds', $bounds);
+    }
+
+    /**
+     * Set the bucket sort order.
+     *
+     * @param string $order     "_count", "_term", or the name of a sub-aggregation or sub-aggregation response field
+     * @param string $direction "asc" or "desc"
+     *
+     * @return $this
+     */
+    public function setOrder(string $order, string $direction): self
+    {
+        return $this->setParam('order', [$order => $direction]);
+    }
+
+    /**
+     * Set the minimum number of documents which must fall into a bucket in order for the bucket to be returned.
+     *
+     * @param int $count set to 0 to include empty buckets
+     *
+     * @return $this
+     */
+    public function setMinimumDocumentCount(int $count): self
+    {
+        return $this->setParam('min_doc_count', $count);
     }
 }

--- a/src/QueryBuilder/DSL/Aggregation.php
+++ b/src/QueryBuilder/DSL/Aggregation.php
@@ -355,9 +355,9 @@ class Aggregation implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-histogram-aggregation.html
      *
-     * @param string $name     the name of this aggregation
-     * @param string $field    the name of the field on which to perform the aggregation
-     * @param int    $interval the interval by which documents will be bucketed
+     * @param string     $name     the name of this aggregation
+     * @param string     $field    the name of the field on which to perform the aggregation
+     * @param int|string $interval the interval by which documents will be bucketed
      */
     public function histogram(string $name, string $field, $interval): Histogram
     {
@@ -373,7 +373,7 @@ class Aggregation implements DSL
      * @param string     $field    the name of the field on which to perform the aggregation
      * @param int|string $interval the interval by which documents will be bucketed
      */
-    public function date_histogram(string $name, string $field, $interval): DateHistogram
+    public function date_histogram(string $name, string $field, $interval = null): DateHistogram
     {
         return new DateHistogram($name, $field, $interval);
     }

--- a/tests/Aggregation/BucketSelectorTest.php
+++ b/tests/Aggregation/BucketSelectorTest.php
@@ -46,9 +46,12 @@ class BucketSelectorTest extends BaseAggregationTest
      */
     public function testMaxAggregation(): void
     {
+        $this->_checkVersion('7.2');
+
         $index = $this->_getIndexForTest();
 
-        $dateHistogramAgg = new DateHistogram('histogram_agg', 'date', 'day');
+        $dateHistogramAgg = new DateHistogram('histogram_agg', 'date');
+        $dateHistogramAgg->setFixedInterval('1d');
         $dateHistogramAgg->setFormat('yyyy-MM-dd');
 
         $maxAgg = new Max('max_agg');

--- a/tests/Aggregation/DerivativeTest.php
+++ b/tests/Aggregation/DerivativeTest.php
@@ -45,9 +45,12 @@ class DerivativeTest extends BaseAggregationTest
      */
     public function testMaxAggregation(): void
     {
+        $this->_checkVersion('7.2');
+
         $index = $this->_getIndexForTest();
 
-        $dateHistogramAgg = new DateHistogram('histogram_agg', 'date', 'day');
+        $dateHistogramAgg = new DateHistogram('histogram_agg', 'date');
+        $dateHistogramAgg->setFixedInterval('1d');
         $dateHistogramAgg->setFormat('yyyy-MM-dd');
 
         $maxAgg = new Max('max_agg');

--- a/tests/Aggregation/SerialDiffTest.php
+++ b/tests/Aggregation/SerialDiffTest.php
@@ -20,7 +20,10 @@ class SerialDiffTest extends BaseAggregationTest
      */
     public function testSerialDiffAggregation(): void
     {
-        $dateHistogramAggregation = new DateHistogram('measurements', 'measured_at', 'hour');
+        $this->_checkVersion('7.2');
+
+        $dateHistogramAggregation = new DateHistogram('measurements', 'measured_at');
+        $dateHistogramAggregation->setFixedInterval('1h');
 
         $dateHistogramAggregation
             ->addAggregation((new Max('max_value'))->setField('value'))

--- a/tests/QueryBuilder/DSL/AggregationTest.php
+++ b/tests/QueryBuilder/DSL/AggregationTest.php
@@ -34,7 +34,7 @@ class AggregationTest extends AbstractDSLTest
 
         $this->_assertImplemented($aggregationDSL, 'avg', Aggregation\Avg::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'cardinality', Aggregation\Cardinality::class, ['name']);
-        $this->_assertImplemented($aggregationDSL, 'date_histogram', Aggregation\DateHistogram::class, ['name', 'field', 1]);
+        $this->_assertImplemented($aggregationDSL, 'date_histogram', Aggregation\DateHistogram::class, ['name', 'field']);
         $this->_assertImplemented($aggregationDSL, 'date_range', Aggregation\DateRange::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'extended_stats', Aggregation\ExtendedStats::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'filter', Aggregation\Filter::class, ['name', new Exists('field')]);


### PR DESCRIPTION
The combined `interval` field has been deprecated in favor of fixed_interval or calendar_interval. See https://www.elastic.co/guide/en/elasticsearch/reference/7.2/search-aggregations-bucket-datehistogram-aggregation.html