### PR TITLE
Fix phpdoc

### DIFF
--- a/src/Index.php
+++ b/src/Index.php
@@ -163,9 +163,9 @@ class Index implements SearchableInterface
     /**
      * Update entries in the db based on a query.
      *
-     * @param array|Query|string $query   Query object or array
-     * @param AbstractScript     $script  Script
-     * @param array              $options Optional params
+     * @param AbstractQuery|array|Collapse|Query|string|Suggest $query   Query object or array
+     * @param AbstractScript                                    $script  Script
+     * @param array                                             $options Optional params
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html
      */
@@ -306,8 +306,8 @@ class Index implements SearchableInterface
     /**
      * Deletes documents matching the given query.
      *
-     * @param AbstractQuery|array|Query|string $query   Query object or array
-     * @param array                            $options Optional params
+     * @param AbstractQuery|array|Collapse|Query|string|Suggest $query   Query object or array
+     * @param array                                             $options Optional params
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
      */
@@ -442,9 +442,9 @@ class Index implements SearchableInterface
     }
 
     /**
-     * @param array|Query|string $query
-     * @param array|int          $options
-     * @param BuilderInterface   $builder
+     * @param AbstractQuery|array|Collapse|Query|string|Suggest $query
+     * @param array|int                                         $options
+     * @param BuilderInterface                                  $builder
      */
     public function createSearch($query = '', $options = null, ?BuilderInterface $builder = null): Search
     {
@@ -456,13 +456,7 @@ class Index implements SearchableInterface
     }
 
     /**
-     * Searches in this index.
-     *
-     * @param array|Query|string $query   Array with all query data inside or a Elastica\Query object
-     * @param array|int          $options Limit or associative array of options (option=>value)
-     * @param string             $method  Request method, see Request's constants
-     *
-     * @see \Elastica\SearchableInterface::search
+     * {@inheritdoc}
      */
     public function search($query = '', $options = null, string $method = Request::POST): ResultSet
     {
@@ -472,12 +466,7 @@ class Index implements SearchableInterface
     }
 
     /**
-     * Counts results of query.
-     *
-     * @param array|Query|string $query  Array with all query data inside or a Elastica\Query object
-     * @param string             $method Request method, see Request's constants
-     *
-     * @see \Elastica\SearchableInterface::count
+     * {@inheritdoc}
      */
     public function count($query = '', string $method = Request::POST): int
     {

--- a/src/Search.php
+++ b/src/Search.php
@@ -3,6 +3,7 @@
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
+use Elastica\Query\AbstractQuery;
 use Elastica\ResultSet\BuilderInterface;
 use Elastica\ResultSet\DefaultBuilder;
 
@@ -253,8 +254,8 @@ class Search
     /**
      * Search in the set indices.
      *
-     * @param array|Query|string $query
-     * @param array|int          $options Limit or associative array of options (option=>value)
+     * @param AbstractQuery|array|Query|string $query
+     * @param array|int                        $options Limit or associative array of options (option=>value)
      *
      * @throws InvalidException
      */
@@ -281,8 +282,8 @@ class Search
     }
 
     /**
-     * @param array|Query|string $query
-     * @param bool               $fullResult By default only the total hit count is returned. If set to true, the full ResultSet including aggregations is returned
+     * @param AbstractQuery|array|Query|string $query
+     * @param bool                             $fullResult By default only the total hit count is returned. If set to true, the full ResultSet including aggregations is returned
      *
      * @return int|ResultSet
      */
@@ -309,8 +310,8 @@ class Search
     }
 
     /**
-     * @param array|int          $options
-     * @param array|Query|string $query
+     * @param array|int                        $options
+     * @param AbstractQuery|array|Query|string $query
      */
     public function setOptionsAndQuery($options = null, $query = ''): self
     {

--- a/src/SearchableInterface.php
+++ b/src/SearchableInterface.php
@@ -2,6 +2,8 @@
 
 namespace Elastica;
 
+use Elastica\Query\AbstractQuery;
+
 /**
  * Elastica searchable interface.
  *
@@ -25,9 +27,9 @@ interface SearchableInterface
      *      }
      * }
      *
-     * @param array|Query|string $query   Array with all query data inside or a Elastica\Query object
-     * @param array|int          $options Limit or associative array of options (option=>value)
-     * @param string             $method  Request method, see Request's constants
+     * @param AbstractQuery|array|Collapse|Query|string|Suggest $query   Array with all query data inside or a Elastica\Query object
+     * @param array|int                                         $options Limit or associative array of options (option=>value)
+     * @param string                                            $method  Request method, see Request's constants
      */
     public function search($query = '', $options = null, string $method = Request::POST): ResultSet;
 
@@ -36,16 +38,16 @@ interface SearchableInterface
      *
      * If no query is set, matchall query is created
      *
-     * @param array|Query|string $query  Array with all query data inside or a Elastica\Query object
-     * @param string             $method Request method, see Request's constants
+     * @param AbstractQuery|array|Collapse|Query|string|Suggest $query  Array with all query data inside or a Elastica\Query object
+     * @param string                                            $method Request method, see Request's constants
      *
      * @return int number of documents matching the query
      */
     public function count($query = '', string $method = Request::POST);
 
     /**
-     * @param Query|string $query
-     * @param mixed|null   $options
+     * @param AbstractQuery|array|Collapse|Query|string|Suggest $query
+     * @param mixed|null                                        $options
      */
     public function createSearch($query = '', $options = null): Search;
 }


### PR DESCRIPTION
This PRs basically adds `AbstractQuery` as possible value in phpdoc when creating searches. `Query::create` supports it:

https://github.com/ruflin/Elastica/blob/e646d300ccbf0a7ec49e45a09ce30e917c97e309/src/Query.php#L57-L76

I've used `inheritdoc` (it could be removed as well) instead of duplicate the phpdoc for `Index`.