### PR TITLE
Use proper types in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed dead code in `AwsAuthV4Test` by @franmomu [#2073](https://github.com/ruflin/Elastica/pull/2073)
 ### Fixed
 * Fixed some PHPDoc types adding `null` as possible value by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
+* Fixed passing wrong types to `GapPolicyInterface::setGapPolicy()`, `Document::setDocAsUpsert()` and `Connection::setPort()` methods.
 ### Security
 
 ## [7.1.5](https://github.com/ruflin/Elastica/compare/7.1.5...7.1.4)

--- a/tests/Aggregation/AvgBucketTest.php
+++ b/tests/Aggregation/AvgBucketTest.php
@@ -4,6 +4,7 @@ namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;
 use Elastica\Aggregation\AvgBucket;
+use Elastica\Aggregation\GapPolicyInterface;
 use Elastica\Aggregation\Terms;
 use Elastica\Document;
 use Elastica\Exception\InvalidException;
@@ -52,14 +53,14 @@ class AvgBucketTest extends BaseAggregationTest
     {
         $aggregation = (new AvgBucket('avg_bucket', 'pages>avg_likes_by_page'))
             ->setFormat('test_format')
-            ->setGapPolicy(10)
+            ->setGapPolicy(GapPolicyInterface::INSERT_ZEROS)
         ;
 
         $expected = [
             'avg_bucket' => [
                 'buckets_path' => 'pages>avg_likes_by_page',
                 'format' => 'test_format',
-                'gap_policy' => 10,
+                'gap_policy' => GapPolicyInterface::INSERT_ZEROS,
             ],
         ];
 

--- a/tests/Aggregation/BucketScriptTest.php
+++ b/tests/Aggregation/BucketScriptTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\BucketScript;
+use Elastica\Aggregation\GapPolicyInterface;
 use Elastica\Aggregation\Histogram;
 use Elastica\Aggregation\Max;
 use Elastica\Document;
@@ -61,7 +62,7 @@ class BucketScriptTest extends BaseAggregationTest
                 'z' => 'agg_min',
             ])
             ->setFormat('test_format')
-            ->setGapPolicy(10)
+            ->setGapPolicy(GapPolicyInterface::INSERT_ZEROS)
         ;
 
         $expected = [
@@ -73,7 +74,7 @@ class BucketScriptTest extends BaseAggregationTest
                     'z' => 'agg_min',
                 ],
                 'format' => 'test_format',
-                'gap_policy' => 10,
+                'gap_policy' => GapPolicyInterface::INSERT_ZEROS,
             ],
         ];
 

--- a/tests/Aggregation/ExtendedStatsBucketTest.php
+++ b/tests/Aggregation/ExtendedStatsBucketTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\ExtendedStatsBucket;
+use Elastica\Aggregation\GapPolicyInterface;
 use Elastica\Aggregation\Histogram;
 use Elastica\Aggregation\Max;
 use Elastica\Document;
@@ -60,14 +61,14 @@ class ExtendedStatsBucketTest extends BaseAggregationTest
         $serialDiffAgg
             ->setBucketsPath('age_groups>max_weight')
             ->setFormat('test_format')
-            ->setGapPolicy(10)
+            ->setGapPolicy(GapPolicyInterface::INSERT_ZEROS)
         ;
 
         $expected = [
             'extended_stats_bucket' => [
                 'buckets_path' => 'age_groups>max_weight',
                 'format' => 'test_format',
-                'gap_policy' => 10,
+                'gap_policy' => GapPolicyInterface::INSERT_ZEROS,
             ],
         ];
 

--- a/tests/Aggregation/PercentilesBucketTest.php
+++ b/tests/Aggregation/PercentilesBucketTest.php
@@ -3,6 +3,7 @@
 namespace Elastica\Test\Aggregation;
 
 use Elastica\Aggregation\Avg;
+use Elastica\Aggregation\GapPolicyInterface;
 use Elastica\Aggregation\PercentilesBucket;
 use Elastica\Aggregation\Terms;
 use Elastica\Document;
@@ -58,7 +59,7 @@ class PercentilesBucketTest extends BaseAggregationTest
         $aggregation = (new PercentilesBucket('percentiles_bucket', 'pages>avg_likes_by_page'))
             ->setFormat('test_format')
             ->setPercents([10, 80])
-            ->setGapPolicy(10)
+            ->setGapPolicy(GapPolicyInterface::INSERT_ZEROS)
             ->setKeyed(false)
         ;
 
@@ -66,7 +67,7 @@ class PercentilesBucketTest extends BaseAggregationTest
             'percentiles_bucket' => [
                 'buckets_path' => 'pages>avg_likes_by_page',
                 'format' => 'test_format',
-                'gap_policy' => 10,
+                'gap_policy' => GapPolicyInterface::INSERT_ZEROS,
                 'percents' => [10, 80],
                 'keyed' => false,
             ],

--- a/tests/Aggregation/StatsBucketTest.php
+++ b/tests/Aggregation/StatsBucketTest.php
@@ -2,6 +2,7 @@
 
 namespace Elastica\Test\Aggregation;
 
+use Elastica\Aggregation\GapPolicyInterface;
 use Elastica\Aggregation\Histogram;
 use Elastica\Aggregation\Max;
 use Elastica\Aggregation\StatsBucket;
@@ -52,14 +53,14 @@ class StatsBucketTest extends BaseAggregationTest
     {
         $aggregation = (new StatsBucket('bucket_part', 'age_groups>max_weight'))
             ->setFormat('test_format')
-            ->setGapPolicy(10)
+            ->setGapPolicy(GapPolicyInterface::INSERT_ZEROS)
         ;
 
         $expected = [
             'stats_bucket' => [
                 'buckets_path' => 'age_groups>max_weight',
                 'format' => 'test_format',
-                'gap_policy' => 10,
+                'gap_policy' => GapPolicyInterface::INSERT_ZEROS,
             ],
         ];
 

--- a/tests/Aggregation/SumBucketTest.php
+++ b/tests/Aggregation/SumBucketTest.php
@@ -2,6 +2,7 @@
 
 namespace Elastica\Test\Aggregation;
 
+use Elastica\Aggregation\GapPolicyInterface;
 use Elastica\Aggregation\Sum;
 use Elastica\Aggregation\SumBucket;
 use Elastica\Aggregation\Terms;
@@ -52,14 +53,14 @@ class SumBucketTest extends BaseAggregationTest
     {
         $aggregation = (new SumBucket('sum_bucket', 'pages>sum_likes_by_page'))
             ->setFormat('test_format')
-            ->setGapPolicy(10)
+            ->setGapPolicy(GapPolicyInterface::INSERT_ZEROS)
         ;
 
         $expected = [
             'sum_bucket' => [
                 'buckets_path' => 'pages>sum_likes_by_page',
                 'format' => 'test_format',
-                'gap_policy' => 10,
+                'gap_policy' => GapPolicyInterface::INSERT_ZEROS,
             ],
         ];
 

--- a/tests/Bulk/Action/UpdateDocumentTest.php
+++ b/tests/Bulk/Action/UpdateDocumentTest.php
@@ -73,7 +73,7 @@ JSON;
 
         $this->assertSame($expected, \trim((string) $action));
 
-        $document->setDocAsUpsert(1);
+        $document->setDocAsUpsert(true);
         $action->setDocument($document);
         $this->assertSame($expected, \trim((string) $action));
 
@@ -87,7 +87,7 @@ JSON;
 
         $this->assertSame($expected, \trim((string) $action));
 
-        $document->setDocAsUpsert(0);
+        $document->setDocAsUpsert(false);
         $action->setDocument($document);
         $this->assertSame($expected, \trim((string) $action));
     }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -51,7 +51,7 @@ class RequestTest extends BaseTest
     {
         $connection = new Connection();
         $connection->setHost($this->_getHost());
-        $connection->setPort('9200');
+        $connection->setPort(9200);
 
         $request = new Request('_stats', Request::GET, [], [], $connection);
 
@@ -72,7 +72,7 @@ class RequestTest extends BaseTest
 
         $connection = new Connection();
         $connection->setHost($this->_getHost());
-        $connection->setPort('9200');
+        $connection->setPort(9200);
 
         $request = new Request($path, $method, $data, $query, $connection);
 

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -164,7 +164,7 @@ class UtilTest extends BaseTest
 
         $connection = new Connection();
         $connection->setHost($this->_getHost());
-        $connection->setPort('9200');
+        $connection->setPort(9200);
 
         $request = new Request($path, $method, $data, $query, $connection);
 


### PR DESCRIPTION
This PR tries to fix some PHPStan findings in level 5, in this case about calling some method with wrong types.

https://github.com/ruflin/Elastica/blob/c0bcdb3b948d9220acb671a0fe130395f6c9b998/src/Aggregation/GapPolicyInterface.php#L15-L35

`setGapPolicy` expects a `string` which is one of the policies.

https://github.com/ruflin/Elastica/blob/c0bcdb3b948d9220acb671a0fe130395f6c9b998/src/Document.php#L208

`Document:: setDocAsUpsert()` expects a `bool`

https://github.com/ruflin/Elastica/blob/c0bcdb3b948d9220acb671a0fe130395f6c9b998/src/Connection.php#L76-L83

`Connection::setPort()` expects an `int` and also the default value (9200) is stored as `int`, internally it casts the value to `int`, but IMO we should stick to `int` since it represents a port.