### PR TITLE
PHPStan level 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Updated `symfony/phpunit-bridge` to `6.0` by @franmomu [#2067](https://github.com/ruflin/Elastica/pull/2067)
 * Updated `php-cs-fixer` to `3.8.0` [#2074](https://github.com/ruflin/Elastica/pull/2074)
+* Increased `PHPStan` level to `4` [#2080](https://github.com/ruflin/Elastica/pull/2080)
 ### Deprecated
 * Deprecated `Elastica\Reindex::WAIT_FOR_COMPLETION_FALSE`, use a boolean as parameter instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
 * Passing anything else than a boolean as 1st argument to `Reindex::setWaitForCompletion`, pass a boolean instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
 			message: "#^Method Elastica\\\\QueryBuilder\\:\\:aggregation\\(\\) should return Elastica\\\\QueryBuilder\\\\DSL\\\\Aggregation but returns Elastica\\\\QueryBuilder\\\\Facade\\.$#"
 			count: 1
 			path: src/QueryBuilder.php
@@ -76,6 +81,31 @@ parameters:
 			path: tests/DocumentTest.php
 
 		-
+			message: "#^Dead catch \\- Elastica\\\\Exception\\\\InvalidException is never thrown in the try block\\.$#"
+			count: 1
+			path: tests/DocumentTest.php
+
+		-
+			message: "#^Expression \"\\$document\\-\\>field5\" on a separate line does not do anything\\.$#"
+			count: 1
+			path: tests/DocumentTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/DocumentTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/IndexTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 2
+			path: tests/Multi/SearchTest.php
+
+		-
 			message: "#^Call to an undefined method ReflectionType\\:\\:getName\\(\\)\\.$#"
 			count: 2
 			path: tests/QueryBuilder/DSL/AbstractDSLTest.php
@@ -94,6 +124,16 @@ parameters:
 			message: "#^Call to an undefined method Elastica\\\\QueryBuilder\\:\\:invalid\\(\\)\\.$#"
 			count: 1
 			path: tests/QueryBuilderTest.php
+
+		-
+			message: "#^Expression \"\\$index\\-\\>search\\('elastica search'\\)\\[3\\]\" on a separate line does not do anything\\.$#"
+			count: 1
+			path: tests/ResultSetTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/SnapshotTest.php
 
 		-
 			message: "#^Call to an undefined method GuzzleHttp\\\\Exception\\\\TransferException\\:\\:getRequest\\(\\)\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,13 +3,14 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 3
+    level: 4
     paths:
         - src
         - tests
     excludePaths:
         - src/Transport/HttpAdapter.php
         - src/Query/Match.php
+    treatPhpDocTypesAsCertain: false
     ignoreErrors:
         # we don't have different constructors for parent/child
         - '~^Unsafe usage of new static\(\)\.$~'

--- a/tests/Collapse/CollapseTest.php
+++ b/tests/Collapse/CollapseTest.php
@@ -112,10 +112,12 @@ class CollapseTest extends BaseTest
         $collapse->setInnerHits($innerHits1);
         $collapse->addInnerHits($innerHits2);
 
-        $this->assertCount(2, $collapse->getParam('inner_hits'));
-        $this->assertIsArray($collapse->getParam('inner_hits'));
-        $this->assertEquals($innerHits1, $collapse->getParam('inner_hits')[0]);
-        $this->assertEquals($innerHits2, $collapse->getParam('inner_hits')[1]);
+        $innerHits = $collapse->getParam('inner_hits');
+
+        $this->assertCount(2, $innerHits);
+        $this->assertIsArray($innerHits);
+        $this->assertEquals($innerHits1, $innerHits[0]);
+        $this->assertEquals($innerHits2, $innerHits[1]);
 
         $innerHitsOverride = new InnerHits();
         $innerHitsOverride->setName('override');


### PR DESCRIPTION
So this PR increases PHPstan level and sets `treatPhpDocTypesAsCertain` as `false`, this is because there are several errors like:

```
 ------ --------------------------------------------------------------------------------------------------------------------------------------------
  Line   src/Aggregation/GeohashGrid.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------
  48     Result of && is always false.
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.
  49     Else branch is unreachable because ternary operator condition is always true.
 ------ --------------------------------------------------------------------------------------------------------------------------------------------
```

but the code is fine:

https://github.com/ruflin/Elastica/blob/ea9fbd6740139d6045c201a6b75d061289009b80/src/Aggregation/GeohashGrid.php#L42-L50

About the ignored errors (all in `tests`), most of them are because of `TestCase::markTestSkipped()` call, so it warns about the code after that call not being executed.
