### PR TITLE
Fix some PHPDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `Http` PHPDoc adding `\CurlHandle` type for Curl connection by @franmomu [#2086](https://github.com/ruflin/Elastica/pull/2086)
 * Fixed case mismatch in method calls by @franmomu [#2087](https://github.com/ruflin/Elastica/pull/2087)
 * Fixed `MoreLikeThis::setLike()` PHPDoc allowing `Document` by @franmomu [#2091](https://github.com/ruflin/Elastica/pull/2091)
+* Fixed `Term::setTerm()` PHPDoc allowing scalar values for `$value` parameter by @franmomu [#2094](https://github.com/ruflin/Elastica/pull/2094)
 
 ### Security
 

--- a/src/AbstractUpdateAction.php
+++ b/src/AbstractUpdateAction.php
@@ -19,6 +19,8 @@ class AbstractUpdateAction extends Param
 
     /**
      * Sets the id of the document.
+     *
+     * @return $this
      */
     public function setId(?string $id = null): self
     {

--- a/src/Query/Term.php
+++ b/src/Query/Term.php
@@ -35,9 +35,9 @@ class Term extends AbstractQuery
     /**
      * Adds a term to the term query.
      *
-     * @param string       $key   Key to query
-     * @param array|string $value Values(s) for the query. Boost can be set with array
-     * @param float        $boost OPTIONAL Boost value (default = 1.0)
+     * @param string                $key   Key to query
+     * @param bool|float|int|string $value Values(s) for the query
+     * @param float                 $boost OPTIONAL Boost value (default = 1.0)
      *
      * @return $this
      */

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -711,7 +711,7 @@ JSON;
     {
         $bulk = new Bulk($this->_getClient());
 
-        $this->assertSame($bulk, $bulk->setShardTimeout(10));
+        $this->assertSame($bulk, $bulk->setShardTimeout('10s'));
     }
 
     /**


### PR DESCRIPTION
`Term::setTerm()` has `array` as possible type because `Boost can be set with array`, but I think that is legacy PHPDoc when there was no `$boost` parameter and `$value` was used for everything:

https://github.com/ruflin/Elastica/blob/7a35358c52e9b863253652c49e2888803cee5986/lib/Elastica/Filter/Term.php#L37-L48

and now is:

https://github.com/ruflin/Elastica/blob/f72262d1cb68668d7a370fb113e04b4809f92e7a/src/Query/Term.php#L35-L47

Apart from `string` other values can be used like:

https://github.com/ruflin/Elastica/blob/50346d813e7c0e764bafc88a0a79cffe8d039b35/tests/Query/MoreLikeThisTest.php#L114-L115

~For `Search::addIndex()` there is a `is_scalar` check below:~

~https://github.com/ruflin/Elastica/blob/50346d813e7c0e764bafc88a0a79cffe8d039b35/src/Search.php#L80-L95~