### PR TITLE
Add 6.x (>= 6.2.0) supports PHP 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ For details on how to contribute, check the [CONTRIBUTING](https://github.com/ru
 
 Versions & Dependencies
 ------------
-This project tries to follow Elasticsearch in terms of [End of Life](https://www.elastic.co/support/eol) and maintenance since 5.x. It is generally recommended to use the latest point release of the relevant branch.
+This project tries to follow Elasticsearch in terms of [End of Life](https://www.elastic.co/support/eol) and maintenance since 5.x.
+It is generally recommended to use the latest point release of the relevant branch.
 
-| Elastica version                                      | ElasticSearch | elasticsearch-php | PHP            |
+| Elastica branch                                       | ElasticSearch | elasticsearch-php | PHP            |
 | ----------------------------------------------------- | ------------- | ----------------- | -------------- |
 | [7.x](https://github.com/ruflin/Elastica/tree/master) | 7.x           | ^7.0              | ^7.2 \|\| ^8.0 |
 | [6.x](https://github.com/ruflin/Elastica/tree/6.x)    | 6.x           | ^6.0              | ^7.0 \|\| ^8.0 |

--- a/README.md
+++ b/README.md
@@ -30,14 +30,18 @@ For details on how to contribute, check the [CONTRIBUTING](https://github.com/ru
 
 Versions & Dependencies
 ------------
-This project tries to follow Elasticsearch in terms of [End of Life](https://www.elastic.co/support/eol) and maintenance since 5.x
+This project tries to follow Elasticsearch in terms of [End of Life](https://www.elastic.co/support/eol) and maintenance since 5.x. It is generally recommended to use the latest point release of the relevant branch.
 
-| Elastica                                                                                | ElasticSearch | elasticsearch-php | PHP            |
-| --------------------------------------------------------------------------------------- | ------------- | ----------------- | -------------- |
-| [7.x](https://github.com/ruflin/Elastica/tree/master)                                   | 7.x           | ^7.0              | ^7.2 \|\| ^8.0 |
-| [7.0](https://github.com/ruflin/Elastica/tree/7.0)                                      | 7.x           | ^7.0              | ^7.2           |
-| [6.x](https://github.com/ruflin/Elastica/tree/6.x)                                      | 6.x           | ^6.0              | ^7.0           |
-| [5.x](https://github.com/ruflin/Elastica/tree/5.x) (unmaintained)                       | 5.x           | ^5.0              | \>=5.6         |
-| [3.2.3](https://github.com/ruflin/Elastica/tree/3.2.3) (unmaintained)                   | 2.4.0         | no                | \>=5.4         |
-| [2.x](https://github.com/ruflin/Elastica/tree/2.x) (unmaintained)                       | 1.7.2         | no                | \>=5.3.3       |
+| Elastica version                                      | ElasticSearch | elasticsearch-php | PHP            |
+| ----------------------------------------------------- | ------------- | ----------------- | -------------- |
+| [7.x](https://github.com/ruflin/Elastica/tree/master) | 7.x           | ^7.0              | ^7.2 \|\| ^8.0 |
+| [6.x](https://github.com/ruflin/Elastica/tree/6.x)    | 6.x           | ^6.0              | ^7.0 \|\| ^8.0 |
+
+Unmaintained versions:
+
+| Elastica version                                      | ElasticSearch | elasticsearch-php | PHP            |
+| ----------------------------------------------------- | ------------- | ----------------- | -------------- |
+| [5.x](https://github.com/ruflin/Elastica/tree/5.x)    | 5.x           | ^5.0              | \>=5.6         |
+| [3.x](https://github.com/ruflin/Elastica/tree/3.x)    | 2.4.0         | no                | \>=5.4         |
+| [2.x](https://github.com/ruflin/Elastica/tree/2.x)    | 1.7.2         | no                | \>=5.3.3       |
 ------------


### PR DESCRIPTION
Not sure if anyone really minds how we want to denote the 6.x releases before 6.2. Happy to change to match.

Will cherry pick into 7.x and 6.x when it's decided (and this lands in master)