### PR TITLE
Add explicit return annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.1.4...master)
 ### Backward Compatibility Breaks
 ### Added
+* Added explicit return annotation to `Elastica\Multi\ResultSet::current()` and `Elastica\Multi\ResultSet::offsetGet()` by @franmomu
+  [2056](https://github.com/ruflin/Elastica/pull/2056)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Multi/ResultSet.php
+++ b/src/Multi/ResultSet.php
@@ -75,6 +75,8 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function current()
@@ -132,6 +134,8 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)


### PR DESCRIPTION
When using Symfony >= 5.4, you get this kind of messages:

```
User Deprecated: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Elastica\Multi\ResultSet" now to avoid errors or add an explicit @return annotation to suppress this message.
```

```
User Deprecated: Method "Iterator::current()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Elastica\Multi\ResultSet" now to avoid errors or add an explicit @return annotation to suppress this message.
```

This PR avoids these messages.