### PR TITLE
added distance precision to GeohashGrid.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Elastica\Aggregation\GeoDistance::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
 * Added `Elastica\Aggregation\Histogram::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
 * Added `Elastica\Aggregation\IpRange::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
-* Added `Elastica\Aggregation\GeohashGrid::setDistancePrecision()` [#1884](https://github.com/ruflin/Elastica/pull/1884)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)
@@ -62,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed type-hint for `Elastica\QueryBuilder\DSL\Aggregation::sampler()` not consistent with the underlying constructor call [#1815](https://github.com/ruflin/Elastica/pull/1815)
 * Replaced `_routing` and `_retry_on_conflict` by `routing` and `retry_on_conflict` in `AbstractUpdateAction` [#1807](https://github.com/ruflin/Elastica/issues/1807)
 * Fixed `Elastica\Util::toSnakeCase()` with first letter being lower cased [#1831](https://github.com/ruflin/Elastica/pull/1831)
+* Fixed handling precision as string in `Elastica\Aggregation\GeohashGrid::setPrecision()` [#1884](https://github.com/ruflin/Elastica/pull/1884)
 ### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Elastica\Aggregation\GeoDistance::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
 * Added `Elastica\Aggregation\Histogram::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
 * Added `Elastica\Aggregation\IpRange::setKeyed()` [#1876](https://github.com/ruflin/Elastica/pull/1876)
+* Added `Elastica\Aggregation\GeohashGrid::setDistancePrecision()` [#1884](https://github.com/ruflin/Elastica/pull/1884)
 ### Changed
 * Allow `string` such as `wait_for` to be passed to `AbstractUpdateAction::setRefresh` [#1791](https://github.com/ruflin/Elastica/pull/1791)
 * Changed the return type of `AbstractUpdateAction::getRefresh` to `boolean|string` [#1791](https://github.com/ruflin/Elastica/pull/1791)

--- a/src/Aggregation/GeohashGrid.php
+++ b/src/Aggregation/GeohashGrid.php
@@ -39,24 +39,16 @@ class GeohashGrid extends AbstractAggregation
     /**
      * Set the precision for this aggregation.
      *
-     * @param int $precision an integer between 1 and 12, inclusive. Defaults to 5.
+     * @param int|string $precision an integer between 1 and 12, inclusive. Defaults to 5 or distance like 1km, 10m
      *
      * @return $this
      */
-    public function setPrecision(int $precision): self
+    public function setPrecision($precision): self
     {
-        return $this->setParam('precision', $precision);
-    }
+        if (!\is_int($precision) && !\is_string($precision)) {
+            throw new \TypeError(\sprintf('Argument 1 passed to "%s()" must be a int or string, %s given.', __METHOD__, \is_object($precision) ? \get_class($precision) : \gettype($precision)));
+        }
 
-    /**
-     * Set the precision for this aggregation in meters or kilometers.
-     *
-     * @param string $precision a string like 100m or 1km
-     *
-     * @return $this
-     */
-    public function setDistancePrecision(string $precision): self
-    {
         return $this->setParam('precision', $precision);
     }
 

--- a/src/Aggregation/GeohashGrid.php
+++ b/src/Aggregation/GeohashGrid.php
@@ -46,7 +46,7 @@ class GeohashGrid extends AbstractAggregation
     public function setPrecision($precision): self
     {
         if (!\is_int($precision) && !\is_string($precision)) {
-            throw new \TypeError(\sprintf('Argument 1 passed to "%s()" must be a int or string, %s given.', __METHOD__, \is_object($precision) ? \get_class($precision) : \gettype($precision)));
+            throw new \TypeError(\sprintf('Argument 1 passed to "%s()" must be of type int|string, %s given.', __METHOD__, \is_object($precision) ? \get_class($precision) : \gettype($precision)));
         }
 
         return $this->setParam('precision', $precision);

--- a/src/Aggregation/GeohashGrid.php
+++ b/src/Aggregation/GeohashGrid.php
@@ -49,6 +49,18 @@ class GeohashGrid extends AbstractAggregation
     }
 
     /**
+     * Set the precision for this aggregation in meters or kilometers.
+     *
+     * @param string $precision a string like 100m or 1km
+     *
+     * @return $this
+     */
+    public function setDistancePrecision(string $precision): self
+    {
+        return $this->setParam('precision', $precision);
+    }
+
+    /**
      * Set the maximum number of buckets to return.
      *
      * @param int $size defaults to 10,000

--- a/tests/Aggregation/GeohashGridTest.php
+++ b/tests/Aggregation/GeohashGridTest.php
@@ -35,7 +35,7 @@ class GeohashGridTest extends BaseAggregationTest
     public function testGeohashGridAggregationWithDistancePrecision(): void
     {
         $agg = new GeohashGrid('hash', 'location');
-        $agg->setDistancePrecision('100km');
+        $agg->setPrecision('100km');
 
         $query = new Query();
         $query->addAggregation($agg);
@@ -43,6 +43,21 @@ class GeohashGridTest extends BaseAggregationTest
 
         $this->assertEquals(2, $results['buckets'][0]['doc_count']);
         $this->assertEquals(1, $results['buckets'][1]['doc_count']);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testGeohashGridAggregationWithNotAllowedPrecision(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        $agg = new GeohashGrid('hash', 'location');
+        $agg->setPrecision(1.5);
+
+        $query = new Query();
+        $query->addAggregation($agg);
+        $this->_createIndex()->search($query)->getAggregation('hash');
     }
 
     protected function _getIndexForTest(): Index

--- a/tests/Aggregation/GeohashGridTest.php
+++ b/tests/Aggregation/GeohashGridTest.php
@@ -46,7 +46,7 @@ class GeohashGridTest extends BaseAggregationTest
     }
 
     /**
-     * @group functional
+     * @group unit
      */
     public function testGeohashGridAggregationWithNotAllowedPrecision(): void
     {
@@ -54,10 +54,6 @@ class GeohashGridTest extends BaseAggregationTest
 
         $agg = new GeohashGrid('hash', 'location');
         $agg->setPrecision(1.5);
-
-        $query = new Query();
-        $query->addAggregation($agg);
-        $this->_createIndex()->search($query)->getAggregation('hash');
     }
 
     protected function _getIndexForTest(): Index

--- a/tests/Aggregation/GeohashGridTest.php
+++ b/tests/Aggregation/GeohashGridTest.php
@@ -16,10 +16,26 @@ class GeohashGridTest extends BaseAggregationTest
     /**
      * @group functional
      */
-    public function testGeohashGridAggregation(): void
+    public function testGeohashGridAggregationWithNumericalPrecision(): void
     {
         $agg = new GeohashGrid('hash', 'location');
         $agg->setPrecision(3);
+
+        $query = new Query();
+        $query->addAggregation($agg);
+        $results = $this->_getIndexForTest()->search($query)->getAggregation('hash');
+
+        $this->assertEquals(2, $results['buckets'][0]['doc_count']);
+        $this->assertEquals(1, $results['buckets'][1]['doc_count']);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testGeohashGridAggregationWithDistancePrecision(): void
+    {
+        $agg = new GeohashGrid('hash', 'location');
+        $agg->setDistancePrecision('100km');
 
         $query = new Query();
         $query->addAggregation($agg);


### PR DESCRIPTION
As described in https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohashgrid-aggregation.html#_options_3 there is possibility to pass precision as string.

It was also working in earlier versions of Elastica.

Got broken after adding `int` to parameter in `setPrecision`.

I think it is better to add second method for that.