### PR TITLE
Restrict terms list param type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 * Removed `CallbackStrategyTestHelper` and `ErrorsCollector` from `tests` [#2111](https://github.com/ruflin/Elastica/pull/2111)
 ### Fixed
+* Fixed `Query/Terms` terms phpdoc from `array<bool|float|int|string>` to `list<bool|float|int|string>` [#2118](https://github.com/ruflin/Elastica/pull/2118)
 ### Security
 
 ## [7.2.0](https://github.com/ruflin/Elastica/compare/7.2.0...7.1.5)

--- a/src/Query/Terms.php
+++ b/src/Query/Terms.php
@@ -20,7 +20,7 @@ class Terms extends AbstractQuery
     private $field;
 
     /**
-     * @param array<bool|float|int|string> $terms Terms list, leave empty if building a terms-lookup query
+     * @param list<bool|float|int|string> $terms Terms list, leave empty if building a terms-lookup query
      */
     public function __construct(string $field, array $terms = [])
     {
@@ -35,7 +35,7 @@ class Terms extends AbstractQuery
     /**
      * Sets terms for the query.
      *
-     * @param array<bool|float|int|string> $terms
+     * @param list<bool|float|int|string> $terms
      */
     public function setTerms(array $terms): self
     {


### PR DESCRIPTION
I'm getting 
```
[1:51] [terms_lookup] unknown field [0] [reason: [1:55] [bool] failed to parse field [must]]
```
error when I passed something like
```
[0 => 3, 2 => 4]
```
to the Query\Terms.

As soon as I use `array_values` on the array I passed, the error is getting away.

I see two solutions for this:
- Restrict the phpdoc to `list<bool|float|int|string>`
- Calling `array_values` inside the setTerms` method.

What do you prefer ? @ruflin 