### PR TITLE
Fix `MoreLikeThis::setLike()` allowing `Document`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed passing wrong types to `GapPolicyInterface::setGapPolicy()`, `Document::setDocAsUpsert()` and `Connection::setPort()` methods  by @franmomu [#2081](https://github.com/ruflin/Elastica/pull/2081)
 * Fixed `Http` PHPDoc adding `\CurlHandle` type for Curl connection by @franmomu [#2086](https://github.com/ruflin/Elastica/pull/2086)
 * Fixed case mismatch in method calls by @franmomu [#2087](https://github.com/ruflin/Elastica/pull/2087)
+* Fixed `MoreLikeThis::setLike()` PHPDoc allowing `Document` by @franmomu [#2091](https://github.com/ruflin/Elastica/pull/2091)
 
 ### Security
 

--- a/src/Query/MoreLikeThis.php
+++ b/src/Query/MoreLikeThis.php
@@ -2,6 +2,8 @@
 
 namespace Elastica\Query;
 
+use Elastica\Document;
+
 /**
  * More Like This query.
  *
@@ -26,7 +28,7 @@ class MoreLikeThis extends AbstractQuery
     /**
      * Set the "like" value.
      *
-     * @param self|string $like
+     * @param Document|self|string $like
      *
      * @return $this
      */

--- a/tests/Query/QueryStringTest.php
+++ b/tests/Query/QueryStringTest.php
@@ -17,7 +17,7 @@ class QueryStringTest extends BaseTest
      */
     public function testSearchMultipleFields(): void
     {
-        $str = \md5(\mt_rand());
+        $str = \uniqid();
         $query = new QueryString($str);
 
         $expected = [
@@ -29,7 +29,7 @@ class QueryStringTest extends BaseTest
         $fields = [];
         $max = \mt_rand(1, 10);
         for ($i = 0; $i < $max; ++$i) {
-            $fields[] = \md5(\mt_rand());
+            $fields[] = \uniqid();
         }
 
         $query->setFields($fields);


### PR DESCRIPTION
`MoreLikeThis::setLike()` allows `Document` as showed in https://github.com/ruflin/Elastica/blob/cd552e1ab6ec7ded4ee59bf693d8e1aba8980be6/tests/Query/MoreLikeThisTest.php#L96-L102