### PR TITLE
Use `string` type for Document id in tests

### DIFF
--- a/tests/Aggregation/AdjacencyMatrixTest.php
+++ b/tests/Aggregation/AdjacencyMatrixTest.php
@@ -128,9 +128,9 @@ class AdjacencyMatrixTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['accounts' => ['hillary', 'sidney']]),
-            new Document(2, ['accounts' => ['hillary', 'donald']]),
-            new Document(3, ['accounts' => ['vladimir', 'donald']]),
+            new Document('1', ['accounts' => ['hillary', 'sidney']]),
+            new Document('2', ['accounts' => ['hillary', 'donald']]),
+            new Document('3', ['accounts' => ['vladimir', 'donald']]),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/AvgTest.php
+++ b/tests/Aggregation/AvgTest.php
@@ -54,11 +54,11 @@ class AvgTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5]),
-            new Document(2, ['price' => 8]),
-            new Document(3, ['price' => 1]),
-            new Document(4, ['price' => 3]),
-            new Document(5, ['anything' => 'anything']),
+            new Document('1', ['price' => 5]),
+            new Document('2', ['price' => 8]),
+            new Document('3', ['price' => 1]),
+            new Document('4', ['price' => 3]),
+            new Document('5', ['anything' => 'anything']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/BucketSelectorTest.php
+++ b/tests/Aggregation/BucketSelectorTest.php
@@ -76,16 +76,16 @@ class BucketSelectorTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['date' => '2018-12-01', 'value' => 1]),
-            new Document(2, ['date' => '2018-12-02', 'value' => 2]),
-            new Document(3, ['date' => '2018-12-03', 'value' => 5]),
-            new Document(4, ['date' => '2018-12-04', 'value' => 4]),
-            new Document(5, ['date' => '2018-12-05', 'value' => 6]),
-            new Document(6, ['date' => '2018-12-06', 'value' => 9]),
-            new Document(7, ['date' => '2018-12-07', 'value' => 11]),
-            new Document(8, ['date' => '2018-12-08', 'value' => 4]),
-            new Document(9, ['date' => '2018-12-09', 'value' => 7]),
-            new Document(10, ['date' => '2018-12-10', 'value' => 4]),
+            new Document('1', ['date' => '2018-12-01', 'value' => 1]),
+            new Document('2', ['date' => '2018-12-02', 'value' => 2]),
+            new Document('3', ['date' => '2018-12-03', 'value' => 5]),
+            new Document('4', ['date' => '2018-12-04', 'value' => 4]),
+            new Document('5', ['date' => '2018-12-05', 'value' => 6]),
+            new Document('6', ['date' => '2018-12-06', 'value' => 9]),
+            new Document('7', ['date' => '2018-12-07', 'value' => 11]),
+            new Document('8', ['date' => '2018-12-08', 'value' => 4]),
+            new Document('9', ['date' => '2018-12-09', 'value' => 7]),
+            new Document('10', ['date' => '2018-12-10', 'value' => 4]),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/CardinalityTest.php
+++ b/tests/Aggregation/CardinalityTest.php
@@ -98,11 +98,11 @@ class CardinalityTest extends BaseAggregationTest
         $index->setMapping($mapping);
 
         $index->addDocuments([
-            new Document(1, ['color' => 'blue']),
-            new Document(2, ['color' => 'blue']),
-            new Document(3, ['color' => 'red']),
-            new Document(4, ['color' => 'green']),
-            new Document(5, ['anything' => 'anything']),
+            new Document('1', ['color' => 'blue']),
+            new Document('2', ['color' => 'blue']),
+            new Document('3', ['color' => 'red']),
+            new Document('4', ['color' => 'green']),
+            new Document('5', ['anything' => 'anything']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/ChildrenTest.php
+++ b/tests/Aggregation/ChildrenTest.php
@@ -103,14 +103,14 @@ class ChildrenTest extends BaseAggregationTest
         $index->setMapping($mapping);
         $index->refresh();
 
-        $doc1 = $index->createDocument(1, [
+        $doc1 = $index->createDocument('1', [
             'text' => 'this is the 1st question',
             'my_join_field' => [
                 'name' => 'question',
             ],
         ]);
 
-        $doc2 = $index->createDocument(2, [
+        $doc2 = $index->createDocument('2', [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
@@ -119,7 +119,7 @@ class ChildrenTest extends BaseAggregationTest
 
         $index->addDocuments([$doc1, $doc2]);
 
-        $doc3 = $index->createDocument(3, [
+        $doc3 = $index->createDocument('3', [
             'text' => 'this is an top answer, the 1st',
             'name' => 'rico',
             'my_join_field' => [
@@ -128,7 +128,7 @@ class ChildrenTest extends BaseAggregationTest
             ],
         ]);
 
-        $doc4 = $index->createDocument(4, [
+        $doc4 = $index->createDocument('4', [
             'text' => 'this is an top answer, the 2nd',
             'name' => 'fede',
             'my_join_field' => [
@@ -137,7 +137,7 @@ class ChildrenTest extends BaseAggregationTest
             ],
         ]);
 
-        $doc5 = $index->createDocument(5, [
+        $doc5 = $index->createDocument('5', [
             'text' => 'this is an answer, the 3rd',
             'name' => 'fede',
             'my_join_field' => [

--- a/tests/Aggregation/CompositeTest.php
+++ b/tests/Aggregation/CompositeTest.php
@@ -220,10 +220,10 @@ class CompositeTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5, 'color' => 'blue']),
-            new Document(2, ['price' => 5, 'color' => 'blue']),
-            new Document(3, ['price' => 3, 'color' => 'red']),
-            new Document(4, ['price' => 3, 'color' => 'green']),
+            new Document('1', ['price' => 5, 'color' => 'blue']),
+            new Document('2', ['price' => 5, 'color' => 'blue']),
+            new Document('3', ['price' => 3, 'color' => 'red']),
+            new Document('4', ['price' => 3, 'color' => 'green']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/DateHistogramTest.php
+++ b/tests/Aggregation/DateHistogramTest.php
@@ -150,10 +150,10 @@ class DateHistogramTest extends BaseAggregationTest
         ]));
 
         $index->addDocuments([
-            new Document(1, ['created' => '2014-01-29T00:20:00']),
-            new Document(2, ['created' => '2014-01-29T02:20:00']),
-            new Document(3, ['created' => '2014-01-29T03:20:00']),
-            new Document(4, ['anything' => 'anything']),
+            new Document('1', ['created' => '2014-01-29T00:20:00']),
+            new Document('2', ['created' => '2014-01-29T02:20:00']),
+            new Document('3', ['created' => '2014-01-29T03:20:00']),
+            new Document('4', ['anything' => 'anything']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/DateRangeTest.php
+++ b/tests/Aggregation/DateRangeTest.php
@@ -149,10 +149,10 @@ class DateRangeTest extends BaseAggregationTest
         ]));
 
         $index->addDocuments([
-            new Document(1, ['created' => 1390962135000]),
-            new Document(2, ['created' => 1390965735000]),
-            new Document(3, ['created' => 1390954935000]),
-            new Document(4, ['anything' => 'anything']),
+            new Document('1', ['created' => 1390962135000]),
+            new Document('2', ['created' => 1390965735000]),
+            new Document('3', ['created' => 1390954935000]),
+            new Document('4', ['anything' => 'anything']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/DerivativeTest.php
+++ b/tests/Aggregation/DerivativeTest.php
@@ -103,11 +103,11 @@ class DerivativeTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['date' => '2018-12-01', 'value' => 1]),
-            new Document(2, ['date' => '2018-12-02', 'value' => 2]),
-            new Document(3, ['date' => '2018-12-03', 'value' => 2]),
-            new Document(4, ['date' => '2018-12-04', 'value' => 4]),
-            new Document(5, ['date' => '2018-12-05', 'value' => 3]),
+            new Document('1', ['date' => '2018-12-01', 'value' => 1]),
+            new Document('2', ['date' => '2018-12-02', 'value' => 2]),
+            new Document('3', ['date' => '2018-12-03', 'value' => 2]),
+            new Document('4', ['date' => '2018-12-04', 'value' => 4]),
+            new Document('5', ['date' => '2018-12-05', 'value' => 3]),
         ], ['refresh' => 'true']);
 
         return $index;

--- a/tests/Aggregation/DiversifiedSamplerTest.php
+++ b/tests/Aggregation/DiversifiedSamplerTest.php
@@ -104,16 +104,16 @@ class DiversifiedSamplerTest extends BaseAggregationTest
         $routing2 = 'second_routing';
 
         $index->addDocuments([
-            (new Document(1, ['price' => 5, 'color' => 'blue']))->setRouting($routing1),
-            (new Document(2, ['price' => 8, 'color' => 'blue']))->setRouting($routing1),
-            (new Document(3, ['price' => 1, 'color' => 'blue']))->setRouting($routing1),
-            (new Document(4, ['price' => 3, 'color' => 'red']))->setRouting($routing1),
-            (new Document(5, ['price' => 1.5, 'color' => 'red']))->setRouting($routing1),
-            (new Document(6, ['price' => 2, 'color' => 'green']))->setRouting($routing1),
-            (new Document(7, ['price' => 5, 'color' => 'blue']))->setRouting($routing2),
-            (new Document(8, ['price' => 8, 'color' => 'blue']))->setRouting($routing2),
-            (new Document(9, ['price' => 1, 'color' => 'red']))->setRouting($routing2),
-            (new Document(10, ['price' => 3, 'color' => 'red']))->setRouting($routing2),
+            (new Document('1', ['price' => 5, 'color' => 'blue']))->setRouting($routing1),
+            (new Document('2', ['price' => 8, 'color' => 'blue']))->setRouting($routing1),
+            (new Document('3', ['price' => 1, 'color' => 'blue']))->setRouting($routing1),
+            (new Document('4', ['price' => 3, 'color' => 'red']))->setRouting($routing1),
+            (new Document('5', ['price' => 1.5, 'color' => 'red']))->setRouting($routing1),
+            (new Document('6', ['price' => 2, 'color' => 'green']))->setRouting($routing1),
+            (new Document('7', ['price' => 5, 'color' => 'blue']))->setRouting($routing2),
+            (new Document('8', ['price' => 8, 'color' => 'blue']))->setRouting($routing2),
+            (new Document('9', ['price' => 1, 'color' => 'red']))->setRouting($routing2),
+            (new Document('10', ['price' => 3, 'color' => 'red']))->setRouting($routing2),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/ExtendedStatsTest.php
+++ b/tests/Aggregation/ExtendedStatsTest.php
@@ -58,11 +58,11 @@ class ExtendedStatsTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5]),
-            new Document(2, ['price' => 8]),
-            new Document(3, ['price' => 1]),
-            new Document(4, ['price' => 3]),
-            new Document(5, ['anything' => 'anything']),
+            new Document('1', ['price' => 5]),
+            new Document('2', ['price' => 8]),
+            new Document('3', ['price' => 1]),
+            new Document('4', ['price' => 3]),
+            new Document('5', ['anything' => 'anything']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/FilterTest.php
+++ b/tests/Aggregation/FilterTest.php
@@ -105,10 +105,10 @@ class FilterTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5, 'color' => 'blue']),
-            new Document(2, ['price' => 8, 'color' => 'blue']),
-            new Document(3, ['price' => 1, 'color' => 'red']),
-            new Document(4, ['price' => 3, 'color' => 'green']),
+            new Document('1', ['price' => 5, 'color' => 'blue']),
+            new Document('2', ['price' => 8, 'color' => 'blue']),
+            new Document('3', ['price' => 1, 'color' => 'red']),
+            new Document('4', ['price' => 3, 'color' => 'green']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/FiltersTest.php
+++ b/tests/Aggregation/FiltersTest.php
@@ -233,10 +233,10 @@ class FiltersTest extends BaseAggregationTest
         $index = $this->_createIndex('filter');
 
         $index->addDocuments([
-            new Document(1, ['price' => 5, 'color' => 'blue']),
-            new Document(2, ['price' => 8, 'color' => 'blue']),
-            new Document(3, ['price' => 1, 'color' => 'red']),
-            new Document(4, ['price' => 3, 'color' => 'green']),
+            new Document('1', ['price' => 5, 'color' => 'blue']),
+            new Document('2', ['price' => 8, 'color' => 'blue']),
+            new Document('3', ['price' => 1, 'color' => 'red']),
+            new Document('4', ['price' => 3, 'color' => 'green']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/GeoBoundsTest.php
+++ b/tests/Aggregation/GeoBoundsTest.php
@@ -38,9 +38,9 @@ class GeoBoundsTest extends BaseAggregationTest
         ]));
 
         $index->addDocuments([
-            new Document(1, ['location' => ['lat' => 32.849437, 'lon' => -117.271732]]),
-            new Document(2, ['location' => ['lat' => 32.798320, 'lon' => -117.246648]]),
-            new Document(3, ['location' => ['lat' => 37.782439, 'lon' => -122.392560]]),
+            new Document('1', ['location' => ['lat' => 32.849437, 'lon' => -117.271732]]),
+            new Document('2', ['location' => ['lat' => 32.798320, 'lon' => -117.246648]]),
+            new Document('3', ['location' => ['lat' => 37.782439, 'lon' => -122.392560]]),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/GeoCentroidTest.php
+++ b/tests/Aggregation/GeoCentroidTest.php
@@ -35,9 +35,9 @@ class GeoCentroidTest extends BaseAggregationTest
         ]));
 
         $index->addDocuments([
-            new Document(1, ['location' => ['lat' => 32.849437, 'lon' => -117.271732]]),
-            new Document(2, ['location' => ['lat' => 32.798320, 'lon' => -117.246648]]),
-            new Document(3, ['location' => ['lat' => 37.782439, 'lon' => -122.392560]]),
+            new Document('1', ['location' => ['lat' => 32.849437, 'lon' => -117.271732]]),
+            new Document('2', ['location' => ['lat' => 32.798320, 'lon' => -117.246648]]),
+            new Document('3', ['location' => ['lat' => 37.782439, 'lon' => -122.392560]]),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/GeoDistanceTest.php
+++ b/tests/Aggregation/GeoDistanceTest.php
@@ -57,9 +57,9 @@ class GeoDistanceTest extends BaseAggregationTest
         ]));
 
         $index->addDocuments([
-            new Document(1, ['location' => ['lat' => 32.849437, 'lon' => -117.271732]]),
-            new Document(2, ['location' => ['lat' => 32.798320, 'lon' => -117.246648]]),
-            new Document(3, ['location' => ['lat' => 37.782439, 'lon' => -122.392560]]),
+            new Document('1', ['location' => ['lat' => 32.849437, 'lon' => -117.271732]]),
+            new Document('2', ['location' => ['lat' => 32.798320, 'lon' => -117.246648]]),
+            new Document('3', ['location' => ['lat' => 37.782439, 'lon' => -122.392560]]),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/GeohashGridTest.php
+++ b/tests/Aggregation/GeohashGridTest.php
@@ -64,9 +64,9 @@ class GeohashGridTest extends BaseAggregationTest
         ]));
 
         $index->addDocuments([
-            new Document(1, ['location' => ['lat' => 32.849437, 'lon' => -117.271732]]),
-            new Document(2, ['location' => ['lat' => 32.798320, 'lon' => -117.246648]]),
-            new Document(3, ['location' => ['lat' => 37.782439, 'lon' => -122.392560]]),
+            new Document('1', ['location' => ['lat' => 32.849437, 'lon' => -117.271732]]),
+            new Document('2', ['location' => ['lat' => 32.798320, 'lon' => -117.246648]]),
+            new Document('3', ['location' => ['lat' => 37.782439, 'lon' => -122.392560]]),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/GeotileGridAggregationTest.php
+++ b/tests/Aggregation/GeotileGridAggregationTest.php
@@ -37,9 +37,9 @@ class GeotileGridAggregationTest extends BaseAggregationTest
         ]));
 
         $index->addDocuments([
-            new Document(1, ['location' => ['lat' => 32.849437, 'lon' => -117.271732]]),
-            new Document(2, ['location' => ['lat' => 32.798320, 'lon' => -117.246648]]),
-            new Document(3, ['location' => ['lat' => 37.782439, 'lon' => -122.392560]]),
+            new Document('1', ['location' => ['lat' => 32.849437, 'lon' => -117.271732]]),
+            new Document('2', ['location' => ['lat' => 32.798320, 'lon' => -117.246648]]),
+            new Document('3', ['location' => ['lat' => 37.782439, 'lon' => -122.392560]]),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/HistogramTest.php
+++ b/tests/Aggregation/HistogramTest.php
@@ -77,15 +77,15 @@ class HistogramTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5, 'color' => 'blue']),
-            new Document(2, ['price' => 8, 'color' => 'blue']),
-            new Document(3, ['price' => 1, 'color' => 'red']),
-            new Document(4, ['price' => 30, 'color' => 'green']),
-            new Document(5, ['price' => 40, 'color' => 'red']),
-            new Document(6, ['price' => 35, 'color' => 'green']),
-            new Document(7, ['price' => 42, 'color' => 'red']),
-            new Document(8, ['price' => 41, 'color' => 'blue']),
-            new Document(9, ['color' => 'yellow']),
+            new Document('1', ['price' => 5, 'color' => 'blue']),
+            new Document('2', ['price' => 8, 'color' => 'blue']),
+            new Document('3', ['price' => 1, 'color' => 'red']),
+            new Document('4', ['price' => 30, 'color' => 'green']),
+            new Document('5', ['price' => 40, 'color' => 'red']),
+            new Document('6', ['price' => 35, 'color' => 'green']),
+            new Document('7', ['price' => 42, 'color' => 'red']),
+            new Document('8', ['price' => 41, 'color' => 'blue']),
+            new Document('9', ['color' => 'yellow']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/IpRangeTest.php
+++ b/tests/Aggregation/IpRangeTest.php
@@ -73,9 +73,9 @@ class IpRangeTest extends BaseAggregationTest
         ]));
 
         $index->addDocuments([
-            new Document(1, ['address' => '192.168.1.100']),
-            new Document(2, ['address' => '192.168.1.150']),
-            new Document(3, ['address' => '192.168.1.200']),
+            new Document('1', ['address' => '192.168.1.100']),
+            new Document('2', ['address' => '192.168.1.150']),
+            new Document('3', ['address' => '192.168.1.200']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/MaxTest.php
+++ b/tests/Aggregation/MaxTest.php
@@ -96,11 +96,11 @@ class MaxTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5]),
-            new Document(2, ['price' => self::MAX_PRICE]),
-            new Document(3, ['price' => 1]),
-            new Document(4, ['price' => 3]),
-            new Document(5, ['anything' => 'anything']),
+            new Document('1', ['price' => 5]),
+            new Document('2', ['price' => self::MAX_PRICE]),
+            new Document('3', ['price' => 1]),
+            new Document('4', ['price' => 3]),
+            new Document('5', ['anything' => 'anything']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/MinTest.php
+++ b/tests/Aggregation/MinTest.php
@@ -53,11 +53,11 @@ class MinTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5]),
-            new Document(2, ['price' => 8]),
-            new Document(3, ['price' => self::MIN_PRICE]),
-            new Document(4, ['price' => 3]),
-            new Document(5, ['anything' => 'anything']),
+            new Document('1', ['price' => 5]),
+            new Document('2', ['price' => 8]),
+            new Document('3', ['price' => self::MIN_PRICE]),
+            new Document('4', ['price' => 3]),
+            new Document('5', ['anything' => 'anything']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/MissingTest.php
+++ b/tests/Aggregation/MissingTest.php
@@ -37,10 +37,10 @@ class MissingTest extends BaseAggregationTest
         $index->setMapping($mapping);
 
         $index->addDocuments([
-            new Document(1, ['price' => 5, 'color' => 'blue']),
-            new Document(2, ['price' => 8, 'color' => 'blue']),
-            new Document(3, ['price' => 1]),
-            new Document(4, ['price' => 3, 'color' => 'green']),
+            new Document('1', ['price' => 5, 'color' => 'blue']),
+            new Document('2', ['price' => 8, 'color' => 'blue']),
+            new Document('3', ['price' => 1]),
+            new Document('4', ['price' => 3, 'color' => 'green']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/NestedTest.php
+++ b/tests/Aggregation/NestedTest.php
@@ -47,13 +47,13 @@ class NestedTest extends BaseAggregationTest
         ]));
 
         $index->addDocuments([
-            new Document(1, [
+            new Document('1', [
                 'resellers' => [
                     'name' => 'spacely sprockets',
                     'price' => 5.55,
                 ],
             ]),
-            new Document(2, [
+            new Document('2', [
                 'resellers' => [
                     'name' => 'cogswell cogs',
                     'price' => 4.98,

--- a/tests/Aggregation/NormalizeAggregationTest.php
+++ b/tests/Aggregation/NormalizeAggregationTest.php
@@ -155,12 +155,12 @@ class NormalizeAggregationTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['date' => '2018-12-01T01:00:00', 'value' => 1]),
-            new Document(2, ['date' => '2018-12-01T10:00:00', 'value' => 2]),
-            new Document(3, ['date' => '2018-12-02T02:00:00', 'value' => 3]),
-            new Document(4, ['date' => '2018-12-02T15:00:00', 'value' => 4]),
-            new Document(5, ['date' => '2018-12-02T20:00:00', 'value' => 5]),
-            new Document(6, ['date' => '2018-12-03T03:00:00', 'value' => 6]),
+            new Document('1', ['date' => '2018-12-01T01:00:00', 'value' => 1]),
+            new Document('2', ['date' => '2018-12-01T10:00:00', 'value' => 2]),
+            new Document('3', ['date' => '2018-12-02T02:00:00', 'value' => 3]),
+            new Document('4', ['date' => '2018-12-02T15:00:00', 'value' => 4]),
+            new Document('5', ['date' => '2018-12-02T20:00:00', 'value' => 5]),
+            new Document('6', ['date' => '2018-12-03T03:00:00', 'value' => 6]),
         ], ['refresh' => 'true']);
 
         return $index;

--- a/tests/Aggregation/ParentAggregationTest.php
+++ b/tests/Aggregation/ParentAggregationTest.php
@@ -108,7 +108,7 @@ class ParentAggregationTest extends BaseAggregationTest
         $index->setMapping($mapping);
         $index->refresh();
 
-        $doc1 = $index->createDocument(1, [
+        $doc1 = $index->createDocument('1', [
             'text' => 'this is the 1st question',
             'tags' => [
                 'windows-server-2003',
@@ -120,7 +120,7 @@ class ParentAggregationTest extends BaseAggregationTest
             ],
         ]);
 
-        $doc2 = $index->createDocument(2, [
+        $doc2 = $index->createDocument('2', [
             'text' => 'this is the 2nd question',
             'tags' => [
                 'windows-server-2008',
@@ -133,7 +133,7 @@ class ParentAggregationTest extends BaseAggregationTest
 
         $index->addDocuments([$doc1, $doc2]);
 
-        $doc3 = $index->createDocument(3, [
+        $doc3 = $index->createDocument('3', [
             'text' => 'this is an top answer, the 1st',
             'owner' => 'Sam',
             'join' => [
@@ -142,7 +142,7 @@ class ParentAggregationTest extends BaseAggregationTest
             ],
         ]);
 
-        $doc4 = $index->createDocument(4, [
+        $doc4 = $index->createDocument('4', [
             'text' => 'this is a top answer, the 2nd',
             'owner' => 'Sam',
             'join' => [
@@ -151,7 +151,7 @@ class ParentAggregationTest extends BaseAggregationTest
             ],
         ]);
 
-        $doc5 = $index->createDocument(5, [
+        $doc5 = $index->createDocument('5', [
             'text' => 'this is an answer, the 3rd',
             'owner' => 'Troll',
             'join' => [

--- a/tests/Aggregation/PercentilesTest.php
+++ b/tests/Aggregation/PercentilesTest.php
@@ -131,16 +131,16 @@ class PercentilesTest extends BaseAggregationTest
         // prepare
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['price' => 100]),
-            new Document(2, ['price' => 200]),
-            new Document(3, ['price' => 300]),
-            new Document(4, ['price' => 400]),
-            new Document(5, ['price' => 500]),
-            new Document(6, ['price' => 600]),
-            new Document(7, ['price' => 700]),
-            new Document(8, ['price' => 800]),
-            new Document(9, ['price' => 900]),
-            new Document(10, ['price' => 1000]),
+            new Document('1', ['price' => 100]),
+            new Document('2', ['price' => 200]),
+            new Document('3', ['price' => 300]),
+            new Document('4', ['price' => 400]),
+            new Document('5', ['price' => 500]),
+            new Document('6', ['price' => 600]),
+            new Document('7', ['price' => 700]),
+            new Document('8', ['price' => 800]),
+            new Document('9', ['price' => 900]),
+            new Document('10', ['price' => 1000]),
         ]);
         $index->refresh();
 
@@ -201,16 +201,16 @@ class PercentilesTest extends BaseAggregationTest
         // prepare
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['price' => 100]),
-            new Document(2, ['price' => 200]),
-            new Document(3, ['price' => 300]),
-            new Document(4, ['price' => 400]),
-            new Document(5, ['price' => 500]),
-            new Document(6, ['price' => 600]),
-            new Document(7, ['price' => 700]),
-            new Document(8, ['price' => 800]),
-            new Document(9, ['price' => 900]),
-            new Document(10, ['price' => 1000]),
+            new Document('1', ['price' => 100]),
+            new Document('2', ['price' => 200]),
+            new Document('3', ['price' => 300]),
+            new Document('4', ['price' => 400]),
+            new Document('5', ['price' => 500]),
+            new Document('6', ['price' => 600]),
+            new Document('7', ['price' => 700]),
+            new Document('8', ['price' => 800]),
+            new Document('9', ['price' => 900]),
+            new Document('10', ['price' => 1000]),
         ]);
         $index->refresh();
 

--- a/tests/Aggregation/RangeTest.php
+++ b/tests/Aggregation/RangeTest.php
@@ -88,12 +88,12 @@ class RangeTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5]),
-            new Document(2, ['price' => 8]),
-            new Document(3, ['price' => 1]),
-            new Document(4, ['price' => 3]),
-            new Document(5, ['price' => 1.5]),
-            new Document(6, ['price' => 2]),
+            new Document('1', ['price' => 5]),
+            new Document('2', ['price' => 8]),
+            new Document('3', ['price' => 1]),
+            new Document('4', ['price' => 3]),
+            new Document('5', ['price' => 1.5]),
+            new Document('6', ['price' => 2]),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/ReverseNestedTest.php
+++ b/tests/Aggregation/ReverseNestedTest.php
@@ -105,7 +105,7 @@ class ReverseNestedTest extends BaseAggregationTest
         $index->setMapping($mapping);
 
         $index->addDocuments([
-            new Document(1, [
+            new Document('1', [
                 'comments' => [
                     [
                         'name' => 'bob',
@@ -118,7 +118,7 @@ class ReverseNestedTest extends BaseAggregationTest
                 ],
                 'tags' => ['foo', 'bar'],
             ]),
-            new Document(2, [
+            new Document('2', [
                 'comments' => [
                     [
                         'name' => 'bob',

--- a/tests/Aggregation/SamplerTest.php
+++ b/tests/Aggregation/SamplerTest.php
@@ -80,11 +80,11 @@ class SamplerTest extends BaseAggregationTest
         $routing2 = 'second_routing';
 
         $index->addDocuments([
-            (new Document(1, ['price' => 5]))->setRouting($routing1),
-            (new Document(2, ['price' => 8]))->setRouting($routing1),
-            (new Document(3, ['price' => 1]))->setRouting($routing1),
-            (new Document(4, ['price' => 3]))->setRouting($routing2),
-            (new Document(5, ['price' => 1.5]))->setRouting($routing2),
+            (new Document('1', ['price' => 5]))->setRouting($routing1),
+            (new Document('2', ['price' => 8]))->setRouting($routing1),
+            (new Document('3', ['price' => 1]))->setRouting($routing1),
+            (new Document('4', ['price' => 3]))->setRouting($routing2),
+            (new Document('5', ['price' => 1.5]))->setRouting($routing2),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/ScriptedMetricTest.php
+++ b/tests/Aggregation/ScriptedMetricTest.php
@@ -44,9 +44,9 @@ class ScriptedMetricTest extends BaseAggregationTest
         ]));
 
         $index->addDocuments([
-            new Document(1, ['start' => 100, 'end' => 200]),
-            new Document(2, ['start' => 200, 'end' => 250]),
-            new Document(3, ['start' => 300, 'end' => 450]),
+            new Document('1', ['start' => 100, 'end' => 200]),
+            new Document('2', ['start' => 200, 'end' => 250]),
+            new Document('3', ['start' => 300, 'end' => 450]),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/SignificantTermsTest.php
+++ b/tests/Aggregation/SignificantTermsTest.php
@@ -93,7 +93,7 @@ class SignificantTermsTest extends BaseAggregationTest
 
         $docs = [];
         for ($i = 0; $i < 250; ++$i) {
-            $docs[] = new Document($i, ['color' => $colors[$i % \count($colors)], 'temperature' => $temperatures[$i % \count($temperatures)]]);
+            $docs[] = new Document((string) $i, ['color' => $colors[$i % \count($colors)], 'temperature' => $temperatures[$i % \count($temperatures)]]);
         }
         $index->addDocuments($docs);
         $index->refresh();

--- a/tests/Aggregation/StatsTest.php
+++ b/tests/Aggregation/StatsTest.php
@@ -56,11 +56,11 @@ class StatsTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5]),
-            new Document(2, ['price' => 8]),
-            new Document(3, ['price' => 1]),
-            new Document(4, ['price' => 3]),
-            new Document(5, ['anything' => 'anything']),
+            new Document('1', ['price' => 5]),
+            new Document('2', ['price' => 8]),
+            new Document('3', ['price' => 1]),
+            new Document('4', ['price' => 3]),
+            new Document('5', ['anything' => 'anything']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/SumTest.php
+++ b/tests/Aggregation/SumTest.php
@@ -48,11 +48,11 @@ class SumTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5]),
-            new Document(2, ['price' => 8]),
-            new Document(3, ['price' => 1]),
-            new Document(4, ['price' => 3]),
-            new Document(5, ['anything' => 'anything']),
+            new Document('1', ['price' => 5]),
+            new Document('2', ['price' => 8]),
+            new Document('3', ['price' => 1]),
+            new Document('4', ['price' => 3]),
+            new Document('5', ['anything' => 'anything']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/TermsTest.php
+++ b/tests/Aggregation/TermsTest.php
@@ -151,11 +151,11 @@ class TermsTest extends BaseAggregationTest
         $index->setMapping($mapping);
 
         $index->addDocuments([
-            new Document(1, ['color' => 'blue']),
-            new Document(2, ['color' => 'blue']),
-            new Document(3, ['color' => 'red']),
-            new Document(4, ['color' => 'green']),
-            new Document(5, ['anything' => 'anything']),
+            new Document('1', ['color' => 'blue']),
+            new Document('2', ['color' => 'blue']),
+            new Document('3', ['color' => 'red']),
+            new Document('4', ['color' => 'green']),
+            new Document('5', ['anything' => 'anything']),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/TopHitsTest.php
+++ b/tests/Aggregation/TopHitsTest.php
@@ -391,27 +391,27 @@ class TopHitsTest extends BaseAggregationTest
         $index->setMapping($mapping);
 
         $index->addDocuments([
-            new Document(1, [
+            new Document('1', [
                 'tags' => ['linux'],
                 'last_activity_date' => '2015-01-05',
                 'title' => 'Question about linux #1',
             ]),
-            new Document(2, [
+            new Document('2', [
                 'tags' => ['linux'],
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about linux #2',
             ]),
-            new Document(3, [
+            new Document('3', [
                 'tags' => ['windows'],
                 'last_activity_date' => '2015-01-05',
                 'title' => 'Question about windows #1',
             ]),
-            new Document(4, [
+            new Document('4', [
                 'tags' => ['windows'],
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about windows #2',
             ]),
-            new Document(5, [
+            new Document('5', [
                 'tags' => ['osx', 'apple'],
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about osx',

--- a/tests/Aggregation/ValueCountTest.php
+++ b/tests/Aggregation/ValueCountTest.php
@@ -31,11 +31,11 @@ class ValueCountTest extends BaseAggregationTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['price' => 5]),
-            new Document(2, ['price' => 8]),
-            new Document(3, ['price' => 1]),
-            new Document(4, ['price' => 3]),
-            new Document(5, ['price' => 3]),
+            new Document('1', ['price' => 5]),
+            new Document('2', ['price' => 8]),
+            new Document('3', ['price' => 1]),
+            new Document('4', ['price' => 3]),
+            new Document('5', ['price' => 3]),
         ]);
 
         $index->refresh();

--- a/tests/Aggregation/WeightedAvgTest.php
+++ b/tests/Aggregation/WeightedAvgTest.php
@@ -85,10 +85,10 @@ class WeightedAvgTest extends BaseAggregationTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['price' => 5, 'weight' => 3]),
-            new Document(2, ['price' => 8, 'weight' => 1]),
-            new Document(3, ['price' => 1, 'weight' => 1]),
-            new Document(4, ['price' => 3]),
+            new Document('1', ['price' => 5, 'weight' => 3]),
+            new Document('2', ['price' => 8, 'weight' => 1]),
+            new Document('3', ['price' => 1, 'weight' => 1]),
+            new Document('4', ['price' => 3]),
         ]);
 
         $index->refresh();

--- a/tests/Bulk/ActionTest.php
+++ b/tests/Bulk/ActionTest.php
@@ -30,7 +30,7 @@ class ActionTest extends BaseTest
         $expected = '{"index":{"_index":"index"}}'."\n";
         $this->assertEquals($expected, (string) $action);
 
-        $action->setId(1);
+        $action->setId('1');
         $expected = '{"index":{"_index":"index","_id":"1"}}'."\n";
         $this->assertEquals($expected, (string) $action);
 

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -34,9 +34,9 @@ class BulkTest extends BaseTest
         $indexName = $index->getName();
         $client = $index->getClient();
 
-        $newDocument1 = new Document(1, ['name' => 'Mister Fantastic'], $index);
-        $newDocument2 = new Document(2, ['name' => 'Invisible Woman']);
-        $newDocument3 = new Document(3, ['name' => 'The Human Torch'], $index);
+        $newDocument1 = new Document('1', ['name' => 'Mister Fantastic'], $index);
+        $newDocument2 = new Document('2', ['name' => 'Invisible Woman']);
+        $newDocument3 = new Document('3', ['name' => 'The Human Torch'], $index);
         $newDocument4 = new Document(null, ['name' => 'The Thing'], $index);
 
         $newDocument3->setOpType(Document::OP_TYPE_CREATE);
@@ -73,11 +73,11 @@ class BulkTest extends BaseTest
         $data = $bulk->toArray();
 
         $expected = [
-            ['index' => ['_id' => 1, '_index' => $indexName]],
+            ['index' => ['_id' => '1', '_index' => $indexName]],
             ['name' => 'Mister Fantastic'],
-            ['index' => ['_id' => 2]],
+            ['index' => ['_id' => '2']],
             ['name' => 'Invisible Woman'],
-            ['create' => ['_id' => 3, '_index' => $indexName]],
+            ['create' => ['_id' => '3', '_index' => $indexName]],
             ['name' => 'The Human Torch'],
             ['index' => ['_index' => $indexName]],
             ['name' => 'The Thing'],
@@ -119,7 +119,7 @@ class BulkTest extends BaseTest
         $data = $bulk->toArray();
 
         $expected = [
-            ['delete' => ['_index' => $indexName, '_id' => 3]],
+            ['delete' => ['_index' => $indexName, '_id' => '3']],
         ];
         $this->assertEquals($expected, $data);
 
@@ -145,9 +145,9 @@ class BulkTest extends BaseTest
         $index = $this->_createIndex();
         $client = $index->getClient();
 
-        $newDocument1 = new Document(1, ['name' => 'Сегодня, я вижу, особенно грустен твой взгляд,'], $index);
-        $newDocument2 = new Document(2, ['name' => 'И руки особенно тонки, колени обняв.']);
-        $newDocument3 = new Document(3, ['name' => 'Послушай: далеко, далеко, на озере Чад / Изысканный бродит жираф.'], $index);
+        $newDocument1 = new Document('1', ['name' => 'Сегодня, я вижу, особенно грустен твой взгляд,'], $index);
+        $newDocument2 = new Document('2', ['name' => 'И руки особенно тонки, колени обняв.']);
+        $newDocument3 = new Document('3', ['name' => 'Послушай: далеко, далеко, на озере Чад / Изысканный бродит жираф.'], $index);
 
         $documents = [
             $newDocument1,
@@ -203,11 +203,11 @@ class BulkTest extends BaseTest
 
         $action1 = new Action(Action::OP_TYPE_DELETE);
         $action1->setIndex('index');
-        $action1->setId(1);
+        $action1->setId('1');
 
         $action2 = new Action(Action::OP_TYPE_INDEX);
         $action2->setIndex('index');
-        $action2->setId(1);
+        $action2->setId('1');
         $action2->setSource(['name' => 'Batman']);
 
         $actions = [
@@ -342,9 +342,9 @@ class BulkTest extends BaseTest
         $client = $index->getClient();
 
         $documents = [
-            new Document(1, ['name' => 'Mister Fantastic'], $index),
-            new Document(2, ['name' => 'Invisible Woman'], $index),
-            new Document(2, ['name' => 'The Human Torch'], $index),
+            new Document('1', ['name' => 'Mister Fantastic'], $index),
+            new Document('2', ['name' => 'Invisible Woman'], $index),
+            new Document('2', ['name' => 'The Human Torch'], $index),
         ];
 
         $documents[2]->setOpType(Document::OP_TYPE_CREATE);
@@ -417,10 +417,10 @@ JSON;
         $index = $this->_createIndex();
         $client = $index->getClient();
 
-        $doc1 = new Document(1, ['name' => 'John'], $index);
-        $doc2 = new Document(2, ['name' => 'Paul'], $index);
-        $doc3 = new Document(3, ['name' => 'George'], $index);
-        $doc4 = new Document(4, ['name' => 'Ringo'], $index);
+        $doc1 = new Document('1', ['name' => 'John'], $index);
+        $doc2 = new Document('2', ['name' => 'Paul'], $index);
+        $doc3 = new Document('3', ['name' => 'George'], $index);
+        $doc4 = new Document('4', ['name' => 'Ringo'], $index);
         $documents = [$doc1, $doc2, $doc3, $doc4];
 
         // index some documents
@@ -436,7 +436,7 @@ JSON;
         $index->getDocument(2);
 
         // test updating via document
-        $doc2 = new Document(2, ['name' => 'The Walrus'], $index);
+        $doc2 = new Document('2', ['name' => 'The Walrus'], $index);
         $bulk = new Bulk($client);
         $bulk->setIndex($index);
         $updateAction = new UpdateDocument($doc2);
@@ -453,7 +453,7 @@ JSON;
         $this->assertEquals('The Walrus', $docData['name']);
 
         // test updating via script
-        $script = new Script('ctx._source.name += params.param1;', ['param1' => ' was Paul'], Script::LANG_PAINLESS, 2);
+        $script = new Script('ctx._source.name += params.param1;', ['param1' => ' was Paul'], Script::LANG_PAINLESS, '2');
         $updateAction = AbstractDocument::create($script, Action::OP_TYPE_UPDATE);
         $bulk = new Bulk($client);
         $bulk->setIndex($index);
@@ -469,7 +469,7 @@ JSON;
         $this->assertEquals('The Walrus was Paul', $doc2->name);
 
         // test upsert
-        $script = new Script('', [], null, 5);
+        $script = new Script('', [], null, '5');
         $doc = new Document('', ['counter' => 1]);
         $script->setUpsert($doc);
         $updateAction = AbstractDocument::create($script, Action::OP_TYPE_UPDATE);
@@ -486,7 +486,7 @@ JSON;
         $this->assertEquals(1, $doc->counter);
 
         // test doc_as_upsert
-        $doc = new Document(6, ['test' => 'test']);
+        $doc = new Document('6', ['test' => 'test']);
         $doc->setDocAsUpsert(true);
         $updateAction = AbstractDocument::create($doc, Action::OP_TYPE_UPDATE);
         $bulk = new Bulk($client);
@@ -502,9 +502,9 @@ JSON;
         $this->assertEquals('test', $doc->test);
 
         // test doc_as_upsert with set of documents (use of addDocuments)
-        $doc1 = new Document(7, ['test' => 'test1']);
+        $doc1 = new Document('7', ['test' => 'test1']);
         $doc1->setDocAsUpsert(true);
-        $doc2 = new Document(8, ['test' => 'test2']);
+        $doc2 = new Document('8', ['test' => 'test2']);
         $doc2->setDocAsUpsert(true);
         $docs = [$doc1, $doc2];
         $bulk = new Bulk($client);
@@ -522,7 +522,7 @@ JSON;
         $this->assertEquals('test2', $doc->test);
 
         // test updating via document with json string as data
-        $doc3 = new Document(2, [], $index);
+        $doc3 = new Document('2', [], $index);
         $bulk = new Bulk($client);
         $bulk->setIndex($index);
         $doc3->setData('{"name" : "Paul it is"}');
@@ -550,10 +550,10 @@ JSON;
         $index = $this->_createIndex();
         $client = $index->getClient();
 
-        $doc1 = new Document(1, ['name' => 'Pele'], $index);
-        $doc2 = new Document(2, ['name' => 'Beckenbauer'], $index);
-        $doc3 = new Document(3, ['name' => 'Baggio'], $index);
-        $doc4 = new Document(4, ['name' => 'Cruyff'], $index);
+        $doc1 = new Document('1', ['name' => 'Pele'], $index);
+        $doc2 = new Document('2', ['name' => 'Beckenbauer'], $index);
+        $doc3 = new Document('3', ['name' => 'Baggio'], $index);
+        $doc4 = new Document('4', ['name' => 'Cruyff'], $index);
         $documents = \array_map(static function ($d) {
             $d->setDocAsUpsert(true);
 
@@ -572,7 +572,7 @@ JSON;
         $index->refresh();
 
         // test updating via document
-        $doc1 = new Document(1, ['name' => 'Maradona'], $index);
+        $doc1 = new Document('1', ['name' => 'Maradona'], $index);
         $doc1->setDocAsUpsert(true);
         $bulk = new Bulk($client);
         $bulk->setIndex($index);
@@ -601,7 +601,7 @@ JSON;
         $bulk = new Bulk($client);
         $bulk->setIndex($index);
 
-        $id = 1;
+        $id = '1';
         $field = 123456789;
         $subField = ['field' => 'a'];
         $subField2 = ['field_2' => 'b'];
@@ -680,7 +680,7 @@ JSON;
         $index = $this->_createIndex();
         $client = $index->getClient();
 
-        $doc1 = new Document(1, ['name' => 'Mister Fantastic'], $index);
+        $doc1 = new Document('1', ['name' => 'Mister Fantastic'], $index);
         $doc1->setOpType(Action::OP_TYPE_UPDATE);
         $doc1->setRetryOnConflict(5);
 
@@ -785,9 +785,9 @@ JSON;
         ;
 
         $documents = [
-            new Document(1, ['name' => 'Mister Fantastic']),
-            new Document(2, ['name' => 'Invisible Woman']),
-            new Document(2, ['name' => 'The Human Torch']),
+            new Document('1', ['name' => 'Mister Fantastic']),
+            new Document('2', ['name' => 'Invisible Woman']),
+            new Document('2', ['name' => 'The Human Torch']),
         ];
 
         $bulk = new Bulk($clientMock);

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -67,7 +67,7 @@ class ClientFunctionalTest extends BaseTest
 
         // Adds 1 document to the index
         $doc1 = new Document(
-            1,
+            '1',
             ['username' => 'hans', 'test' => ['2', '3', '5']]
         );
         $index->addDocument($doc1);
@@ -75,11 +75,11 @@ class ClientFunctionalTest extends BaseTest
         // Adds a list of documents with _bulk upload to the index
         $docs = [];
         $docs[] = new Document(
-            2,
+            '2',
             ['username' => 'john', 'test' => ['1', '3', '6']]
         );
         $docs[] = new Document(
-            3,
+            '3',
             ['username' => 'rolf', 'test' => ['2', '3', '7']]
         );
         $index->addDocuments($docs);
@@ -104,7 +104,7 @@ class ClientFunctionalTest extends BaseTest
 
         // Adds 1 document to the index
         $doc1 = new Document(
-            1,
+            '1',
             ['username' => 'hans', 'test' => ['2', '3', '5']]
         );
         $index->addDocument($doc1);
@@ -112,11 +112,11 @@ class ClientFunctionalTest extends BaseTest
         // Adds a list of documents with _bulk upload to the index
         $docs = [];
         $docs[] = new Document(
-            2,
+            '2',
             ['username' => 'john', 'test' => ['1', '3', '6']]
         );
         $docs[] = new Document(
-            3,
+            '3',
             ['username' => 'rolf', 'test' => ['2', '3', '7']]
         );
         $index->addDocuments($docs);
@@ -158,8 +158,8 @@ class ClientFunctionalTest extends BaseTest
     {
         $index = $this->_getClient()->getIndex('cryptocurrencies');
 
-        $anonCoin = new Document(1, ['name' => 'anoncoin']);
-        $ixCoin = new Document(2, ['name' => 'ixcoin']);
+        $anonCoin = new Document('1', ['name' => 'anoncoin']);
+        $ixCoin = new Document('2', ['name' => 'ixcoin']);
 
         $index->addDocuments([$anonCoin, $ixCoin]);
 
@@ -167,8 +167,8 @@ class ClientFunctionalTest extends BaseTest
         $this->assertEquals('ixcoin', $index->getDocument(2)->get('name'));
 
         $index->updateDocuments([
-            new Document(1, ['name' => 'AnonCoin']),
-            new Document(2, ['name' => 'iXcoin']),
+            new Document('1', ['name' => 'AnonCoin']),
+            new Document('2', ['name' => 'iXcoin']),
         ]);
 
         $this->assertEquals('AnonCoin', $index->getDocument(1)->get('name'));
@@ -193,12 +193,12 @@ class ClientFunctionalTest extends BaseTest
         $modifiedValue = 27;
 
         $doc1 = new Document(
-            1,
+            '1',
             ['name' => 'hans', 'age' => $initialValue],
             $indexName
         );
         $doc2 = new Document(
-            2,
+            '2',
             ['name' => 'anna', 'age' => $initialValue],
             $indexName
         );
@@ -229,7 +229,7 @@ class ClientFunctionalTest extends BaseTest
         $initialValue = 28;
 
         $doc1 = new Document(
-            1,
+            '1',
             ['name' => 'hans', 'age' => $initialValue],
             $indexName
         );
@@ -459,10 +459,10 @@ class ClientFunctionalTest extends BaseTest
         $index = $this->_createIndex();
         $client = $index->getClient();
 
-        $newDocument = new Document(1, ['field1' => 'value1', 'field2' => 'value2']);
+        $newDocument = new Document('1', ['field1' => 'value1', 'field2' => 'value2']);
         $index->addDocument($newDocument);
 
-        $updateDocument = new Document(1, ['field2' => 'value2changed', 'field3' => 'value3added']);
+        $updateDocument = new Document('1', ['field2' => 'value2changed', 'field3' => 'value3added']);
         $client->updateDocument(1, $updateDocument, $index->getName());
 
         $document = $index->getDocument(1);
@@ -481,7 +481,7 @@ class ClientFunctionalTest extends BaseTest
         $index = $this->_createIndex();
         $client = $index->getClient();
 
-        $newDocument = new Document(1, ['field1' => 'value1', 'field2' => 10, 'field3' => 'should be removed', 'field4' => 'should be changed']);
+        $newDocument = new Document('1', ['field1' => 'value1', 'field2' => 10, 'field3' => 'should be removed', 'field4' => 'should be changed']);
         $index->addDocument($newDocument);
 
         $script = new Script('ctx._source.field2 += 5; ctx._source.remove("field3"); ctx._source.field4 = "changed"', null, Script::LANG_PAINLESS);
@@ -545,7 +545,7 @@ class ClientFunctionalTest extends BaseTest
         $index = $this->_createIndex();
         $client = $index->getClient();
 
-        $newDocument = new Document(1, ['field1' => 'value1']);
+        $newDocument = new Document('1', ['field1' => 'value1']);
         $index->addDocument($newDocument);
 
         $rawData = [
@@ -571,8 +571,8 @@ class ClientFunctionalTest extends BaseTest
         $index = $this->_createIndex();
         $client = $index->getClient();
 
-        $newDocument = new Document(1, ['field1' => 'value1updated', 'field2' => 'value2updated']);
-        $upsert = new Document(1, ['field1' => 'value1', 'field2' => 'value2']);
+        $newDocument = new Document('1', ['field1' => 'value1updated', 'field2' => 'value2updated']);
+        $upsert = new Document('1', ['field1' => 'value1', 'field2' => 'value2']);
         $newDocument->setUpsert($upsert);
         $client->updateDocument(1, $newDocument, $index->getName());
 
@@ -609,7 +609,7 @@ class ClientFunctionalTest extends BaseTest
             // Ignore the exception because we expect the document to not exist.
         }
 
-        $newDocument = new Document(1, ['field1' => 'value1', 'field2' => 'value2']);
+        $newDocument = new Document('1', ['field1' => 'value1', 'field2' => 'value2']);
         $newDocument->setDocAsUpsert(true);
         $client->updateDocument(1, $newDocument, $index->getName());
 
@@ -643,9 +643,9 @@ class ClientFunctionalTest extends BaseTest
         $client = $index->getClient();
 
         $docs = [
-            new Document(1, ['field' => 'value1'], $index),
-            new Document(2, ['field' => 'value2'], $index),
-            new Document(3, ['field' => 'value3'], $index),
+            new Document('1', ['field' => 'value1'], $index),
+            new Document('2', ['field' => 'value2'], $index),
+            new Document('3', ['field' => 'value3'], $index),
         ];
 
         $response = $client->addDocuments($docs);
@@ -684,9 +684,9 @@ class ClientFunctionalTest extends BaseTest
         $client = $index->getClient();
 
         $docs = [
-            new Document(1, ['field' => 'value1'], $index),
-            new Document(2, ['field' => 'value2'], $index),
-            new Document(3, ['field' => 'value3'], $index),
+            new Document('1', ['field' => 'value1'], $index),
+            new Document('2', ['field' => 'value2'], $index),
+            new Document('3', ['field' => 'value3'], $index),
         ];
 
         $response = $client->addDocuments($docs);
@@ -737,7 +737,7 @@ class ClientFunctionalTest extends BaseTest
         $index = $this->_createIndex();
         $client = $index->getClient();
 
-        $newDocument = new Document(1, ['field1' => 'value1', 'field2' => 10, 'field3' => 'should be removed', 'field4' => 'value4']);
+        $newDocument = new Document('1', ['field1' => 'value1', 'field2' => 10, 'field3' => 'should be removed', 'field4' => 'value4']);
         $newDocument->setAutoPopulate();
         $index->addDocument($newDocument);
 
@@ -746,7 +746,7 @@ class ClientFunctionalTest extends BaseTest
         $script->setUpsert($newDocument);
 
         $client->updateDocument(
-            1,
+            '1',
             $script,
             $index->getName()
         );
@@ -766,7 +766,7 @@ class ClientFunctionalTest extends BaseTest
         $script->setUpsert($newDocument);
 
         $client->updateDocument(
-            1,
+            '1',
             $script,
             $index->getName()
         );
@@ -839,7 +839,7 @@ class ClientFunctionalTest extends BaseTest
         $index->create([], [
             'recreate' => true,
         ]);
-        $index->addDocument(new Document(1, ['username' => 'ruflin']));
+        $index->addDocument(new Document('1', ['username' => 'ruflin']));
         $index->refresh();
 
         $query = [
@@ -866,7 +866,7 @@ class ClientFunctionalTest extends BaseTest
         $index->create([], [
             'recreate' => true,
         ]);
-        $index->addDocument(new Document(1, ['username' => 'ruflin']));
+        $index->addDocument(new Document('1', ['username' => 'ruflin']));
         $index->refresh();
 
         $query = '{"query":{"query_string":{"query":"ruflin"}}}';
@@ -942,8 +942,8 @@ class ClientFunctionalTest extends BaseTest
         // Also, index should exist (matches $staticIndex)
         $dynamicIndex->refresh();
 
-        $doc1 = $dynamicIndex->createDocument(1, ['name' => 'one']);
-        $doc2 = $dynamicIndex->createDocument(2, ['name' => 'two']);
+        $doc1 = $dynamicIndex->createDocument('1', ['name' => 'one']);
+        $doc2 = $dynamicIndex->createDocument('2', ['name' => 'two']);
 
         // Index name goes through JSON body, should remain unescaped
         $bulk = new Bulk($client);
@@ -1005,7 +1005,7 @@ class ClientFunctionalTest extends BaseTest
         $index->create([], [
             'recreate' => true,
         ]);
-        $index->addDocument(new Document(1, ['username' => 'ruflin']));
+        $index->addDocument(new Document('1', ['username' => 'ruflin']));
         $index->refresh();
 
         $query = [

--- a/tests/Collapse/CollapseTest.php
+++ b/tests/Collapse/CollapseTest.php
@@ -294,42 +294,42 @@ class CollapseTest extends BaseTest
         ]));
 
         $index->addDocuments([
-            new Document(1, [
+            new Document('1', [
                 'user' => 'Veronica',
                 'message' => 'Always keeping an eye on elasticsearch.',
                 'date' => '2019-08-15',
                 'likes' => 10,
                 'zip' => '07',
             ]),
-            new Document(2, [
+            new Document('2', [
                 'user' => 'Wallace',
                 'message' => 'Elasticsearch DevOps is awesome!',
                 'date' => '2019-08-05',
                 'likes' => 50,
                 'zip' => '06',
             ]),
-            new Document(3, [
+            new Document('3', [
                 'user' => 'Logan',
                 'message' => 'Can I find my lost stuff on elasticsearch?',
                 'date' => '2019-08-02',
                 'likes' => 1,
                 'zip' => '09',
             ]),
-            new Document(4, [
+            new Document('4', [
                 'user' => 'Keith',
                 'message' => 'Investigating again.',
                 'date' => '2019-08-10',
                 'likes' => 30,
                 'zip' => '07',
             ]),
-            new Document(5, [
+            new Document('5', [
                 'user' => 'Veronica',
                 'message' => 'Finding out new stuff.',
                 'date' => '2019-08-01',
                 'likes' => 20,
                 'zip' => '07',
             ]),
-            new Document(6, [
+            new Document('6', [
                 'user' => 'Wallace',
                 'message' => 'Baller.',
                 'date' => '2019-08-15',

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -94,7 +94,7 @@ class DocumentTest extends BaseTest
         $this->assertFalse($document->hasId());
         $document->setId(null);
         $this->assertFalse($document->hasId());
-        $document->setId(0);
+        $document->setId('0');
         $this->assertTrue($document->hasId());
         $document->setId('hello');
         $this->assertTrue($document->hasId());
@@ -136,7 +136,7 @@ class DocumentTest extends BaseTest
         $document = new Document();
         $document->setIndex('index');
         $document->setOpType('create');
-        $document->setId(1);
+        $document->setId('1');
 
         $options = $document->getOptions(['_index', 'type', '_id', 'op_type']);
 
@@ -159,7 +159,7 @@ class DocumentTest extends BaseTest
      */
     public function testGetSetHasRemove(): void
     {
-        $document = new Document(1, ['field1' => 'value1', 'field2' => 'value2', 'field3' => 'value3', 'field4' => null]);
+        $document = new Document('1', ['field1' => 'value1', 'field2' => 'value2', 'field3' => 'value3', 'field4' => null]);
 
         $this->assertEquals('value1', $document->get('field1'));
         $this->assertEquals('value2', $document->get('field2'));
@@ -213,7 +213,7 @@ class DocumentTest extends BaseTest
      */
     public function testDataPropertiesOverloading(): void
     {
-        $document = new Document(1, ['field1' => 'value1', 'field2' => 'value2', 'field3' => 'value3', 'field4' => null]);
+        $document = new Document('1', ['field1' => 'value1', 'field2' => 'value2', 'field3' => 'value3', 'field4' => null]);
 
         $this->assertEquals('value1', $document->field1);
         $this->assertEquals('value2', $document->field2);
@@ -266,7 +266,7 @@ class DocumentTest extends BaseTest
     public function testSerializedData(): void
     {
         $data = '{"user":"rolf"}';
-        $document = new Document(1, $data);
+        $document = new Document('1', $data);
 
         $this->assertFalse($document->has('user'));
 

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -20,7 +20,7 @@ class ExampleTest extends BaseTest
         $client = $this->_getClient();
         $index = $client->getIndex('ruflin');
 
-        $id = 2;
+        $id = '2';
         $data = ['firstname' => 'Nicolas', 'lastname' => 'Ruflin'];
         $doc = new Document($id, $data);
 
@@ -40,12 +40,12 @@ class ExampleTest extends BaseTest
         ]);
 
         // Adds 1 document to the index
-        $index->addDocument(new Document(1, ['username' => 'hans', 'test' => ['2', '3', '5']]));
+        $index->addDocument(new Document('1', ['username' => 'hans', 'test' => ['2', '3', '5']]));
 
         // Adds a list of documents with _bulk upload to the index
         $index->addDocuments([
-            new Document(2, ['username' => 'john', 'test' => ['1', '3', '6']]),
-            new Document(3, ['username' => 'rolf', 'test' => ['2', '3', '7']]),
+            new Document('2', ['username' => 'john', 'test' => ['1', '3', '6']]),
+            new Document('3', ['username' => 'rolf', 'test' => ['2', '3', '7']]),
         ]);
 
         // Refresh index

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -40,7 +40,7 @@ class IndexTest extends BaseTest
         ]);
         $index->setMapping($mappings);
         $index->addDocument(
-            new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'hanswurst', 'test' => ['2', '3', '5']])
+            new Document('1', ['id' => 1, 'email' => 'test@test.com', 'username' => 'hanswurst', 'test' => ['2', '3', '5']])
         );
         $index->forcemerge();
 
@@ -108,7 +108,7 @@ class IndexTest extends BaseTest
                 'recreate' => true,
             ]
         );
-        $index->addDocument(new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'ruflin']));
+        $index->addDocument(new Document('1', ['id' => 1, 'email' => 'test@test.com', 'username' => 'ruflin']));
         $index->refresh();
 
         $resultSet = $index->search('ruflin');
@@ -182,8 +182,8 @@ class IndexTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['name' => 'ruflin nicolas']),
-            new Document(2, ['name' => 'ruflin']),
+            new Document('1', ['name' => 'ruflin nicolas']),
+            new Document('2', ['name' => 'ruflin']),
         ]);
         $index->refresh();
 
@@ -214,8 +214,8 @@ class IndexTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['name' => 'ruflin nicolas']),
-            new Document(2, ['name' => 'ruflin']),
+            new Document('1', ['name' => 'ruflin nicolas']),
+            new Document('2', ['name' => 'ruflin']),
         ]);
         $index->refresh();
 
@@ -246,8 +246,8 @@ class IndexTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['name' => 'ruflin nicolas']),
-            new Document(2, ['name' => 'ruflin']),
+            new Document('1', ['name' => 'ruflin nicolas']),
+            new Document('2', ['name' => 'ruflin']),
         ]);
         $index->refresh();
 
@@ -281,15 +281,15 @@ class IndexTest extends BaseTest
         $routing1 = 'first_routing';
         $routing2 = 'second_routing';
 
-        $doc = new Document(1, ['name' => 'ruflin nicolas']);
+        $doc = new Document('1', ['name' => 'ruflin nicolas']);
         $doc->setRouting($routing1);
         $index->addDocument($doc);
 
-        $doc = new Document(2, ['name' => 'ruflin']);
+        $doc = new Document('2', ['name' => 'ruflin']);
         $doc->setRouting($routing1);
         $index->addDocument($doc);
 
-        $doc = new Document(2, ['name' => 'ruflin']);
+        $doc = new Document('2', ['name' => 'ruflin']);
         $doc->setRouting($routing1);
         $index->addDocument($doc);
 
@@ -337,8 +337,8 @@ class IndexTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['name' => 'ruflin nicolas']),
-            new Document(2, ['name' => 'ruflin']),
+            new Document('1', ['name' => 'ruflin nicolas']),
+            new Document('2', ['name' => 'ruflin']),
         ]);
         $index->refresh();
 
@@ -372,8 +372,8 @@ class IndexTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['name' => 'ruflin nicolas']),
-            new Document(2, ['name' => 'ruflin']),
+            new Document('1', ['name' => 'ruflin nicolas']),
+            new Document('2', ['name' => 'ruflin']),
         ]);
         $index->refresh();
 
@@ -507,7 +507,7 @@ class IndexTest extends BaseTest
             'recreate' => true,
         ]);
 
-        $doc1 = new Document(1);
+        $doc1 = new Document('1');
         $doc1->set('title', 'Hello world');
 
         $return = $index->addDocument($doc1);
@@ -528,7 +528,7 @@ class IndexTest extends BaseTest
         $index1 = $client->getIndex('test');
         $index2 = $client->getIndex('test_2');
 
-        $doc = new Document(1);
+        $doc = new Document('1');
         $doc->set('title', 'Hello world');
 
         $index1->addDocument($doc);
@@ -645,17 +645,17 @@ class IndexTest extends BaseTest
         $index->create(['settings' => ['index' => ['number_of_shards' => 1, 'number_of_replicas' => 0]]]);
 
         $docs = [
-            new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(2, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(3, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(4, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(5, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(6, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(7, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(8, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(9, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('1', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('2', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('3', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('4', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('5', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('6', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('7', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('8', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('9', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('10', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('11', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
         ];
         $index->addDocuments($docs);
         $index->refresh();
@@ -777,9 +777,9 @@ class IndexTest extends BaseTest
         $index = $this->_createIndex();
 
         $docs = [];
-        $docs[] = new Document(1, ['username' => 'hans', 'test' => ['2', '3', '5']]);
-        $docs[] = new Document(2, ['username' => 'john', 'test' => ['1', '3', '6']]);
-        $docs[] = new Document(3, ['username' => 'rolf', 'test' => ['2', '3', '7']]);
+        $docs[] = new Document('1', ['username' => 'hans', 'test' => ['2', '3', '5']]);
+        $docs[] = new Document('2', ['username' => 'john', 'test' => ['1', '3', '6']]);
+        $docs[] = new Document('3', ['username' => 'rolf', 'test' => ['2', '3', '7']]);
         $index->addDocuments($docs);
         $index->refresh();
 
@@ -806,7 +806,7 @@ class IndexTest extends BaseTest
     {
         $index = $this->_createIndex();
         $docs = [];
-        $docs[] = new Document(1, ['username' => 'hans']);
+        $docs[] = new Document('1', ['username' => 'hans']);
         $index->addDocuments($docs);
         $index->refresh();
 
@@ -840,8 +840,8 @@ class IndexTest extends BaseTest
         ]);
 
         $docs = [
-            new Document(1, ['foo' => 'bar']),
-            new Document(2, ['foo' => 'bar']),
+            new Document('1', ['foo' => 'bar']),
+            new Document('2', ['foo' => 'bar']),
         ];
         $index->addDocuments($docs, ['refresh' => 'true']);
 

--- a/tests/MappingTest.php
+++ b/tests/MappingTest.php
@@ -36,7 +36,7 @@ class MappingTest extends BaseTest
 
         $firstname = 'Nicolas';
         $doc = new Document(
-            1,
+            '1',
             [
                 'firstname' => $firstname,
                 'lastname' => 'Ruflin',
@@ -91,7 +91,7 @@ class MappingTest extends BaseTest
         $response = $index->setMapping($mapping);
         $this->assertFalse($response->hasError());
 
-        $doc = new Document(1, [
+        $doc = new Document('1', [
             'user' => [
                 'firstname' => 'Nicolas',
                 'lastname' => 'Ruflin',
@@ -146,14 +146,14 @@ class MappingTest extends BaseTest
         $this->assertEquals($expected, $mapping->toArray());
         $index->refresh();
 
-        $doc1 = new Document(1, [
+        $doc1 = new Document('1', [
             'text' => 'this is the 1st question',
             'my_join_field' => [
                 'name' => 'question',
             ],
         ]);
 
-        $doc2 = new Document(2, [
+        $doc2 = new Document('2', [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
@@ -162,7 +162,7 @@ class MappingTest extends BaseTest
 
         $index->addDocuments([$doc1, $doc2]);
 
-        $doc3 = new Document(3, [
+        $doc3 = new Document('3', [
             'text' => 'this is an answer, the 1st',
             'my_join_field' => [
                 'name' => 'answer',
@@ -170,7 +170,7 @@ class MappingTest extends BaseTest
             ],
         ]);
 
-        $doc4 = new Document(4, [
+        $doc4 = new Document('4', [
             'text' => 'this is an answer, the 2nd',
             'my_join_field' => [
                 'name' => 'answer',
@@ -209,7 +209,7 @@ class MappingTest extends BaseTest
         $index->setMapping($mapping);
 
         $doc = new Document(
-            1,
+            '1',
             [
                 'note' => [
                     [

--- a/tests/Multi/SearchTest.php
+++ b/tests/Multi/SearchTest.php
@@ -581,17 +581,17 @@ class SearchTest extends BaseTest
         );
 
         $docs = [];
-        $docs[] = new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']);
-        $docs[] = new Document(2, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']);
-        $docs[] = new Document(3, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']);
-        $docs[] = new Document(4, ['id' => 1, 'email' => 'test@test.com', 'username' => 'kate']);
-        $docs[] = new Document(5, ['id' => 1, 'email' => 'test@test.com', 'username' => 'kate']);
-        $docs[] = new Document(6, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
-        $docs[] = new Document(7, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
-        $docs[] = new Document(8, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
-        $docs[] = new Document(9, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
-        $docs[] = new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
-        $docs[] = new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
+        $docs[] = new Document('1', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']);
+        $docs[] = new Document('2', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']);
+        $docs[] = new Document('3', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']);
+        $docs[] = new Document('4', ['id' => 1, 'email' => 'test@test.com', 'username' => 'kate']);
+        $docs[] = new Document('5', ['id' => 1, 'email' => 'test@test.com', 'username' => 'kate']);
+        $docs[] = new Document('6', ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
+        $docs[] = new Document('7', ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
+        $docs[] = new Document('8', ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
+        $docs[] = new Document('9', ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
+        $docs[] = new Document('10', ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
+        $docs[] = new Document('11', ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']);
         $index->addDocuments($docs);
         $index->refresh();
 

--- a/tests/Processor/AttachmentProcessorTest.php
+++ b/tests/Processor/AttachmentProcessorTest.php
@@ -70,7 +70,7 @@ class AttachmentProcessorTest extends BasePipelineTest
 
         $doc1 = new Document(null);
         $doc1->addFile('data', __DIR__.'/../data/test.pdf');
-        $doc2 = new Document(2, ['data' => '', 'text' => 'test running in basel']);
+        $doc2 = new Document('2', ['data' => '', 'text' => 'test running in basel']);
 
         $bulk->addDocuments([
             $doc1, $doc2,
@@ -114,7 +114,7 @@ class AttachmentProcessorTest extends BasePipelineTest
         $doc1->addFile('data', __DIR__.'/../data/test.pdf');
         $doc1->set('text', 'basel world');
 
-        $doc2 = new Document(2, ['data' => '', 'text' => 'test running in basel']);
+        $doc2 = new Document('2', ['data' => '', 'text' => 'test running in basel']);
         $doc2->set('text', 'running in basel');
 
         $bulk->addDocuments([
@@ -159,7 +159,7 @@ class AttachmentProcessorTest extends BasePipelineTest
         $doc1->addFile('data', __DIR__.'/../data/test.docx');
         $doc1->set('text', 'basel world');
 
-        $doc2 = new Document(2, ['data' => '', 'text' => 'test running in basel']);
+        $doc2 = new Document('2', ['data' => '', 'text' => 'test running in basel']);
 
         $bulk->addDocuments([
             $doc1, $doc2,
@@ -203,7 +203,7 @@ class AttachmentProcessorTest extends BasePipelineTest
 
         $index->setMapping($mapping);
 
-        $docId = 1;
+        $docId = '1';
         $text = 'Basel World';
         $title = 'No Title';
 

--- a/tests/Query/BoolQueryTest.php
+++ b/tests/Query/BoolQueryTest.php
@@ -22,13 +22,13 @@ class BoolQueryTest extends BaseTest
         $query = new BoolQuery();
 
         $idsQuery1 = new Ids();
-        $idsQuery1->setIds(1);
+        $idsQuery1->setIds('1');
 
         $idsQuery2 = new Ids();
-        $idsQuery2->setIds(2);
+        $idsQuery2->setIds('2');
 
         $idsQuery3 = new Ids();
-        $idsQuery3->setIds(3);
+        $idsQuery3->setIds('3');
 
         $filter1 = new Term();
         $filter1->setTerm('test', '1');
@@ -95,13 +95,13 @@ class BoolQueryTest extends BaseTest
             'recreate' => true,
         ]);
 
-        $doc = new Document(1, ['id' => 1, 'email' => 'hans@test.com', 'username' => 'hans', 'test' => ['2', '4', '5']]);
+        $doc = new Document('1', ['id' => 1, 'email' => 'hans@test.com', 'username' => 'hans', 'test' => ['2', '4', '5']]);
         $index->addDocument($doc);
-        $doc = new Document(2, ['id' => 2, 'email' => 'emil@test.com', 'username' => 'emil', 'test' => ['1', '3', '6']]);
+        $doc = new Document('2', ['id' => 2, 'email' => 'emil@test.com', 'username' => 'emil', 'test' => ['1', '3', '6']]);
         $index->addDocument($doc);
-        $doc = new Document(3, ['id' => 3, 'email' => 'ruth@test.com', 'username' => 'ruth', 'test' => ['2', '3', '7']]);
+        $doc = new Document('3', ['id' => 3, 'email' => 'ruth@test.com', 'username' => 'ruth', 'test' => ['2', '3', '7']]);
         $index->addDocument($doc);
-        $doc = new Document(4, ['id' => 4, 'email' => 'john@test.com', 'username' => 'john', 'test' => ['2', '4', '8']]);
+        $doc = new Document('4', ['id' => 4, 'email' => 'john@test.com', 'username' => 'john', 'test' => ['2', '4', '8']]);
         $index->addDocument($doc);
 
         // Refresh index
@@ -148,7 +148,7 @@ class BoolQueryTest extends BaseTest
 
         $docNumber = 3;
         for ($i = 0; $i < $docNumber; ++$i) {
-            $doc = new Document($i, ['email' => 'test@test.com']);
+            $doc = new Document((string) $i, ['email' => 'test@test.com']);
             $index->addDocument($doc);
         }
 

--- a/tests/Query/CommonTest.php
+++ b/tests/Query/CommonTest.php
@@ -47,13 +47,13 @@ class CommonTest extends BaseTest
         $index = $this->_createIndex();
 
         $docs = [
-            new Document(1, ['body' => 'foo baz']),
-            new Document(2, ['body' => 'foo bar baz']),
-            new Document(3, ['body' => 'foo bar baz bat']),
+            new Document('1', ['body' => 'foo baz']),
+            new Document('2', ['body' => 'foo bar baz']),
+            new Document('3', ['body' => 'foo bar baz bat']),
         ];
         // add documents to create common terms
         for ($i = 4; $i < 24; ++$i) {
-            $docs[] = new Document($i, ['body' => 'foo bar']);
+            $docs[] = new Document((string) $i, ['body' => 'foo bar']);
         }
         $index->addDocuments($docs);
         $index->refresh();

--- a/tests/Query/DisMaxTest.php
+++ b/tests/Query/DisMaxTest.php
@@ -21,13 +21,13 @@ class DisMaxTest extends BaseTest
         $query = new DisMax();
 
         $idsQuery1 = new Ids();
-        $idsQuery1->setIds(1);
+        $idsQuery1->setIds('1');
 
         $idsQuery2 = new Ids();
-        $idsQuery2->setIds(2);
+        $idsQuery2->setIds('2');
 
         $idsQuery3 = new Ids();
-        $idsQuery3->setIds(3);
+        $idsQuery3->setIds('3');
 
         $boost = 1.2;
         $tieBreaker = 0.7;
@@ -61,10 +61,10 @@ class DisMaxTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'Baden']),
-            new Document(4, ['name' => 'Baden Baden']),
+            new Document('1', ['name' => 'Basel-Stadt']),
+            new Document('2', ['name' => 'New York']),
+            new Document('3', ['name' => 'Baden']),
+            new Document('4', ['name' => 'Baden Baden']),
         ]);
 
         $index->refresh();
@@ -93,10 +93,10 @@ class DisMaxTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'Baden']),
-            new Document(4, ['name' => 'Baden Baden']),
+            new Document('1', ['name' => 'Basel-Stadt']),
+            new Document('2', ['name' => 'New York']),
+            new Document('3', ['name' => 'Baden']),
+            new Document('4', ['name' => 'Baden Baden']),
         ]);
 
         $index->refresh();

--- a/tests/Query/EscapeStringTest.php
+++ b/tests/Query/EscapeStringTest.php
@@ -21,7 +21,7 @@ class EscapeStringTest extends BaseTest
         $index->getSettings()->setNumberOfReplicas(0);
 
         $doc = new Document(
-            1,
+            '1',
             [
                 'email' => 'test@test.com', 'username' => 'test 7/6 123', 'test' => ['2', '3', '5'], ]
         );

--- a/tests/Query/FunctionScoreTest.php
+++ b/tests/Query/FunctionScoreTest.php
@@ -561,13 +561,13 @@ class FunctionScoreTest extends BaseTest
         ]));
 
         $index->addDocuments([
-            new Document(1, [
+            new Document('1', [
                 'name' => "Mr. Frostie's",
                 'location' => [['lat' => 32.799605, 'lon' => -117.243027], ['lat' => 32.792744, 'lon' => -117.2387341]],
                 'price' => 4.5,
                 'popularity' => null,
             ]),
-            new Document(2, [
+            new Document('2', [
                 'name' => "Miller's Field",
                 'location' => ['lat' => 32.795964, 'lon' => -117.255028],
                 'price' => 9.5,

--- a/tests/Query/FuzzyTest.php
+++ b/tests/Query/FuzzyTest.php
@@ -94,10 +94,10 @@ class FuzzyTest extends BaseTest
         ]);
 
         $index->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'Baden']),
-            new Document(4, ['name' => 'Baden Baden']),
+            new Document('1', ['name' => 'Basel-Stadt']),
+            new Document('2', ['name' => 'New York']),
+            new Document('3', ['name' => 'Baden']),
+            new Document('4', ['name' => 'Baden Baden']),
         ]);
 
         $index->refresh();

--- a/tests/Query/GeoDistanceTest.php
+++ b/tests/Query/GeoDistanceTest.php
@@ -22,12 +22,12 @@ class GeoDistanceTest extends BaseTest
         $index->setMapping(new Mapping(['point' => ['type' => 'geo_point']]));
 
         // Add doc 1
-        $doc1 = new Document(1);
+        $doc1 = new Document('1');
         $doc1->addGeoPoint('point', 17, 19);
         $index->addDocument($doc1);
 
         // Add doc 2
-        $doc2 = new Document(2);
+        $doc2 = new Document('2');
         $doc2->addGeoPoint('point', 30, 40);
         $index->addDocument($doc2);
 

--- a/tests/Query/GeoPolygonTest.php
+++ b/tests/Query/GeoPolygonTest.php
@@ -26,7 +26,7 @@ class GeoPolygonTest extends BaseTest
 
         // Add doc 1
         $doc1 = new Document(
-            1,
+            '1',
             [
                 'name' => 'ruflin',
             ]
@@ -37,7 +37,7 @@ class GeoPolygonTest extends BaseTest
 
         // Add doc 2
         $doc2 = new Document(
-            2,
+            '2',
             [
                 'name' => 'ruflin',
             ]

--- a/tests/Query/GeoShapeProvidedTest.php
+++ b/tests/Query/GeoShapeProvidedTest.php
@@ -28,7 +28,7 @@ class GeoShapeProvidedTest extends BaseTest
         $index->setMapping($mapping);
 
         // add docs
-        $index->addDocument(new Document(1, [
+        $index->addDocument(new Document('1', [
             'location' => [
                 'type' => 'envelope',
                 'coordinates' => [

--- a/tests/Query/HasChildTest.php
+++ b/tests/Query/HasChildTest.php
@@ -81,14 +81,14 @@ class HasChildTest extends BaseTest
         $index->setMapping($mapping);
         $index->refresh();
 
-        $doc1 = $index->createDocument(1, [
+        $doc1 = $index->createDocument('1', [
             'text' => 'this is the 1st question',
             'my_join_field' => [
                 'name' => 'question',
             ],
         ]);
 
-        $doc2 = $index->createDocument(2, [
+        $doc2 = $index->createDocument('2', [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
@@ -97,7 +97,7 @@ class HasChildTest extends BaseTest
 
         $index->addDocuments([$doc1, $doc2]);
 
-        $doc3 = $index->createDocument(3, [
+        $doc3 = $index->createDocument('3', [
             'text' => 'this is an answer, the 1st',
             'name' => 'rico',
             'my_join_field' => [
@@ -106,7 +106,7 @@ class HasChildTest extends BaseTest
             ],
         ]);
 
-        $doc4 = $index->createDocument(4, [
+        $doc4 = $index->createDocument('4', [
             'text' => 'this is an answer, the 2nd',
             'name' => 'fede',
             'my_join_field' => [
@@ -115,7 +115,7 @@ class HasChildTest extends BaseTest
             ],
         ]);
 
-        $doc5 = $index->createDocument(5, [
+        $doc5 = $index->createDocument('5', [
             'text' => 'this is an answer, the 3rd',
             'name' => 'fede',
             'my_join_field' => [

--- a/tests/Query/HasParentTest.php
+++ b/tests/Query/HasParentTest.php
@@ -83,13 +83,13 @@ class HasParentTest extends BaseTest
         $index->setMapping($mapping);
         $index->refresh();
 
-        $doc1 = $index->createDocument(1, [
+        $doc1 = $index->createDocument('1', [
             'text' => 'this is the 1st question',
             'my_join_field' => [
                 'name' => 'question',
             ],
         ]);
-        $doc2 = $index->createDocument(2, [
+        $doc2 = $index->createDocument('2', [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
@@ -97,7 +97,7 @@ class HasParentTest extends BaseTest
         ]);
         $index->addDocuments([$doc1, $doc2]);
 
-        $doc3 = $index->createDocument(3, [
+        $doc3 = $index->createDocument('3', [
             'text' => 'this is an answer, the 1st',
             'name' => 'rico',
             'my_join_field' => [
@@ -105,7 +105,7 @@ class HasParentTest extends BaseTest
                 'parent' => 1,
             ],
         ]);
-        $doc4 = $index->createDocument(4, [
+        $doc4 = $index->createDocument('4', [
             'text' => 'this is an answer, the 2nd',
             'name' => 'fede',
             'my_join_field' => [
@@ -113,7 +113,7 @@ class HasParentTest extends BaseTest
                 'parent' => 2,
             ],
         ]);
-        $doc5 = $index->createDocument(5, [
+        $doc5 = $index->createDocument('5', [
             'text' => 'this is an answer, the 3rd',
             'name' => 'fede',
             'my_join_field' => [

--- a/tests/Query/HighlightTest.php
+++ b/tests/Query/HighlightTest.php
@@ -22,8 +22,8 @@ class HighlightTest extends BaseTest
         $phrase = 'My name is ruflin';
 
         $index->addDocuments([
-            new Document(1, ['id' => 1, 'phrase' => $phrase, 'username' => 'hanswurst', 'test' => ['2', '3', '5']]),
-            new Document(2, ['id' => 2, 'phrase' => $phrase, 'username' => 'peter', 'test' => ['2', '3', '5']]),
+            new Document('1', ['id' => 1, 'phrase' => $phrase, 'username' => 'hanswurst', 'test' => ['2', '3', '5']]),
+            new Document('2', ['id' => 2, 'phrase' => $phrase, 'username' => 'peter', 'test' => ['2', '3', '5']]),
         ]);
 
         $matchQuery = new MatchPhrase('phrase', 'ruflin');

--- a/tests/Query/IdsTest.php
+++ b/tests/Query/IdsTest.php
@@ -21,9 +21,9 @@ class IdsTest extends BaseTest
 
         $this->index = $this->_createIndex();
 
-        $this->index->addDocument(new Document(1, ['name' => 'hello world']));
-        $this->index->addDocument(new Document(2, ['name' => 'nicolas ruflin']));
-        $this->index->addDocument(new Document(3, ['name' => 'ruflin']));
+        $this->index->addDocument(new Document('1', ['name' => 'hello world']));
+        $this->index->addDocument(new Document('2', ['name' => 'nicolas ruflin']));
+        $this->index->addDocument(new Document('3', ['name' => 'ruflin']));
 
         $this->index->refresh();
     }

--- a/tests/Query/InnerHitsTest.php
+++ b/tests/Query/InnerHitsTest.php
@@ -397,7 +397,7 @@ class InnerHitsTest extends BaseTest
         ]));
 
         $index->addDocuments([
-            $index->createDocument(1, [
+            $index->createDocument('1', [
                 'users' => [
                     ['name' => 'John Smith', 'last_activity_date' => '2015-01-05'],
                     ['name' => 'Conan', 'last_activity_date' => '2015-01-05'],
@@ -405,7 +405,7 @@ class InnerHitsTest extends BaseTest
                 'last_activity_date' => '2015-01-05',
                 'title' => 'Question about linux #1',
             ]),
-            $index->createDocument(2, [
+            $index->createDocument('2', [
                 'users' => [
                     ['name' => 'John Doe', 'last_activity_date' => '2015-01-05'],
                     ['name' => 'Simon', 'last_activity_date' => '2015-01-05'],
@@ -413,7 +413,7 @@ class InnerHitsTest extends BaseTest
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about linux #2',
             ]),
-            $index->createDocument(3, [
+            $index->createDocument('3', [
                 'users' => [
                     ['name' => 'Simon', 'last_activity_date' => '2015-01-05'],
                     ['name' => 'Garfunkel', 'last_activity_date' => '2015-01-05'],
@@ -421,7 +421,7 @@ class InnerHitsTest extends BaseTest
                 'last_activity_date' => '2015-01-05',
                 'title' => 'Question about windows #1',
             ]),
-            $index->createDocument(4, [
+            $index->createDocument('4', [
                 'users' => [
                     ['name' => 'Einstein'],
                     ['name' => 'Newton'],
@@ -430,7 +430,7 @@ class InnerHitsTest extends BaseTest
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about windows #2',
             ]),
-            $index->createDocument(5, [
+            $index->createDocument('5', [
                 'users' => [
                     ['name' => 'Faraday'],
                     ['name' => 'Leibniz'],
@@ -464,35 +464,35 @@ class InnerHitsTest extends BaseTest
 
         $index->setMapping($mappingQuestion);
         $index->addDocuments([
-            $index->createDocument(1, [
+            $index->createDocument('1', [
                 'last_activity_date' => '2015-01-05',
                 'title' => 'Question about linux #1',
                 'my_join_field' => [
                     'name' => 'questions',
                 ],
             ]),
-            $index->createDocument(2, [
+            $index->createDocument('2', [
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about linux #2',
                 'my_join_field' => [
                     'name' => 'questions',
                 ],
             ]),
-            $index->createDocument(3, [
+            $index->createDocument('3', [
                 'last_activity_date' => '2015-01-05',
                 'title' => 'Question about windows #1',
                 'my_join_field' => [
                     'name' => 'questions',
                 ],
             ]),
-            $index->createDocument(4, [
+            $index->createDocument('4', [
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about windows #2',
                 'my_join_field' => [
                     'name' => 'questions',
                 ],
             ]),
-            $index->createDocument(5, [
+            $index->createDocument('5', [
                 'last_activity_date' => '2014-12-23',
                 'title' => 'Question about osx',
                 'my_join_field' => [
@@ -501,7 +501,7 @@ class InnerHitsTest extends BaseTest
             ]),
         ]);
 
-        $doc1 = $index->createDocument(6, [
+        $doc1 = $index->createDocument('6', [
             'answer' => 'linux is cool',
             'last_activity_date' => '2016-01-05',
             'my_join_field' => [
@@ -510,7 +510,7 @@ class InnerHitsTest extends BaseTest
             ],
         ]);
 
-        $doc2 = $index->createDocument(7, [
+        $doc2 = $index->createDocument('7', [
             'answer' => 'linux is bad',
             'last_activity_date' => '2005-01-05',
             'my_join_field' => [
@@ -519,7 +519,7 @@ class InnerHitsTest extends BaseTest
             ],
         ]);
 
-        $doc3 = $index->createDocument(8, [
+        $doc3 = $index->createDocument('8', [
             'answer' => 'windows was cool',
             'last_activity_date' => '2005-01-05',
             'my_join_field' => [

--- a/tests/Query/MatchAllTest.php
+++ b/tests/Query/MatchAllTest.php
@@ -36,8 +36,8 @@ class MatchAllTest extends BaseTest
         $search1 = new Search($client);
         $resultSet1 = $search1->search(new MatchAll());
 
-        $doc1 = new Document(1, ['name' => 'kimchy']);
-        $doc2 = new Document(2, ['name' => 'ruflin']);
+        $doc1 = new Document('1', ['name' => 'kimchy']);
+        $doc2 = new Document('2', ['name' => 'ruflin']);
         $index1->addDocuments([$doc1, $doc2]);
 
         $index1->refresh();

--- a/tests/Query/MatchNoneTest.php
+++ b/tests/Query/MatchNoneTest.php
@@ -32,7 +32,7 @@ class MatchNoneTest extends BaseTest
         $index = $this->_createIndex();
         $client = $index->getClient();
 
-        $doc = new Document(1, ['name' => 'ruflin']);
+        $doc = new Document('1', ['name' => 'ruflin']);
         $index->addDocument($doc);
 
         $index->refresh();

--- a/tests/Query/MatchPhrasePrefixTest.php
+++ b/tests/Query/MatchPhrasePrefixTest.php
@@ -54,10 +54,10 @@ class MatchPhrasePrefixTest extends BaseTest
         ]);
 
         $index->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'New Hampshire']),
-            new Document(4, ['name' => 'Basel Land']),
+            new Document('1', ['name' => 'Basel-Stadt']),
+            new Document('2', ['name' => 'New York']),
+            new Document('3', ['name' => 'New Hampshire']),
+            new Document('4', ['name' => 'Basel Land']),
         ]);
 
         $index->refresh();

--- a/tests/Query/MatchPhraseTest.php
+++ b/tests/Query/MatchPhraseTest.php
@@ -51,10 +51,10 @@ class MatchPhraseTest extends BaseTest
         ]);
 
         $index->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'New Hampshire']),
-            new Document(4, ['name' => 'Basel Land']),
+            new Document('1', ['name' => 'Basel-Stadt']),
+            new Document('2', ['name' => 'New York']),
+            new Document('3', ['name' => 'New Hampshire']),
+            new Document('4', ['name' => 'Basel Land']),
         ]);
 
         $index->refresh();

--- a/tests/Query/MatchQueryTest.php
+++ b/tests/Query/MatchQueryTest.php
@@ -71,10 +71,10 @@ class MatchQueryTest extends BaseTest
         ]);
 
         $index->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'New Hampshire']),
-            new Document(4, ['name' => 'Basel Land']),
+            new Document('1', ['name' => 'Basel-Stadt']),
+            new Document('2', ['name' => 'New York']),
+            new Document('3', ['name' => 'New Hampshire']),
+            new Document('4', ['name' => 'Basel Land']),
         ]);
 
         $index->refresh();
@@ -103,10 +103,10 @@ class MatchQueryTest extends BaseTest
         ]);
 
         $index->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'New Hampshire']),
-            new Document(4, ['name' => 'Basel Land']),
+            new Document('1', ['name' => 'Basel-Stadt']),
+            new Document('2', ['name' => 'New York']),
+            new Document('3', ['name' => 'New Hampshire']),
+            new Document('4', ['name' => 'Basel Land']),
         ]);
 
         $index->refresh();
@@ -136,10 +136,10 @@ class MatchQueryTest extends BaseTest
         ]);
 
         $index->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'New Hampshire']),
-            new Document(4, ['name' => 'Basel Land']),
+            new Document('1', ['name' => 'Basel-Stadt']),
+            new Document('2', ['name' => 'New York']),
+            new Document('3', ['name' => 'New Hampshire']),
+            new Document('4', ['name' => 'Basel Land']),
         ]);
 
         $index->refresh();
@@ -169,8 +169,8 @@ class MatchQueryTest extends BaseTest
         ]);
 
         $index->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
+            new Document('1', ['name' => 'Basel-Stadt']),
+            new Document('2', ['name' => 'New York']),
         ]);
 
         $index->refresh();

--- a/tests/Query/MoreLikeThisTest.php
+++ b/tests/Query/MoreLikeThisTest.php
@@ -36,10 +36,10 @@ class MoreLikeThisTest extends BaseTest
         $mapping->setSource(['enabled' => false]);
         $index->setMapping($mapping);
 
-        $doc = new Document(1000, ['email' => 'testemail@gmail.com', 'content' => 'This is a sample post. Hello World Fuzzy Like This!']);
+        $doc = new Document('1000', ['email' => 'testemail@gmail.com', 'content' => 'This is a sample post. Hello World Fuzzy Like This!']);
         $index->addDocument($doc);
 
-        $doc = new Document(1001, ['email' => 'nospam@gmail.com', 'content' => 'This is a fake nospam email address for gmail']);
+        $doc = new Document('1001', ['email' => 'nospam@gmail.com', 'content' => 'This is a fake nospam email address for gmail']);
         $index->addDocument($doc);
 
         // Refresh index
@@ -82,13 +82,13 @@ class MoreLikeThisTest extends BaseTest
         );
 
         $index->addDocuments([
-            new Document(1, ['visible' => true, 'name' => 'bruce wayne batman']),
-            new Document(2, ['visible' => true, 'name' => 'bruce wayne']),
-            new Document(3, ['visible' => false, 'name' => 'bruce wayne']),
-            new Document(4, ['visible' => true, 'name' => 'batman']),
-            new Document(5, ['visible' => false, 'name' => 'batman']),
-            new Document(6, ['visible' => true, 'name' => 'superman']),
-            new Document(7, ['visible' => true, 'name' => 'spiderman']),
+            new Document('1', ['visible' => true, 'name' => 'bruce wayne batman']),
+            new Document('2', ['visible' => true, 'name' => 'bruce wayne']),
+            new Document('3', ['visible' => false, 'name' => 'bruce wayne']),
+            new Document('4', ['visible' => true, 'name' => 'batman']),
+            new Document('5', ['visible' => false, 'name' => 'batman']),
+            new Document('6', ['visible' => true, 'name' => 'superman']),
+            new Document('7', ['visible' => true, 'name' => 'spiderman']),
         ]);
 
         $index->refresh();

--- a/tests/Query/ParentIdTest.php
+++ b/tests/Query/ParentIdTest.php
@@ -108,7 +108,7 @@ class ParentIdTest extends BaseTest
         $this->_getClient()->addDocuments([$doc3, $doc4, $doc5], ['routing' => 1]);
         $index->refresh();
 
-        $parentQuery = new ParentId('answer', 1, true);
+        $parentQuery = new ParentId('answer', '1', true);
         $search = new Search($index->getClient());
         $results = $search->search($parentQuery);
         $this->assertEquals(1, $results->count());

--- a/tests/Query/PercolateTest.php
+++ b/tests/Query/PercolateTest.php
@@ -26,8 +26,8 @@ class PercolateTest extends BaseTest
     {
         $this->_prepareIndexForPercolate();
         // Register a query in the percolator:
-        $queryDoc = new Document(1, ['query' => ['match' => ['message' => 'bonsai tree']]]);
-        $doc = new Document(2, ['message' => 'A new bonsai tree in the office']);
+        $queryDoc = new Document('1', ['query' => ['match' => ['message' => 'bonsai tree']]]);
+        $doc = new Document('2', ['message' => 'A new bonsai tree in the office']);
         $this->index->addDocument($queryDoc);
         $this->index->refresh();
         // Match a document to the registered percolator queries:
@@ -40,7 +40,7 @@ class PercolateTest extends BaseTest
         $this->assertEquals(1, $resultSet->count());
 
         // Register a new query in the percolator:
-        $queryDoc = new Document(3, ['query' => ['match' => ['message' => 'i have nice bonsai tree']]]);
+        $queryDoc = new Document('3', ['query' => ['match' => ['message' => 'i have nice bonsai tree']]]);
         $this->index->addDocument($queryDoc);
         $this->index->refresh();
         $resultSet = $this->index->search($percolateQuery);
@@ -49,7 +49,7 @@ class PercolateTest extends BaseTest
         $this->assertEquals(2, $resultSet->count());
 
         // Check on the document without keywords from percolate stored query
-        $doc2 = new Document(4, ['message' => 'Just a simple text for test']);
+        $doc2 = new Document('4', ['message' => 'Just a simple text for test']);
         $percolateQuery = new Percolate();
         $percolateQuery->setField('query')
             ->setDocument($doc2->getData())
@@ -66,8 +66,8 @@ class PercolateTest extends BaseTest
     {
         $this->_prepareIndexForPercolate();
         // Register a query in the percolator:
-        $queryDoc = new Document(1, ['query' => ['match' => ['message' => 'bonsai tree']]]);
-        $doc = new Document(2, ['message' => 'A new bonsai tree in the office']);
+        $queryDoc = new Document('1', ['query' => ['match' => ['message' => 'bonsai tree']]]);
+        $doc = new Document('2', ['message' => 'A new bonsai tree in the office']);
         $this->index->addDocument($doc);
         $this->index->addDocument($queryDoc);
         $this->index->refresh();
@@ -81,14 +81,14 @@ class PercolateTest extends BaseTest
 
         $this->assertEquals(1, $resultSet->count());
 
-        $queryDoc = new Document(3, ['query' => ['match' => ['message' => 'i have nice bonsai tree']]]);
+        $queryDoc = new Document('3', ['query' => ['match' => ['message' => 'i have nice bonsai tree']]]);
         $this->index->addDocument($queryDoc);
         $this->index->refresh();
         $resultSet = $this->index->search($percolateQuery);
 
         $this->assertEquals(2, $resultSet->count());
 
-        $doc2 = new Document(4, ['message' => 'Just a simple text for test']);
+        $doc2 = new Document('4', ['message' => 'Just a simple text for test']);
         $this->index->addDocument($doc2);
         $percolateQuery = new Percolate();
         $percolateQuery->setField('query')
@@ -120,7 +120,7 @@ class PercolateTest extends BaseTest
     public function testSetDocument(): void
     {
         $query = new Percolate();
-        $doc = new Document(1, ['message' => 'A new bonsai tree in the office']);
+        $doc = new Document('1', ['message' => 'A new bonsai tree in the office']);
         $query->setDocument($doc->getData());
 
         $data = $query->toArray();

--- a/tests/Query/PostFilterTest.php
+++ b/tests/Query/PostFilterTest.php
@@ -54,10 +54,10 @@ class PostFilterTest extends BaseTest
     {
         $index = $this->_createIndex();
         $docs = [
-            new Document(1, ['color' => 'green', 'make' => 'ford']),
-            new Document(2, ['color' => 'blue', 'make' => 'volvo']),
-            new Document(3, ['color' => 'red', 'make' => 'ford']),
-            new Document(4, ['color' => 'green', 'make' => 'renault']),
+            new Document('1', ['color' => 'green', 'make' => 'ford']),
+            new Document('2', ['color' => 'blue', 'make' => 'volvo']),
+            new Document('3', ['color' => 'red', 'make' => 'ford']),
+            new Document('4', ['color' => 'green', 'make' => 'renault']),
         ];
         $index->addDocuments($docs);
         $index->refresh();

--- a/tests/Query/QueryStringTest.php
+++ b/tests/Query/QueryStringTest.php
@@ -52,7 +52,7 @@ class QueryStringTest extends BaseTest
         $index = $this->_createIndex();
         $index->getSettings()->setNumberOfReplicas(0);
 
-        $doc = new Document(1, ['email' => 'test@test.com', 'username' => 'hanswurst', 'test' => ['2', '3', '5']]);
+        $doc = new Document('1', ['email' => 'test@test.com', 'username' => 'hanswurst', 'test' => ['2', '3', '5']]);
         $index->addDocument($doc);
         $index->refresh();
 
@@ -71,7 +71,7 @@ class QueryStringTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $doc = new Document(1, ['title' => 'hello world', 'firstname' => 'nicolas', 'lastname' => 'ruflin', 'price' => '102', 'year' => '2012']);
+        $doc = new Document('1', ['title' => 'hello world', 'firstname' => 'nicolas', 'lastname' => 'ruflin', 'price' => '102', 'year' => '2012']);
         $index->addDocument($doc);
         $index->refresh();
 
@@ -92,7 +92,7 @@ class QueryStringTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $doc = new Document(1, ['title' => 'hello world', 'firstname' => 'nicolas', 'lastname' => 'ruflin', 'price' => '102', 'year' => '2012']);
+        $doc = new Document('1', ['title' => 'hello world', 'firstname' => 'nicolas', 'lastname' => 'ruflin', 'price' => '102', 'year' => '2012']);
         $index->addDocument($doc);
         $index->refresh();
 

--- a/tests/Query/RangeTest.php
+++ b/tests/Query/RangeTest.php
@@ -23,10 +23,10 @@ class RangeTest extends BaseTest
         ]);
 
         $index->addDocuments([
-            new Document(1, ['age' => 16, 'height' => 140]),
-            new Document(2, ['age' => 21, 'height' => 155]),
-            new Document(3, ['age' => 33, 'height' => 160]),
-            new Document(4, ['age' => 68, 'height' => 160]),
+            new Document('1', ['age' => 16, 'height' => 140]),
+            new Document('2', ['age' => 21, 'height' => 155]),
+            new Document('3', ['age' => 33, 'height' => 160]),
+            new Document('4', ['age' => 68, 'height' => 160]),
         ]);
 
         $index->forcemerge();

--- a/tests/Query/SimpleQueryStringTest.php
+++ b/tests/Query/SimpleQueryStringTest.php
@@ -41,11 +41,11 @@ class SimpleQueryStringTest extends Base
     {
         $index = $this->_createIndex();
         $docs = [
-            new Document(1, ['make' => 'Gibson', 'model' => 'Les Paul']),
-            new Document(2, ['make' => 'Gibson', 'model' => 'SG Standard']),
-            new Document(3, ['make' => 'Gibson', 'model' => 'SG Supreme']),
-            new Document(4, ['make' => 'Gibson', 'model' => 'SG Faded']),
-            new Document(5, ['make' => 'Fender', 'model' => 'Stratocaster']),
+            new Document('1', ['make' => 'Gibson', 'model' => 'Les Paul']),
+            new Document('2', ['make' => 'Gibson', 'model' => 'SG Standard']),
+            new Document('3', ['make' => 'Gibson', 'model' => 'SG Supreme']),
+            new Document('4', ['make' => 'Gibson', 'model' => 'SG Faded']),
+            new Document('5', ['make' => 'Fender', 'model' => 'Stratocaster']),
         ];
         $index->addDocuments($docs);
         $index->refresh();
@@ -89,10 +89,10 @@ class SimpleQueryStringTest extends Base
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['body' => 'foo']),
-            new Document(2, ['body' => 'bar']),
-            new Document(3, ['body' => 'foo bar']),
-            new Document(4, ['body' => 'foo baz bar']),
+            new Document('1', ['body' => 'foo']),
+            new Document('2', ['body' => 'bar']),
+            new Document('3', ['body' => 'foo bar']),
+            new Document('4', ['body' => 'foo baz bar']),
         ]);
         $index->refresh();
 

--- a/tests/Query/SpanContainingTest.php
+++ b/tests/Query/SpanContainingTest.php
@@ -71,7 +71,7 @@ class SpanContainingTest extends BaseTest
         $index = $this->_createIndex();
 
         $docHitData = [$field => $value];
-        $doc = new Document(1, $docHitData);
+        $doc = new Document('1', $docHitData);
         $index->addDocument($doc);
         $index->refresh();
 

--- a/tests/Query/SpanFirstTest.php
+++ b/tests/Query/SpanFirstTest.php
@@ -44,7 +44,7 @@ class SpanFirstTest extends BaseTest
         $index = $this->_createIndex();
 
         $docHitData = [$field => $value];
-        $doc = new Document(1, $docHitData);
+        $doc = new Document('1', $docHitData);
         $index->addDocument($doc);
         $index->refresh();
 

--- a/tests/Query/SpanMultiTest.php
+++ b/tests/Query/SpanMultiTest.php
@@ -71,11 +71,11 @@ class SpanMultiTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, [$field => $text1]),
-            new Document(2, [$field => $text2]),
-            new Document(3, [$field => $text3]),
-            new Document(4, [$field => $text4]),
-            new Document(5, [$field => $text5]),
+            new Document('1', [$field => $text1]),
+            new Document('2', [$field => $text2]),
+            new Document('3', [$field => $text3]),
+            new Document('4', [$field => $text4]),
+            new Document('5', [$field => $text5]),
         ]);
         $index->refresh();
 

--- a/tests/Query/SpanNearTest.php
+++ b/tests/Query/SpanNearTest.php
@@ -74,7 +74,7 @@ class SpanNearTest extends BaseTest
         $index = $this->_createIndex();
 
         $docHitData = [$field => $value];
-        $doc = new Document(1, $docHitData);
+        $doc = new Document('1', $docHitData);
         $index->addDocument($doc);
         $index->refresh();
 

--- a/tests/Query/SpanNotTest.php
+++ b/tests/Query/SpanNotTest.php
@@ -71,7 +71,7 @@ class SpanNotTest extends BaseTest
         $index = $this->_createIndex();
 
         $docHitData = [$field => $value];
-        $doc = new Document(1, $docHitData);
+        $doc = new Document('1', $docHitData);
         $index->addDocument($doc);
         $index->refresh();
 

--- a/tests/Query/SpanOrTest.php
+++ b/tests/Query/SpanOrTest.php
@@ -74,9 +74,9 @@ class SpanOrTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, [$field => $text1]),
-            new Document(2, [$field => $text2]),
-            new Document(3, [$field => $text3]),
+            new Document('1', [$field => $text1]),
+            new Document('2', [$field => $text2]),
+            new Document('3', [$field => $text3]),
         ]);
         $index->refresh();
 

--- a/tests/Query/SpanTermTest.php
+++ b/tests/Query/SpanTermTest.php
@@ -42,8 +42,8 @@ class SpanTermTest extends BaseTest
         $docMisData = [$field => 'mismatch', 'email' => 'test2@test.com'];
         $docHitData = [$field => $value, 'email' => 'test@test.com'];
 
-        $doc1 = new Document(1, $docMisData);
-        $doc2 = new Document(2, $docHitData);
+        $doc1 = new Document('1', $docMisData);
+        $doc2 = new Document('2', $docHitData);
         $index->addDocuments([$doc1, $doc2]);
         $index->refresh();
 

--- a/tests/Query/SpanWithinTest.php
+++ b/tests/Query/SpanWithinTest.php
@@ -71,7 +71,7 @@ class SpanWithinTest extends BaseTest
         $index = $this->_createIndex();
 
         $docHitData = [$field => $value];
-        $doc = new Document(1, $docHitData);
+        $doc = new Document('1', $docHitData);
         $index->addDocument($doc);
         $index->refresh();
 

--- a/tests/Query/TermsSetTest.php
+++ b/tests/Query/TermsSetTest.php
@@ -51,9 +51,9 @@ class TermsSetTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['skills' => ['php', 'js']]),
-            new Document(2, ['skills' => ['php']]),
-            new Document(3, ['skills' => ['java']]),
+            new Document('1', ['skills' => ['php', 'js']]),
+            new Document('2', ['skills' => ['php']]),
+            new Document('3', ['skills' => ['java']]),
         ]);
 
         $index->refresh();
@@ -87,9 +87,9 @@ class TermsSetTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['skill_count' => 2, 'skills' => ['php', 'js']]),
-            new Document(2, ['skill_count' => 1, 'skills' => ['php']]),
-            new Document(3, ['skill_count' => 1, 'skills' => ['java']]),
+            new Document('1', ['skill_count' => 2, 'skills' => ['php', 'js']]),
+            new Document('2', ['skill_count' => 1, 'skills' => ['php']]),
+            new Document('3', ['skill_count' => 1, 'skills' => ['java']]),
         ]);
 
         $index->refresh();
@@ -123,7 +123,7 @@ class TermsSetTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['some_numeric_field' => 9876]),
+            new Document('1', ['some_numeric_field' => 9876]),
         ]);
         $index->refresh();
 

--- a/tests/Query/TermsTest.php
+++ b/tests/Query/TermsTest.php
@@ -86,9 +86,9 @@ class TermsTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['name' => 'hello world']),
-            new Document(2, ['name' => 'nicolas ruflin']),
-            new Document(3, ['name' => 'ruflin']),
+            new Document('1', ['name' => 'hello world']),
+            new Document('2', ['name' => 'nicolas ruflin']),
+            new Document('3', ['name' => 'ruflin']),
         ]);
 
         $query = new Terms('name', ['nicolas', 'hello']);
@@ -113,13 +113,13 @@ class TermsTest extends BaseTest
 
         $lookupIndex = $this->_createIndex('lookup_index');
         $lookupIndex->addDocuments([
-            new Document(1, ['terms' => ['ruflin', 'nicolas']]),
+            new Document('1', ['terms' => ['ruflin', 'nicolas']]),
         ]);
 
         $index->addDocuments([
-            new Document(1, ['name' => 'hello world']),
-            new Document(2, ['name' => 'nicolas ruflin']),
-            new Document(3, ['name' => 'ruflin']),
+            new Document('1', ['name' => 'hello world']),
+            new Document('2', ['name' => 'nicolas ruflin']),
+            new Document('3', ['name' => 'ruflin']),
         ]);
 
         $query = new Terms('name');
@@ -140,7 +140,7 @@ class TermsTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['some_numeric_field' => 9876]),
+            new Document('1', ['some_numeric_field' => 9876]),
         ]);
         $index->refresh();
 
@@ -168,10 +168,10 @@ class TermsTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['some_numeric_field' => 9876]),
-            new Document(2, ['some_numeric_field' => 5678]),
-            new Document(3, ['some_numeric_field' => 1234]),
-            new Document(4, ['some_numeric_field' => 8899]),
+            new Document('1', ['some_numeric_field' => 9876]),
+            new Document('2', ['some_numeric_field' => 5678]),
+            new Document('3', ['some_numeric_field' => 1234]),
+            new Document('4', ['some_numeric_field' => 8899]),
         ]);
         $index->refresh();
 
@@ -188,7 +188,7 @@ class TermsTest extends BaseTest
         $index = $this->_createIndex();
 
         $index->addDocuments([
-            new Document(1, ['some_numeric_field' => 9876]),
+            new Document('1', ['some_numeric_field' => 9876]),
         ]);
         $index->refresh();
 

--- a/tests/Query/WildcardTest.php
+++ b/tests/Query/WildcardTest.php
@@ -77,11 +77,11 @@ class WildcardTest extends BaseTest
         $index->setMapping($mapping);
 
         $index->addDocuments([
-            new Document(1, ['name' => 'Basel-Stadt']),
-            new Document(2, ['name' => 'New York']),
-            new Document(3, ['name' => 'Baden']),
-            new Document(4, ['name' => 'Baden Baden']),
-            new Document(5, ['name' => 'New Orleans']),
+            new Document('1', ['name' => 'Basel-Stadt']),
+            new Document('2', ['name' => 'New York']),
+            new Document('3', ['name' => 'Baden']),
+            new Document('4', ['name' => 'Baden Baden']),
+            new Document('5', ['name' => 'New Orleans']),
         ]);
 
         $index->refresh();

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -92,9 +92,9 @@ class QueryTest extends BaseTest
         ]));
 
         $index->addDocuments([
-            new Document(1, ['name' => 'hello world']),
-            new Document(2, ['firstname' => 'guschti', 'lastname' => 'ruflin']),
-            new Document(3, ['firstname' => 'nicolas', 'lastname' => 'ruflin']),
+            new Document('1', ['name' => 'hello world']),
+            new Document('2', ['firstname' => 'guschti', 'lastname' => 'ruflin']),
+            new Document('3', ['firstname' => 'nicolas', 'lastname' => 'ruflin']),
         ]);
         $index->refresh();
 
@@ -427,7 +427,7 @@ class QueryTest extends BaseTest
 
         // Adds 1 document to the index
         $doc1 = new Document(
-            1,
+            '1',
             ['username' => 'ruflin', 'test' => ['2', '3', '5']]
         );
         $index->addDocument($doc1);
@@ -653,7 +653,7 @@ class QueryTest extends BaseTest
 
         $documents = [];
         for ($i = 0; $i < 50; ++$i) {
-            $documents[] = new Document($i, ['firstname' => 'antoine '.$i]);
+            $documents[] = new Document((string) $i, ['firstname' => 'antoine '.$i]);
         }
 
         $index->addDocuments($documents);

--- a/tests/ReindexTest.php
+++ b/tests/ReindexTest.php
@@ -271,7 +271,7 @@ class ReindexTest extends Base
     {
         $insert = [];
         for ($i = 1; $i <= $docs; ++$i) {
-            $insert[] = new Document($i, ['id' => $i, 'key' => 'value']);
+            $insert[] = new Document((string) $i, ['id' => $i, 'key' => 'value']);
         }
 
         $index->addDocuments($insert);

--- a/tests/ResultSetTest.php
+++ b/tests/ResultSetTest.php
@@ -19,9 +19,9 @@ class ResultSetTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['name' => 'elastica search']),
-            new Document(2, ['name' => 'elastica library']),
-            new Document(3, ['name' => 'elastica test']),
+            new Document('1', ['name' => 'elastica search']),
+            new Document('2', ['name' => 'elastica library']),
+            new Document('3', ['name' => 'elastica test']),
         ]);
         $index->refresh();
 
@@ -45,9 +45,9 @@ class ResultSetTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['name' => 'elastica search']),
-            new Document(2, ['name' => 'elastica library']),
-            new Document(3, ['name' => 'elastica test']),
+            new Document('1', ['name' => 'elastica search']),
+            new Document('2', ['name' => 'elastica library']),
+            new Document('3', ['name' => 'elastica test']),
         ]);
         $index->refresh();
 
@@ -64,9 +64,9 @@ class ResultSetTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['name' => 'elastica search']),
-            new Document(2, ['name' => 'elastica library']),
-            new Document(3, ['name' => 'elastica test']),
+            new Document('1', ['name' => 'elastica search']),
+            new Document('2', ['name' => 'elastica library']),
+            new Document('3', ['name' => 'elastica test']),
         ]);
         $index->refresh();
 
@@ -88,7 +88,7 @@ class ResultSetTest extends BaseTest
         $this->expectException(InvalidException::class);
 
         $index = $this->_createIndex();
-        $index->addDocument(new Document(1, ['name' => 'elastica search']));
+        $index->addDocument(new Document('1', ['name' => 'elastica search']));
         $index->refresh();
 
         $resultSet = $index->search('elastica search');
@@ -104,7 +104,7 @@ class ResultSetTest extends BaseTest
 
         $index = $this->_createIndex();
 
-        $doc = new Document(1, ['name' => 'elastica search']);
+        $doc = new Document('1', ['name' => 'elastica search']);
         $index->addDocument($doc);
         $index->refresh();
 

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -20,7 +20,7 @@ class ResultTest extends BaseTest
     {
         // Creates a new index 'xodoa'
         $index = $this->_createIndex();
-        $index->addDocument(new Document(3, ['username' => 'hans']));
+        $index->addDocument(new Document('3', ['username' => 'hans']));
         $index->refresh();
 
         $resultSet = $index->search('hans');
@@ -56,7 +56,7 @@ class ResultTest extends BaseTest
         $index->setMapping($mapping);
 
         // Adds 1 document to the index
-        $docId = 3;
+        $docId = '3';
         $doc1 = new Document($docId, ['username' => 'hans']);
         $index->addDocument($doc1);
 
@@ -84,7 +84,7 @@ class ResultTest extends BaseTest
         $index = $this->_createIndex();
 
         // Adds 1 document to the index
-        $docId = 3;
+        $docId = '3';
         $doc1 = new Document($docId, ['username' => 'hans']);
         $index->addDocument($doc1);
 

--- a/tests/Script/ScriptFieldsTest.php
+++ b/tests/Script/ScriptFieldsTest.php
@@ -66,7 +66,7 @@ class ScriptFieldsTest extends BaseTest
     {
         $index = $this->_createIndex();
 
-        $doc = $index->createDocument(1, ['firstname' => 'guschti', 'lastname' => 'ruflin']);
+        $doc = $index->createDocument('1', ['firstname' => 'guschti', 'lastname' => 'ruflin']);
         $index->addDocument($doc);
         $index->refresh();
 
@@ -109,13 +109,13 @@ class ScriptFieldsTest extends BaseTest
         $index->setMapping($mapping);
         $index->refresh();
 
-        $doc1 = $index->createDocument(1, [
+        $doc1 = $index->createDocument('1', [
             'text' => 'this is the 1st question',
             'my_join_field' => [
                 'name' => 'question',
             ],
         ]);
-        $doc2 = $index->createDocument(2, [
+        $doc2 = $index->createDocument('2', [
             'text' => 'this is the 2nd question',
             'my_join_field' => [
                 'name' => 'question',
@@ -123,7 +123,7 @@ class ScriptFieldsTest extends BaseTest
         ]);
         $index->addDocuments([$doc1, $doc2]);
 
-        $doc3 = $index->createDocument(3, [
+        $doc3 = $index->createDocument('3', [
             'text' => 'this is an answer, the 1st',
             'name' => 'rico',
             'my_join_field' => [
@@ -131,7 +131,7 @@ class ScriptFieldsTest extends BaseTest
                 'parent' => 1,
             ],
         ]);
-        $doc4 = $index->createDocument(4, [
+        $doc4 = $index->createDocument('4', [
             'text' => 'this is an answer, the 2nd',
             'name' => 'fede',
             'my_join_field' => [
@@ -139,7 +139,7 @@ class ScriptFieldsTest extends BaseTest
                 'parent' => 2,
             ],
         ]);
-        $doc5 = $index->createDocument(5, [
+        $doc5 = $index->createDocument('5', [
             'text' => 'this is an answer, the 3rd',
             'name' => 'fede',
             'my_join_field' => [

--- a/tests/ScrollTest.php
+++ b/tests/ScrollTest.php
@@ -160,7 +160,7 @@ class ScrollTest extends Base
         if ($indexSize > 0) {
             $docs = [];
             for ($x = 1; $x <= $indexSize; ++$x) {
-                $docs[] = new Document($x, ['id' => $x, 'key' => 'value']);
+                $docs[] = new Document((string) $x, ['id' => $x, 'key' => 'value']);
             }
             $index->addDocuments($docs);
             $index->refresh();

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -165,7 +165,7 @@ class SearchTest extends BaseTest
 
         $docs = [];
         for ($x = 1; $x <= 10; ++$x) {
-            $docs[] = new Document($x, ['id' => $x, 'testscroll' => 'jbafford']);
+            $docs[] = new Document((string) $x, ['id' => $x, 'testscroll' => 'jbafford']);
         }
 
         $index->addDocuments($docs);
@@ -233,17 +233,17 @@ class SearchTest extends BaseTest
         );
 
         $index->addDocuments([
-            new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(2, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(3, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(4, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(5, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(6, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(7, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(8, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(9, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('1', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('2', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('3', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('4', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('5', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('6', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('7', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('8', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('9', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('10', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('11', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
         ]);
         $index->refresh();
 
@@ -283,7 +283,7 @@ class SearchTest extends BaseTest
 
         $docs = [];
         for ($i = 0; $i < 11; ++$i) {
-            $docs[] = new Document($i, ['id' => 1, 'email' => 'test@test.com', 'username' => 'test']);
+            $docs[] = new Document((string) $i, ['id' => 1, 'email' => 'test@test.com', 'username' => 'test']);
         }
 
         $index->addDocuments($docs);
@@ -371,7 +371,7 @@ class SearchTest extends BaseTest
     public function testSearchWithVersionOption(): void
     {
         $index = $this->_createIndex();
-        $doc = new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'ruflin']);
+        $doc = new Document('1', ['id' => 1, 'email' => 'test@test.com', 'username' => 'ruflin']);
         $index->addDocuments([$doc]);
         $index->refresh();
 
@@ -425,17 +425,17 @@ class SearchTest extends BaseTest
         );
 
         $index->addDocuments([
-            new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(2, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(3, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(4, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(5, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(6, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(7, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(8, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(9, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('1', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('2', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('3', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('4', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('5', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('6', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('7', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('8', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('9', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('10', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('11', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
         ]);
         $index->refresh();
 
@@ -481,17 +481,17 @@ class SearchTest extends BaseTest
         );
 
         $index->addDocuments([
-            new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(2, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(3, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(4, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(5, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(6, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(7, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(8, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(9, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
-            new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('1', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('2', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('3', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('4', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('5', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('6', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('7', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('8', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('9', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('10', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
+            new Document('11', ['id' => 1, 'email' => 'test@test.com', 'username' => 'marley']),
         ]);
         $index->refresh();
 
@@ -536,17 +536,17 @@ class SearchTest extends BaseTest
             ]
         );
         $index->addDocuments([
-            new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(2, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(3, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(4, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(5, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(6, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(7, ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
-            new Document(8, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']),
-            new Document(9, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']),
-            new Document(10, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']),
-            new Document(11, ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']),
+            new Document('1', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('2', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('3', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('4', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('5', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('6', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('7', ['id' => 1, 'email' => 'test@test.com', 'username' => 'farrelley']),
+            new Document('8', ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']),
+            new Document('9', ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']),
+            new Document('10', ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']),
+            new Document('11', ['id' => 1, 'email' => 'test@test.com', 'username' => 'bunny']),
         ]);
         $index->refresh();
 
@@ -575,7 +575,7 @@ class SearchTest extends BaseTest
         $index = $this->_createIndex();
         $search = new Search($index->getClient());
 
-        $doc = new Document(1, ['id' => 1, 'username' => 'ruflin']);
+        $doc = new Document('1', ['id' => 1, 'username' => 'ruflin']);
 
         $index->addDocuments([$doc]);
         $index->refresh();

--- a/tests/Suggest/CompletionTest.php
+++ b/tests/Suggest/CompletionTest.php
@@ -162,31 +162,31 @@ class CompletionTest extends BaseTest
         ]));
 
         $index->addDocuments([
-            new Document(1, [
+            new Document('1', [
                 'fieldName' => [
                     'input' => ['Nevermind', 'Nirvana'],
                     'weight' => 5,
                 ],
             ]),
-            new Document(2, [
+            new Document('2', [
                 'fieldName' => [
                     'input' => ['Bleach', 'Nirvana'],
                     'weight' => 2,
                 ],
             ]),
-            new Document(3, [
+            new Document('3', [
                 'fieldName' => [
                     'input' => ['Incesticide', 'Nirvana'],
                     'weight' => 7,
                 ],
             ]),
-            new Document(4, [
+            new Document('4', [
                 'fieldName2' => [
                     'input' => ['Bleach', 'Nirvana'],
                     'weight' => 3,
                 ],
             ]),
-            new Document(5, [
+            new Document('5', [
                 'fieldName2' => [
                     'input' => ['Incesticide', 'Nirvana'],
                     'weight' => 3,

--- a/tests/Suggest/PhraseTest.php
+++ b/tests/Suggest/PhraseTest.php
@@ -111,11 +111,11 @@ class PhraseTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['text' => 'Github is pretty cool']),
-            new Document(2, ['text' => 'Elasticsearch is bonsai cool']),
-            new Document(3, ['text' => 'This is a test phrase']),
-            new Document(4, ['text' => 'Another sentence for testing']),
-            new Document(5, ['text' => 'Some more words here']),
+            new Document('1', ['text' => 'Github is pretty cool']),
+            new Document('2', ['text' => 'Elasticsearch is bonsai cool']),
+            new Document('3', ['text' => 'This is a test phrase']),
+            new Document('4', ['text' => 'Another sentence for testing']),
+            new Document('5', ['text' => 'Some more words here']),
         ]);
         $index->refresh();
 

--- a/tests/Suggest/TermTest.php
+++ b/tests/Suggest/TermTest.php
@@ -139,12 +139,12 @@ class TermTest extends BaseTest
     {
         $index = $this->_createIndex();
         $index->addDocuments([
-            new Document(1, ['id' => 1, 'text' => 'GitHub']),
-            new Document(2, ['id' => 1, 'text' => 'Elastic']),
-            new Document(3, ['id' => 1, 'text' => 'Search']),
-            new Document(4, ['id' => 1, 'text' => 'Food']),
-            new Document(5, ['id' => 1, 'text' => 'Flood']),
-            new Document(6, ['id' => 1, 'text' => 'Folks']),
+            new Document('1', ['id' => 1, 'text' => 'GitHub']),
+            new Document('2', ['id' => 1, 'text' => 'Elastic']),
+            new Document('3', ['id' => 1, 'text' => 'Search']),
+            new Document('4', ['id' => 1, 'text' => 'Food']),
+            new Document('5', ['id' => 1, 'text' => 'Flood']),
+            new Document('6', ['id' => 1, 'text' => 'Folks']),
         ]);
         $index->refresh();
 

--- a/tests/TaskTest.php
+++ b/tests/TaskTest.php
@@ -109,7 +109,7 @@ class TaskTest extends Base
     protected function _createIndexWithDocument(): Index
     {
         $index = $this->_createIndex();
-        $index->addDocument(new Document(1, ['name' => 'ruflin nicolas']));
+        $index->addDocument(new Document('1', ['name' => 'ruflin nicolas']));
         $index->refresh();
 
         return $index;

--- a/tests/Transport/AbstractTransportTest.php
+++ b/tests/Transport/AbstractTransportTest.php
@@ -122,7 +122,7 @@ class AbstractTransportTest extends BaseTest
         $client = $this->_getClient($transport);
         $index = $client->getIndex('elastica_testbooleanstringvalues');
 
-        $doc = new Document(1, ['id' => 1, 'email' => 'test@test.com', 'username' => 'ruflin']);
+        $doc = new Document('1', ['id' => 1, 'email' => 'test@test.com', 'username' => 'ruflin']);
         $index->addDocument($doc);
         $index->refresh();
 

--- a/tests/Transport/GuzzleTest.php
+++ b/tests/Transport/GuzzleTest.php
@@ -104,7 +104,7 @@ class GuzzleTest extends BaseTest
         ]);
         $this->_waitForAllocation($index);
 
-        $index->addDocument(new Document(1, ['test' => 'test']));
+        $index->addDocument(new Document('1', ['test' => 'test']));
 
         $index->refresh();
 

--- a/tests/Transport/HttpTest.php
+++ b/tests/Transport/HttpTest.php
@@ -33,7 +33,7 @@ class HttpTest extends BaseTest
         // Force HEAD request to set CURLOPT_NOBODY = true
         $index->exists();
 
-        $id = 1;
+        $id = '1';
         $data = ['id' => $id, 'name' => 'Item 1'];
         $doc = new Document($id, $data);
 
@@ -63,7 +63,7 @@ class HttpTest extends BaseTest
         // Force HEAD request to set CURLOPT_NOBODY = true
         $index->exists();
 
-        $id = 22;
+        $id = '22';
         $data = ['id' => $id, 'name' => '
             Сегодня, я вижу, особенно грустен твой взгляд, /
             И руки особенно тонки, колени обняв. /
@@ -154,7 +154,7 @@ class HttpTest extends BaseTest
         ]);
         $this->_waitForAllocation($index);
 
-        $index->addDocument(new Document(1, ['test' => 'test']));
+        $index->addDocument(new Document('1', ['test' => 'test']));
 
         $index->refresh();
 

--- a/tests/Transport/TransportBenchmarkTest.php
+++ b/tests/Transport/TransportBenchmarkTest.php
@@ -46,7 +46,7 @@ class TransportBenchmarkTest extends BaseTest
         $times = [];
         for ($i = 0; $i < $this->_max; ++$i) {
             $data = $this->getData($i);
-            $doc = new Document($i, $data);
+            $doc = new Document((string) $i, $data);
             $result = $index->addDocument($doc);
             $times[] = $result->getQueryTime();
             $this->assertTrue($result->isOk());
@@ -96,7 +96,7 @@ class TransportBenchmarkTest extends BaseTest
             $docs = [];
             for ($j = 0; $j < 10; ++$j) {
                 $data = $this->getData($i.$j);
-                $docs[] = new Document($i, $data);
+                $docs[] = new Document((string) $i, $data);
             }
 
             $result = $index->addDocuments($docs);


### PR DESCRIPTION
Ref: https://github.com/ruflin/Elastica/issues/2079#issuecomment-1160163215

~This PR allows `int` as possible type for `id` when creating `Document` and also in `AbstractScript`, `Script` and `ParentId`.~

~The idea of this PR is to be BC, but then we should change `AbstractUpdateAction::setId()`, `Index::createDocument()` and maybe some other that would mean BC break, for them we could maybe leave it as it is, ignore the error in PHPStan and add some kind of reminder to change it in `8.x`.~

~BTW with this change errors in PHPStan level 5 go from 624 to 81.~

This is just a proposal, we could also ignore those errors in PHPStan. I'm open to any alternative.

**Update**: This PR updates our test suite to use `string` type for `Document` ids.