### PR TITLE
Add missing `throws exception`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added `PHPStan` at level 3 by @franmomu [#2064](https://github.com/ruflin/Elastica/pull/2064)
 * Added coverage check to CI by @franmomu [#2071](https://github.com/ruflin/Elastica/pull/2071)
+* Added missing `throws` PHPDoc tags
 ### Changed
 * Updated `symfony/phpunit-bridge` to `6.0` by @franmomu [#2067](https://github.com/ruflin/Elastica/pull/2067)
 * Updated `php-cs-fixer` to `3.8.0` [#2074](https://github.com/ruflin/Elastica/pull/2074)

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -2,6 +2,8 @@
 
 namespace Elastica;
 
+use Elastica\Exception\InvalidException;
+
 /**
  * Base class for things that can be sent to the update api (Document and
  * Script).
@@ -55,7 +57,7 @@ class AbstractUpdateAction extends Param
     /**
      * Get the document index name.
      *
-     * @throws \Elastica\Exception\InvalidException
+     * @throws InvalidException
      *
      * @return string Index name
      */
@@ -103,6 +105,8 @@ class AbstractUpdateAction extends Param
     /**
      * Returns document version.
      *
+     * @throws InvalidException
+     *
      * @return int Document version
      */
     public function getSequenceNumber(): int
@@ -132,6 +136,8 @@ class AbstractUpdateAction extends Param
     /**
      * Returns document version.
      *
+     * @throws InvalidException
+     *
      * @return int Document version
      */
     public function getPrimaryTerm(): int
@@ -160,6 +166,8 @@ class AbstractUpdateAction extends Param
 
     /**
      * Returns document version.
+     *
+     * @throws InvalidException
      *
      * @return int|string Document version
      */
@@ -191,6 +199,8 @@ class AbstractUpdateAction extends Param
     /**
      * Get operation type.
      *
+     * @throws InvalidException
+     *
      * @return string
      */
     public function getOpType()
@@ -220,6 +230,8 @@ class AbstractUpdateAction extends Param
 
     /**
      * Get routing parameter.
+     *
+     * @throws InvalidException
      *
      * @return string
      */
@@ -259,6 +271,8 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * @throws InvalidException
+     *
      * @return string
      */
     public function getFields()
@@ -285,6 +299,8 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * @throws InvalidException
+     *
      * @return int
      */
     public function getRetryOnConflict()
@@ -317,6 +333,8 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * @throws InvalidException
+     *
      * @return bool|string
      */
     public function getRefresh()
@@ -347,6 +365,8 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * @throws InvalidException
+     *
      * @return bool
      */
     public function getTimeout()
@@ -373,6 +393,8 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * @throws InvalidException
+     *
      * @return string
      */
     public function getConsistency()
@@ -399,6 +421,8 @@ class AbstractUpdateAction extends Param
     }
 
     /**
+     * @throws InvalidException
+     *
      * @return string
      */
     public function getReplication()

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,8 +4,10 @@ namespace Elastica;
 
 use Elastica\Bulk\Action;
 use Elastica\Bulk\ResponseSet;
+use Elastica\Exception\ClientException;
 use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\ResponseException;
 use Elastica\Script\AbstractScript;
 use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Endpoints\ClosePointInTime;
@@ -474,7 +476,7 @@ class Client
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      *
-     * @throws \Elastica\Exception\ResponseException
+     * @throws ResponseException
      * @throws InvalidException
      */
     public function bulk(array $params): ResponseSet
@@ -501,7 +503,9 @@ class Client
      * @param array        $query       OPTIONAL Query params
      * @param string       $contentType Content-Type sent with this request
      *
-     * @throws Exception\ClientException|Exception\ConnectionException
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function request(string $path, string $method = Request::GET, $data = [], array $query = [], string $contentType = Request::DEFAULT_CONTENT_TYPE): Response
     {

--- a/src/Request.php
+++ b/src/Request.php
@@ -2,7 +2,9 @@
 
 namespace Elastica;
 
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\ResponseException;
 
 /**
  * Elastica Request object.
@@ -169,6 +171,9 @@ class Request extends Param
 
     /**
      * Sends request to server.
+     *
+     * @throws ResponseException
+     * @throws ConnectionException
      */
     public function send(): Response
     {

--- a/src/Search.php
+++ b/src/Search.php
@@ -3,6 +3,7 @@
 namespace Elastica;
 
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\ResponseException;
 use Elastica\ResultSet\BuilderInterface;
 use Elastica\ResultSet\DefaultBuilder;
 
@@ -257,6 +258,7 @@ class Search
      * @param array|int                              $options Limit or associative array of options (option=>value)
      *
      * @throws InvalidException
+     * @throws ResponseException
      */
     public function search($query = '', $options = null, string $method = Request::POST): ResultSet
     {

--- a/src/Transport/AbstractTransport.php
+++ b/src/Transport/AbstractTransport.php
@@ -3,7 +3,9 @@
 namespace Elastica\Transport;
 
 use Elastica\Connection;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\ResponseException;
 use Elastica\Param;
 use Elastica\Request;
 use Elastica\Response;
@@ -50,6 +52,9 @@ abstract class AbstractTransport extends Param
      *
      * @param Request $request Request object
      * @param array   $params  Hostname, port, path, ...
+     *
+     * @throws ResponseException
+     * @throws ConnectionException
      */
     abstract public function exec(Request $request, array $params): Response;
 


### PR DESCRIPTION
To reach level 4 of PHPStan, there are a couple of issues in `tests` about exceptions never thrown, like:

```
 ------ -------------------------------------------------------------------------------------
  Line   tests/Transport/AbstractTransportTest.php
 ------ -------------------------------------------------------------------------------------
  136    Dead catch - Elastica\Exception\ResponseException is never thrown in the try block.
 ------ -------------------------------------------------------------------------------------
```

This PR adds `throws InvalidException` to methods which call `getParam` directly (there are already other with it) and also adds `ResponseException` and propagates it.