### PR TITLE
Deprecate common terms query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `bytes` processor [#2008](https://github.com/ruflin/Elastica/pull/2008)
 ### Changed
 ### Deprecated
+* Deprecated `Elastica\Query\Common` class, use `Elastica\Query\MatchQuery` instead [#2013](https://github.com/ruflin/Elastica/pull/2013)
+* Deprecated `Elastica\QueryBuilder\DSL\Query::common_terms()`, use `match()` instead [#2013](https://github.com/ruflin/Elastica/pull/2013)
 * Deprecated passing an `int` as 1st argument to `Elastica\Search::setOptionsAndQuery()`, pass an array with the key `size` instead [#2010](https://github.com/ruflin/Elastica/pull/2010)
 ### Removed
 ### Fixed

--- a/src/Query/Common.php
+++ b/src/Query/Common.php
@@ -2,6 +2,8 @@
 
 namespace Elastica\Query;
 
+\trigger_deprecation('ruflin/elastica', '7.1.3', 'The "%s" class is deprecated, use "%s" instead. It will be removed in 8.0.', Common::class, MatchQuery::class);
+
 /**
  * Class Common.
  *

--- a/src/Query/Common.php
+++ b/src/Query/Common.php
@@ -8,6 +8,7 @@ namespace Elastica\Query;
  * Class Common.
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html
+ * @deprecated since version 7.1.3, use the MatchQuery class instead.
  */
 class Common extends AbstractQuery
 {

--- a/src/QueryBuilder/DSL/Query.php
+++ b/src/QueryBuilder/DSL/Query.php
@@ -111,6 +111,7 @@ class Query implements DSL
      * common terms query.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-common-terms-query.html
+     * @deprecated since version 7.1.3, use the "match()" method instead.
      *
      * @param float $cutoffFrequency percentage in decimal form (.001 == 0.1%)
      */

--- a/src/QueryBuilder/DSL/Query.php
+++ b/src/QueryBuilder/DSL/Query.php
@@ -116,6 +116,8 @@ class Query implements DSL
      */
     public function common_terms(string $field, string $query, float $cutoffFrequency): Common
     {
+        \trigger_deprecation('ruflin/elastica', '7.1.3', 'The "%s()" method is deprecated, use "match()" instead. It will be removed in 8.0.', __METHOD__);
+
         return new Common($field, $query, $cutoffFrequency);
     }
 

--- a/tests/Query/CommonTest.php
+++ b/tests/Query/CommonTest.php
@@ -5,17 +5,23 @@ namespace Elastica\Test\Query;
 use Elastica\Document;
 use Elastica\Query\Common;
 use Elastica\Test\Base as BaseTest;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @internal
  */
 class CommonTest extends BaseTest
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @group unit
+     * @group legacy
      */
     public function testToArray(): void
     {
+        $this->expectDeprecation('Since ruflin/elastica 7.1.3: The "Elastica\Query\Common" class is deprecated, use "Elastica\Query\MatchQuery" instead. It will be removed in 8.0.');
+
         $query = new Common('body', 'test query', .001);
         $query->setLowFrequencyOperator(Common::OPERATOR_AND);
 
@@ -34,6 +40,7 @@ class CommonTest extends BaseTest
 
     /**
      * @group functional
+     * @group legacy
      */
     public function testQuery(): void
     {
@@ -66,6 +73,7 @@ class CommonTest extends BaseTest
 
     /**
      * @group unit
+     * @group legacy
      */
     public function testSetHighFrequencyOperator(): void
     {
@@ -78,6 +86,7 @@ class CommonTest extends BaseTest
 
     /**
      * @group unit
+     * @group legacy
      */
     public function testSetBoost(): void
     {
@@ -90,6 +99,7 @@ class CommonTest extends BaseTest
 
     /**
      * @group unit
+     * @group legacy
      */
     public function testSetAnalyzer(): void
     {

--- a/tests/QueryBuilder/DSL/QueryTest.php
+++ b/tests/QueryBuilder/DSL/QueryTest.php
@@ -5,12 +5,15 @@ namespace Elastica\Test\QueryBuilder\DSL;
 use Elastica\Query;
 use Elastica\Query\MatchQuery;
 use Elastica\QueryBuilder\DSL;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @internal
  */
 class QueryTest extends AbstractDSLTest
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @group unit
      */
@@ -36,6 +39,7 @@ class QueryTest extends AbstractDSLTest
 
     /**
      * @group unit
+     * @group legacy
      */
     public function testInterface(): void
     {
@@ -43,6 +47,7 @@ class QueryTest extends AbstractDSLTest
 
         $this->_assertImplemented($queryDSL, 'bool', Query\BoolQuery::class, []);
         $this->_assertImplemented($queryDSL, 'boosting', Query\Boosting::class, []);
+        $this->expectDeprecation('Since ruflin/elastica 7.1.3: The "Elastica\QueryBuilder\DSL\Query::common_terms()" method is deprecated, use "match()" instead. It will be removed in 8.0.');
         $this->_assertImplemented($queryDSL, 'common_terms', Query\Common::class, ['field', 'query', 0.001]);
         $this->_assertImplemented($queryDSL, 'dis_max', Query\DisMax::class, []);
         $this->_assertImplemented($queryDSL, 'distance_feature', Query\DistanceFeature::class, ['field', 'now', '7d']);


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/pull/42654
This will help to remove deprecated code for 8.x version