### PR TITLE
Avoid deprecations with PHP 8.1

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -39,7 +39,8 @@ jobs:
             elasticsearch: '7.14.1'
           - php: '8.0'
             elasticsearch: '7.14.1'
-            composer_flags: '--ignore-platform-reqs'
+          - php: '8.1'
+            elasticsearch: '7.14.1'
       fail-fast: false
     steps:
       - name: 'Checkout'

--- a/src/Multi/ResultSet.php
+++ b/src/Multi/ResultSet.php
@@ -76,6 +76,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_resultSets[$this->key()];
@@ -132,6 +133,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->_resultSets[$offset] ?? null;

--- a/src/Param.php
+++ b/src/Param.php
@@ -136,6 +136,7 @@ class Param implements ArrayableInterface, \Countable
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return \count($this->_params);


### PR DESCRIPTION
Using PHP 8.1, it triggers deprecations for implementations of some core interfaces without a return type.

Adding the return type will break BC, so [using `#[\ReturnTypeWillChange]` attribute will suppress the deprecation](https://wiki.php.net/rfc/internal_method_return_types).

I've added a job in the CI to test PHP 8.1 and removed the `composer_flags: '--ignore-platform-reqs'` option since I've guessed it was for testing `8.0` when it wasn't supported.

