### PR TITLE
Remove useless PHPUnit assertions

### DIFF
--- a/tests/Aggregation/DateHistogramTest.php
+++ b/tests/Aggregation/DateHistogramTest.php
@@ -92,9 +92,9 @@ class DateHistogramTest extends BaseAggregationTest
      */
     public function testSetOffset(): void
     {
-        $agg = new DateHistogram('hist', 'created', '1h');
-
-        $agg->setOffset('3m');
+        $agg = (new DateHistogram('hist', 'created', '1h'))
+            ->setOffset('3m')
+        ;
 
         $expected = [
             'date_histogram' => [
@@ -104,9 +104,7 @@ class DateHistogramTest extends BaseAggregationTest
             ],
         ];
 
-        $this->assertEquals($expected, $agg->toArray());
-
-        $this->assertInstanceOf(DateHistogram::class, $agg->setOffset('3m'));
+        $this->assertSame($expected, $agg->toArray());
     }
 
     /**
@@ -131,9 +129,9 @@ class DateHistogramTest extends BaseAggregationTest
      */
     public function testSetTimezone(): void
     {
-        $agg = new DateHistogram('hist', 'created', '1h');
-
-        $agg->setTimezone('-02:30');
+        $agg = (new DateHistogram('hist', 'created', '1h'))
+            ->setTimezone('-02:30')
+        ;
 
         $expected = [
             'date_histogram' => [
@@ -143,9 +141,7 @@ class DateHistogramTest extends BaseAggregationTest
             ],
         ];
 
-        $this->assertEquals($expected, $agg->toArray());
-
-        $this->assertInstanceOf(DateHistogram::class, $agg->setTimezone('-02:30'));
+        $this->assertSame($expected, $agg->toArray());
     }
 
     protected function _getIndexForTest(): Index

--- a/tests/Aggregation/PercentilesTest.php
+++ b/tests/Aggregation/PercentilesTest.php
@@ -16,11 +16,11 @@ class PercentilesTest extends BaseAggregationTest
      */
     public function testConstruct(): void
     {
-        $aggr = new Percentiles('price_percentile');
-        $this->assertEquals('price_percentile', $aggr->getName());
+        $agg = new Percentiles('price_percentile');
+        $this->assertSame('price_percentile', $agg->getName());
 
-        $aggr = new Percentiles('price_percentile', 'price');
-        $this->assertEquals('price', $aggr->getParam('field'));
+        $agg = new Percentiles('price_percentile', 'price');
+        $this->assertSame('price', $agg->getParam('field'));
     }
 
     /**
@@ -28,11 +28,11 @@ class PercentilesTest extends BaseAggregationTest
      */
     public function testSetField(): void
     {
-        $aggr = new Percentiles('price_percentile');
-        $aggr->setField('price');
+        $agg = (new Percentiles('price_percentile'))
+            ->setField('price')
+        ;
 
-        $this->assertEquals('price', $aggr->getParam('field'));
-        $this->assertInstanceOf(Percentiles::class, $aggr->setField('price'));
+        $this->assertSame('price', $agg->getParam('field'));
     }
 
     /**
@@ -49,12 +49,13 @@ class PercentilesTest extends BaseAggregationTest
                 ],
             ],
         ];
-        $aggr = new Percentiles('price_percentile');
-        $aggr->setField('price');
-        $aggr->setKeyed(false);
-        $aggr->setCompression(100);
 
-        $this->assertEquals($expected, $aggr->toArray());
+        $agg = (new Percentiles('price_percentile', 'price'))
+            ->setKeyed(false)
+            ->setCompression(100)
+        ;
+
+        $this->assertEquals($expected, $agg->toArray());
     }
 
     /**
@@ -71,12 +72,13 @@ class PercentilesTest extends BaseAggregationTest
                 ],
             ],
         ];
-        $aggr = new Percentiles('price_percentile');
-        $aggr->setField('price');
-        $aggr->setKeyed(false);
-        $aggr->setHdr('number_of_significant_value_digits', 2);
 
-        $this->assertEquals($expected, $aggr->toArray());
+        $agg = (new Percentiles('price_percentile', 'price'))
+            ->setKeyed(false)
+            ->setHdr('number_of_significant_value_digits', 2)
+        ;
+
+        $this->assertEquals($expected, $agg->toArray());
     }
 
     /**
@@ -85,10 +87,11 @@ class PercentilesTest extends BaseAggregationTest
     public function testSetPercents(): void
     {
         $percents = [1, 2, 3];
-        $aggr = new Percentiles('price_percentile');
-        $aggr->setPercents($percents);
-        $this->assertEquals($percents, $aggr->getParam('percents'));
-        $this->assertInstanceOf(Percentiles::class, $aggr->setPercents($percents));
+        $agg = (new Percentiles('price_percentile'))
+            ->setPercents($percents)
+        ;
+
+        $this->assertSame($percents, $agg->getParam('percents'));
     }
 
     /**
@@ -97,13 +100,14 @@ class PercentilesTest extends BaseAggregationTest
     public function testAddPercent(): void
     {
         $percents = [1, 2, 3];
-        $aggr = new Percentiles('price_percentile');
-        $aggr->setPercents($percents);
-        $this->assertEquals($percents, $aggr->getParam('percents'));
-        $aggr->addPercent(4);
-        $percents[] = 4;
-        $this->assertEquals($percents, $aggr->getParam('percents'));
-        $this->assertInstanceOf(Percentiles::class, $aggr->addPercent(4));
+        $agg = (new Percentiles('price_percentile'))
+            ->setPercents($percents)
+        ;
+
+        $this->assertEquals($percents, $agg->getParam('percents'));
+
+        $agg->addPercent($percents[] = 4);
+        $this->assertEquals($percents, $agg->getParam('percents'));
     }
 
     /**
@@ -112,10 +116,11 @@ class PercentilesTest extends BaseAggregationTest
     public function testSetScript(): void
     {
         $script = 'doc["load_time"].value / 20';
-        $aggr = new Percentiles('price_percentile');
-        $aggr->setScript($script);
-        $this->assertEquals($script, $aggr->getParam('script'));
-        $this->assertInstanceOf(Percentiles::class, $aggr->setScript($script));
+        $agg = (new Percentiles('price_percentile'))
+            ->setScript($script)
+        ;
+
+        $this->assertEquals($script, $agg->getParam('script'));
     }
 
     /**
@@ -140,22 +145,19 @@ class PercentilesTest extends BaseAggregationTest
         $index->refresh();
 
         // execute
-        $aggr = new Percentiles('price_percentile');
-        $aggr->setField('price');
-
         $query = new Query();
-        $query->addAggregation($aggr);
+        $query->addAggregation(new Percentiles('price_percentile', 'price'));
 
         $resultSet = $index->search($query);
-        $aggrResult = $resultSet->getAggregation('price_percentile');
+        $aggResult = $resultSet->getAggregation('price_percentile');
 
-        $this->assertEquals(100.0, $aggrResult['values']['1.0']);
-        $this->assertEquals(100.0, $aggrResult['values']['5.0']);
-        $this->assertEquals(300.0, $aggrResult['values']['25.0']);
-        $this->assertEquals(550.0, $aggrResult['values']['50.0']);
-        $this->assertEquals(800.0, $aggrResult['values']['75.0']);
-        $this->assertEquals(1000.0, $aggrResult['values']['95.0']);
-        $this->assertEquals(1000.0, $aggrResult['values']['99.0']);
+        $this->assertEquals(100.0, $aggResult['values']['1.0']);
+        $this->assertEquals(100.0, $aggResult['values']['5.0']);
+        $this->assertEquals(300.0, $aggResult['values']['25.0']);
+        $this->assertEquals(550.0, $aggResult['values']['50.0']);
+        $this->assertEquals(800.0, $aggResult['values']['75.0']);
+        $this->assertEquals(1000.0, $aggResult['values']['95.0']);
+        $this->assertEquals(1000.0, $aggResult['values']['99.0']);
     }
 
     /**
@@ -213,17 +215,17 @@ class PercentilesTest extends BaseAggregationTest
         $index->refresh();
 
         // execute
-        $aggr = new Percentiles('price_percentile');
-        $aggr->setField('price');
-        $aggr->setKeyed(false);
+        $agg = (new Percentiles('price_percentile', 'price'))
+            ->setKeyed(false)
+        ;
 
         $query = new Query();
-        $query->addAggregation($aggr);
+        $query->addAggregation($agg);
 
         $resultSet = $index->search($query);
-        $aggrResult = $resultSet->getAggregation('price_percentile');
+        $aggResult = $resultSet->getAggregation('price_percentile');
 
-        $this->assertEquals($expected, $aggrResult);
+        $this->assertEquals($expected, $aggResult);
     }
 
     /**
@@ -241,12 +243,13 @@ class PercentilesTest extends BaseAggregationTest
                 'missing' => 10,
             ],
         ];
-        $aggr = new Percentiles('price_percentile');
-        $aggr->setField('price');
-        $aggr->setKeyed(false);
-        $aggr->setHdr('number_of_significant_value_digits', 2);
-        $aggr->setMissing(10);
 
-        $this->assertEquals($expected, $aggr->toArray());
+        $agg = (new Percentiles('price_percentile', 'price'))
+            ->setKeyed(false)
+            ->setHdr('number_of_significant_value_digits', 2)
+            ->setMissing(10)
+        ;
+
+        $this->assertEquals($expected, $agg->toArray());
     }
 }

--- a/tests/Aggregation/TopHitsTest.php
+++ b/tests/Aggregation/TopHitsTest.php
@@ -2,6 +2,7 @@
 
 namespace Elastica\Test\Aggregation;
 
+use Elastica\Aggregation\AbstractAggregation;
 use Elastica\Aggregation\Terms;
 use Elastica\Aggregation\TopHits;
 use Elastica\Document;
@@ -23,10 +24,11 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testSetSize(): void
     {
-        $agg = new TopHits('agg_name');
-        $returnValue = $agg->setSize(12);
-        $this->assertEquals(12, $agg->getParam('size'));
-        $this->assertInstanceOf(TopHits::class, $returnValue);
+        $agg = (new TopHits('agg_name'))
+            ->setSize(12)
+        ;
+
+        $this->assertSame(12, $agg->getParam('size'));
     }
 
     /**
@@ -34,10 +36,11 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testSetFrom(): void
     {
-        $agg = new TopHits('agg_name');
-        $returnValue = $agg->setFrom(12);
+        $agg = (new TopHits('agg_name'))
+            ->setFrom(12)
+        ;
+
         $this->assertEquals(12, $agg->getParam('from'));
-        $this->assertInstanceOf(TopHits::class, $returnValue);
     }
 
     /**
@@ -46,10 +49,11 @@ class TopHitsTest extends BaseAggregationTest
     public function testSetSort(): void
     {
         $sort = ['last_activity_date' => ['order' => 'desc']];
-        $agg = new TopHits('agg_name');
-        $returnValue = $agg->setSort($sort);
-        $this->assertEquals($sort, $agg->getParam('sort'));
-        $this->assertInstanceOf(TopHits::class, $returnValue);
+        $agg = (new TopHits('agg_name'))
+            ->setSort($sort)
+        ;
+
+        $this->assertSame($sort, $agg->getParam('sort'));
     }
 
     /**
@@ -58,10 +62,11 @@ class TopHitsTest extends BaseAggregationTest
     public function testSetSource(): void
     {
         $fields = ['title', 'tags'];
-        $agg = new TopHits('agg_name');
-        $returnValue = $agg->setSource($fields);
-        $this->assertEquals($fields, $agg->getParam('_source'));
-        $this->assertInstanceOf(TopHits::class, $returnValue);
+        $agg = (new TopHits('agg_name'))
+            ->setSource($fields)
+        ;
+
+        $this->assertSame($fields, $agg->getParam('_source'));
     }
 
     /**
@@ -69,10 +74,11 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testSetVersion(): void
     {
-        $agg = new TopHits('agg_name');
-        $returnValue = $agg->setVersion(true);
+        $agg = (new TopHits('agg_name'))
+            ->setVersion(true)
+        ;
+
         $this->assertTrue($agg->getParam('version'));
-        $this->assertInstanceOf(TopHits::class, $returnValue);
 
         $agg->setVersion(false);
         $this->assertFalse($agg->getParam('version'));
@@ -83,10 +89,11 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testSetExplain(): void
     {
-        $agg = new TopHits('agg_name');
-        $returnValue = $agg->setExplain(true);
+        $agg = (new TopHits('agg_name'))
+            ->setExplain(true)
+        ;
+
         $this->assertTrue($agg->getParam('explain'));
-        $this->assertInstanceOf(TopHits::class, $returnValue);
 
         $agg->setExplain(false);
         $this->assertFalse($agg->getParam('explain'));
@@ -102,10 +109,11 @@ class TopHitsTest extends BaseAggregationTest
                 'title',
             ],
         ];
-        $agg = new TopHits('agg_name');
-        $returnValue = $agg->setHighlight($highlight);
-        $this->assertEquals($highlight, $agg->getParam('highlight'));
-        $this->assertInstanceOf(TopHits::class, $returnValue);
+        $agg = (new TopHits('agg_name'))
+            ->setHighlight($highlight)
+        ;
+
+        $this->assertSame($highlight, $agg->getParam('highlight'));
     }
 
     /**
@@ -114,10 +122,11 @@ class TopHitsTest extends BaseAggregationTest
     public function testSetFieldDataFields(): void
     {
         $fields = ['title', 'tags'];
-        $agg = new TopHits('agg_name');
-        $returnValue = $agg->setFieldDataFields($fields);
-        $this->assertEquals($fields, $agg->getParam('docvalue_fields'));
-        $this->assertInstanceOf(TopHits::class, $returnValue);
+        $agg = (new TopHits('agg_name'))
+            ->setFieldDataFields($fields)
+        ;
+
+        $this->assertSame($fields, $agg->getParam('docvalue_fields'));
     }
 
     /**
@@ -128,10 +137,11 @@ class TopHitsTest extends BaseAggregationTest
         $script = new Script('1 + 2');
         $scriptFields = new ScriptFields(['three' => $script]);
 
-        $agg = new TopHits('agg_name');
-        $returnValue = $agg->setScriptFields($scriptFields);
-        $this->assertEquals($scriptFields->toArray(), $agg->getParam('script_fields')->toArray());
-        $this->assertInstanceOf(TopHits::class, $returnValue);
+        $agg = (new TopHits('agg_name'))
+            ->setScriptFields($scriptFields)
+        ;
+
+        $this->assertSame($scriptFields, $agg->getParam('script_fields'));
     }
 
     /**
@@ -140,10 +150,11 @@ class TopHitsTest extends BaseAggregationTest
     public function testAddScriptField(): void
     {
         $script = new Script('2+3');
-        $agg = new TopHits('agg_name');
-        $returnValue = $agg->addScriptField('five', $script);
+        $agg = (new TopHits('agg_name'))
+            ->addScriptField('five', $script)
+        ;
+
         $this->assertEquals(['five' => $script->toArray()], $agg->getParam('script_fields')->toArray());
-        $this->assertInstanceOf(TopHits::class, $returnValue);
     }
 
     /**
@@ -151,17 +162,19 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testAggregateUpdatedRecently(): void
     {
-        $aggr = new TopHits('top_tag_hits');
-        $aggr->setSize(1);
-        $aggr->setSort(['last_activity_date' => ['order' => 'desc']]);
+        $agg = (new TopHits('top_tag_hits'))
+            ->setSize(1)
+            ->setSort(['last_activity_date' => ['order' => 'desc']])
+        ;
 
         $resultDocs = [];
-        $outerAggrResult = $this->getOuterAggregationResult($aggr);
-        foreach ($outerAggrResult['buckets'] as $bucket) {
+        $outerAggResult = $this->getOuterAggregationResult($agg);
+        foreach ($outerAggResult['buckets'] as $bucket) {
             foreach ($bucket['top_tag_hits']['hits']['hits'] as $doc) {
                 $resultDocs[] = $doc['_id'];
             }
         }
+
         $this->assertEquals([1, 3], $resultDocs);
     }
 
@@ -170,17 +183,19 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testAggregateUpdatedFarAgo(): void
     {
-        $aggr = new TopHits('top_tag_hits');
-        $aggr->setSize(1);
-        $aggr->setSort(['last_activity_date' => ['order' => 'asc']]);
+        $agg = (new TopHits('top_tag_hits'))
+            ->setSize(1)
+            ->setSort(['last_activity_date' => ['order' => 'asc']])
+        ;
 
         $resultDocs = [];
-        $outerAggrResult = $this->getOuterAggregationResult($aggr);
-        foreach ($outerAggrResult['buckets'] as $bucket) {
+        $outerAggResult = $this->getOuterAggregationResult($agg);
+        foreach ($outerAggResult['buckets'] as $bucket) {
             foreach ($bucket['top_tag_hits']['hits']['hits'] as $doc) {
                 $resultDocs[] = $doc['_id'];
             }
         }
+
         $this->assertEquals([2, 4], $resultDocs);
     }
 
@@ -189,16 +204,18 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testAggregateTwoDocumentPerTag(): void
     {
-        $aggr = new TopHits('top_tag_hits');
-        $aggr->setSize(2);
+        $agg = (new TopHits('top_tag_hits'))
+            ->setSize(2)
+        ;
 
         $resultDocs = [];
-        $outerAggrResult = $this->getOuterAggregationResult($aggr);
-        foreach ($outerAggrResult['buckets'] as $bucket) {
+        $outerAggResult = $this->getOuterAggregationResult($agg);
+        foreach ($outerAggResult['buckets'] as $bucket) {
             foreach ($bucket['top_tag_hits']['hits']['hits'] as $doc) {
                 $resultDocs[] = $doc['_id'];
             }
         }
+
         $this->assertEquals([1, 2, 3, 4], $resultDocs);
     }
 
@@ -207,18 +224,20 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testAggregateTwoDocumentPerTagWithOffset(): void
     {
-        $aggr = new TopHits('top_tag_hits');
-        $aggr->setSize(2);
-        $aggr->setFrom(1);
-        $aggr->setSort(['last_activity_date' => ['order' => 'desc']]);
+        $agg = (new TopHits('top_tag_hits'))
+            ->setSize(2)
+            ->setFrom(1)
+            ->setSort(['last_activity_date' => ['order' => 'desc']])
+        ;
 
         $resultDocs = [];
-        $outerAggrResult = $this->getOuterAggregationResult($aggr);
-        foreach ($outerAggrResult['buckets'] as $bucket) {
+        $outerAggResult = $this->getOuterAggregationResult($agg);
+        foreach ($outerAggResult['buckets'] as $bucket) {
             foreach ($bucket['top_tag_hits']['hits']['hits'] as $doc) {
                 $resultDocs[] = $doc['_id'];
             }
         }
+
         $this->assertEquals([2, 4], $resultDocs);
     }
 
@@ -238,12 +257,12 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testAggregateWithLimitedSource($source): void
     {
-        $aggr = new TopHits('top_tag_hits');
-        $aggr->setSource($source);
+        $agg = (new TopHits('top_tag_hits'))
+            ->setSource($source)
+        ;
 
-        $resultDocs = [];
-        $outerAggrResult = $this->getOuterAggregationResult($aggr);
-        foreach ($outerAggrResult['buckets'] as $bucket) {
+        $outerAggResult = $this->getOuterAggregationResult($agg);
+        foreach ($outerAggResult['buckets'] as $bucket) {
             foreach ($bucket['top_tag_hits']['hits']['hits'] as $doc) {
                 $this->assertArrayHasKey('title', $doc['_source']);
                 $this->assertArrayNotHasKey('tags', $doc['_source']);
@@ -257,12 +276,12 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testAggregateWithVersion(): void
     {
-        $aggr = new TopHits('top_tag_hits');
-        $aggr->setVersion(true);
+        $agg = (new TopHits('top_tag_hits'))
+            ->setVersion(true)
+        ;
 
-        $resultDocs = [];
-        $outerAggrResult = $this->getOuterAggregationResult($aggr);
-        foreach ($outerAggrResult['buckets'] as $bucket) {
+        $outerAggResult = $this->getOuterAggregationResult($agg);
+        foreach ($outerAggResult['buckets'] as $bucket) {
             foreach ($bucket['top_tag_hits']['hits']['hits'] as $doc) {
                 $this->assertArrayHasKey('_version', $doc);
             }
@@ -274,12 +293,12 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testAggregateWithExplain(): void
     {
-        $aggr = new TopHits('top_tag_hits');
-        $aggr->setExplain(true);
+        $agg = (new TopHits('top_tag_hits'))
+            ->setExplain(true)
+        ;
 
-        $resultDocs = [];
-        $outerAggrResult = $this->getOuterAggregationResult($aggr);
-        foreach ($outerAggrResult['buckets'] as $bucket) {
+        $outerAggResult = $this->getOuterAggregationResult($agg);
+        foreach ($outerAggResult['buckets'] as $bucket) {
             foreach ($bucket['top_tag_hits']['hits']['hits'] as $doc) {
                 $this->assertArrayHasKey('_explanation', $doc);
             }
@@ -291,14 +310,14 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testAggregateWithScriptFields(): void
     {
-        $aggr = new TopHits('top_tag_hits');
-        $aggr->setSize(1);
-        $aggr->setScriptFields(['three' => new Script('1 + 2')]);
-        $aggr->addScriptField('five', new Script('3 + 2'));
+        $agg = (new TopHits('top_tag_hits'))
+            ->setSize(1)
+            ->setScriptFields(['three' => new Script('1 + 2')])
+            ->addScriptField('five', new Script('3 + 2'))
+        ;
 
-        $resultDocs = [];
-        $outerAggrResult = $this->getOuterAggregationResult($aggr);
-        foreach ($outerAggrResult['buckets'] as $bucket) {
+        $outerAggResult = $this->getOuterAggregationResult($agg);
+        foreach ($outerAggResult['buckets'] as $bucket) {
             foreach ($bucket['top_tag_hits']['hits']['hits'] as $doc) {
                 $this->assertEquals(3, $doc['fields']['three'][0]);
                 $this->assertEquals(5, $doc['fields']['five'][0]);
@@ -313,16 +332,17 @@ class TopHitsTest extends BaseAggregationTest
     {
         $queryString = new SimpleQueryString('linux', ['title']);
 
-        $aggr = new TopHits('top_tag_hits');
-        $aggr->setHighlight(['fields' => ['title' => new \stdClass()]]);
+        $agg = (new TopHits('top_tag_hits'))
+            ->setHighlight(['fields' => ['title' => new \stdClass()]])
+        ;
 
         $query = new Query($queryString);
-        $query->addAggregation($aggr);
+        $query->addAggregation($agg);
 
         $resultSet = $this->_getIndexForTest()->search($query);
-        $aggrResult = $resultSet->getAggregation('top_tag_hits');
+        $aggResult = $resultSet->getAggregation('top_tag_hits');
 
-        foreach ($aggrResult['hits']['hits'] as $doc) {
+        foreach ($aggResult['hits']['hits'] as $doc) {
             $this->assertArrayHasKey('highlight', $doc);
             if (\method_exists($this, 'assertMatchesRegularExpression')) {
                 $this->assertMatchesRegularExpression('#<em>linux</em>#', $doc['highlight']['title'][0]);
@@ -337,16 +357,17 @@ class TopHitsTest extends BaseAggregationTest
      */
     public function testAggregateWithFieldData(): void
     {
-        $aggr = new TopHits('top_tag_hits');
-        $aggr->setFieldDataFields(['title']);
+        $agg = (new TopHits('top_tag_hits'))
+            ->setFieldDataFields(['title'])
+        ;
 
         $query = new Query(new MatchAll());
-        $query->addAggregation($aggr);
+        $query->addAggregation($agg);
 
         $resultSet = $this->_getIndexForTest()->search($query);
-        $aggrResult = $resultSet->getAggregation('top_tag_hits');
+        $aggResult = $resultSet->getAggregation('top_tag_hits');
 
-        foreach ($aggrResult['hits']['hits'] as $doc) {
+        foreach ($aggResult['hits']['hits'] as $doc) {
             $this->assertArrayHasKey('fields', $doc);
             $this->assertArrayHasKey('title', $doc['fields']);
             $this->assertArrayNotHasKey('tags', $doc['fields']);
@@ -402,15 +423,16 @@ class TopHitsTest extends BaseAggregationTest
         return $index;
     }
 
-    protected function getOuterAggregationResult($innerAggr)
+    protected function getOuterAggregationResult(AbstractAggregation $innerAgg): array
     {
-        $outerAggr = new Terms('top_tags');
-        $outerAggr->setField('tags');
-        $outerAggr->setMinimumDocumentCount(2);
-        $outerAggr->addAggregation($innerAggr);
+        $outerAgg = (new Terms('top_tags'))
+            ->setField('tags')
+            ->setMinimumDocumentCount(2)
+            ->addAggregation($innerAgg)
+        ;
 
         $query = new Query(new MatchAll());
-        $query->addAggregation($outerAggr);
+        $query->addAggregation($outerAgg);
 
         return $this->_getIndexForTest()->search($query)->getAggregation('top_tags');
     }

--- a/tests/Bulk/ResponseSetTest.php
+++ b/tests/Bulk/ResponseSetTest.php
@@ -130,7 +130,6 @@ class ResponseSetTest extends BaseTest
 
         $this->assertEquals(0, $responseSet->key());
         $this->assertTrue($responseSet->valid());
-        $this->assertInstanceOf(Bulk\Response::class, $responseSet->current());
     }
 
     public function isOkDataProvider(): \Generator

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -9,7 +9,6 @@ use Elastica\Bulk\Action\CreateDocument;
 use Elastica\Bulk\Action\IndexDocument;
 use Elastica\Bulk\Action\UpdateDocument;
 use Elastica\Bulk\Response;
-use Elastica\Bulk\ResponseSet;
 use Elastica\Document;
 use Elastica\Exception\Bulk\ResponseException;
 use Elastica\Exception\NotFoundException;
@@ -94,8 +93,6 @@ class BulkTest extends BaseTest
         $this->assertEquals($expected, (string) \str_replace(\PHP_EOL, "\n", (string) $bulk));
 
         $response = $bulk->send();
-
-        $this->assertInstanceOf(ResponseSet::class, $response);
 
         $this->assertTrue($response->isOk());
         $this->assertFalse($response->hasError());
@@ -640,7 +637,8 @@ class BulkTest extends BaseTest
     public function testSetShardTimeout(): void
     {
         $bulk = new Bulk($this->_getClient());
-        $this->assertInstanceOf(Bulk::class, $bulk->setShardTimeout(10));
+
+        $this->assertSame($bulk, $bulk->setShardTimeout(10));
     }
 
     /**
@@ -649,7 +647,8 @@ class BulkTest extends BaseTest
     public function testSetRequestParam(): void
     {
         $bulk = new Bulk($this->_getClient());
-        $this->assertInstanceOf(Bulk::class, $bulk->setRequestParam('key', 'value'));
+
+        $this->assertSame($bulk, $bulk->setRequestParam('key', 'value'));
     }
 
     /**

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -429,7 +429,8 @@ class ClientFunctionalTest extends BaseTest
         $client = $this->_getClient(['url' => $url, 'port' => '9101', 'timeout' => 2]);
 
         $response = $client->request('_stats');
-        $this->assertInstanceOf(Response::class, $response);
+
+        $this->assertTrue($response->isOk());
     }
 
     public function testUpdateDocumentByDocument(): void

--- a/tests/Cluster/HealthTest.php
+++ b/tests/Cluster/HealthTest.php
@@ -53,9 +53,8 @@ class HealthTest extends BaseTest
         ;
 
         $health
-            ->expects($this->any())
             ->method('_retrieveHealthData')
-            ->will($this->returnValue($data))
+            ->willReturn($data)
         ;
 
         // need to explicitly refresh because the mocking won't refresh the data in the constructor

--- a/tests/Collapse/CollapseTest.php
+++ b/tests/Collapse/CollapseTest.php
@@ -19,10 +19,11 @@ class CollapseTest extends BaseTest
      */
     public function testSetFieldName(): void
     {
-        $collapse = new Collapse();
-        $returnValue = $collapse->setFieldname('some_name');
-        $this->assertEquals('some_name', $collapse->getParam('field'));
-        $this->assertInstanceOf(Collapse::class, $returnValue);
+        $collapse = (new Collapse())
+            ->setFieldname('some_name')
+        ;
+
+        $this->assertSame('some_name', $collapse->getParam('field'));
     }
 
     /**
@@ -30,12 +31,11 @@ class CollapseTest extends BaseTest
      */
     public function testSetInnerHits(): void
     {
-        $collapse = new Collapse();
-        $innerHits = new InnerHits();
-        $returnValue = $collapse->setInnerHits($innerHits);
-        $this->assertEquals($innerHits, $collapse->getParam('inner_hits'));
-        $this->assertInstanceOf(Collapse::class, $returnValue);
-        $this->assertInstanceOf(InnerHits::class, $collapse->getParam('inner_hits'));
+        $collapse = (new Collapse())
+            ->setInnerHits($innerHits = new InnerHits())
+        ;
+
+        $this->assertSame($innerHits, $collapse->getParam('inner_hits'));
     }
 
     /**
@@ -43,10 +43,11 @@ class CollapseTest extends BaseTest
      */
     public function testSetMaxConcurrentGroupSearches(): void
     {
-        $collapse = new Collapse();
-        $returnValue = $collapse->setMaxConcurrentGroupSearches(5);
-        $this->assertEquals(5, $collapse->getParam('max_concurrent_group_searches'));
-        $this->assertInstanceOf(Collapse::class, $returnValue);
+        $collapse = (new Collapse())
+            ->setMaxConcurrentGroupSearches(5)
+        ;
+
+        $this->assertSame(5, $collapse->getParam('max_concurrent_group_searches'));
     }
 
     /**

--- a/tests/Connection/ConnectionPoolTest.php
+++ b/tests/Connection/ConnectionPoolTest.php
@@ -35,9 +35,7 @@ class ConnectionPoolTest extends BaseTest
 
         $pool->setConnections($connections);
 
-        $this->assertEquals($connections, $pool->getConnections());
-
-        $this->assertInstanceOf(ConnectionPool::class, $pool->setConnections($connections));
+        $this->assertSame($connections, $pool->getConnections());
     }
 
     /**
@@ -54,9 +52,7 @@ class ConnectionPoolTest extends BaseTest
             $pool->addConnection($connection);
         }
 
-        $this->assertEquals($connections, $pool->getConnections());
-
-        $this->assertInstanceOf(ConnectionPool::class, $pool->addConnection($connections[0]));
+        $this->assertSame($connections, $pool->getConnections());
     }
 
     /**

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -24,7 +24,8 @@ class DocumentTest extends BaseTest
         }
         $doc = new Document();
         $returnValue = $doc->addFile('key', $fileName);
-        $this->assertInstanceOf(Document::class, $returnValue);
+
+        $this->assertSame($doc, $returnValue);
     }
 
     /**
@@ -34,7 +35,8 @@ class DocumentTest extends BaseTest
     {
         $doc = new Document();
         $returnValue = $doc->addGeoPoint('point', 38.89859, -77.035971);
-        $this->assertInstanceOf(Document::class, $returnValue);
+
+        $this->assertSame($doc, $returnValue);
     }
 
     /**
@@ -44,7 +46,8 @@ class DocumentTest extends BaseTest
     {
         $doc = new Document();
         $returnValue = $doc->setData(['data']);
-        $this->assertInstanceOf(Document::class, $returnValue);
+
+        $this->assertSame($doc, $returnValue);
     }
 
     /**

--- a/tests/Index/SettingsTest.php
+++ b/tests/Index/SettingsTest.php
@@ -4,9 +4,7 @@ namespace Elastica\Test\Index;
 
 use Elastica\Document;
 use Elastica\Exception\ResponseException;
-use Elastica\Index;
 use Elastica\Index\Settings as IndexSettings;
-use Elastica\Response;
 use Elastica\Test\Base as BaseTest;
 
 /**
@@ -264,7 +262,6 @@ class SettingsTest extends BaseTest
 
         $response = $settings->setMergePolicy('max_merge_at_once', 15);
         $this->assertEquals(15, $settings->getMergePolicy('max_merge_at_once'));
-        $this->assertInstanceOf(Response::class, $response);
         $this->assertTrue($response->isOk());
 
         $settings->setMergePolicy('max_merge_at_once', 10);
@@ -396,10 +393,9 @@ class SettingsTest extends BaseTest
     {
         $client = $this->_getClient();
         $index = $client->getIndex('not_found_index');
-        //wait for the shards to be allocated
 
         try {
-            $settings = $index->getSettings()->get();
+            $index->getSettings()->get();
             $this->fail('Should throw exception because of index not found');
         } catch (ResponseException $e) {
             $error = $e->getResponse()->getFullError();

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -556,10 +556,7 @@ class IndexTest extends BaseTest
             $index->delete();
             $this->fail('This should never be reached. Deleting an unknown index will throw an exception');
         } catch (ResponseException $error) {
-            $response = $error->getResponse();
-            $this->assertTrue($response->hasError());
-            $request = $error->getRequest();
-            $this->assertInstanceOf(Request::class, $request);
+            $this->assertTrue($error->getResponse()->hasError());
         }
     }
 

--- a/tests/Multi/MultiBuilderTest.php
+++ b/tests/Multi/MultiBuilderTest.php
@@ -3,7 +3,6 @@
 namespace Elastica\Test\Multi;
 
 use Elastica\Multi\MultiBuilder;
-use Elastica\Multi\ResultSet as MultiResultSet;
 use Elastica\Response;
 use Elastica\ResultSet;
 use Elastica\ResultSet\BuilderInterface;
@@ -46,7 +45,7 @@ class MultiBuilderTest extends BaseTest
 
         $result = $this->multiBuilder->buildMultiResultSet($response, $searches);
 
-        $this->assertInstanceOf(MultiResultSet::class, $result);
+        $this->assertCount(0, $result->getResultSets());
     }
 
     public function testBuildMultiResultSet(): void
@@ -75,7 +74,6 @@ class MultiBuilderTest extends BaseTest
 
         $result = $this->multiBuilder->buildMultiResultSet($response, $searches);
 
-        $this->assertInstanceOf(MultiResultSet::class, $result);
         $this->assertSame($resultSet1, $result[0]);
         $this->assertSame($resultSet2, $result[1]);
     }

--- a/tests/Multi/SearchTest.php
+++ b/tests/Multi/SearchTest.php
@@ -8,7 +8,6 @@ use Elastica\Multi\ResultSet as MultiResultSet;
 use Elastica\Multi\Search as MultiSearch;
 use Elastica\Query;
 use Elastica\Query\Term;
-use Elastica\Response;
 use Elastica\ResultSet;
 use Elastica\Search;
 use Elastica\Test\Base as BaseTest;
@@ -137,7 +136,6 @@ class SearchTest extends BaseTest
 
         $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
         $this->assertContainsOnlyInstancesOf(ResultSet::class, $multiResultSet);
 
         $resultSets = $multiResultSet->getResultSets();
@@ -164,7 +162,6 @@ class SearchTest extends BaseTest
 
         $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
@@ -227,7 +224,6 @@ class SearchTest extends BaseTest
 
         $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
         $this->assertContainsOnlyInstancesOf(ResultSet::class, $multiResultSet);
         $this->assertInstanceOf(ResultSet::class, $multiResultSet['search1']);
         $this->assertInstanceOf(ResultSet::class, $multiResultSet['search2']);
@@ -256,7 +252,6 @@ class SearchTest extends BaseTest
 
         $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
@@ -298,8 +293,6 @@ class SearchTest extends BaseTest
         $multiSearch->addSearch($searchBad);
 
         $multiResultSet = $multiSearch->search();
-
-        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $resultSets = $multiResultSet->getResultSets();
         $this->assertIsArray($resultSets);
 
@@ -343,8 +336,6 @@ class SearchTest extends BaseTest
         $multiSearch->addSearch($searchBad);
 
         $multiResultSet = $multiSearch->search();
-
-        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $resultSets = $multiResultSet->getResultSets();
         $this->assertIsArray($resultSets);
 
@@ -405,7 +396,6 @@ class SearchTest extends BaseTest
 
         $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
@@ -427,9 +417,7 @@ class SearchTest extends BaseTest
 
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
@@ -489,7 +477,6 @@ class SearchTest extends BaseTest
 
         $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 
@@ -511,9 +498,7 @@ class SearchTest extends BaseTest
 
         $multiResultSet = $multiSearch->search();
 
-        $this->assertInstanceOf(MultiResultSet::class, $multiResultSet);
         $this->assertCount(2, $multiResultSet);
-        $this->assertInstanceOf(Response::class, $multiResultSet->getResponse());
 
         $resultSets = $multiResultSet->getResultSets();
 

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -3,8 +3,6 @@
 namespace Elastica\Test;
 
 use Elastica\Node;
-use Elastica\Node\Info;
-use Elastica\Node\Stats;
 use Elastica\Test\Base as BaseTest;
 
 /**
@@ -38,7 +36,7 @@ class NodeTest extends BaseTest
 
         $info = $node->getInfo();
 
-        $this->assertInstanceOf(Info::class, $info);
+        $this->assertSame($node, $info->getNode());
     }
 
     /**
@@ -54,7 +52,7 @@ class NodeTest extends BaseTest
 
         $stats = $node->getStats();
 
-        $this->assertInstanceOf(Stats::class, $stats);
+        $this->assertSame($node, $stats->getNode());
     }
 
     /**

--- a/tests/Query/ExistsTest.php
+++ b/tests/Query/ExistsTest.php
@@ -30,10 +30,10 @@ class ExistsTest extends BaseTest
         $field = 'test';
         $query = new Exists($field);
 
-        $this->assertEquals($field, $query->getParam('field'));
+        $this->assertSame($field, $query->getParam('field'));
 
         $newField = 'hello world';
-        $this->assertInstanceOf(Exists::class, $query->setField($newField));
+        $query->setField($newField);
 
         $this->assertEquals($newField, $query->getParam('field'));
     }

--- a/tests/Query/FunctionScoreTest.php
+++ b/tests/Query/FunctionScoreTest.php
@@ -505,12 +505,12 @@ class FunctionScoreTest extends BaseTest
             ],
         ];
 
-        $query = new FunctionScore();
-        $query->addDecayFunction(FunctionScore::DECAY_GAUSS, 'price', 0, 10);
-        $returnedValue = $query->setMinScore(0.8);
+        $query = (new FunctionScore())
+            ->addDecayFunction(FunctionScore::DECAY_GAUSS, 'price', 0, 10)
+            ->setMinScore(0.8)
+        ;
 
         $this->assertEquals($expected, $query->toArray());
-        $this->assertInstanceOf(FunctionScore::class, $returnedValue);
 
         $response = $this->_getIndexForTest()->search($query);
         $results = $response->getResults();

--- a/tests/Query/GeoBoundingBoxTest.php
+++ b/tests/Query/GeoBoundingBoxTest.php
@@ -21,10 +21,7 @@ class GeoBoundingBoxTest extends BaseTest
 
         $query->addCoordinates($key, $coords);
         $expectedArray = ['top_left' => $coords[0], 'bottom_right' => $coords[1]];
-        $this->assertEquals($expectedArray, $query->getParam($key));
-
-        $returnValue = $query->addCoordinates($key, $coords);
-        $this->assertInstanceOf(GeoBoundingBox::class, $returnValue);
+        $this->assertSame($expectedArray, $query->getParam($key));
     }
 
     /**

--- a/tests/Query/InnerHitsTest.php
+++ b/tests/Query/InnerHitsTest.php
@@ -23,10 +23,11 @@ class InnerHitsTest extends BaseTest
      */
     public function testSetSize(): void
     {
-        $innerHits = new InnerHits();
-        $returnValue = $innerHits->setSize(12);
-        $this->assertEquals(12, $innerHits->getParam('size'));
-        $this->assertInstanceOf(InnerHits::class, $returnValue);
+        $innerHits = (new InnerHits())
+            ->setSize(12)
+        ;
+
+        $this->assertSame(12, $innerHits->getParam('size'));
     }
 
     /**
@@ -34,10 +35,11 @@ class InnerHitsTest extends BaseTest
      */
     public function testSetFrom(): void
     {
-        $innerHits = new InnerHits();
-        $returnValue = $innerHits->setFrom(12);
-        $this->assertEquals(12, $innerHits->getParam('from'));
-        $this->assertInstanceOf(InnerHits::class, $returnValue);
+        $innerHits = (new InnerHits())
+            ->setFrom(12)
+        ;
+
+        $this->assertSame(12, $innerHits->getParam('from'));
     }
 
     /**
@@ -46,10 +48,11 @@ class InnerHitsTest extends BaseTest
     public function testSetSort(): void
     {
         $sort = ['last_activity_date' => ['order' => 'desc']];
-        $innerHits = new InnerHits();
-        $returnValue = $innerHits->setSort($sort);
-        $this->assertEquals($sort, $innerHits->getParam('sort'));
-        $this->assertInstanceOf(InnerHits::class, $returnValue);
+        $innerHits = (new InnerHits())
+            ->setSort($sort)
+        ;
+
+        $this->assertSame($sort, $innerHits->getParam('sort'));
     }
 
     /**
@@ -58,10 +61,11 @@ class InnerHitsTest extends BaseTest
     public function testSetSource(): void
     {
         $fields = ['title', 'tags'];
-        $innerHits = new InnerHits();
-        $returnValue = $innerHits->setSource($fields);
-        $this->assertEquals($fields, $innerHits->getParam('_source'));
-        $this->assertInstanceOf(InnerHits::class, $returnValue);
+        $innerHits = (new InnerHits())
+            ->setSource($fields)
+        ;
+
+        $this->assertSame($fields, $innerHits->getParam('_source'));
     }
 
     /**
@@ -69,12 +73,14 @@ class InnerHitsTest extends BaseTest
      */
     public function testSetVersion(): void
     {
-        $innerHits = new InnerHits();
-        $returnValue = $innerHits->setVersion(true);
+        $innerHits = (new InnerHits())
+            ->setVersion(true)
+        ;
+
         $this->assertTrue($innerHits->getParam('version'));
-        $this->assertInstanceOf(InnerHits::class, $returnValue);
 
         $innerHits->setVersion(false);
+
         $this->assertFalse($innerHits->getParam('version'));
     }
 
@@ -83,12 +89,14 @@ class InnerHitsTest extends BaseTest
      */
     public function testSetExplain(): void
     {
-        $innerHits = new InnerHits();
-        $returnValue = $innerHits->setExplain(true);
+        $innerHits = (new InnerHits())
+            ->setExplain(true)
+        ;
+
         $this->assertTrue($innerHits->getParam('explain'));
-        $this->assertInstanceOf(InnerHits::class, $returnValue);
 
         $innerHits->setExplain(false);
+
         $this->assertFalse($innerHits->getParam('explain'));
     }
 
@@ -102,10 +110,11 @@ class InnerHitsTest extends BaseTest
                 'title',
             ],
         ];
-        $innerHits = new InnerHits();
-        $returnValue = $innerHits->setHighlight($highlight);
-        $this->assertEquals($highlight, $innerHits->getParam('highlight'));
-        $this->assertInstanceOf(InnerHits::class, $returnValue);
+        $innerHits = (new InnerHits())
+            ->setHighlight($highlight)
+        ;
+
+        $this->assertSame($highlight, $innerHits->getParam('highlight'));
     }
 
     /**
@@ -114,10 +123,11 @@ class InnerHitsTest extends BaseTest
     public function testSetFieldDataFields(): void
     {
         $fields = ['title', 'tags'];
-        $innerHits = new InnerHits();
-        $returnValue = $innerHits->setFieldDataFields($fields);
-        $this->assertEquals($fields, $innerHits->getParam('docvalue_fields'));
-        $this->assertInstanceOf(InnerHits::class, $returnValue);
+        $innerHits = (new InnerHits())
+            ->setFieldDataFields($fields)
+        ;
+
+        $this->assertSame($fields, $innerHits->getParam('docvalue_fields'));
     }
 
     /**
@@ -128,10 +138,11 @@ class InnerHitsTest extends BaseTest
         $script = new Script('1 + 2');
         $scriptFields = new ScriptFields(['three' => $script]);
 
-        $innerHits = new InnerHits();
-        $returnValue = $innerHits->setScriptFields($scriptFields);
-        $this->assertEquals($scriptFields->toArray(), $innerHits->getParam('script_fields')->toArray());
-        $this->assertInstanceOf(InnerHits::class, $returnValue);
+        $innerHits = (new InnerHits())
+            ->setScriptFields($scriptFields)
+        ;
+
+        $this->assertSame($scriptFields, $innerHits->getParam('script_fields'));
     }
 
     /**
@@ -140,10 +151,11 @@ class InnerHitsTest extends BaseTest
     public function testAddScriptField(): void
     {
         $script = new Script('2+3');
-        $innerHits = new InnerHits();
-        $returnValue = $innerHits->addScriptField('five', $script);
-        $this->assertEquals(['five' => $script->toArray()], $innerHits->getParam('script_fields')->toArray());
-        $this->assertInstanceOf(InnerHits::class, $returnValue);
+        $innerHits = (new InnerHits())
+            ->addScriptField('five', $script)
+        ;
+
+        $this->assertSame(['five' => $script->toArray()], $innerHits->getParam('script_fields')->toArray());
     }
 
     /**

--- a/tests/Query/LimitTest.php
+++ b/tests/Query/LimitTest.php
@@ -16,10 +16,10 @@ class LimitTest extends BaseTest
     public function testSetType(): void
     {
         $query = new Limit(10);
-        $this->assertEquals(10, $query->getParam('value'));
+        $this->assertSame(10, $query->getParam('value'));
 
-        $this->assertInstanceOf(Limit::class, $query->setLimit(20));
-        $this->assertEquals(20, $query->getParam('value'));
+        $query->setLimit(20);
+        $this->assertSame(20, $query->getParam('value'));
     }
 
     /**

--- a/tests/Query/NestedTest.php
+++ b/tests/Query/NestedTest.php
@@ -16,12 +16,14 @@ class NestedTest extends BaseTest
      */
     public function testSetQuery(): void
     {
-        $nested = new Nested();
+        $queryString = new QueryString('test');
         $path = 'test1';
 
-        $queryString = new QueryString('test');
-        $this->assertInstanceOf(Nested::class, $nested->setQuery($queryString));
-        $this->assertInstanceOf(Nested::class, $nested->setPath($path));
+        $nested = (new Nested())
+            ->setQuery($queryString)
+            ->setPath($path)
+        ;
+
         $expected = [
             'nested' => [
                 'query' => $queryString->toArray(),
@@ -29,6 +31,6 @@ class NestedTest extends BaseTest
             ],
         ];
 
-        $this->assertEquals($expected, $nested->toArray());
+        $this->assertSame($expected, $nested->toArray());
     }
 }

--- a/tests/Query/QueryStringTest.php
+++ b/tests/Query/QueryStringTest.php
@@ -248,8 +248,9 @@ class QueryStringTest extends BaseTest
         $timezone = 'Europe/Paris';
         $text = 'date:[2012 TO 2014]';
 
-        $query = new QueryString($text);
-        $query->setTimezone($timezone);
+        $query = (new QueryString($text))
+            ->setTimezone($timezone)
+        ;
 
         $expected = [
             'query_string' => [
@@ -258,8 +259,7 @@ class QueryStringTest extends BaseTest
             ],
         ];
 
-        $this->assertEquals($expected, $query->toArray());
-        $this->assertInstanceOf(QueryString::class, $query->setTimezone($timezone));
+        $this->assertSame($expected, $query->toArray());
     }
 
     /**

--- a/tests/Query/SimpleQueryStringTest.php
+++ b/tests/Query/SimpleQueryStringTest.php
@@ -74,11 +74,11 @@ class SimpleQueryStringTest extends Base
             ],
         ];
 
-        $query = new SimpleQueryString($expected['simple_query_string']['query']);
-        $query->setMinimumShouldMatch($expected['simple_query_string']['minimum_should_match']);
+        $query = (new SimpleQueryString($expected['simple_query_string']['query']))
+            ->setMinimumShouldMatch($expected['simple_query_string']['minimum_should_match'])
+        ;
 
         $this->assertEquals($expected, $query->toArray());
-        $this->assertInstanceOf(SimpleQueryString::class, $query->setMinimumShouldMatch('75%'));
     }
 
     /**

--- a/tests/QueryBuilder/DSL/CollapseTest.php
+++ b/tests/QueryBuilder/DSL/CollapseTest.php
@@ -29,7 +29,5 @@ class CollapseTest extends AbstractDSLTest
         $collapseDSL = new DSL\Collapse();
 
         $this->_assertImplemented($collapseDSL, 'inner_hits', Collapse\InnerHits::class, []);
-        // Make sure collapse returns an instance of Collapse\InnerHits instead of Query\InnerHits
-        $this->assertInstanceOf(Collapse\InnerHits::class, $collapseDSL->inner_hits());
     }
 }

--- a/tests/QueryBuilder/DSL/QueryTest.php
+++ b/tests/QueryBuilder/DSL/QueryTest.php
@@ -27,11 +27,11 @@ class QueryTest extends AbstractDSLTest
      */
     public function testMatch(): void
     {
-        $queryDSL = new DSL\Query();
+        $match = (new DSL\Query())
+            ->match('field', 'value')
+        ;
 
-        $match = $queryDSL->match('field', 'match');
-        $this->assertEquals('match', $match->getParam('field'));
-        $this->assertInstanceOf(MatchQuery::class, $match);
+        $this->assertEquals('value', $match->getParam('field'));
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -60,16 +60,6 @@ class QueryTest extends BaseTest
     /**
      * @group unit
      */
-    public function testSetSuggestMustReturnQueryInstance(): void
-    {
-        $query = new Query();
-        $suggest = new Suggest();
-        $this->assertInstanceOf(Query::class, $query->setSuggest($suggest));
-    }
-
-    /**
-     * @group unit
-     */
     public function testArrayQuery(): void
     {
         $query = [

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -4,7 +4,6 @@ namespace Elastica\Test;
 
 use Elastica\Connection;
 use Elastica\Request;
-use Elastica\Response;
 use Elastica\Test\Base as BaseTest;
 
 /**
@@ -54,7 +53,7 @@ class RequestTest extends BaseTest
 
         $response = $request->send();
 
-        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($response->isOk());
     }
 
     /**

--- a/tests/ResultSetTest.php
+++ b/tests/ResultSetTest.php
@@ -5,7 +5,6 @@ namespace Elastica\Test;
 use Elastica\Document;
 use Elastica\Exception\InvalidException;
 use Elastica\Result;
-use Elastica\ResultSet;
 use Elastica\Test\Base as BaseTest;
 
 /**
@@ -28,7 +27,6 @@ class ResultSetTest extends BaseTest
 
         $resultSet = $index->search('elastica search');
 
-        $this->assertInstanceOf(ResultSet::class, $resultSet);
         $this->assertEquals(3, $resultSet->getTotalHits());
         $this->assertEquals('eq', $resultSet->getTotalHitsRelation());
         $this->assertGreaterThan(0, $resultSet->getMaxScore());
@@ -54,11 +52,7 @@ class ResultSetTest extends BaseTest
 
         $resultSet = $index->search('elastica search');
 
-        $this->assertInstanceOf(ResultSet::class, $resultSet);
-        $this->assertInstanceOf(Result::class, $resultSet[0]);
-        $this->assertInstanceOf(Result::class, $resultSet[1]);
-        $this->assertInstanceOf(Result::class, $resultSet[2]);
-
+        $this->assertContainsOnlyInstancesOf(Result::class, $resultSet);
         $this->assertArrayNotHasKey(3, $resultSet);
     }
 
@@ -76,16 +70,11 @@ class ResultSetTest extends BaseTest
         $index->refresh();
 
         $resultSet = $index->search('elastica search');
-
-        $this->assertInstanceOf(ResultSet::class, $resultSet);
-
         $documents = $resultSet->getDocuments();
 
         $this->assertIsArray($documents);
         $this->assertCount(3, $documents);
-        $this->assertInstanceOf(Document::class, $documents[0]);
-        $this->assertInstanceOf(Document::class, $documents[1]);
-        $this->assertInstanceOf(Document::class, $documents[2]);
+        $this->assertContainsOnlyInstancesOf(Document::class, $documents);
         $this->assertArrayNotHasKey(3, $documents);
         $this->assertEquals('elastica search', $documents[0]->get('name'));
     }

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -28,8 +28,6 @@ class ResultTest extends BaseTest
 
         $result = $resultSet->current();
 
-        $this->assertInstanceOf(Result::class, $result);
-        $this->assertInstanceOf(Document::class, $result->getDocument());
         $this->assertEquals($index->getName(), $result->getIndex());
         $this->assertEquals(3, $result->getId());
         $this->assertGreaterThan(0, $result->getScore());
@@ -71,7 +69,6 @@ class ResultTest extends BaseTest
         $result = $resultSet->current();
 
         $this->assertEquals([], $result->getSource());
-        $this->assertInstanceOf(Result::class, $result);
         $this->assertEquals($indexName, $result->getIndex());
         $this->assertEquals($docId, $result->getId());
         $this->assertGreaterThan(0, $result->getScore());

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -347,7 +347,7 @@ class SearchTest extends BaseTest
         $mockResponse = new Response(\json_encode(['timed_out' => true]));
         $client = $this->createMock(Client::class);
         $client->method('request')
-            ->will($this->returnValue($mockResponse))
+            ->willReturn($mockResponse)
         ;
         $search = new Search($client);
         $script = new Script('Thread.sleep(100); return _score;');
@@ -618,8 +618,7 @@ class SearchTest extends BaseTest
             $this->assertEquals('no such index [elastica_7086b4c2ee585bbb6740ece5ed7ece01]', $error['reason']);
         }
 
-        $results = $search->search($query, [Search::OPTION_SEARCH_IGNORE_UNAVAILABLE => true]);
-        $this->assertInstanceOf(ResultSet::class, $results);
+        $search->search($query, [Search::OPTION_SEARCH_IGNORE_UNAVAILABLE => true]);
     }
 
     /**

--- a/tests/Suggest/CompletionTest.php
+++ b/tests/Suggest/CompletionTest.php
@@ -130,9 +130,7 @@ class CompletionTest extends BaseTest
 
         $suggest->setFuzzy($fuzzy);
 
-        $this->assertEquals($fuzzy, $suggest->getParam('fuzzy'));
-
-        $this->assertInstanceOf(Completion::class, $suggest->setFuzzy($fuzzy));
+        $this->assertSame($fuzzy, $suggest->getParam('fuzzy'));
     }
 
     /**

--- a/tests/Transport/AbstractTransportTest.php
+++ b/tests/Transport/AbstractTransportTest.php
@@ -61,7 +61,7 @@ class AbstractTransportTest extends BaseTest
         $connection = new Connection();
         $params = [];
         $transport = AbstractTransport::create($transport, $connection, $params);
-        $this->assertInstanceOf(AbstractTransport::class, $transport);
+
         $this->assertSame($connection, $transport->getConnection());
     }
 

--- a/tests/Transport/NullTransportTest.php
+++ b/tests/Transport/NullTransportTest.php
@@ -83,8 +83,6 @@ class NullTransportTest extends BaseTest
         $transport = new NullTransport();
         $response = $transport->exec($request, $params);
 
-        $this->assertInstanceOf(Response::class, $response);
-
         $data = $response->getData();
         $this->assertEquals($params, $data['params']);
     }


### PR DESCRIPTION
As a lot of method returns were type-hinted, many PHPUnit assertions checking for instanceof can be deleted.