### PR TITLE
Use dedicated namespace for aggregation traits

### DIFF
--- a/src/Aggregation/GeoDistance.php
+++ b/src/Aggregation/GeoDistance.php
@@ -11,7 +11,7 @@ use Elastica\Exception\InvalidException;
  */
 class GeoDistance extends AbstractAggregation
 {
-    use KeyedTrait;
+    use Traits\KeyedTrait;
 
     public const DISTANCE_TYPE_ARC = 'arc';
     public const DISTANCE_TYPE_PLANE = 'plane';

--- a/src/Aggregation/Histogram.php
+++ b/src/Aggregation/Histogram.php
@@ -9,7 +9,7 @@ namespace Elastica\Aggregation;
  */
 class Histogram extends AbstractSimpleAggregation
 {
-    use KeyedTrait;
+    use Traits\KeyedTrait;
 
     /**
      * @param string     $name     the name of this aggregation

--- a/src/Aggregation/IpRange.php
+++ b/src/Aggregation/IpRange.php
@@ -11,7 +11,7 @@ use Elastica\Exception\InvalidException;
  */
 class IpRange extends AbstractAggregation
 {
-    use KeyedTrait;
+    use Traits\KeyedTrait;
 
     /**
      * @param string $name  the name of this aggregation

--- a/src/Aggregation/Percentiles.php
+++ b/src/Aggregation/Percentiles.php
@@ -9,7 +9,7 @@ namespace Elastica\Aggregation;
  */
 class Percentiles extends AbstractSimpleAggregation
 {
-    use KeyedTrait;
+    use Traits\KeyedTrait;
 
     /**
      * @param string $name  the name of this aggregation

--- a/src/Aggregation/PercentilesBucket.php
+++ b/src/Aggregation/PercentilesBucket.php
@@ -11,7 +11,7 @@ use Elastica\Exception\InvalidException;
  */
 class PercentilesBucket extends AbstractAggregation
 {
-    use KeyedTrait;
+    use Traits\KeyedTrait;
 
     /**
      * @param string      $name        the name of this aggregation

--- a/src/Aggregation/Range.php
+++ b/src/Aggregation/Range.php
@@ -11,7 +11,7 @@ use Elastica\Exception\InvalidException;
  */
 class Range extends AbstractSimpleAggregation
 {
-    use KeyedTrait;
+    use Traits\KeyedTrait;
 
     /**
      * Add a range to this aggregation.

--- a/src/Aggregation/Traits/KeyedTrait.php
+++ b/src/Aggregation/Traits/KeyedTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Elastica\Aggregation;
+namespace Elastica\Aggregation\Traits;
 
 trait KeyedTrait
 {


### PR DESCRIPTION
This follow the recent addition of traits by @romainneutron for aggregations (first PR merged, second is awaiting a rebase).
As the usage of traits should increase in the future, let's use a dedicated namespace for them.