### PR TITLE
Remove version/version_type options from Index::addDocument()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 * Fixed version parameters for DeleteDocument by @pheyse24 [#2048](https://github.com/ruflin/Elastica/pull/2048)
+* Fixed version parameters for Index::addDocument() by @pidera [#2050](https://github.com/ruflin/Elastica/pull/2050)
 ### Security
 
 ## [7.1.3](https://github.com/ruflin/Elastica/compare/7.1.2...7.1.3)

--- a/src/Index.php
+++ b/src/Index.php
@@ -198,17 +198,16 @@ class Index implements SearchableInterface
 
         $options = $doc->getOptions(
             [
-                'version',
-                'version_type',
-                'routing',
-                'percolate',
-                'parent',
-                'op_type',
                 'consistency',
-                'replication',
-                'refresh',
-                'timeout',
+                'op_type',
+                'parent',
+                'percolate',
                 'pipeline',
+                'refresh',
+                'replication',
+                'retry_on_conflict',
+                'routing',
+                'timeout',
             ]
         );
 

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -522,6 +522,28 @@ class IndexTest extends BaseTest
     /**
      * @group functional
      */
+    public function testAddDocumentAcrossIndices(): void
+    {
+        $client = $this->_getClient();
+        $index1 = $client->getIndex('test');
+        $index2 = $client->getIndex('test_2');
+
+        $doc = new Document(1);
+        $doc->set('title', 'Hello world');
+
+        $index1->addDocument($doc);
+
+        $index1Doc = $index1->getDocument(1);
+
+        $index2->addDocument($index1Doc);
+        $index2Doc = $index1->getDocument(1);
+
+        $this->assertEquals('Hello world', $index2Doc->get('title'));
+    }
+
+    /**
+     * @group functional
+     */
     public function testClearCache(): void
     {
         $index = $this->_createIndex();


### PR DESCRIPTION
As mentioned in #2049, the version/version_type has been removed in 7.x as concurrency control.

These options were still always added in the `addDocument` method which causes an issue when adding a document from one index to another.

This PR removes those options, and sorts the other options alphabetically cfr #1803.