### PR TITLE
Add conflict with some guzzle versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     },
     "suggest": {
         "aws/aws-sdk-php": "Allow using IAM authentication with Amazon ElasticSearch Service",
-        "egeloen/http-adapter": "Allow using httpadapter as transport",
         "guzzlehttp/guzzle": "Allow using guzzle as transport",
         "monolog/monolog": "Logging request"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         "symfony/deprecation-contracts": "^2.2 || ^3.0",
         "symfony/polyfill-php73": "^1.19"
     },
+    "conflict": {
+        "guzzlehttp/guzzle": "<6.3 || >=7.0,<7.2"
+    },
     "require-dev": {
         "aws/aws-sdk-php": "^3.155",
         "guzzlehttp/guzzle": "^6.3 || ^7.2",


### PR DESCRIPTION
Closes https://github.com/ruflin/Elastica/issues/2065

The thing is that we are testing `"guzzlehttp/guzzle": "^6.3 || ^7.2"`, but a user right now could for example use version `4` and will probably get some errors.

Adding a conflict allow us to be able to restrict which versions of the library we are supporting.