### PR TITLE
Bump PHPStan to level 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `Elastica\Index\Settings::get` adding ability to get default settings by @krasilnikovm [#2115](https://github.com/ruflin/Elastica/pull/2115)
 * Update `AWSAuthV4 transport` to sanitize host name for AWS requests before signing [#2090](https://github.com/ruflin/Elastica/pull/2090)
 * New method `Elastica\Aggregation\Terms::setMissingBucket`. For Composite Agg. Include in the response documents without a value for a given source. [#2117](https://github.com/ruflin/Elastica/pull/2117)
+* Increased `PHPStan` level to `5` by @franmomu [#2108](https://github.com/ruflin/Elastica/pull/2108)
 ### Deprecated
 ### Removed
 * Removed `CallbackStrategyTestHelper` and `ErrorsCollector` from `tests` [#2111](https://github.com/ruflin/Elastica/pull/2111)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,9 +26,24 @@ parameters:
 			path: src/QueryBuilder.php
 
 		-
+			message: "#^Function GuzzleHttp\\\\Psr7\\\\modify_request not found\\.$#"
+			count: 1
+			path: src/Transport/AwsAuthV4.php
+
+		-
 			message: "#^Function GuzzleHttp\\\\Psr7\\\\stream_for not found\\.$#"
 			count: 1
 			path: src/Transport/Guzzle.php
+
+		-
+			message: "#^Parameter \\#1 \\$precision of method Elastica\\\\Aggregation\\\\GeohashGrid\\:\\:setPrecision\\(\\) expects int\\|string, float given\\.$#"
+			count: 1
+			path: tests/Aggregation/GeohashGridTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$data of static method Elastica\\\\Bulk\\\\Action\\\\AbstractDocument\\:\\:create\\(\\) expects Elastica\\\\Document\\|Elastica\\\\Script\\\\AbstractScript, stdClass given\\.$#"
+			count: 1
+			path: tests/Bulk/Action/AbstractDocumentTest.php
 
 		-
 			message: "#^Access to an undefined property Elastica\\\\Document\\:\\:\\$counter\\.$#"
@@ -54,6 +69,16 @@ parameters:
 			message: "#^Access to an undefined property Elastica\\\\Document\\:\\:\\$age\\.$#"
 			count: 1
 			path: tests/ClientFunctionalTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of method Elastica\\\\Client\\:\\:updateDocument\\(\\) expects array\\|Elastica\\\\Document\\|Elastica\\\\Script\\\\AbstractScript, stdClass given\\.$#"
+			count: 1
+			path: tests/ClientFunctionalTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$params of static method Elastica\\\\Connection\\:\\:create\\(\\) expects array\\|Elastica\\\\Connection, string given\\.$#"
+			count: 1
+			path: tests/ConnectionTest.php
 
 		-
 			message: "#^Access to an undefined property Elastica\\\\Document\\:\\:\\$field1\\.$#"
@@ -96,6 +121,11 @@ parameters:
 			path: tests/DocumentTest.php
 
 		-
+			message: "#^Parameter \\#2 \\$name of class Elastica\\\\IndexTemplate constructor expects string, null given\\.$#"
+			count: 1
+			path: tests/IndexTemplateTest.php
+
+		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: tests/IndexTest.php
@@ -104,6 +134,36 @@ parameters:
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 2
 			path: tests/Multi/SearchTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$origin of method Elastica\\\\Query\\\\FunctionScore\\:\\:addDecayFunction\\(\\) expects string, int given\\.$#"
+			count: 4
+			path: tests/Query/FunctionScoreTest.php
+
+		-
+			message: "#^Parameter \\#4 \\$scale of method Elastica\\\\Query\\\\FunctionScore\\:\\:addDecayFunction\\(\\) expects string, float given\\.$#"
+			count: 2
+			path: tests/Query/FunctionScoreTest.php
+
+		-
+			message: "#^Parameter \\#4 \\$scale of method Elastica\\\\Query\\\\FunctionScore\\:\\:addDecayFunction\\(\\) expects string, int given\\.$#"
+			count: 2
+			path: tests/Query/FunctionScoreTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$clauses of class Elastica\\\\Query\\\\SpanNear constructor expects array\\<Elastica\\\\Query\\\\AbstractSpanQuery\\>, array\\<int, Elastica\\\\Query\\\\Term\\> given\\.$#"
+			count: 1
+			path: tests/Query/SpanNearTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$clauses of class Elastica\\\\Query\\\\SpanOr constructor expects array\\<Elastica\\\\Query\\\\AbstractSpanQuery\\>, array\\<int, Elastica\\\\Query\\\\Term\\> given\\.$#"
+			count: 1
+			path: tests/Query/SpanOrTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$term of method Elastica\\\\Query\\\\Terms\\:\\:addTerm\\(\\) expects bool\\|float\\|int\\|string, stdClass given\\.$#"
+			count: 1
+			path: tests/Query/TermsTest.php
 
 		-
 			message: "#^Call to an undefined method ReflectionType\\:\\:getName\\(\\)\\.$#"
@@ -126,9 +186,49 @@ parameters:
 			path: tests/QueryBuilderTest.php
 
 		-
+			message: "#^Parameter \\#1 \\$value of method Elastica\\\\Reindex\\:\\:setWaitForCompletion\\(\\) expects bool, string given\\.$#"
+			count: 1
+			path: tests/ReindexTest.php
+
+		-
 			message: "#^Expression \"\\$index\\-\\>search\\('elastica search'\\)\\[3\\]\" on a separate line does not do anything\\.$#"
 			count: 1
 			path: tests/ResultSetTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method Elastica\\\\Search\\:\\:addIndex\\(\\) expects Elastica\\\\Index, int given\\.$#"
+			count: 1
+			path: tests/SearchTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method Elastica\\\\Search\\:\\:addIndex\\(\\) expects Elastica\\\\Index, stdClass given\\.$#"
+			count: 1
+			path: tests/SearchTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method Elastica\\\\Search\\:\\:addIndex\\(\\) expects Elastica\\\\Index, string given\\.$#"
+			count: 1
+			path: tests/SearchTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method Elastica\\\\Search\\:\\:hasIndex\\(\\) expects Elastica\\\\Index, string given\\.$#"
+			count: 2
+			path: tests/SearchTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$indices of method Elastica\\\\Search\\:\\:addIndices\\(\\) expects array\\<Elastica\\\\Index\\>, array\\<int, Elastica\\\\Index\\|string\\> given\\.$#"
+			count: 1
+			path: tests/SearchTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$indices of method Elastica\\\\Search\\:\\:addIndices\\(\\) expects array\\<Elastica\\\\Index\\>, array\\<int, stdClass\\> given\\.$#"
+			count: 1
+			path: tests/SearchTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$indices of method Elastica\\\\Search\\:\\:addIndicesByName\\(\\) expects array\\<string\\>, array\\<int, stdClass\\> given\\.$#"
+			count: 1
+			path: tests/SearchTest.php
 
 		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
@@ -136,6 +236,7 @@ parameters:
 			path: tests/SnapshotTest.php
 
 		-
-			message: "#^Function GuzzleHttp\\\\Psr7\\\\modify_request not found\\.$#"
+			message: "#^Parameter \\#1 \\$suggestion of static method Elastica\\\\Suggest\\:\\:create\\(\\) expects Elastica\\\\Suggest\\|Elastica\\\\Suggest\\\\AbstractSuggest, Elastica\\\\Query\\\\BoolQuery given\\.$#"
 			count: 1
-			path: src/Transport/AwsAuthV4.php
+			path: tests/SuggestTest.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 4
+    level: 5
     paths:
         - src
         - tests

--- a/src/Query/FunctionScore.php
+++ b/src/Query/FunctionScore.php
@@ -110,6 +110,8 @@ class FunctionScore extends AbstractQuery
     /**
      * Add a decay function to the query.
      *
+     * TODO: Change "$origin" and "$scale" parameter types to allow "float|int|string".
+     *
      * @param string             $function       see DECAY_* constants for valid options
      * @param string             $field          the document field on which to perform the decay function
      * @param string             $origin         the origin value for this decay function

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -174,8 +174,10 @@ class ClientFunctionalTest extends BaseTest
         $this->assertEquals('AnonCoin', $index->getDocument(1)->get('name'));
         $this->assertEquals('iXcoin', $index->getDocument(2)->get('name'));
 
-        $ixCoin->setIndex(null);  // Make sure the index gets set properly if missing
-        $index->deleteDocuments([$anonCoin, $ixCoin]);
+        $index->deleteDocuments([
+            new Document('1', ['name' => 'AnonCoin']),
+            new Document('2', ['name' => 'iXcoin']),
+        ]);
 
         $this->expectException(NotFoundException::class);
         $index->getDocument(1);

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -166,18 +166,15 @@ class ClientFunctionalTest extends BaseTest
         $this->assertEquals('anoncoin', $index->getDocument(1)->get('name'));
         $this->assertEquals('ixcoin', $index->getDocument(2)->get('name'));
 
-        $index->updateDocuments([
-            new Document('1', ['name' => 'AnonCoin']),
-            new Document('2', ['name' => 'iXcoin']),
-        ]);
+        $anonCoin->set('name', 'AnonCoin');
+        $ixCoin->set('name', 'iXcoin');
+
+        $index->updateDocuments([$anonCoin, $ixCoin]);
 
         $this->assertEquals('AnonCoin', $index->getDocument(1)->get('name'));
         $this->assertEquals('iXcoin', $index->getDocument(2)->get('name'));
 
-        $index->deleteDocuments([
-            new Document('1', ['name' => 'AnonCoin']),
-            new Document('2', ['name' => 'iXcoin']),
-        ]);
+        $index->deleteDocuments([$anonCoin, $ixCoin]);
 
         $this->expectException(NotFoundException::class);
         $index->getDocument(1);

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -176,6 +176,23 @@ class IndexTest extends BaseTest
     }
 
     /**
+     * @group unit
+     */
+    public function testDeleteDocumentsSetsIndex(): void
+    {
+        $client = $this->createMock(Client::class);
+        $index = new Index($client, 'test');
+
+        $doc1 = new Document('1', ['name' => 'ruflin']);
+        $doc2 = new Document('2', ['name' => 'nicolas']);
+
+        $index->deleteDocuments([$doc1, $doc2]);
+
+        $this->assertEquals('test', $doc1->getIndex());
+        $this->assertEquals('test', $doc2->getIndex());
+    }
+
+    /**
      * @group functional
      */
     public function testDeleteByQueryWithQueryString(): void
@@ -328,6 +345,23 @@ class IndexTest extends BaseTest
 
         $response = $index->search('nicolas');
         $this->assertEquals(0, $response->count());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testUpdateDocumentsSetsIndex(): void
+    {
+        $client = $this->createMock(Client::class);
+        $index = new Index($client, 'test');
+
+        $doc1 = new Document('1', ['name' => 'ruflin']);
+        $doc2 = new Document('2', ['name' => 'nicolas']);
+
+        $index->updateDocuments([$doc1, $doc2]);
+
+        $this->assertEquals('test', $doc1->getIndex());
+        $this->assertEquals('test', $doc2->getIndex());
     }
 
     /**

--- a/tests/Transport/TransportBenchmarkTest.php
+++ b/tests/Transport/TransportBenchmarkTest.php
@@ -45,7 +45,7 @@ class TransportBenchmarkTest extends BaseTest
 
         $times = [];
         for ($i = 0; $i < $this->_max; ++$i) {
-            $data = $this->getData($i);
+            $data = $this->getData((string) $i);
             $doc = new Document((string) $i, $data);
             $result = $index->addDocument($doc);
             $times[] = $result->getQueryTime();


### PR DESCRIPTION
Most of the ignored errors are expected because they are testing exceptions using wrong types and PHPStan complains about that. Like:

https://github.com/ruflin/Elastica/blob/8fe61767b604a10e40b0b59c9511c4317cae3cb8/tests/Aggregation/GeohashGridTest.php#L51-L57

```
 ------ ---------------------------------------------------------------------------------------------------------------------
  Line   tests/Aggregation/GeohashGridTest.php
 ------ ---------------------------------------------------------------------------------------------------------------------
  56     Parameter #1 $precision of method Elastica\Aggregation\GeohashGrid::setPrecision() expects int|string, float given.
 ------ ---------------------------------------------------------------------------------------------------------------------
```

The different ones are:
- The ones in `tests/Query/FunctionScoreTest.php`, which I think it's fine to  add `TODO` just in case someone has overridden `FunctionScore::addDecayFunction()` method, if this is fine we can close https://github.com/ruflin/Elastica/pull/2089
- In `ClientFunctionTest`, there is a call to `Document::setIndex()` passing `null` which is not allowed, that is done to make sure that the index is properly set when deleting the documents. Instead of that a new document can be passed as we do lines above to update them:
https://github.com/ruflin/Elastica/blob/8fe61767b604a10e40b0b59c9511c4317cae3cb8/tests/ClientFunctionalTest.php#L161-L182

