### PR TITLE
Deprecate ivory http adapter transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated `php-cs-fixer` to `2.18.3` [#1915](https://github.com/ruflin/Elastica/pull/1915)
 * Updated `composer-normalize` to `2.13.3` [#1927](https://github.com/ruflin/Elastica/pull/1927)
 ### Deprecated
+* Deprecated `Elastica\Transport\HttpAdapter` class [#1940](https://github.com/ruflin/Elastica/pull/1940)
 ### Removed
 ### Fixed
 * Fixed `_seq_no` and `_primary_term` wrong initialization [#1920](https://github.com/ruflin/Elastica/pull/1920)

--- a/src/Transport/HttpAdapter.php
+++ b/src/Transport/HttpAdapter.php
@@ -15,6 +15,11 @@ use Ivory\HttpAdapter\Message\Request as HttpAdapterRequest;
 use Ivory\HttpAdapter\Message\Response as HttpAdapterResponse;
 use Ivory\HttpAdapter\Message\Stream\StringStream;
 
+trigger_deprecation('ruflin/elastica', '7.1.1', 'The "%s" class is deprecated. It will be removed in 8.0.', HttpAdapter::class);
+
+/**
+ * @deprecated since version 7.1.1
+ */
 class HttpAdapter extends AbstractTransport
 {
     /**


### PR DESCRIPTION
https://github.com/egeloen/ivory-http-adapter is deprecated, let's deprecate it in this project too.