### PR TITLE
Replace old curl constant CURLINFO_HTTP_CODE by CURLINFO_RESPONSE_CODE

### DIFF
--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -166,7 +166,7 @@ class Http extends AbstractTransport
         // Checks if error exists
         $errorNumber = \curl_errno($conn);
 
-        $response = new Response($responseString, \curl_getinfo($conn, \CURLINFO_HTTP_CODE));
+        $response = new Response($responseString, \curl_getinfo($conn, \CURLINFO_RESPONSE_CODE));
         $response->setQueryTime($end - $start);
         $response->setTransferInfo(\curl_getinfo($conn));
         if ($connection->hasConfig('bigintConversion')) {


### PR DESCRIPTION
https://www.php.net/manual/en/function.curl-getinfo.php#refsect1-function.curl-getinfo-parameters

```
CURLINFO_HTTP_CODE - The last response code. As of PHP 5.5.0 and cURL 7.10.8, this is a legacy alias of CURLINFO_RESPONSE_CODE
```