### PR TITLE
Use default Elasticsearch images for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Backward Compatibility Breaks
 ### Added
 ### Changed
+
+* Using default Elasticsearch images for testing instead of OSS https://github.com/ruflin/Elastica/pull/1954
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/docker/docker-compose.es.yml
+++ b/docker/docker-compose.es.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
     es01:
-        image: docker.elastic.co/elasticsearch/elasticsearch-oss:${ES_VERSION:-7.3.2}
+        image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-7.3.2}
         command: >
             /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment
             || ./bin/elasticsearch-plugin install --batch ingest-attachment;
@@ -29,7 +29,7 @@ services:
         networks:
             - elastic
     es02:
-        image: docker.elastic.co/elasticsearch/elasticsearch-oss:${ES_VERSION:-7.3.2}
+        image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-7.3.2}
         command: >
             /bin/sh -c "./bin/elasticsearch-plugin list | grep -q ingest-attachment
             || ./bin/elasticsearch-plugin install --batch ingest-attachment;


### PR DESCRIPTION
Many great features in Elasticsearch are available in the basic release. Switch over the testing images to make it possible to also test these features.