### PR TITLE
[6.x] No php 8.1 deprecation warnings

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -39,6 +39,8 @@ jobs:
             elasticsearch: '6.5.2'
           - php: '8.0'
             elasticsearch: '6.5.2'
+          - php: '8.1'
+            elasticsearch: '6.5.2'
       fail-fast: false
     steps:
       - name: 'Checkout'

--- a/lib/Elastica/Bulk/ResponseSet.php
+++ b/lib/Elastica/Bulk/ResponseSet.php
@@ -101,11 +101,13 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
     /**
      * @return \Elastica\Bulk\Response
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_bulkResponses[$this->key()];
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->_position;
@@ -114,6 +116,7 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->_position;
@@ -122,11 +125,13 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
     /**
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->_bulkResponses[$this->key()]);
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->_position = 0;
@@ -135,6 +140,7 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_bulkResponses);

--- a/lib/Elastica/Multi/ResultSet.php
+++ b/lib/Elastica/Multi/ResultSet.php
@@ -82,11 +82,13 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     /**
      * @return \Elastica\ResultSet
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_resultSets[$this->key()];
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->_position;
@@ -95,6 +97,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->_position;
@@ -103,11 +106,13 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     /**
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->_resultSets[$this->key()]);
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->_position = 0;
@@ -116,6 +121,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_resultSets);
@@ -126,6 +132,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
      *
      * @return bool true on success or false on failure
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_resultSets[$offset]);
@@ -136,6 +143,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
      *
      * @return mixed can return all value types
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->_resultSets[$offset] ?? null;
@@ -145,6 +153,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
      * @param mixed $offset
      * @param mixed $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -157,6 +166,7 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
     /**
      * @param mixed $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_resultSets[$offset]);

--- a/lib/Elastica/Param.php
+++ b/lib/Elastica/Param.php
@@ -187,6 +187,7 @@ class Param implements ArrayableInterface, \Countable
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_params);

--- a/lib/Elastica/ResultSet.php
+++ b/lib/Elastica/ResultSet.php
@@ -219,6 +219,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @return int Size of set
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_results);
@@ -239,6 +240,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @return \Elastica\Result Set object
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_results[$this->key()];
@@ -247,6 +249,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     /**
      * Sets pointer (current) to the next item of the set.
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->_position;
@@ -257,6 +260,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @return int Current position
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->_position;
@@ -267,6 +271,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @return bool True if object exists
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->_results[$this->key()]);
@@ -275,6 +280,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
     /**
      * Resets position to 0, restarts iterator.
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->_position = 0;
@@ -289,6 +295,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @return bool true on success or false on failure
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_results[$offset]);
@@ -305,6 +312,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @return Result
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {
@@ -324,6 +332,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @throws Exception\InvalidException
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (!($value instanceof Result)) {
@@ -344,6 +353,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @param int $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_results[$offset]);


### PR DESCRIPTION
Using PHP 8.1, it triggers deprecations for implementations of some core interfaces without a return type.

Adding the return type will break BC, so [using #[\ReturnTypeWillChange] attribute will suppress the deprecation](https://wiki.php.net/rfc/internal_method_return_types).