### PR TITLE
Allow `string` for Request data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added `PHPStan` at level 3 by @franmomu [#2064](https://github.com/ruflin/Elastica/pull/2064)
 * Added coverage check to CI by @franmomu [#2071](https://github.com/ruflin/Elastica/pull/2071)
+* Added `string` as a valid type for `data` in `Request`
 ### Changed
 * Updated `symfony/phpunit-bridge` to `6.0` by @franmomu [#2067](https://github.com/ruflin/Elastica/pull/2067)
 * Updated `php-cs-fixer` to `3.8.0` [#2074](https://github.com/ruflin/Elastica/pull/2074)

--- a/src/Request.php
+++ b/src/Request.php
@@ -27,11 +27,11 @@ class Request extends Param
     /**
      * Construct.
      *
-     * @param string $path        Request path
-     * @param string $method      OPTIONAL Request method (use const's) (default = self::GET)
-     * @param array  $data        OPTIONAL Data array
-     * @param array  $query       OPTIONAL Query params
-     * @param string $contentType Content-Type sent with this request
+     * @param string       $path        Request path
+     * @param string       $method      OPTIONAL Request method (use const's) (default = self::GET)
+     * @param array|string $data        OPTIONAL Data array
+     * @param array        $query       OPTIONAL Query params
+     * @param string       $contentType Content-Type sent with this request
      */
     public function __construct(string $path, string $method = self::GET, $data = [], array $query = [], ?Connection $connection = null, string $contentType = self::DEFAULT_CONTENT_TYPE)
     {
@@ -72,7 +72,7 @@ class Request extends Param
     /**
      * Sets the request data.
      *
-     * @param array $data Request data
+     * @param array|string $data Request data
      *
      * @return $this
      */
@@ -84,7 +84,7 @@ class Request extends Param
     /**
      * Return request data.
      *
-     * @return array Request data
+     * @return array|string Request data
      */
     public function getData()
     {


### PR DESCRIPTION
Looking at the `Client::request`:

https://github.com/ruflin/Elastica/blob/682b78d775a2147eda66e8d12e56aa4db3b85809/src/Client.php#L500-L509

It uses `array|string` for the `data` that is passed to `Request`.

And also in `Http` transport:

https://github.com/ruflin/Elastica/blob/682b78d775a2147eda66e8d12e56aa4db3b85809/src/Transport/Http.php#L120-L137

It treats `data` as a `string|array`.

PHPStan found this at level 4:

```
 ------ -----------------------------------------------------------------------
  Line   src/Transport/Http.php
 ------ -----------------------------------------------------------------------
  132    Else branch is unreachable because previous condition is always true.
 ------ -----------------------------------------------------------------------
```