### PR TITLE
Fix Elasticsearch 7 double array issue

### DIFF
--- a/src/Query/AbstractQuery.php
+++ b/src/Query/AbstractQuery.php
@@ -19,4 +19,13 @@ abstract class AbstractQuery extends Param
 
         return Util::toSnakeCase($shortName);
     }
+
+    public function isNotAssociativeArray(array $arr)
+    {
+        if ([] === $arr) {
+            return true;
+        }
+
+        return \array_keys($arr) === \range(0, \count($arr) - 1);
+    }
 }

--- a/src/Query/BoolQuery.php
+++ b/src/Query/BoolQuery.php
@@ -111,6 +111,10 @@ class BoolQuery extends AbstractQuery
             throw new InvalidException('Invalid parameter. Has to be array or instance of Elastica\Query\AbstractQuery');
         }
 
+        if (\is_array($args) && $this->isNotAssociativeArray($args)) {
+            throw new InvalidException('Invalid parameter. The array must be an associative array.');
+        }
+
         return $this->addParam($type, $args);
     }
 }


### PR DESCRIPTION
### What does this PR do?
This throws an exception when you try to build an ES query with a deprecated format since ES 7.7. 

This would be a breaking change for anybody who uses ES prior to version 7.7.

This PR will give developers the opportunities to find the breaking change by the line number in their code via the exception and prevent future queries in the old format. 

Opening PR early can add a test if it seems like a reasonable approach. 

Here is the demonstration of other people running into the same issue:
https://gitlab.com/gitlab-org/gitlab/-/merge_requests/32813
> This fixes an issue in Elasticsearch 7.7+ versions ([#218324 (closed)](https://gitlab.com/gitlab-org/gitlab/-/issues/218324)). Previously the query parser was forgiving about nested arrays and would just automatically flatten them for you but now we need to flatten them ourselves. I did read about this in https://discuss.elastic.co/t/must-not-boolean-query-in-7-7/233269 but sadly they [do not consider this a breaking change](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.7.html) so it was not obvious the cause initially.

```bash
# Example request
GET /addresses/_search
{
  "query": {
    "bool": {
      "should": [
        [
          {
            "terms": {
              "Example": [
                1,
                2
              ]
            }
          }
        ]
      ]
    }
  }
}

# Example response
{
  "error" : {
    "root_cause" : [
      {
        "type" : "x_content_parse_exception",
        "reason" : "[5:9] [bool] failed to parse field [should]"
      }
    ],
    "type" : "x_content_parse_exception",
    "reason" : "[5:9] [bool] failed to parse field [should]",
    "caused_by" : {
      "type" : "illegal_state_exception",
      "reason" : "expected value but got [START_ARRAY]"
    }
  },
  "status" : 400
}
 ```