### PR TITLE
Allow PHP 8 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.0|^8.0",
         "psr/log": "~1.0",
         "elasticsearch/elasticsearch": "^6.0"
     },


### PR DESCRIPTION
Simple change to allow PHP 8 on Elastica 6.x