### PR TITLE
Allow psr/log 2.0 + 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added `Elastica\Aggregation\NormalizeAggregation` [#1956](https://github.com/ruflin/Elastica/pull/1956)
 * Added `Elastica\Suggest\Phrase::addDirectGenerator` to align with ES specification [#1964](https://github.com/ruflin/Elastica/pull/1964)
+* Added support for `psr/log` 2.0 and 3.0 [#1971](https://github.com/ruflin/Elastica/pull/1971)
 ### Changed
 * Updated `php-cs-fixer` to `2.18.6` [#1955](https://github.com/ruflin/Elastica/pull/1955)
 * Updated `php-cs-fixer` to `3.0.0` [#1959](https://github.com/ruflin/Elastica/pull/1959)

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "elasticsearch/elasticsearch": "^7.1.1",
         "nyholm/dsn": "^2.0.0",
-        "psr/log": "^1.0 || ^2.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/deprecation-contracts": "^2.2",
         "symfony/polyfill-php73": "^1.19"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "elasticsearch/elasticsearch": "^7.1.1",
         "nyholm/dsn": "^2.0.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0",
         "symfony/deprecation-contracts": "^2.2",
         "symfony/polyfill-php73": "^1.19"
     },


### PR DESCRIPTION
`psr/log` 2.0 was tagged a couple of weeks ago: https://twitter.com/phpfig/status/1415413578191024130

3.0 has been tagged too, and it can be allowed since the interface us just used but not implemented anywhere.
This PR is also a blocker for https://github.com/Seldaek/monolog/pull/1564

More details are available in the new meta document: https://www.php-fig.org/psr/psr-3/meta/