### PR TITLE
Fix some PHPStan findings in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 * Removed `egeloen/http-adapter` as suggested package since the project is abandoned by @franmomu [#2069](https://github.com/ruflin/Elastica/pull/2069)
 * Removed `0` as valid request data using Analyze API by @franmomu [#2068](https://github.com/ruflin/Elastica/pull/2068)
+* Removed dead code in `AwsAuthV4Test` by @franmomu [#2073](https://github.com/ruflin/Elastica/pull/2073)
 ### Fixed
 * Fixed some PHPDoc types adding `null` as possible value by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
 ### Security

--- a/tests/ReindexTest.php
+++ b/tests/ReindexTest.php
@@ -208,7 +208,8 @@ class ReindexTest extends Base
 
         try {
             $reindex->run();
-            $this->assertFalse(true, 'Elasticsearch should have thrown an Exception, maybe the remote option has not been sent.');
+
+            $this->fail('Elasticsearch should have thrown an Exception, maybe the remote option has not been sent.');
         } catch (ResponseException $exception) {
             $this->assertStringContainsString('reindex.remote.whitelist', $exception->getMessage());
         }

--- a/tests/Transport/AwsAuthV4Test.php
+++ b/tests/Transport/AwsAuthV4Test.php
@@ -6,7 +6,6 @@ use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\Sdk;
 use Elastica\Exception\Connection\GuzzleException;
-use GuzzleHttp\Exception\TransferException;
 
 /**
  * @internal
@@ -40,21 +39,17 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
-            if ($guzzleException instanceof TransferException) {
-                $request = $guzzleException->getRequest();
-                $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
-                    .\date('Ymd').'/us-east-1/es/aws4_request, ';
-                $this->assertStringStartsWith(
-                    $expected,
-                    $request->getHeaderLine('Authorization')
-                );
-                $this->assertSame(
-                    'baz',
-                    $request->getHeaderLine('X-Amz-Security-Token')
-                );
-            } else {
-                throw $e;
-            }
+            $request = $guzzleException->getRequest();
+            $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
+                .\date('Ymd').'/us-east-1/es/aws4_request, ';
+            $this->assertStringStartsWith(
+                $expected,
+                $request->getHeaderLine('Authorization')
+            );
+            $this->assertSame(
+                'baz',
+                $request->getHeaderLine('X-Amz-Security-Token')
+            );
         }
     }
 
@@ -81,21 +76,17 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
-            if ($guzzleException instanceof TransferException) {
-                $request = $guzzleException->getRequest();
-                $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
-                    .\date('Ymd').'/us-east-1/es/aws4_request, ';
-                $this->assertStringStartsWith(
-                    $expected,
-                    $request->getHeaderLine('Authorization')
-                );
-                $this->assertSame(
-                    'baz',
-                    $request->getHeaderLine('X-Amz-Security-Token')
-                );
-            } else {
-                throw $e;
-            }
+            $request = $guzzleException->getRequest();
+            $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
+                .\date('Ymd').'/us-east-1/es/aws4_request, ';
+            $this->assertStringStartsWith(
+                $expected,
+                $request->getHeaderLine('Authorization')
+            );
+            $this->assertSame(
+                'baz',
+                $request->getHeaderLine('X-Amz-Security-Token')
+            );
         }
     }
 
@@ -119,21 +110,17 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
-            if ($guzzleException instanceof TransferException) {
-                $request = $guzzleException->getRequest();
-                $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
-                    .\date('Ymd').'/us-east-1/es/aws4_request, ';
-                $this->assertStringStartsWith(
-                    $expected,
-                    $request->getHeaderLine('Authorization')
-                );
-                $this->assertSame(
-                    'baz',
-                    $request->getHeaderLine('X-Amz-Security-Token')
-                );
-            } else {
-                throw $e;
-            }
+            $request = $guzzleException->getRequest();
+            $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
+                .\date('Ymd').'/us-east-1/es/aws4_request, ';
+            $this->assertStringStartsWith(
+                $expected,
+                $request->getHeaderLine('Authorization')
+            );
+            $this->assertSame(
+                'baz',
+                $request->getHeaderLine('X-Amz-Security-Token')
+            );
         }
     }
 
@@ -153,11 +140,9 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
-            if ($guzzleException instanceof TransferException) {
-                $request = $guzzleException->getRequest();
+            $request = $guzzleException->getRequest();
 
-                $this->assertSame('http', $request->getUri()->getScheme());
-            }
+            $this->assertSame('http', $request->getUri()->getScheme());
         }
     }
 
@@ -178,11 +163,9 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
-            if ($guzzleException instanceof TransferException) {
-                $request = $guzzleException->getRequest();
+            $request = $guzzleException->getRequest();
 
-                $this->assertSame('https', $request->getUri()->getScheme());
-            }
+            $this->assertSame('https', $request->getUri()->getScheme());
         }
     }
 
@@ -202,21 +185,17 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
-            if ($guzzleException instanceof TransferException) {
-                $request = $guzzleException->getRequest();
-                $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
-                    .\date('Ymd').'/us-east-1/es/aws4_request, ';
-                $this->assertStringStartsWith(
-                    $expected,
-                    $request->getHeaderLine('Authorization')
-                );
-                $this->assertSame(
-                    'baz',
-                    $request->getHeaderLine('X-Amz-Security-Token')
-                );
-            } else {
-                throw $e;
-            }
+            $request = $guzzleException->getRequest();
+            $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
+                .\date('Ymd').'/us-east-1/es/aws4_request, ';
+            $this->assertStringStartsWith(
+                $expected,
+                $request->getHeaderLine('Authorization')
+            );
+            $this->assertSame(
+                'baz',
+                $request->getHeaderLine('X-Amz-Security-Token')
+            );
         }
     }
 }


### PR DESCRIPTION
`GuzzleException::getGuzzleException()` always returns a `TransferException`:

https://github.com/ruflin/Elastica/blob/4087569dfe7e0c8a24470fa22532c7a69bb86343/src/Exception/Connection/GuzzleException.php#L18-L41