### PR TITLE
Add missing types

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -25,6 +25,7 @@ return (new PhpCsFixer\Config())
         'ordered_imports' => true,
         'php_unit_dedicate_assert' => ['target' => 'newest'],
         'php_unit_test_class_requires_covers' => false,
+        'phpdoc_no_empty_return' => false,
         'phpdoc_order' => true,
         'phpdoc_types_order' => ['null_adjustment' => 'always_last'],
         'static_lambda' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/7.2.0...master)
 ### Backward Compatibility Breaks
 ### Added
+* Added missing type declarations [#2112](https://github.com/ruflin/Elastica/pull/2112)
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Bulk/ResponseSet.php
+++ b/src/Bulk/ResponseSet.php
@@ -4,6 +4,9 @@ namespace Elastica\Bulk;
 
 use Elastica\Response as BaseResponse;
 
+/**
+ * @template-implements \Iterator<int, Response>
+ */
 class ResponseSet extends BaseResponse implements \Iterator, \Countable
 {
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -360,6 +360,8 @@ class Client
 
     /**
      * Establishes the client connections.
+     *
+     * @return void
      */
     public function connect()
     {

--- a/src/Index/Stats.php
+++ b/src/Index/Stats.php
@@ -58,6 +58,8 @@ class Stats
      * Returns the entry in the data array based on the params.
      * Various params possible.
      *
+     * @param mixed $args
+     *
      * @return mixed Data array entry or null if not found
      */
     public function get(...$args)

--- a/src/Multi/ResultSet.php
+++ b/src/Multi/ResultSet.php
@@ -10,6 +10,9 @@ use Elastica\ResultSet as BaseResultSet;
  * List of result sets for each search request.
  *
  * @author munkie
+ *
+ * @template-implements \Iterator<int, BaseResultSet>
+ * @template-implements \ArrayAccess<int|string, BaseResultSet>
  */
 class ResultSet implements \Iterator, \ArrayAccess, \Countable
 {

--- a/src/Multi/Search.php
+++ b/src/Multi/Search.php
@@ -30,8 +30,9 @@ class Search
      * @var BaseSearch[]
      */
     protected $_searches = [];
+
     /**
-     * @const string[] valid header options
+     * @var string[] valid header options
      */
     private static $HEADER_OPTIONS = [
         'index',

--- a/src/Node/Info.php
+++ b/src/Node/Info.php
@@ -70,6 +70,8 @@ class Info
      * node is running on
      * Example 2: get('os', 'mem') returns an array with all mem infos
      *
+     * @param mixed $args
+     *
      * @return mixed Data array entry or null if not found
      */
     public function get(...$args)

--- a/src/Node/Stats.php
+++ b/src/Node/Stats.php
@@ -53,6 +53,8 @@ class Stats
      * Several arguments can be use
      * get('index', 'test', 'example')
      *
+     * @param mixed $args
+     *
      * @return array|null Node stats for the given field or null if not found
      */
     public function get(...$args)

--- a/src/Query.php
+++ b/src/Query.php
@@ -24,6 +24,8 @@ class Query extends Param
 {
     /**
      * If the current query has a suggest in it.
+     *
+     * @var bool
      */
     private $hasSuggest = false;
 

--- a/src/Query/DistanceFeature.php
+++ b/src/Query/DistanceFeature.php
@@ -9,6 +9,9 @@ namespace Elastica\Query;
  */
 class DistanceFeature extends AbstractQuery
 {
+    /**
+     * @param array{float, float}|string $origin
+     */
     public function __construct(string $field, $origin, string $pivot)
     {
         $this->setField($field);
@@ -22,7 +25,7 @@ class DistanceFeature extends AbstractQuery
     }
 
     /**
-     * @param array|string $origin
+     * @param array{float, float}|string $origin
      */
     public function setOrigin($origin): self
     {

--- a/src/Query/FunctionScore.php
+++ b/src/Query/FunctionScore.php
@@ -48,6 +48,9 @@ class FunctionScore extends AbstractQuery
     public const RANDOM_SCORE_FIELD_ID = '_id';
     public const RANDOM_SCORE_FIELD_SEQ_NO = '_seq_no';
 
+    /**
+     * @var array<string, mixed>
+     */
     protected $_functions = [];
 
     /**

--- a/src/Reindex.php
+++ b/src/Reindex.php
@@ -91,21 +91,33 @@ class Reindex extends Param
         $this->setParam(self::WAIT_FOR_COMPLETION, $value);
     }
 
+    /**
+     * @param string $value
+     */
     public function setWaitForActiveShards($value): void
     {
         $this->setParam(self::WAIT_FOR_ACTIVE_SHARDS, $value);
     }
 
+    /**
+     * @param string $value
+     */
     public function setTimeout($value): void
     {
         $this->setParam(self::TIMEOUT, $value);
     }
 
+    /**
+     * @param string $value
+     */
     public function setScroll($value): void
     {
         $this->setParam(self::SCROLL, $value);
     }
 
+    /**
+     * @param int $value
+     */
     public function setRequestsPerSecond($value): void
     {
         $this->setParam(self::REQUESTS_PER_SECOND, $value);
@@ -131,6 +143,9 @@ class Reindex extends Param
         $this->setParam(self::REFRESH, $value);
     }
 
+    /**
+     * @return string|null
+     */
     public function getTaskId()
     {
         $taskId = null;

--- a/src/Request.php
+++ b/src/Request.php
@@ -155,6 +155,8 @@ class Request extends Param
 
     /**
      * Set the Content-Type of this request.
+     *
+     * @return $this
      */
     public function setContentType(string $contentType)
     {

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -11,6 +11,9 @@ use Elastica\Exception\InvalidException;
  * Result set implements iterator
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
+ *
+ * @template-implements \Iterator<int, Result>
+ * @template-implements \ArrayAccess<int, Result>
  */
 class ResultSet implements \Iterator, \Countable, \ArrayAccess
 {

--- a/src/ResultSet/ProcessorInterface.php
+++ b/src/ResultSet/ProcessorInterface.php
@@ -9,6 +9,8 @@ interface ProcessorInterface
     /**
      * Iterates over a ResultSet allowing a processor to iterate over any
      * Results as required.
+     *
+     * @return void
      */
     public function process(ResultSet $resultSet);
 }

--- a/src/Script/AbstractScript.php
+++ b/src/Script/AbstractScript.php
@@ -54,7 +54,7 @@ abstract class AbstractScript extends AbstractUpdateAction
     /**
      * Factory to create a script object from data structure (reverse toArray).
      *
-     * @param AbstractScript|array|string $data
+     * @param AbstractScript|array{script: array<string, mixed>}|string $data
      *
      * @throws InvalidException
      *
@@ -114,6 +114,11 @@ abstract class AbstractScript extends AbstractUpdateAction
      */
     abstract protected function getScriptTypeArray(): array;
 
+    /**
+     * @param array{script: array<string, mixed>} $data
+     *
+     * @return Script|ScriptId
+     */
     private static function _createFromArray(array $data)
     {
         $params = $data['script']['params'] ?? [];

--- a/src/Scroll.php
+++ b/src/Scroll.php
@@ -10,6 +10,8 @@ use Elastica\Exception\InvalidException;
  * @author Manuel Andreo Garcia <andreo.garcia@gmail.com>
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
+ *
+ * @template-implements \Iterator<string|null, ResultSet>
  */
 class Scroll implements \Iterator
 {
@@ -38,11 +40,18 @@ class Scroll implements \Iterator
      * 1: scroll id.
      * 2: ignore_unavailable.
      *
-     * @var array
+     * @var array{mixed, mixed, mixed}
      */
     protected $_options = [null, null, null];
 
+    /**
+     * @var int
+     */
     private $totalPages = 0;
+
+    /**
+     * @var int
+     */
     private $currentPage = 0;
 
     public function __construct(Search $search, string $expiryTime = '1m')

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -125,7 +125,7 @@ class Base extends TestCase
         $client->requestEndpoint($endpoint);
     }
 
-    protected function _checkPlugin($plugin): void
+    protected function _checkPlugin(string $plugin): void
     {
         $nodes = $this->_getClient()->getCluster()->getNodes();
         if (!$nodes[0]->getInfo()->hasPlugin($plugin)) {
@@ -133,14 +133,14 @@ class Base extends TestCase
         }
     }
 
-    protected function _getVersion()
+    protected function _getVersion(): string
     {
         $data = $this->_getClient()->request('/')->getData();
 
         return \substr($data['version']['number'], 0, 1);
     }
 
-    protected function _checkVersion($version): void
+    protected function _checkVersion(string $version): void
     {
         $data = $this->_getClient()->request('/')->getData();
         $installedVersion = $data['version']['number'];

--- a/tests/Exception/AbstractExceptionTest.php
+++ b/tests/Exception/AbstractExceptionTest.php
@@ -18,7 +18,7 @@ abstract class AbstractExceptionTest extends BaseTest
         $this->assertTrue($reflection->implementsInterface(ExceptionInterface::class));
     }
 
-    protected function _getExceptionClass()
+    protected function _getExceptionClass(): string
     {
         $reflection = new \ReflectionObject($this);
 

--- a/tests/Query/FunctionScoreTest.php
+++ b/tests/Query/FunctionScoreTest.php
@@ -16,6 +16,9 @@ use Elastica\Test\Base as BaseTest;
  */
 class FunctionScoreTest extends BaseTest
 {
+    /**
+     * @var string
+     */
     protected $locationOrigin = '32.804654, -117.242594';
 
     /**

--- a/tests/Query/MultiMatchTest.php
+++ b/tests/Query/MultiMatchTest.php
@@ -15,6 +15,14 @@ use Elastica\Test\Base as BaseTest;
  */
 class MultiMatchTest extends BaseTest
 {
+    /**
+     * @var array<array{
+     *   id: int,
+     *   name: string,
+     *   last_name: string,
+     *   full_name: string,
+     * }>
+     */
     private static $data = [
         ['id' => 1, 'name' => 'Rodolfo', 'last_name' => 'Moraes',   'full_name' => 'Rodolfo Moraes'],
         ['id' => 2, 'name' => 'Tristan', 'last_name' => 'Maindron', 'full_name' => 'Tristan Maindron'],

--- a/tests/Transport/TransportBenchmarkTest.php
+++ b/tests/Transport/TransportBenchmarkTest.php
@@ -18,8 +18,24 @@ use Elastica\Test\Base as BaseTest;
  */
 class TransportBenchmarkTest extends BaseTest
 {
+    /**
+     * @var int
+     */
     protected $_max = 1000;
+
+    /**
+     * @var int
+     */
     protected $_maxData = 20;
+
+    /**
+     * @var array<string, array<string, array{
+     *    count: int,
+     *    max: int,
+     *    min: int,
+     *    mean: float,
+     * }>>
+     */
     protected static $_results = [];
 
     public static function tearDownAfterClass(): void
@@ -176,6 +192,12 @@ class TransportBenchmarkTest extends BaseTest
         return $index;
     }
 
+    /**
+     * @return array{
+     *   test: string,
+     *   name: string[],
+     * }
+     */
     protected function getData(string $test): array
     {
         $data = [


### PR DESCRIPTION
Raising PHPStan level to 6 shows missing types, this PR tries to add missing types and generics (we still need to add iterable types).