### PR TITLE
Specify some iterable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `ExceptionInterface` extends `Throwable` [#2083](https://github.com/ruflin/Elastica/pull/2083)
 * Changed `value` in `SetProcessor` to accept `mixed` instead of `string` by @franmomu [#2082](https://github.com/ruflin/Elastica/pull/2082)
 * Updated `Query::create` PHPDoc to include supported types and propagate it to callers by @franmomu [#2088](https://github.com/ruflin/Elastica/pull/2088)
+* Update some iterable types in PHPDoc to be more specific by @franmomu [#2092](https://github.com/ruflin/Elastica/pull/2092)
 
 ### Deprecated
 * Deprecated `Elastica\Reindex::WAIT_FOR_COMPLETION_FALSE`, use a boolean as parameter instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)

--- a/src/Param.php
+++ b/src/Param.php
@@ -16,14 +16,14 @@ class Param implements ArrayableInterface, \Countable
     /**
      * Params.
      *
-     * @var array|\stdClass
+     * @var array<string, mixed>|\stdClass
      */
     protected $_params = [];
 
     /**
      * Raw Params.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_rawParams = [];
 
@@ -32,7 +32,7 @@ class Param implements ArrayableInterface, \Countable
      * the an array out of the class name (last part of the class name)
      * and the params.
      *
-     * @return array Filter array
+     * @return array<string, mixed> Filter array
      */
     public function toArray()
     {

--- a/src/Response.php
+++ b/src/Response.php
@@ -203,7 +203,7 @@ class Response
     /**
      * Response data array.
      *
-     * @return array Response data array
+     * @return array<string, mixed> Response data array
      */
     public function getData()
     {

--- a/src/Status.php
+++ b/src/Status.php
@@ -26,7 +26,7 @@ class Status
     /**
      * Data.
      *
-     * @var array Data
+     * @var array<string, mixed> Data
      */
     protected $_data;
 
@@ -43,7 +43,7 @@ class Status
     /**
      * Returns status data.
      *
-     * @return array Status data
+     * @return array<string, mixed> Status data
      */
     public function getData()
     {
@@ -136,7 +136,7 @@ class Status
     /**
      * Return shards info.
      *
-     * @return array Shards info
+     * @return array<string, mixed> Shards info
      */
     public function getShards()
     {

--- a/src/Suggest/AbstractSuggest.php
+++ b/src/Suggest/AbstractSuggest.php
@@ -56,6 +56,11 @@ abstract class AbstractSuggest extends Param implements NameableInterface
      * Expects one of the next params: max_determinized_states - defaults to 10000,
      * flags are ALL (default), ANYSTRING, COMPLEMENT, EMPTY, INTERSECTION, INTERVAL, or NONE.
      *
+     * @phpstan-param array{
+     *     max_determinized_states?: int,
+     *     flags: 'ALL'|'ANYSTRING'|'COMPLEMENT'|'EMPTY'|'INTERSECTION'|'INTERVAL'|'NONE'
+     * } $value
+     *
      * @return $this
      */
     public function setRegexOptions(array $value): self

--- a/src/Suggest/Completion.php
+++ b/src/Suggest/Completion.php
@@ -16,6 +16,8 @@ class Completion extends AbstractSuggest
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-completion.html#fuzzy
      *
+     * @param array<string, mixed> $fuzzy
+     *
      * @return $this
      */
     public function setFuzzy(array $fuzzy): Completion

--- a/src/Suggest/Phrase.php
+++ b/src/Suggest/Phrase.php
@@ -125,7 +125,8 @@ class Phrase extends AbstractSuggest
     }
 
     /**
-     * @param string $model the name of the smoothing model
+     * @param string               $model  the name of the smoothing model
+     * @param array<string, mixed> $params
      *
      * @return $this
      */

--- a/src/Task.php
+++ b/src/Task.php
@@ -28,7 +28,7 @@ class Task extends Param
     protected $_response;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $_data;
 
@@ -55,6 +55,8 @@ class Task extends Param
 
     /**
      * Returns task data.
+     *
+     * @return array<string, mixed>
      */
     public function getData(): array
     {
@@ -79,6 +81,8 @@ class Task extends Param
 
     /**
      * Refresh task status.
+     *
+     * @param array<string, mixed> $options
      */
     public function refresh(array $options = []): void
     {

--- a/src/Transport/AbstractTransport.php
+++ b/src/Transport/AbstractTransport.php
@@ -50,8 +50,8 @@ abstract class AbstractTransport extends Param
     /**
      * Executes the transport request.
      *
-     * @param Request $request Request object
-     * @param array   $params  Hostname, port, path, ...
+     * @param Request              $request Request object
+     * @param array<string, mixed> $params  Hostname, port, path, ...
      *
      * @throws ResponseException
      * @throws ConnectionException
@@ -62,7 +62,9 @@ abstract class AbstractTransport extends Param
      * BOOL values true|false should be sanityzed and passed to Elasticsearch
      * as string.
      *
-     * @return array
+     * @param array<string, mixed> $query
+     *
+     * @return array<string, mixed>
      */
     public function sanityzeQueryStringBool(array $query)
     {
@@ -85,9 +87,9 @@ abstract class AbstractTransport extends Param
      * * array: An array with a "type" key which must be set to one of the two options. All other
      *          keys in the array will be set as parameters in the transport instance
      *
-     * @param mixed      $transport  A transport definition
-     * @param Connection $connection A connection instance
-     * @param array      $params     Parameters for the transport class
+     * @param AbstractTransport|array<string, mixed>|string $transport  A transport definition
+     * @param Connection                                    $connection A connection instance
+     * @param array<string, mixed>                          $params     Parameters for the transport class
      *
      * @throws InvalidException
      */

--- a/src/Transport/Guzzle.php
+++ b/src/Transport/Guzzle.php
@@ -195,6 +195,9 @@ class Guzzle extends AbstractTransport
         return $action;
     }
 
+    /**
+     * @param mixed $data
+     */
     private function streamFor($data): StreamInterface
     {
         if (\is_array($data)) {

--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -37,7 +37,7 @@ class Http extends AbstractTransport
      *
      * All calls that are made to the server are done through this function
      *
-     * @param array $params Host, Port, ...
+     * @param array<string, mixed> $params Host, Port, ...
      *
      * @throws ConnectionException
      * @throws ResponseException
@@ -219,6 +219,9 @@ class Http extends AbstractTransport
         return self::$_curlConnection;
     }
 
+    /**
+     * @return int
+     */
     protected function _getAuthType()
     {
         switch ($this->_connection->getAuthType()) {

--- a/src/Transport/HttpAdapter.php
+++ b/src/Transport/HttpAdapter.php
@@ -46,7 +46,7 @@ class HttpAdapter extends AbstractTransport
      *
      * All calls that are made to the server are done through this function
      *
-     * @param array $params Host, Port, ...
+     * @param array<string, mixed> $params Host, Port, ...
      *
      * @throws \Elastica\Exception\ConnectionException
      * @throws ResponseException

--- a/src/Transport/NullTransport.php
+++ b/src/Transport/NullTransport.php
@@ -27,7 +27,7 @@ class NullTransport extends AbstractTransport
     /**
      * Set response object the transport returns.
      *
-     * @param array $params Hostname, port, path, ...
+     * @param array<string, mixed> $params Hostname, port, path, ...
      */
     public function getResponse(array $params = []): Response
     {
@@ -49,7 +49,7 @@ class NullTransport extends AbstractTransport
     /**
      * Generate an example response object.
      *
-     * @param array $params Hostname, port, path, ...
+     * @param array<string, mixed> $params Hostname, port, path, ...
      *
      * @return Response $response
      */
@@ -79,7 +79,7 @@ class NullTransport extends AbstractTransport
     /**
      * Null transport.
      *
-     * @param array $params Hostname, port, path, ...
+     * @param array<string, mixed> $params Hostname, port, path, ...
      *
      * @return Response Response empty object
      */

--- a/src/Util.php
+++ b/src/Util.php
@@ -12,10 +12,10 @@ namespace Elastica;
  */
 class Util
 {
-    /** @var array */
+    /** @var list<string> */
     protected static $dateMathSymbols = ['<', '>', '/', '{', '}', '|', '+', ':', ','];
 
-    /** @var array */
+    /** @var list<string> */
     protected static $escapedDateMathSymbols = ['%3C', '%3E', '%2F', '%7B', '%7D', '%7C', '%2B', '%3A', '%2C'];
 
     /**


### PR DESCRIPTION
There are quite `array` types in the code, the idea is to be more specific about what types are holding, but I guess most of them are `array<string, mixed>`, we could maybe be more specific in some cases like `AbstractSuggestion:: setRegexOptions()`.