### PR TITLE
Deprecate passing `string` to `Search::addIndex`, `hasIndex` and `addIndices`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added coverage check to CI by @franmomu [#2071](https://github.com/ruflin/Elastica/pull/2071)
 * Added `string` as a valid type for `data` in `Request`  by @franmomu [#2078](https://github.com/ruflin/Elastica/pull/2078)
 * Added missing `throws` PHPDoc tags by @franmomu [#2077](https://github.com/ruflin/Elastica/pull/2077)
+* Added `Search::addIndexByName()`, `Search::hasIndexByName()` and `Search::addIndicesByName()` by @franmomu [#2103](https://github.com/ruflin/Elastica/pull/2103)
 
 ### Changed
 * Updated `symfony/phpunit-bridge` to `6.0` by @franmomu [#2067](https://github.com/ruflin/Elastica/pull/2067)
@@ -28,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 * Deprecated `Elastica\Reindex::WAIT_FOR_COMPLETION_FALSE`, use a boolean as parameter instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
 * Passing anything else than a boolean as 1st argument to `Reindex::setWaitForCompletion`, pass a boolean instead by @franmomu [#2070](https://github.com/ruflin/Elastica/pull/2070)
+* Deprecated passing a `string` as 1st argument to `Search::addIndex()` and `Search::hasIndex()`, pass an Index instance instead by @franmomu [#2103](https://github.com/ruflin/Elastica/pull/2103)
+* Deprecated passing an array of `string` as 1st argument to `Search::addIndices()`, use an array of Index instances by @franmomu [#2103](https://github.com/ruflin/Elastica/pull/2103)
+
 ### Removed
 * Removed `egeloen/http-adapter` as suggested package since the project is abandoned by @franmomu [#2069](https://github.com/ruflin/Elastica/pull/2069)
 * Removed `0` as valid request data using Analyze API by @franmomu [#2068](https://github.com/ruflin/Elastica/pull/2068)

--- a/src/Search.php
+++ b/src/Search.php
@@ -80,7 +80,7 @@ class Search
     /**
      * Adds a index to the list.
      *
-     * @param Index|string $index Index object or string
+     * @param Index $index Index object or string
      *
      * @throws InvalidException
      */
@@ -88,13 +88,29 @@ class Search
     {
         if ($index instanceof Index) {
             $index = $index->getName();
+        } else {
+            \trigger_deprecation(
+                'ruflin/elastica',
+                '7.2.0',
+                'Passing a string as 1st argument to "%s()" is deprecated, pass an Index instance or use "addIndexByName" instead. It will throw a %s in 8.0.',
+                __METHOD__,
+                \TypeError::class
+            );
         }
 
         if (!\is_scalar($index)) {
             throw new InvalidException('Invalid param type');
         }
 
-        $this->_indices[] = (string) $index;
+        return $this->addIndexByName((string) $index);
+    }
+
+    /**
+     * Adds an index to the list.
+     */
+    public function addIndexByName(string $index): self
+    {
+        $this->_indices[] = $index;
 
         return $this;
     }
@@ -102,12 +118,44 @@ class Search
     /**
      * Add array of indices at once.
      *
-     * @param Index[]|string[] $indices
+     * @param Index[] $indices
      */
     public function addIndices(array $indices = []): self
     {
         foreach ($indices as $index) {
+            if (\is_string($index)) {
+                \trigger_deprecation(
+                    'ruflin/elastica',
+                    '7.2.0',
+                    'Passing a array of strings as 1st argument to "%s()" is deprecated, pass an array of Indexes or use "addIndicesByName" instead. It will throw a %s in 8.0.',
+                    __METHOD__,
+                    \TypeError::class
+                );
+                $this->addIndexByName($index);
+
+                continue;
+            }
+
+            if (!$index instanceof Index) {
+                throw new InvalidException('Invalid param type for addIndices(), expected Index[]');
+            }
+
             $this->addIndex($index);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string[] $indices
+     */
+    public function addIndicesByName(array $indices = []): self
+    {
+        foreach ($indices as $index) {
+            if (!\is_string($index)) {
+                throw new InvalidException('Invalid param type for addIndicesByName(), expected string[]');
+            }
+            $this->addIndexByName($index);
         }
 
         return $this;
@@ -213,14 +261,27 @@ class Search
     }
 
     /**
-     * @param Index|string $index
+     * @param Index $index
      */
     public function hasIndex($index): bool
     {
         if ($index instanceof Index) {
             $index = $index->getName();
+        } else {
+            \trigger_deprecation(
+                'ruflin/elastica',
+                '7.2.0',
+                'Passing a string as 1st argument to "%s()" is deprecated, pass an Index instance or use "hasIndexByName" instead. It will throw a %s in 8.0.',
+                __METHOD__,
+                \TypeError::class
+            );
         }
 
+        return $this->hasIndexByName($index);
+    }
+
+    public function hasIndexByName(string $index): bool
+    {
         return \in_array($index, $this->_indices, true);
     }
 

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -765,7 +765,7 @@ class IndexTest extends BaseTest
         $this->assertEquals($expected, $search->getQuery()->toArray());
         $this->assertEquals(['test'], $search->getIndices());
         $this->assertTrue($search->hasIndices());
-        $this->assertTrue($search->hasIndex('test'));
+        $this->assertTrue($search->hasIndexByName('test'));
         $this->assertTrue($search->hasIndex($index));
     }
 

--- a/tests/ScrollTest.php
+++ b/tests/ScrollTest.php
@@ -108,7 +108,7 @@ class ScrollTest extends Base
     public function testScrollWithIgnoreUnavailable(): void
     {
         $search = $this->_prepareSearch();
-        $search->addIndex('unavailable_index');
+        $search->addIndexByName('unavailable_index');
         $search->setOption($search::OPTION_SEARCH_IGNORE_UNAVAILABLE, 'true');
         $scroll = new Scroll($search);
         $count = 1;


### PR DESCRIPTION
See #2103

Poke @franmomu here (I added 2 more tests, covering the `array` parameter in `addIndices()` and `addIndicesByName()`