### PR TITLE
Adding new ElasticSearch 7.10 'case_insensitive' param to Wildcard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `Elastica\Aggregation\NormalizeAggregation` [#1956](https://github.com/ruflin/Elastica/pull/1956)
 * Added `Elastica\Suggest\Phrase::addDirectGenerator` to align with ES specification [#1964](https://github.com/ruflin/Elastica/pull/1964)
 * Added support for `psr/log` 2.0 and 3.0 [#1971](https://github.com/ruflin/Elastica/pull/1971)
+* Added new optional 'case_insensitive' option to `Elastica\Query\Wildcard` [#1894](https://github.com/ruflin/Elastica/pull/1894)
 ### Changed
 * Updated `php-cs-fixer` to `2.18.6` [#1955](https://github.com/ruflin/Elastica/pull/1955)
 * Updated `php-cs-fixer` to `3.0.0` [#1959](https://github.com/ruflin/Elastica/pull/1959)

--- a/src/Query/Wildcard.php
+++ b/src/Query/Wildcard.php
@@ -30,7 +30,7 @@ class Wildcard extends AbstractQuery
         $this->setParam($field, [
             'value' => $value,
             'boost' => $boost,
-            'case_insensitive' => $caseInsensitive
+            'case_insensitive' => $caseInsensitive,
         ]);
     }
 

--- a/src/Query/Wildcard.php
+++ b/src/Query/Wildcard.php
@@ -23,13 +23,14 @@ class Wildcard extends AbstractQuery
      */
     private $field;
 
-    public function __construct(string $field, string $value, float $boost = 1.0)
+    public function __construct(string $field, string $value, float $boost = 1.0, bool $caseInsensitive = true)
     {
         $this->field = $field;
 
         $this->setParam($field, [
             'value' => $value,
             'boost' => $boost,
+            'case_insensitive' => $caseInsensitive
         ]);
     }
 

--- a/src/Query/Wildcard.php
+++ b/src/Query/Wildcard.php
@@ -31,7 +31,7 @@ class Wildcard extends AbstractQuery
             'value' => $value,
             'boost' => $boost,
         ]);
-        if (null !== $caseInsensitive){
+        if (null !== $caseInsensitive) {
             $this->setCaseInsensitive($caseInsensitive);
         }
     }

--- a/src/Query/Wildcard.php
+++ b/src/Query/Wildcard.php
@@ -23,15 +23,17 @@ class Wildcard extends AbstractQuery
      */
     private $field;
 
-    public function __construct(string $field, string $value, float $boost = 1.0, bool $caseInsensitive = true)
+    public function __construct(string $field, string $value, float $boost = 1.0, ?bool $caseInsensitive = null)
     {
         $this->field = $field;
 
         $this->setParam($field, [
             'value' => $value,
             'boost' => $boost,
-            'case_insensitive' => $caseInsensitive,
         ]);
+        if (null !== $caseInsensitive){
+            $this->setCaseInsensitive($caseInsensitive);
+        }
     }
 
     public function getField(): string

--- a/src/Query/Wildcard.php
+++ b/src/Query/Wildcard.php
@@ -23,13 +23,14 @@ class Wildcard extends AbstractQuery
      */
     private $field;
 
-    public function __construct(string $field, string $value, float $boost = 1.0)
+    public function __construct(string $field, string $value, float $boost = 1.0, bool $caseInsensitive = false)
     {
         $this->field = $field;
 
         $this->setParam($field, [
             'value' => $value,
             'boost' => $boost,
+            'case_insensitive' => $caseInsensitive
         ]);
     }
 
@@ -64,6 +65,14 @@ class Wildcard extends AbstractQuery
     {
         $data = $this->getParam($this->field);
         $this->setParam($this->field, \array_merge($data, ['rewrite' => $rewriteMode]));
+
+        return $this;
+    }
+
+    public function setCaseInsensitive(bool $caseInsensitive): self
+    {
+        $data = $this->getParam($this->field);
+        $this->setParam($this->field, \array_merge($data, ['case_insensitive' => $caseInsensitive]));
 
         return $this;
     }

--- a/src/Query/Wildcard.php
+++ b/src/Query/Wildcard.php
@@ -23,14 +23,13 @@ class Wildcard extends AbstractQuery
      */
     private $field;
 
-    public function __construct(string $field, string $value, float $boost = 1.0, bool $caseInsensitive = false)
+    public function __construct(string $field, string $value, float $boost = 1.0)
     {
         $this->field = $field;
 
         $this->setParam($field, [
             'value' => $value,
             'boost' => $boost,
-            'case_insensitive' => $caseInsensitive,
         ]);
     }
 
@@ -69,6 +68,9 @@ class Wildcard extends AbstractQuery
         return $this;
     }
 
+    /**
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-wildcard-query.html#wildcard-query-field-params
+     */
     public function setCaseInsensitive(bool $caseInsensitive): self
     {
         $data = $this->getParam($this->field);

--- a/src/Query/Wildcard.php
+++ b/src/Query/Wildcard.php
@@ -23,7 +23,7 @@ class Wildcard extends AbstractQuery
      */
     private $field;
 
-    public function __construct(string $field, string $value, float $boost = 1.0, ?bool $caseInsensitive = null)
+    public function __construct(string $field, string $value, float $boost = 1.0)
     {
         $this->field = $field;
 
@@ -31,9 +31,6 @@ class Wildcard extends AbstractQuery
             'value' => $value,
             'boost' => $boost,
         ]);
-        if (null !== $caseInsensitive) {
-            $this->setCaseInsensitive($caseInsensitive);
-        }
     }
 
     public function getField(): string

--- a/src/QueryBuilder/DSL/Query.php
+++ b/src/QueryBuilder/DSL/Query.php
@@ -476,7 +476,7 @@ class Query implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
      */
-    public function wildcard(string $field, string $value, float $boost = 1.0, bool $caseInsensitive = true): Wildcard
+    public function wildcard(string $field, string $value, float $boost = 1.0, ?bool $caseInsensitive = null): Wildcard
     {
         return new Wildcard($field, $value, $boost, $caseInsensitive);
     }

--- a/src/QueryBuilder/DSL/Query.php
+++ b/src/QueryBuilder/DSL/Query.php
@@ -476,9 +476,9 @@ class Query implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
      */
-    public function wildcard(string $field, string $value, float $boost = 1.0): Wildcard
+    public function wildcard(string $field, string $value, float $boost = 1.0, bool $caseInsensitive = true): Wildcard
     {
-        return new Wildcard($field, $value, $boost);
+        return new Wildcard($field, $value, $boost, $caseInsensitive);
     }
 
     /**

--- a/src/QueryBuilder/DSL/Query.php
+++ b/src/QueryBuilder/DSL/Query.php
@@ -476,9 +476,9 @@ class Query implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
      */
-    public function wildcard(string $field, string $value, float $boost = 1.0, ?bool $caseInsensitive = null): Wildcard
+    public function wildcard(string $field, string $value, float $boost = 1.0): Wildcard
     {
-        return new Wildcard($field, $value, $boost, $caseInsensitive);
+        return new Wildcard($field, $value, $boost);
     }
 
     /**

--- a/src/QueryBuilder/DSL/Query.php
+++ b/src/QueryBuilder/DSL/Query.php
@@ -476,9 +476,9 @@ class Query implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
      */
-    public function wildcard(string $field, string $value, float $boost = 1.0, bool $caseInsensitive = false): Wildcard
+    public function wildcard(string $field, string $value, float $boost = 1.0): Wildcard
     {
-        return new Wildcard($field, $value, $boost, $caseInsensitive);
+        return new Wildcard($field, $value, $boost);
     }
 
     /**

--- a/src/QueryBuilder/DSL/Query.php
+++ b/src/QueryBuilder/DSL/Query.php
@@ -476,9 +476,9 @@ class Query implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
      */
-    public function wildcard(string $field, string $value, float $boost = 1.0): Wildcard
+    public function wildcard(string $field, string $value, float $boost = 1.0, bool $caseInsensitive = false): Wildcard
     {
-        return new Wildcard($field, $value, $boost);
+        return new Wildcard($field, $value, $boost, $caseInsensitive);
     }
 
     /**

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -40,7 +40,6 @@ class WildcardTest extends BaseTest
                     'value' => 'value*',
                     'boost' => 2.0,
                     'rewrite' => 'scoring_boolean',
-                    'case_insensitive' => false,
                 ],
             ],
         ];

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -129,9 +129,6 @@ class WildcardTest extends BaseTest
         $query = new Wildcard('name', 'exampl*', 1.0);
         $query->setCaseInsensitive($expected);
         $this->assertEquals($expectedArray, $query->toArray());
-
-        $query = new Wildcard('name', 'exampl*', 1.0, $expected);
-        $this->assertEquals($expectedArray, $query->toArray());
     }
 
     public function caseInsensitiveDataProvider(): iterable

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -112,6 +112,9 @@ class WildcardTest extends BaseTest
      */
     public function testCaseInsensitive(): void
     {
+        // feature doesn't exist on version prior 7.10;
+        $this->_checkVersion('7.10');
+
         foreach ([true, false] as $expected) {
             $expectedArray = [
                 'wildcard' => [

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -40,7 +40,7 @@ class WildcardTest extends BaseTest
                     'value' => 'value*',
                     'boost' => 2.0,
                     'rewrite' => 'scoring_boolean',
-                    'case_insensitive' => false
+                    'case_insensitive' => false,
                 ],
             ],
         ];
@@ -120,7 +120,7 @@ class WildcardTest extends BaseTest
                         'value' => 'exampl*',
                         'boost' => 1.0,
                         'rewrite' => 'scoring_boolean',
-                        'case_insensitive' => $expected
+                        'case_insensitive' => $expected,
                     ],
                 ],
             ];

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -40,6 +40,7 @@ class WildcardTest extends BaseTest
                     'value' => 'value*',
                     'boost' => 2.0,
                     'rewrite' => 'scoring_boolean',
+                    'case_insensitive' => true,
                 ],
             ],
         ];
@@ -127,9 +128,10 @@ class WildcardTest extends BaseTest
         ];
 
         $query = new Wildcard('name', 'exampl*', 1.0);
+        $query->setCaseInsensitive($expected);
         $this->assertEquals($expectedArray, $query->toArray());
 
-        $query->setCaseInsensitive($expected);
+        $query = new Wildcard('name', 'exampl*', 1.0, $expected);
         $this->assertEquals($expectedArray, $query->toArray());
     }
 

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -40,7 +40,6 @@ class WildcardTest extends BaseTest
                     'value' => 'value*',
                     'boost' => 2.0,
                     'rewrite' => 'scoring_boolean',
-                    'case_insensitive' => true,
                 ],
             ],
         ];

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -40,6 +40,7 @@ class WildcardTest extends BaseTest
                     'value' => 'value*',
                     'boost' => 2.0,
                     'rewrite' => 'scoring_boolean',
+                    'case_insensitive' => false
                 ],
             ],
         ];
@@ -105,5 +106,30 @@ class WildcardTest extends BaseTest
         $resultSet = $index->search($query);
 
         $this->assertEquals(0, $resultSet->count());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testCaseInsensitive(): void
+    {
+        foreach ([true, false] as $expected) {
+            $expectedArray = [
+                'wildcard' => [
+                    'name' => [
+                        'value' => 'exampl*',
+                        'boost' => 1.0,
+                        'rewrite' => 'scoring_boolean',
+                        'case_insensitive' => $expected
+                    ],
+                ],
+            ];
+
+            $query = new Wildcard('name', 'exampl*', 1.0, true);
+            $this->assertEquals($expectedArray, $query->toArray());
+
+            $query->setCaseInsensitive($expected);
+            $this->assertEquals($expectedArray, $query->toArray());
+        }
     }
 }

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -109,28 +109,33 @@ class WildcardTest extends BaseTest
 
     /**
      * @group functional
+     * @dataProvider caseInsensitiveDataProvider
      */
-    public function testCaseInsensitive(): void
+    public function testCaseInsensitive(bool $expected): void
     {
         // feature doesn't exist on version prior 7.10;
         $this->_checkVersion('7.10');
 
-        foreach ([true, false] as $expected) {
-            $expectedArray = [
-                'wildcard' => [
-                    'name' => [
-                        'value' => 'exampl*',
-                        'boost' => 1.0,
-                        'case_insensitive' => $expected,
-                    ],
+        $expectedArray = [
+            'wildcard' => [
+                'name' => [
+                    'value' => 'exampl*',
+                    'boost' => 1.0,
+                    'case_insensitive' => $expected,
                 ],
-            ];
+            ],
+        ];
 
-            $query = new Wildcard('name', 'exampl*', 1.0);
-            $this->assertEquals($expectedArray, $query->toArray());
+        $query = new Wildcard('name', 'exampl*', 1.0);
+        $this->assertEquals($expectedArray, $query->toArray());
 
-            $query->setCaseInsensitive($expected);
-            $this->assertEquals($expectedArray, $query->toArray());
-        }
+        $query->setCaseInsensitive($expected);
+        $this->assertEquals($expectedArray, $query->toArray());
+    }
+
+    public function caseInsensitiveDataProvider(): iterable
+    {
+        yield [true];
+        yield [false];
     }
 }

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -124,7 +124,7 @@ class WildcardTest extends BaseTest
                 ],
             ];
 
-            $query = new Wildcard('name', 'exampl*', 1.0, true);
+            $query = new Wildcard('name', 'exampl*', 1.0);
             $this->assertEquals($expectedArray, $query->toArray());
 
             $query->setCaseInsensitive($expected);

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -119,7 +119,6 @@ class WildcardTest extends BaseTest
                     'name' => [
                         'value' => 'exampl*',
                         'boost' => 1.0,
-                        'rewrite' => 'scoring_boolean',
                         'case_insensitive' => $expected,
                     ],
                 ],


### PR DESCRIPTION
Elasticsearch 7.x introduced a new parameter in Wildcard query which was missing in the Elastica object, the purpose of this pull request is to add it.