### PR TITLE
Relax `value` type in `SetProcessor` to allow `mixed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.1.5...master)
 ### Backward Compatibility Breaks
+* Changed `SetProcessor::setValue` signature to allow to pass any type, if you are overriding this method you must update the signature removing the `string` type-hint.
 ### Added
 * Added `PHPStan` at level 3 by @franmomu [#2064](https://github.com/ruflin/Elastica/pull/2064)
 * Added coverage check to CI by @franmomu [#2071](https://github.com/ruflin/Elastica/pull/2071)
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated `composer-normalize` to `2.2.28` by @deguif [#2084](https://github.com/ruflin/Elastica/pull/2084)
 * Increased `PHPStan` level to `4` [#2080](https://github.com/ruflin/Elastica/pull/2080)
 * `ExceptionInterface` extends `Throwable` [#2083](https://github.com/ruflin/Elastica/pull/2083)
+* Changed `value` in `SetProcessor` to accept `mixed` instead of `string`.
 ### Deprecated
 * Deprecated `Elastica\Reindex::WAIT_FOR_COMPLETION_FALSE`, use a boolean as parameter instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
 * Passing anything else than a boolean as 1st argument to `Reindex::setWaitForCompletion`, pass a boolean instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)

--- a/src/Processor/SetProcessor.php
+++ b/src/Processor/SetProcessor.php
@@ -16,7 +16,10 @@ class SetProcessor extends AbstractProcessor
 
     public const DEFAULT_OVERRIDE_VALUE = true;
 
-    public function __construct(string $field, string $value)
+    /**
+     * @param mixed $value
+     */
+    public function __construct(string $field, $value)
     {
         $this->setField($field);
         $this->setValue($value);
@@ -25,9 +28,11 @@ class SetProcessor extends AbstractProcessor
     /**
      * Set field value.
      *
+     * @param mixed $value
+     *
      * @return $this
      */
-    public function setValue(string $value): self
+    public function setValue($value): self
     {
         return $this->setParam('value', $value);
     }

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -76,7 +76,7 @@ class PipelineTest extends BasePipeline
 
         $this->assertSame('pipeline for Set', $result['my_custom_pipeline']['description']);
         $this->assertSame('field4', $result['my_custom_pipeline']['processors'][0]['set']['field']);
-        $this->assertSame('333', $result['my_custom_pipeline']['processors'][0]['set']['value']);
+        $this->assertSame(333, $result['my_custom_pipeline']['processors'][0]['set']['value']);
         $this->assertSame('field1', $result['my_custom_pipeline']['processors'][0]['trim']['field']);
     }
 


### PR DESCRIPTION
It is defined as `string`, but in `tests` there are a couple of places where another type is used:

https://github.com/ruflin/Elastica/blob/732ccf3874c4b77861c88ce0f1e92bc40cf4e119/tests/Processor/SetProcessorTest.php#L20

https://github.com/ruflin/Elastica/blob/8ecc5cdadd5bf0b69c1eb20e56246a940b43bdb7/tests/PipelineTest.php#L26

Looking at the documentation: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/set-processor.html#set-processor looks like any type can be used.