### PR TITLE
Allow bool, float, int in field params values for match phrase query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.1.0...master)
 ### Backward Compatibility Breaks
 * Changed `Elastica\Query\MatchQuery::setFieldParam()` signature to allow passing bool, float or int [#1941](https://github.com/ruflin/Elastica/pull/1941)
+* Changed `Elastica\Query\MatchPhraseQuery::setFieldParam()` signature to allow passing bool, float or int [#1944](https://github.com/ruflin/Elastica/pull/1944)
 ### Added
 ### Changed
 * Changed `Elastica\Status::indexExists()`, `Elastica\Status::aliasExists()` and `Elastica\Status::getIndicesWithAlias()` signatures [#1929](https://github.com/ruflin/Elastica/pull/1929)

--- a/src/Query/MatchPhrase.php
+++ b/src/Query/MatchPhrase.php
@@ -38,9 +38,11 @@ class MatchPhrase extends AbstractQuery
     /**
      * Sets a param for the given field.
      *
+     * @param bool|float|int|string $value
+     *
      * @return $this
      */
-    public function setFieldParam(string $field, string $key, string $value): self
+    public function setFieldParam(string $field, string $key, $value): self
     {
         if (!isset($this->_params[$field])) {
             $this->_params[$field] = [];


### PR DESCRIPTION
```shell
 ------ ------------------------------------------------------------------- 
  Line   Query/MatchPhrase.php                                              
 ------ ------------------------------------------------------------------- 
  83     Parameter #3 $value of method                                      
         Elastica\Query\MatchPhrase::setFieldParam() expects string, float  
         given.                                                             
 ------ ------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------- 
  Line   Query/MatchPhrasePrefix.php                                      
 ------ ----------------------------------------------------------------- 
  26     Parameter #3 $value of method                                    
         Elastica\Query\MatchPhrase::setFieldParam() expects string, int  
         given.                                                           
 ------ ----------------------------------------------------------------- 
```