### PR TITLE
Add `null` to some PHPDoc types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Updated `symfony/phpunit-bridge` to `6.0` by @franmomu [#2067](https://github.com/ruflin/Elastica/pull/2067)
 ### Deprecated
+* Deprecated `Elastica\Reindex::WAIT_FOR_COMPLETION_FALSE`, use a boolean as parameter instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
+* Passing anything else than a boolean as 1st argument to `Reindex::setWaitForCompletion`, pass a boolean instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
 ### Removed
 * Removed `egeloen/http-adapter` as suggested package since the project is abandoned by @franmomu [#2069](https://github.com/ruflin/Elastica/pull/2069)
 * Removed `0` as valid request data using Analyze API by @franmomu [#2068](https://github.com/ruflin/Elastica/pull/2068)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed `egeloen/http-adapter` as suggested package since the project is abandoned by @franmomu [#2069](https://github.com/ruflin/Elastica/pull/2069)
 * Removed `0` as valid request data using Analyze API by @franmomu [#2068](https://github.com/ruflin/Elastica/pull/2068)
 ### Fixed
+* Fixed some PHPDoc types adding `null` as possible value by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
 ### Security
 
 ## [7.1.5](https://github.com/ruflin/Elastica/compare/7.1.5...7.1.4)

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -307,9 +307,9 @@ class AbstractUpdateAction extends Param
      */
     public function setRefresh($refresh = true)
     {
-        \is_bool($refresh) && $refresh = $refresh
-            ? Reindex::REFRESH_TRUE
-            : Reindex::REFRESH_FALSE;
+        if (\is_bool($refresh)) {
+            $refresh = $refresh ? Reindex::REFRESH_TRUE : Reindex::REFRESH_FALSE;
+        }
 
         return $this->setParam(Reindex::REFRESH, $refresh);
     }

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -303,6 +303,8 @@ class AbstractUpdateAction extends Param
     /**
      * @param bool|string $refresh
      *
+     * @phpstan-param bool|Reindex::REFRESH_* $refresh
+     *
      * @return $this
      */
     public function setRefresh($refresh = true)

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -341,7 +341,7 @@ class Connection extends Param
     }
 
     /**
-     * @return string User
+     * @return string|null User
      */
     public function getUsername()
     {
@@ -349,7 +349,7 @@ class Connection extends Param
     }
 
     /**
-     * @return string Password
+     * @return string|null Password
      */
     public function getPassword()
     {

--- a/src/Query/AbstractGeoDistance.php
+++ b/src/Query/AbstractGeoDistance.php
@@ -36,14 +36,14 @@ abstract class AbstractGeoDistance extends AbstractQuery
     /**
      * Latitude.
      *
-     * @var float
+     * @var float|null
      */
     protected $_latitude;
 
     /**
      * Longitude.
      *
-     * @var float
+     * @var float|null
      */
     protected $_longitude;
 

--- a/src/Reindex.php
+++ b/src/Reindex.php
@@ -75,7 +75,9 @@ class Reindex extends Param
 
     public function setWaitForCompletion($value): void
     {
-        \is_bool($value) && $value = $value ? 'true' : 'false';
+        if (\is_bool($value)) {
+            $value = $value ? 'true' : 'false';
+        }
 
         $this->setParam(self::WAIT_FOR_COMPLETION, $value);
     }

--- a/src/Reindex.php
+++ b/src/Reindex.php
@@ -27,6 +27,10 @@ class Reindex extends Param
     public const REFRESH_FALSE = 'false';
     public const REFRESH_WAIT_FOR = 'wait_for';
     public const WAIT_FOR_COMPLETION = 'wait_for_completion';
+
+    /**
+     * @deprecated since version 7.2.0, use a boolean as parameter instead.
+     */
     public const WAIT_FOR_COMPLETION_FALSE = 'false';
     public const WAIT_FOR_ACTIVE_SHARDS = 'wait_for_active_shards';
     public const TIMEOUT = 'timeout';
@@ -80,6 +84,8 @@ class Reindex extends Param
     {
         if (\is_bool($value)) {
             $value = $value ? 'true' : 'false';
+        } else {
+            \trigger_deprecation('ruflin/elastica', '7.1.6', 'Passing anything else than a boolean as 1st argument to "%s()" is deprecated, pass a boolean instead. It will be removed in 8.0.', __METHOD__);
         }
 
         $this->setParam(self::WAIT_FOR_COMPLETION, $value);

--- a/src/Reindex.php
+++ b/src/Reindex.php
@@ -73,6 +73,9 @@ class Reindex extends Param
         return $this->_lastResponse;
     }
 
+    /**
+     * @param bool $value
+     */
     public function setWaitForCompletion($value): void
     {
         if (\is_bool($value)) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -20,7 +20,7 @@ class Request extends Param
     public const NDJSON_CONTENT_TYPE = 'application/x-ndjson';
 
     /**
-     * @var Connection
+     * @var Connection|null
      */
     protected $_connection;
 

--- a/src/Transport/NullTransport.php
+++ b/src/Transport/NullTransport.php
@@ -20,7 +20,7 @@ class NullTransport extends AbstractTransport
     /**
      * Response you want to get from the transport.
      *
-     * @var Response Response
+     * @var Response|null Response
      */
     protected $_response;
 

--- a/tests/ReindexTest.php
+++ b/tests/ReindexTest.php
@@ -143,13 +143,25 @@ class ReindexTest extends Base
         $newIndex = $this->_createIndex('idx2', true, 2);
 
         $reindex = new Reindex($oldIndex, $newIndex);
-        $reindex->setWaitForCompletion(Reindex::WAIT_FOR_COMPLETION_FALSE);
+        $reindex->setWaitForCompletion(false);
         $reindex->run();
 
         $this->assertNotEmpty($reindex->getTaskId());
+    }
+
+    /**
+     * @group functional
+     * @group legacy
+     */
+    public function testReindexWithDeprecatedConstantSetOnWaitForCompletion(): void
+    {
+        $oldIndex = $this->_createIndex('idx1', true, 2);
+        $this->_addDocs($oldIndex, 10);
+
+        $newIndex = $this->_createIndex('idx2', true, 2);
 
         $reindex = new Reindex($oldIndex, $newIndex);
-        $reindex->setWaitForCompletion(false);
+        $reindex->setWaitForCompletion(Reindex::WAIT_FOR_COMPLETION_FALSE);
         $reindex->run();
 
         $this->assertNotEmpty($reindex->getTaskId());


### PR DESCRIPTION
This PR fixes some issues found by PHPStan raising level to 4, this include the fixes of @deguif in https://github.com/deguif/Elastica/commit/c74d4f0d226d9f14c64a2c068dd286f55d07af67

This first commit is only about extracting the variable assignment out of the logical statement.