### PR TITLE
added geotile grid support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Elastica\Aggregation\GeoDistance::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
 * Added `Elastica\Aggregation\Histogram::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
 * Added `Elastica\Aggregation\IpRange::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
-* Added `Elastica\Aggregation\GeotileGrid` [#1880](https://github.com/ruflin/Elastica/pull/1880)
+* Added `Elastica\Aggregation\GeotileGridAggregation` [#1880](https://github.com/ruflin/Elastica/pull/1880)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Elastica\Aggregation\GeoDistance::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
 * Added `Elastica\Aggregation\Histogram::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
 * Added `Elastica\Aggregation\IpRange::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
+* Added `Elastica\Aggregation\GeotileGrid` [#1880](https://github.com/ruflin/Elastica/pull/1880)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)

--- a/src/Aggregation/GeotileGrid.php
+++ b/src/Aggregation/GeotileGrid.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Elastica\Aggregation;
+
+/**
+ * Class GeotileGrid.
+ *
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geotilegrid-aggregation.html
+ */
+class GeotileGrid extends AbstractAggregation
+{
+    public const DEFAULT_PRECISION_VALUE = 5;
+    public const DEFAULT_SIZE_VALUE = 10000;
+
+    /**
+     * @param string $name  the name of this aggregation
+     * @param string $field the field on which to perform this aggregation
+     */
+    public function __construct(string $name, string $field)
+    {
+        parent::__construct($name);
+        $this->setField($field);
+    }
+
+    /**
+     * Set the field for this aggregation.
+     *
+     * @param string $field the name of the document field on which to perform this aggregation
+     *
+     * @return $this
+     */
+    public function setField(string $field): self
+    {
+        return $this->setParam('field', $field);
+    }
+
+    /**
+     * Set the precision for this aggregation.
+     *
+     * @param int $precision an integer between 1 and 12, inclusive. Defaults to 5.
+     *
+     * @return $this
+     */
+    public function setPrecision(int $precision): self
+    {
+        return $this->setParam('precision', $precision);
+    }
+
+    /**
+     * Set the maximum number of buckets to return.
+     *
+     * @param int $size defaults to 10,000
+     *
+     * @return $this
+     */
+    public function setSize(int $size): self
+    {
+        return $this->setParam('size', $size);
+    }
+
+    /**
+     * Set the number of results returned from each shard.
+     *
+     * @return $this
+     */
+    public function setShardSize(int $shardSize): self
+    {
+        return $this->setParam('shard_size', $shardSize);
+    }
+}

--- a/src/Aggregation/GeotileGridAggregation.php
+++ b/src/Aggregation/GeotileGridAggregation.php
@@ -3,13 +3,15 @@
 namespace Elastica\Aggregation;
 
 /**
- * Class GeotileGrid.
+ * Class GeotileGridAggregation.
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geotilegrid-aggregation.html
  */
-class GeotileGrid extends AbstractAggregation
+class GeotileGridAggregation extends AbstractAggregation
 {
-    public const DEFAULT_PRECISION_VALUE = 5;
+    use Traits\ShardSizeTrait;
+
+    public const DEFAULT_PRECISION_VALUE = 7;
     public const DEFAULT_SIZE_VALUE = 10000;
 
     /**
@@ -56,15 +58,5 @@ class GeotileGrid extends AbstractAggregation
     public function setSize(int $size): self
     {
         return $this->setParam('size', $size);
-    }
-
-    /**
-     * Set the number of results returned from each shard.
-     *
-     * @return $this
-     */
-    public function setShardSize(int $shardSize): self
-    {
-        return $this->setParam('shard_size', $shardSize);
     }
 }

--- a/src/QueryBuilder/DSL/Aggregation.php
+++ b/src/QueryBuilder/DSL/Aggregation.php
@@ -16,6 +16,7 @@ use Elastica\Aggregation\Filter;
 use Elastica\Aggregation\Filters;
 use Elastica\Aggregation\GeoDistance;
 use Elastica\Aggregation\GeohashGrid;
+use Elastica\Aggregation\GeotileGrid;
 use Elastica\Aggregation\GlobalAggregation;
 use Elastica\Aggregation\Histogram;
 use Elastica\Aggregation\IpRange;
@@ -402,6 +403,19 @@ class Aggregation implements DSL
     public function geohash_grid(string $name, string $field): GeohashGrid
     {
         return new GeohashGrid($name, $field);
+    }
+
+    /**
+     * geotile grid aggregation.
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geotilegrid-aggregation.html
+     *
+     * @param string $name  the name of this aggregation
+     * @param string $field the field on which to perform this aggregation
+     */
+    public function geotile_grid(string $name, string $field): GeotileGrid
+    {
+        return new GeotileGrid($name, $field);
     }
 
     /**

--- a/src/QueryBuilder/DSL/Aggregation.php
+++ b/src/QueryBuilder/DSL/Aggregation.php
@@ -16,7 +16,7 @@ use Elastica\Aggregation\Filter;
 use Elastica\Aggregation\Filters;
 use Elastica\Aggregation\GeoDistance;
 use Elastica\Aggregation\GeohashGrid;
-use Elastica\Aggregation\GeotileGrid;
+use Elastica\Aggregation\GeotileGridAggregation;
 use Elastica\Aggregation\GlobalAggregation;
 use Elastica\Aggregation\Histogram;
 use Elastica\Aggregation\IpRange;
@@ -413,9 +413,9 @@ class Aggregation implements DSL
      * @param string $name  the name of this aggregation
      * @param string $field the field on which to perform this aggregation
      */
-    public function geotile_grid(string $name, string $field): GeotileGrid
+    public function geotile_grid(string $name, string $field): GeotileGridAggregation
     {
-        return new GeotileGrid($name, $field);
+        return new GeotileGridAggregation($name, $field);
     }
 
     /**

--- a/tests/Aggregation/GeotileGridAggregationTest.php
+++ b/tests/Aggregation/GeotileGridAggregationTest.php
@@ -2,7 +2,7 @@
 
 namespace Elastica\Test\Aggregation;
 
-use Elastica\Aggregation\GeotileGrid;
+use Elastica\Aggregation\GeotileGridAggregation;
 use Elastica\Document;
 use Elastica\Index;
 use Elastica\Mapping;
@@ -11,14 +11,14 @@ use Elastica\Query;
 /**
  * @internal
  */
-class GeotileGridTest extends BaseAggregationTest
+class GeotileGridAggregationTest extends BaseAggregationTest
 {
     /**
      * @group functional
      */
     public function testGeotileGridAggregation(): void
     {
-        $agg = new GeotileGrid('tile', 'location');
+        $agg = new GeotileGridAggregation('tile', 'location');
         $agg->setPrecision(7);
 
         $query = new Query();

--- a/tests/Aggregation/GeotileGridTest.php
+++ b/tests/Aggregation/GeotileGridTest.php
@@ -2,7 +2,7 @@
 
 namespace Elastica\Test\Aggregation;
 
-use Elastica\Aggregation\GeoCentroid;
+use Elastica\Aggregation\GeotileGrid;
 use Elastica\Document;
 use Elastica\Index;
 use Elastica\Mapping;
@@ -11,20 +11,22 @@ use Elastica\Query;
 /**
  * @internal
  */
-class GeoCentroidTest extends BaseAggregationTest
+class GeotileGridTest extends BaseAggregationTest
 {
     /**
      * @group functional
      */
-    public function testGeoCentroidGridAggregation(): void
+    public function testGeotileGridAggregation(): void
     {
-        $agg = new GeoCentroid('centroid', 'location');
+        $agg = new GeotileGrid('tile', 'location');
+        $agg->setPrecision(7);
 
         $query = new Query();
         $query->addAggregation($agg);
-        $results = $this->_getIndexForTest()->search($query)->getAggregation('centroid');
+        $results = $this->_getIndexForTest()->search($query)->getAggregation('tile');
 
-        $this->assertEquals(3, $results['count']);
+        $this->assertEquals(2, $results['buckets'][0]['doc_count']);
+        $this->assertEquals(1, $results['buckets'][1]['doc_count']);
     }
 
     protected function _getIndexForTest(): Index

--- a/tests/QueryBuilder/DSL/AggregationTest.php
+++ b/tests/QueryBuilder/DSL/AggregationTest.php
@@ -41,7 +41,7 @@ class AggregationTest extends AbstractDSLTest
         $this->_assertImplemented($aggregationDSL, 'filters', Aggregation\Filters::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'geo_distance', Aggregation\GeoDistance::class, ['name', 'field', 'origin']);
         $this->_assertImplemented($aggregationDSL, 'geohash_grid', Aggregation\GeohashGrid::class, ['name', 'field']);
-        $this->_assertImplemented($aggregationDSL, 'geotile_grid', Aggregation\GeotileGrid::class, ['name', 'field']);
+        $this->_assertImplemented($aggregationDSL, 'geotile_grid', Aggregation\GeotileGridAggregation::class, ['name', 'field']);
         $this->_assertImplemented($aggregationDSL, 'global', Aggregation\GlobalAggregation::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'histogram', Aggregation\Histogram::class, ['name', 'field', 1]);
         $this->_assertImplemented($aggregationDSL, 'ipv4_range', Aggregation\IpRange::class, ['name', 'field']);

--- a/tests/QueryBuilder/DSL/AggregationTest.php
+++ b/tests/QueryBuilder/DSL/AggregationTest.php
@@ -41,6 +41,7 @@ class AggregationTest extends AbstractDSLTest
         $this->_assertImplemented($aggregationDSL, 'filters', Aggregation\Filters::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'geo_distance', Aggregation\GeoDistance::class, ['name', 'field', 'origin']);
         $this->_assertImplemented($aggregationDSL, 'geohash_grid', Aggregation\GeohashGrid::class, ['name', 'field']);
+        $this->_assertImplemented($aggregationDSL, 'geotile_grid', Aggregation\GeotileGrid::class, ['name', 'field']);
         $this->_assertImplemented($aggregationDSL, 'global', Aggregation\GlobalAggregation::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'histogram', Aggregation\Histogram::class, ['name', 'field', 1]);
         $this->_assertImplemented($aggregationDSL, 'ipv4_range', Aggregation\IpRange::class, ['name', 'field']);


### PR DESCRIPTION
In ElasticSearch 7 and above there is new aggregation type which is not supported here yet -> [GeoTile Grid](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geotilegrid-aggregation.html
)

I have added support of it. It is very similar to existing [GeoHash Grid]( https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html ) except it has more detailed precision levels.

I also renamed one test in other class which had incorrect name.