### PR TITLE
Fix symfony/deprecation-contracts package for Symfony 6 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.1.3...master)
 ### Backward Compatibility Breaks
 ### Added
+* Added support for `symfony/deprecation-contracts` 3.0 by @rguennichi [#2047](https://github.com/ruflin/Elastica/pull/2047)
 ### Changed
 ### Deprecated
 ### Removed

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "elasticsearch/elasticsearch": "^7.1.1",
         "nyholm/dsn": "^2.0.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/deprecation-contracts": "^2.2",
+        "symfony/deprecation-contracts": "^2.2 || ^3.0",
         "symfony/polyfill-php73": "^1.19"
     },
     "require-dev": {


### PR DESCRIPTION
For Symfony 6.0.x compatibility

```
- ruflin/elastica[7.1.2, ..., 7.1.3] require symfony/deprecation-contracts ^2.2 -> found symfony/deprecation-contracts[v2.2.0, v2.4.0, v2.4.1, v2.5.0] but the package is fixed to v3.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```