### PR TITLE
Update `Query::create` parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Increased `PHPStan` level to `4` [#2080](https://github.com/ruflin/Elastica/pull/2080)
 * `ExceptionInterface` extends `Throwable` [#2083](https://github.com/ruflin/Elastica/pull/2083)
 * Changed `value` in `SetProcessor` to accept `mixed` instead of `string` by @franmomu [#2082](https://github.com/ruflin/Elastica/pull/2082)
+* Updated `Query::create` PHPDoc to include supported types and propagate it to callers by @franmomu [#2088](https://github.com/ruflin/Elastica/pull/2088)
+
 ### Deprecated
 * Deprecated `Elastica\Reindex::WAIT_FOR_COMPLETION_FALSE`, use a boolean as parameter instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
 * Passing anything else than a boolean as 1st argument to `Reindex::setWaitForCompletion`, pass a boolean instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)

--- a/src/Index.php
+++ b/src/Index.php
@@ -455,8 +455,7 @@ class Index implements SearchableInterface
     }
 
     /**
-     * @param AbstractQuery|array|Collapse|Query|string|Suggest $query
-     * @param array|int                                         $options
+     * {@inheritdoc}
      */
     public function createSearch($query = '', $options = null, ?BuilderInterface $builder = null): Search
     {

--- a/src/Query.php
+++ b/src/Query.php
@@ -50,7 +50,7 @@ class Query extends Param
      *
      * For example, an empty argument will return a \Elastica\Query with a \Elastica\Query\MatchAll.
      *
-     * @param mixed $query
+     * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest|null $query
      *
      * @throws InvalidException For an invalid argument
      */

--- a/src/Search.php
+++ b/src/Search.php
@@ -4,8 +4,10 @@ namespace Elastica;
 
 use Elastica\Exception\InvalidException;
 use Elastica\Exception\ResponseException;
+use Elastica\Query\AbstractQuery;
 use Elastica\ResultSet\BuilderInterface;
 use Elastica\ResultSet\DefaultBuilder;
+use Elastica\Suggest\AbstractSuggest;
 
 /**
  * Elastica search object.
@@ -112,7 +114,7 @@ class Search
     }
 
     /**
-     * @param array|Query|Query\AbstractQuery|string|Suggest $query
+     * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest $query
      */
     public function setQuery($query): self
     {
@@ -254,8 +256,8 @@ class Search
     /**
      * Search in the set indices.
      *
-     * @param array|Query|Query\AbstractQuery|string $query
-     * @param array|int                              $options Limit or associative array of options (option=>value)
+     * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest $query
+     * @param array|int                                                         $options Limit or associative array of options (option=>value)
      *
      * @throws InvalidException
      * @throws ResponseException
@@ -311,8 +313,8 @@ class Search
     }
 
     /**
-     * @param array|int                                      $options
-     * @param array|Query|Query\AbstractQuery|string|Suggest $query
+     * @param array|int                                                         $options
+     * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest $query
      */
     public function setOptionsAndQuery($options = null, $query = ''): self
     {

--- a/src/SearchableInterface.php
+++ b/src/SearchableInterface.php
@@ -3,6 +3,7 @@
 namespace Elastica;
 
 use Elastica\Query\AbstractQuery;
+use Elastica\Suggest\AbstractSuggest;
 
 /**
  * Elastica searchable interface.
@@ -27,9 +28,9 @@ interface SearchableInterface
      *      }
      * }
      *
-     * @param AbstractQuery|array|Collapse|Query|string|Suggest $query   Array with all query data inside or a Elastica\Query object
-     * @param array|int                                         $options Limit or associative array of options (option=>value)
-     * @param string                                            $method  Request method, see Request's constants
+     * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest $query   Array with all query data inside or a Elastica\Query object
+     * @param array|int|null                                                    $options Limit or associative array of options (option=>value)
+     * @param string                                                            $method  Request method, see Request's constants
      */
     public function search($query = '', $options = null, string $method = Request::POST): ResultSet;
 
@@ -38,16 +39,16 @@ interface SearchableInterface
      *
      * If no query is set, matchall query is created
      *
-     * @param AbstractQuery|array|Collapse|Query|string|Suggest $query  Array with all query data inside or a Elastica\Query object
-     * @param string                                            $method Request method, see Request's constants
+     * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest $query  Array with all query data inside or a Elastica\Query object
+     * @param string                                                            $method Request method, see Request's constants
      *
      * @return int number of documents matching the query
      */
     public function count($query = '', string $method = Request::POST);
 
     /**
-     * @param AbstractQuery|array|Collapse|Query|string|Suggest $query
-     * @param mixed|null                                        $options
+     * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest $query
+     * @param array|int|null                                                    $options
      */
     public function createSearch($query = '', $options = null): Search;
 }


### PR DESCRIPTION
It was triggered by

https://github.com/ruflin/Elastica/blob/a0a2dc27f4d8ef633893de6edf088b3c922f3767/tests/Suggest/TermTest.php#L125-L129

where a `Term` (`AbstractSuggest`) is passed to `Index::search()`.