### PR TITLE
Fix addRange phpdoc

### DIFF
--- a/src/Aggregation/Range.php
+++ b/src/Aggregation/Range.php
@@ -16,7 +16,7 @@ class Range extends AbstractSimpleAggregation
     /**
      * Add a range to this aggregation.
      *
-     * @param string|float|int|null $fromValue low end of this range, exclusive (greater than or equal to)
+     * @param float|int|string|null $fromValue low end of this range, exclusive (greater than or equal to)
      * @param float|int|string|null $toValue   high end of this range, exclusive (less than)
      * @param string|null           $key       customized key value
      *


### PR DESCRIPTION
Hi, I'm not familiar with elastica but my static analysis tool is reporting me that I'm using this method with string values for `from` or `to` and I think it's correct: string should be allowed for dates.

For example: 
```
$agg_range_date->addRange(sprintf('%s 00:00:00', $dates['yesterday_YMD']), sprintf('%s 23:59:59', $dates['yesterday_YMD']), 'current');
```

 So I opened a PR to update the phpdoc.
