### PR TITLE
Import class instead of using fully qualified class name

### DIFF
--- a/tests/Aggregation/AvgBucketTest.php
+++ b/tests/Aggregation/AvgBucketTest.php
@@ -6,6 +6,7 @@ use Elastica\Aggregation\Avg;
 use Elastica\Aggregation\AvgBucket;
 use Elastica\Aggregation\Terms;
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
 
@@ -71,7 +72,7 @@ class AvgBucketTest extends BaseAggregationTest
      */
     public function testToArrayInvalidBucketsPath(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $serialDiffAgg = new AvgBucket('avg_bucket');
         $serialDiffAgg->toArray();

--- a/tests/Aggregation/FiltersTest.php
+++ b/tests/Aggregation/FiltersTest.php
@@ -5,6 +5,7 @@ namespace Elastica\Test\Aggregation;
 use Elastica\Aggregation\Avg;
 use Elastica\Aggregation\Filters;
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
 use Elastica\Query\Term;
@@ -60,7 +61,7 @@ class FiltersTest extends BaseAggregationTest
      */
     public function testMixNamedAndAnonymousFilters(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
         $this->expectExceptionMessage('Mix named and anonymous keys are not allowed');
 
         $agg = new Filters('by_color');
@@ -73,7 +74,7 @@ class FiltersTest extends BaseAggregationTest
      */
     public function testMixAnonymousAndNamedFilters(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
         $this->expectExceptionMessage('Mix named and anonymous keys are not allowed');
 
         $agg = new Filters('by_color');

--- a/tests/Aggregation/PercentilesBucketTest.php
+++ b/tests/Aggregation/PercentilesBucketTest.php
@@ -6,6 +6,7 @@ use Elastica\Aggregation\Avg;
 use Elastica\Aggregation\PercentilesBucket;
 use Elastica\Aggregation\Terms;
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
 
@@ -80,7 +81,7 @@ class PercentilesBucketTest extends BaseAggregationTest
      */
     public function testToArrayInvalidBucketsPath(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $serialDiffAgg = new PercentilesBucket('avg_bucket');
         $serialDiffAgg->toArray();

--- a/tests/Aggregation/SerialDiffTest.php
+++ b/tests/Aggregation/SerialDiffTest.php
@@ -6,6 +6,7 @@ use Elastica\Aggregation\DateHistogram;
 use Elastica\Aggregation\Max;
 use Elastica\Aggregation\SerialDiff;
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Mapping;
 use Elastica\Query;
@@ -68,7 +69,7 @@ class SerialDiffTest extends BaseAggregationTest
      */
     public function testToArrayInvalidBucketsPath(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $serialDiffAgg = new SerialDiff('difference');
         $serialDiffAgg->toArray();

--- a/tests/Aggregation/StatsBucketTest.php
+++ b/tests/Aggregation/StatsBucketTest.php
@@ -6,6 +6,7 @@ use Elastica\Aggregation\Histogram;
 use Elastica\Aggregation\Max;
 use Elastica\Aggregation\StatsBucket;
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
 
@@ -68,7 +69,7 @@ class StatsBucketTest extends BaseAggregationTest
      */
     public function testToArrayInvalidBucketsPath(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $serialDiffAgg = new StatsBucket('bucket_part');
         $serialDiffAgg->toArray();

--- a/tests/Aggregation/SumBucketTest.php
+++ b/tests/Aggregation/SumBucketTest.php
@@ -6,6 +6,7 @@ use Elastica\Aggregation\Sum;
 use Elastica\Aggregation\SumBucket;
 use Elastica\Aggregation\Terms;
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
 
@@ -71,7 +72,7 @@ class SumBucketTest extends BaseAggregationTest
      */
     public function testToArrayInvalidBucketsPath(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $serialDiffAgg = new SumBucket('sum_bucket');
         $serialDiffAgg->toArray();

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -12,6 +12,7 @@ use Elastica\Bulk\Response;
 use Elastica\Bulk\ResponseSet;
 use Elastica\Document;
 use Elastica\Exception\Bulk\ResponseException;
+use Elastica\Exception\InvalidException;
 use Elastica\Exception\NotFoundException;
 use Elastica\Script\Script;
 use Elastica\Test\Base as BaseTest;
@@ -282,7 +283,7 @@ class BulkTest extends BaseTest
      */
     public function testInvalidRawData($rawData, $failMessage): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $bulk = new Bulk($this->_getClient());
 

--- a/tests/ClientConfigurationTest.php
+++ b/tests/ClientConfigurationTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test;
 
 use Elastica\ClientConfiguration;
+use Elastica\Exception\InvalidException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,7 @@ class ClientConfigurationTest extends TestCase
 {
     public function testInvalidDsn(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
         $this->expectExceptionMessage('DSN "test foo" is invalid.');
 
         ClientConfiguration::fromDsn('test foo');
@@ -22,7 +23,7 @@ class ClientConfigurationTest extends TestCase
 
     public function testInvalidDsnPortOnly(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
         $this->expectExceptionMessage('DSN ":0" is invalid.');
 
         ClientConfiguration::fromDsn(':0');
@@ -192,7 +193,7 @@ class ClientConfigurationTest extends TestCase
 
         $this->assertEquals($expected, $configuration->get(''));
 
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
         $configuration->get('invalidKey');
     }
 

--- a/tests/Collapse/CollapseTest.php
+++ b/tests/Collapse/CollapseTest.php
@@ -5,8 +5,10 @@ namespace Elastica\Test\Collapse;
 use Elastica\Collapse;
 use Elastica\Collapse\InnerHits;
 use Elastica\Document;
+use Elastica\Index;
 use Elastica\Mapping;
 use Elastica\Query;
+use Elastica\ResultSet;
 use Elastica\Test\Base as BaseTest;
 
 /**
@@ -277,7 +279,7 @@ class CollapseTest extends BaseTest
         $this->assertEquals('Keith', $results->getResults()[0]->getInnerHits()['by_zip']['hits']['hits'][1]['fields']['user'][0]);
     }
 
-    private function _getIndexForCollapseTest()
+    private function _getIndexForCollapseTest(): Index
     {
         $index = $this->_createIndex();
         $index->setMapping(new Mapping([
@@ -338,10 +340,7 @@ class CollapseTest extends BaseTest
         return $index;
     }
 
-    /**
-     * @return \Elastica\ResultSet
-     */
-    private function search(Query $query)
+    private function search(Query $query): ResultSet
     {
         return $this->_getIndexForCollapseTest()->search($query);
     }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -4,6 +4,8 @@ namespace Elastica\Test;
 
 use Elastica\Client;
 use Elastica\Connection;
+use Elastica\Exception\ConnectionException;
+use Elastica\Exception\InvalidException;
 use Elastica\Request;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Transport\AbstractTransport;
@@ -48,7 +50,7 @@ class ConnectionTest extends BaseTest
      */
     public function testInvalidConnection(): void
     {
-        $this->expectException(\Elastica\Exception\ConnectionException::class);
+        $this->expectException(ConnectionException::class);
 
         $connection = new Connection(['port' => 9999]);
 
@@ -81,7 +83,7 @@ class ConnectionTest extends BaseTest
      */
     public function testCreateInvalid(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         Connection::create('test');
     }
@@ -111,7 +113,7 @@ class ConnectionTest extends BaseTest
      */
     public function testGetInvalidConfigWithArrayUsedForTransport(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
         $this->expectExceptionMessage('Invalid transport');
 
         $connection = new Connection(['transport' => ['type' => 'invalidtransport']]);
@@ -123,7 +125,7 @@ class ConnectionTest extends BaseTest
      */
     public function testGetConfigInvalidValue(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $connection = new Connection();
         $connection->getConfig('url');

--- a/tests/IndexTemplateTest.php
+++ b/tests/IndexTemplateTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test;
 
 use Elastica\Client;
+use Elastica\Exception\InvalidException;
 use Elastica\Exception\ResponseException;
 use Elastica\IndexTemplate;
 use Elastica\Request;
@@ -36,7 +37,7 @@ class IndexTemplateTest extends BaseTest
      */
     public function testIncorrectInstantiate(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $client = $this->_getClient();
         new IndexTemplate($client, null);

--- a/tests/JSONTest.php
+++ b/tests/JSONTest.php
@@ -2,6 +2,7 @@
 
 namespace Elastica\Test;
 
+use Elastica\Exception\JSONParseException;
 use Elastica\JSON;
 use PHPUnit\Framework\TestCase;
 
@@ -22,7 +23,7 @@ class JSONTest extends TestCase
 
     public function testStringifyMustThrowExceptionNanOrInf(): void
     {
-        $this->expectException(\Elastica\Exception\JSONParseException::class);
+        $this->expectException(JSONParseException::class);
         $this->expectExceptionMessage('Inf and NaN cannot be JSON encoded');
 
         $arr = [\NAN, \INF];
@@ -32,7 +33,7 @@ class JSONTest extends TestCase
 
     public function testStringifyMustThrowExceptionMaximumDepth(): void
     {
-        $this->expectException(\Elastica\Exception\JSONParseException::class);
+        $this->expectException(JSONParseException::class);
         $this->expectExceptionMessage('Maximum stack depth exceeded');
 
         $arr = [[[]]];

--- a/tests/ParamTest.php
+++ b/tests/ParamTest.php
@@ -2,6 +2,7 @@
 
 namespace Elastica\Test;
 
+use Elastica\Exception\InvalidException;
 use Elastica\Param;
 use Elastica\Test\Base as BaseTest;
 
@@ -89,7 +90,7 @@ class ParamTest extends BaseTest
      */
     public function testGetParamInvalid(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $param = new Param();
 

--- a/tests/Query/GeoBoundingBoxTest.php
+++ b/tests/Query/GeoBoundingBoxTest.php
@@ -2,6 +2,7 @@
 
 namespace Elastica\Test\Query;
 
+use Elastica\Exception\InvalidException;
 use Elastica\Query\GeoBoundingBox;
 use Elastica\Test\Base as BaseTest;
 
@@ -32,7 +33,7 @@ class GeoBoundingBoxTest extends BaseTest
      */
     public function testAddCoordinatesInvalidException(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $query = new GeoBoundingBox('foo', []);
     }

--- a/tests/Query/SpanNearTest.php
+++ b/tests/Query/SpanNearTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Query\SpanNear;
 use Elastica\Query\SpanTerm;
 use Elastica\Query\Term;
@@ -18,7 +19,7 @@ class SpanNearTest extends BaseTest
      */
     public function testConstructWrongTypeInvalid(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $term1 = new Term(['name' => 'marek']);
         $term2 = new Term(['name' => 'nicolas']);

--- a/tests/Query/SpanOrTest.php
+++ b/tests/Query/SpanOrTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test\Query;
 
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Query\SpanOr;
 use Elastica\Query\SpanTerm;
 use Elastica\Query\Term;
@@ -18,7 +19,7 @@ class SpanOrTest extends BaseTest
      */
     public function testConstructWrongTypeInvalid(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $term1 = new Term(['name' => 'marek']);
         $term2 = new Term(['name' => 'nicolas']);

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test;
 
 use Elastica\Connection;
+use Elastica\Exception\InvalidException;
 use Elastica\Request;
 use Elastica\Response;
 use Elastica\Test\Base as BaseTest;
@@ -35,7 +36,7 @@ class RequestTest extends BaseTest
      */
     public function testInvalidConnection(): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         $request = new Request('', Request::GET);
         $request->send();

--- a/tests/Script/ScriptIdTest.php
+++ b/tests/Script/ScriptIdTest.php
@@ -2,6 +2,7 @@
 
 namespace Elastica\Test\Script;
 
+use Elastica\Exception\InvalidException;
 use Elastica\Script\ScriptId;
 use Elastica\Test\Base as BaseTest;
 
@@ -120,7 +121,7 @@ class ScriptIdTest extends BaseTest
      */
     public function testCreateInvalid($data): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         ScriptId::create($data);
     }

--- a/tests/Script/ScriptTest.php
+++ b/tests/Script/ScriptTest.php
@@ -2,6 +2,7 @@
 
 namespace Elastica\Test\Script;
 
+use Elastica\Exception\InvalidException;
 use Elastica\Script\Script;
 use Elastica\Test\Base as BaseTest;
 
@@ -120,7 +121,7 @@ class ScriptTest extends BaseTest
      */
     public function testCreateInvalid($data): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
 
         Script::create($data);
     }

--- a/tests/TaskTest.php
+++ b/tests/TaskTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test;
 
 use Elastica\Document;
+use Elastica\Index;
 use Elastica\Task;
 
 /**
@@ -105,7 +106,7 @@ class TaskTest extends Base
         return new Task($this->_getClient(), $id);
     }
 
-    protected function _createIndexWithDocument(): \Elastica\Index
+    protected function _createIndexWithDocument(): Index
     {
         $index = $this->_createIndex();
         $index->addDocument(new Document(1, ['name' => 'ruflin nicolas']));

--- a/tests/Transport/AbstractTransportTest.php
+++ b/tests/Transport/AbstractTransportTest.php
@@ -4,6 +4,7 @@ namespace Elastica\Test\Transport;
 
 use Elastica\Connection;
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Exception\ResponseException;
 use Elastica\Search;
 use Elastica\Test\Base as BaseTest;
@@ -81,7 +82,7 @@ class AbstractTransportTest extends BaseTest
      */
     public function testThrowsExecptionOnInvalidTransportDefinition($transport): void
     {
-        $this->expectException(\Elastica\Exception\InvalidException::class);
+        $this->expectException(InvalidException::class);
         $this->expectExceptionMessage('Invalid transport');
 
         AbstractTransport::create($transport, new Connection());

--- a/tests/Transport/GuzzleTest.php
+++ b/tests/Transport/GuzzleTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test\Transport;
 
 use Elastica\Document;
+use Elastica\Exception\Connection\GuzzleException;
 use Elastica\Query;
 use Elastica\ResultSet\DefaultBuilder;
 use Elastica\Test\Base as BaseTest;
@@ -133,7 +134,7 @@ class GuzzleTest extends BaseTest
      */
     public function testInvalidConnection(): void
     {
-        $this->expectException(\Elastica\Exception\Connection\GuzzleException::class);
+        $this->expectException(GuzzleException::class);
 
         $client = $this->_getClient(['transport' => 'Guzzle', 'port' => 4500, 'persistent' => false]);
         $response = $client->request('_stats', 'GET');


### PR DESCRIPTION
Let's keep on fixing the PHPStorm inspections results.