### PR TITLE
Fix Composite::addAfter(null) aggregation behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Replaced `_routing` and `_retry_on_conflict` by `routing` and `retry_on_conflict` in `AbstractUpdateAction` [#1807](https://github.com/ruflin/Elastica/issues/1807)
 * Fixed `Elastica\Util::toSnakeCase()` with first letter being lower cased [#1831](https://github.com/ruflin/Elastica/pull/1831)
 * Fixed handling precision as string in `Elastica\Aggregation\GeohashGrid::setPrecision()` [#1884](https://github.com/ruflin/Elastica/pull/1884)
+* Fixed calling `Elastica\Aggregation\Composite::addAfter()` with the `null` value [1877](https://github.com/ruflin/Elastica/pull/1877)
 ### Security
 
 

--- a/src/Aggregation/Composite.php
+++ b/src/Aggregation/Composite.php
@@ -25,6 +25,10 @@ class Composite extends AbstractAggregation
      */
     public function addAfter(?array $checkpoint): self
     {
+        if (null === $checkpoint) {
+            return $this;
+        }
+
         return $this->setParam('after', $checkpoint);
     }
 }

--- a/tests/Aggregation/CompositeTest.php
+++ b/tests/Aggregation/CompositeTest.php
@@ -178,6 +178,43 @@ class CompositeTest extends BaseAggregationTest
         $this->assertEquals($expected, $results);
     }
 
+    /**
+     * @group functional
+     */
+    public function testCompositeWithNullAfter(): void
+    {
+        $composite = new Composite('products');
+        $composite->setSize(2);
+        $composite->addSource((new Terms('color'))->setField('color.keyword'));
+        $composite->addAfter(null);
+
+        $query = new Query();
+        $query->addAggregation($composite);
+
+        $results = $this->_getIndexForTest()->search($query)->getAggregation('products');
+        $expected = [
+            'after_key' => [
+                'color' => 'green',
+            ],
+            'buckets' => [
+                [
+                    'key' => [
+                        'color' => 'blue',
+                    ],
+                    'doc_count' => 2,
+                ],
+                [
+                    'key' => [
+                        'color' => 'green',
+                    ],
+                    'doc_count' => 1,
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $results);
+    }
+
     protected function _getIndexForTest(): Index
     {
         $index = $this->_createIndex();


### PR DESCRIPTION
`Elastica\Aggregation\Composite::addAfter` accepts `null` value. However, it's not allowed by elasticsearch It returns an error: `[composite] after doesn't support values of type: VALUE_NULL`

This PR fixes this bug