### PR TITLE
Remove tests with using wrong type

### DIFF
--- a/tests/Query/MatchQueryTest.php
+++ b/tests/Query/MatchQueryTest.php
@@ -127,39 +127,6 @@ class MatchQueryTest extends BaseTest
     /**
      * @group functional
      */
-    public function testMatchSetFieldBoostWithString(): void
-    {
-        $client = $this->_getClient();
-        $index = $client->getIndex('test');
-        $index->create([], [
-            'recreate' => true,
-        ]);
-
-        $index->addDocuments([
-            new Document('1', ['name' => 'Basel-Stadt']),
-            new Document('2', ['name' => 'New York']),
-            new Document('3', ['name' => 'New Hampshire']),
-            new Document('4', ['name' => 'Basel Land']),
-        ]);
-
-        $index->refresh();
-
-        $field = 'name';
-        $operator = 'or';
-
-        $query = new MatchQuery();
-        $query->setFieldQuery($field, 'Basel New');
-        $query->setFieldOperator($field, $operator);
-        $query->setFieldBoost($field, '1.2');
-
-        $resultSet = $index->search($query);
-
-        $this->assertEquals(4, $resultSet->count());
-    }
-
-    /**
-     * @group functional
-     */
     public function testMatchZeroTerm(): void
     {
         $client = $this->_getClient();

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -98,19 +98,6 @@ class SearchTest extends BaseTest
     }
 
     /**
-     * @group unit
-     */
-    public function testAddNumericIndex(): void
-    {
-        $client = $this->_getClient();
-        $search = new Search($client);
-
-        $search->addIndex(1);
-
-        $this->assertContains('1', $search->getIndices(), 'Make sure it has been added and converted to string');
-    }
-
-    /**
      * @group functional
      */
     public function testGetPath(): void


### PR DESCRIPTION
For reference: https://github.com/ruflin/Elastica/pull/2096#discussion_r924191185

https://github.com/ruflin/Elastica/blob/0015bf0805712aba78da81cc59f6a28c0c12ca3d/src/Search.php#L80-L100

I was going to deprecate passing something different than `string` and `Index` to `Search::addIndex()` method and saw that `Search::hasIndex()` method does not have any extra check for scalar:

https://github.com/ruflin/Elastica/blob/0015bf0805712aba78da81cc59f6a28c0c12ca3d/src/Search.php#L215-L225

Something similar happens to `MatchQuery::setFieldBoost()` 

https://github.com/ruflin/Elastica/blob/0015bf0805712aba78da81cc59f6a28c0c12ca3d/src/Query/MatchQuery.php#L100-L103

which already has `float` as parameter type.

But there are a couple of tests that check these calls with different types, so I've chosen the easy path 😬 removing those tests. 

If in `8.0` we are going to add strict types to all files these tests will throw a `TypeError` (if we use PHP 8.0).

So is this fine? or should we add a deprecation for `Search::addIndex`