### PR TITLE
Fix numeric index names returned as int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `_seq_no` and `_primary_term` wrong initialization [#1920](https://github.com/ruflin/Elastica/pull/1920)
 * Fixed `Elastica\Connection\StrategyInterface` instance checks [#1921](https://github.com/ruflin/Elastica/pull/1921)
 * Fixed various PHPDoc annotations [#1922](https://github.com/ruflin/Elastica/pull/1922)
+* Fixed numeric index names are returned as `int` in `Elastica\Status::getIndexNames()` [#1928](https://github.com/ruflin/Elastica/pull/1928)
 ### Security
 
 ## [7.1.0](https://github.com/ruflin/Elastica/compare/7.0.0...7.1.0)

--- a/src/Status.php
+++ b/src/Status.php
@@ -57,13 +57,15 @@ class Status
     /**
      * Returns a list of the existing index names.
      *
-     * @return array Index names list
+     * @return string[]
      */
     public function getIndexNames()
     {
         $data = $this->getData();
 
-        return \array_keys($data['indices']);
+        return \array_map(static function ($name): string {
+            return (string) $name;
+        }, \array_keys($data['indices']));
     }
 
     /**

--- a/tests/StatusTest.php
+++ b/tests/StatusTest.php
@@ -27,25 +27,24 @@ class StatusTest extends BaseTest
      */
     public function testGetIndexNames(): void
     {
-        $indexName = 'test';
         $client = $this->_getClient();
-        $index = $client->getIndex($indexName);
-        $index->create([], [
-            'recreate' => true,
-        ]);
-        $index = $this->_createIndex();
-        $index->refresh();
-        $index->forcemerge();
+        $indexes = [
+            '1',
+            'test',
+        ];
 
-        $status = new Status($index->getClient());
-        $names = $status->getIndexNames();
-
-        $this->assertIsArray($names);
-        $this->assertContains($index->getName(), $names);
-
-        foreach ($names as $name) {
-            $this->assertIsString($name);
+        foreach ($indexes as $name) {
+            $client->getIndex($name)->create([], [
+                'recreate' => true,
+            ]);
         }
+
+        $status = new Status($client);
+        $indexNames = $status->getIndexNames();
+
+        $this->assertIsArray($indexNames);
+        $this->assertContainsOnly('string', $indexNames);
+        $this->assertSame($indexes, \array_intersect($indexes, $indexNames));
     }
 
     /**


### PR DESCRIPTION
When index name is numeric, `Elastica\Status::getIndexNames()` will return `int` instead of `string`.

For example, an elasticsearch response for `/_stats` for numeric index names (`0`, `1`, `2`):
```json
{
  "_shards": {},
  "_all": {},
  "indices": {
    "0": {},
    "1": {},
    "2": {}
  }
}
```

I first added a failing test in order to demonstrate the issue.
