### PR TITLE
Add assertion for exception type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `value` in `SetProcessor` to accept `mixed` instead of `string` by @franmomu [#2082](https://github.com/ruflin/Elastica/pull/2082)
 * Updated `Query::create` PHPDoc to include supported types and propagate it to callers by @franmomu [#2088](https://github.com/ruflin/Elastica/pull/2088)
 * Update some iterable types in PHPDoc to be more specific by @franmomu [#2092](https://github.com/ruflin/Elastica/pull/2092)
+* Updated `AwsAuthV4Test` adding assertions for exception type by @franmomu [#2094](https://github.com/ruflin/Elastica/pull/2094)
 
 ### Deprecated
 * Deprecated `Elastica\Reindex::WAIT_FOR_COMPLETION_FALSE`, use a boolean as parameter instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -135,8 +135,3 @@ parameters:
 			count: 1
 			path: tests/SnapshotTest.php
 
-		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\Exception\\\\TransferException\\:\\:getRequest\\(\\)\\.$#"
-			count: 6
-			path: tests/Transport/AwsAuthV4Test.php
-

--- a/tests/Transport/AwsAuthV4Test.php
+++ b/tests/Transport/AwsAuthV4Test.php
@@ -6,6 +6,7 @@ use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\Sdk;
 use Elastica\Exception\Connection\GuzzleException;
+use GuzzleHttp\Exception\ConnectException;
 
 /**
  * @internal
@@ -39,6 +40,7 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
+            $this->assertInstanceOf(ConnectException::class, $guzzleException);
             $request = $guzzleException->getRequest();
             $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
                 .\date('Ymd').'/us-east-1/es/aws4_request, ';
@@ -76,6 +78,7 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
+            $this->assertInstanceOf(ConnectException::class, $guzzleException);
             $request = $guzzleException->getRequest();
             $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
                 .\date('Ymd').'/us-east-1/es/aws4_request, ';
@@ -110,6 +113,7 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
+            $this->assertInstanceOf(ConnectException::class, $guzzleException);
             $request = $guzzleException->getRequest();
             $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
                 .\date('Ymd').'/us-east-1/es/aws4_request, ';
@@ -140,6 +144,7 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
+            $this->assertInstanceOf(ConnectException::class, $guzzleException);
             $request = $guzzleException->getRequest();
 
             $this->assertSame('http', $request->getUri()->getScheme());
@@ -163,6 +168,7 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
+            $this->assertInstanceOf(ConnectException::class, $guzzleException);
             $request = $guzzleException->getRequest();
 
             $this->assertSame('https', $request->getUri()->getScheme());
@@ -185,6 +191,7 @@ class AwsAuthV4Test extends GuzzleTest
             $client->request('_stats');
         } catch (GuzzleException $e) {
             $guzzleException = $e->getGuzzleException();
+            $this->assertInstanceOf(ConnectException::class, $guzzleException);
             $request = $guzzleException->getRequest();
             $expected = 'AWS4-HMAC-SHA256 Credential=foo/'
                 .\date('Ymd').'/us-east-1/es/aws4_request, ';


### PR DESCRIPTION
Instead of ignored the error in PHPStan, adding the `assertInstanceOf` allows PHPStan to understand the rest of the code.

Ref: https://github.com/ruflin/Elastica/pull/2090#discussion_r909228434