### PR TITLE
[6.x] Update Versions & Dependencies table

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Versions & Dependencies
 ------------
 This project tries to follow Elasticsearch in terms of [End of Life](https://www.elastic.co/support/eol) and maintenance since 5.x
 
-| Elastica                                                                                | ElasticSearch | elasticsearch-php | PHP          |
-| --------------------------------------------------------------------------------------- | ------------- | ----------------- | ------------ |
-| [7.x](https://github.com/ruflin/Elastica/tree/master)                                   | 7.x           | ^7.0              | ^7.2 || ^8.0 |
-| [7.0](https://github.com/ruflin/Elastica/tree/7.0)                                      | 7.x           | ^7.0              | ^7.2         |
-| [6.x](https://github.com/ruflin/Elastica/tree/6.x)                                      | 6.x           | ^6.0              | ^7.0         |
-| [5.x](https://github.com/ruflin/Elastica/tree/5.x) (unmaintained)                       | 5.x           | ^5.0              | \>=5.6       |
-| [3.2.3](https://github.com/ruflin/Elastica/tree/3.2.3) (unmaintained)                   | 2.4.0         | no                | \>=5.4       |
-| [2.x](https://github.com/ruflin/Elastica/tree/2.x) (unmaintained)                       | 1.7.2         | no                | \>=5.3.3     |
+| Elastica                                                                                | ElasticSearch | elasticsearch-php | PHP            |
+| --------------------------------------------------------------------------------------- | ------------- | ----------------- | -------------- |
+| [7.x](https://github.com/ruflin/Elastica/tree/master)                                   | 7.x           | ^7.0              | ^7.2 \|\| ^8.0 |
+| [7.0](https://github.com/ruflin/Elastica/tree/7.0)                                      | 7.x           | ^7.0              | ^7.2           |
+| [6.x](https://github.com/ruflin/Elastica/tree/6.x)                                      | 6.x           | ^6.0              | ^7.0           |
+| [5.x](https://github.com/ruflin/Elastica/tree/5.x) (unmaintained)                       | 5.x           | ^5.0              | \>=5.6         |
+| [3.2.3](https://github.com/ruflin/Elastica/tree/3.2.3) (unmaintained)                   | 2.4.0         | no                | \>=5.4         |
+| [2.x](https://github.com/ruflin/Elastica/tree/2.x) (unmaintained)                       | 1.7.2         | no                | \>=5.3.3       |
 ------------


### PR DESCRIPTION
Copy updated table from https://github.com/ruflin/Elastica/commit/8ecc5cdadd5bf0b69c1eb20e56246a940b43bdb7

Escapes `|` primarily so that the 7.x supported PHP version shows `^7.2 || ^8.0` rather than just `^7.2`