### PR TITLE
Backport installation of GitHub Actions to 6.x

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,92 @@
+name: 'Continuous integration'
+on: ['push', 'pull_request']
+jobs:
+  cs:
+    runs-on: 'ubuntu-20.04'
+    name: 'Coding style'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '7.2'
+          coverage: 'none'
+          extensions: 'json, mbstring, tokenizer'
+          tools: 'composer-normalize:2.13.2, php-cs-fixer:2.18.2'
+
+      - name: 'Check PHP code'
+        run: |
+          php-cs-fixer fix --diff --dry-run --allow-risky=yes --using-cache=false
+
+      - name: 'Check composer.json'
+        run: |
+          composer-normalize --diff --dry-run --indent-size=4 --indent-style=space --no-update-lock
+
+  phpunit:
+    runs-on: 'ubuntu-20.04'
+    name: 'PHPUnit (PHP ${{ matrix.php }}, ES ${{ matrix.elasticsearch }})'
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        include:
+          - php: '7.2'
+            elasticsearch: '7.1.1'
+          - php: '7.2'
+            elasticsearch: '7.2.1'
+          - php: '7.3'
+            elasticsearch: '7.3.2'
+          - php: '7.4'
+            elasticsearch: '7.3.2'
+        # No support for 8.0 on 6.x branch
+        #  - php: '8.0'
+        #    elasticsearch: '7.3.2'
+      fail-fast: false
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '${{ matrix.php }}'
+          coverage: 'none'
+          tools: 'pecl, composer:v2'
+          extensions: 'curl, json, mbstring, openssl'
+
+      - name: 'Get composer cache directory'
+        id: 'composer_cache'
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: 'Cache dependencies'
+        uses: 'actions/cache@v2'
+        with:
+          path: '${{ steps.composer_cache.outputs.dir }}'
+          key: '${{ runner.os }}-composer-php${{ matrix.php }}-${{ hashFiles(''**/composer.json'') }}'
+          restore-keys: |
+            ${{ runner.os }}-composer-php${{ matrix.php }}-
+            ${{ runner.os }}-composer-
+
+      - name: 'Update dependencies'
+        run: |
+          composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_flags }}
+
+      - name: 'Run unit tests'
+        run: |
+          vendor/bin/phpunit --group unit
+
+      - name: 'Setup Elasticsearch'
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+          ES_VERSION=${{ matrix.elasticsearch }} docker-compose --file=docker/docker-compose.proxy.yml --file=docker/docker-compose.es.yml up --detach
+          docker run --rm --network=docker_elastic curlimages/curl --max-time 120 --retry-max-time 120 --retry 120 --retry-delay 5 --retry-all-errors --show-error --silent http://es01:9200
+          docker run --rm --network=docker_elastic curlimages/curl --max-time 120 --retry-max-time 120 --retry 120 --retry-delay 5 --retry-all-errors --show-error --silent http://es02:9200
+
+      - name: 'Run functional tests'
+        run: |
+          vendor/bin/phpunit --group functional


### PR DESCRIPTION
This is a copy of the CI file for master as of ec22ea0, with a change to drop PHP 8.0 testing (as that's not supported on the 6.x branch).

Fixes #1903.