### PR TITLE
PHPDoc: Add `CurlHandle` as curl connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fixed some PHPDoc types adding `null` as possible value by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
 * Fixed passing wrong types to `GapPolicyInterface::setGapPolicy()`, `Document::setDocAsUpsert()` and `Connection::setPort()` methods.
+* Fixed `Http` PHPDoc adding `\CurlHandle` type for Curl connection by @franmomu [#2086](https://github.com/ruflin/Elastica/pull/2086)
 ### Security
 
 ## [7.1.5](https://github.com/ruflin/Elastica/compare/7.1.5...7.1.4)

--- a/src/ClientConfiguration.php
+++ b/src/ClientConfiguration.php
@@ -81,6 +81,7 @@ class ClientConfiguration
         } elseif ('pool' === $func->getName()) {
             $connections = [];
             $clientConfiguration = new static();
+            /** @var Url $arg */
             foreach ($func->getArguments() as $arg) {
                 $connections[] = self::parseDsn($arg);
             }

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -35,6 +35,7 @@ class Pipeline extends Param
 
     /**
      * @var AbstractProcessor[]
+     * @phpstan-var array{processors?: AbstractProcessor[]}
      */
     protected $_processors = [];
 

--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -192,7 +192,7 @@ class Http extends AbstractTransport
     /**
      * Called to add additional curl params.
      *
-     * @param resource $curlConnection Curl connection
+     * @param \CurlHandle|resource $curlConnection Curl connection
      */
     protected function _setupCurl($curlConnection): void
     {
@@ -208,7 +208,7 @@ class Http extends AbstractTransport
      *
      * @param bool $persistent False if not persistent connection
      *
-     * @return resource Connection resource
+     * @return \CurlHandle|resource Connection resource
      */
     protected function _getConnection(bool $persistent = true)
     {


### PR DESCRIPTION
Since PHP 8.0, `curl_init` return a `\CurlHandle` instead of `resource`: https://www.php.net/manual/en/function.curl-init.php#refsect1-function.curl-init-changelog