### PR TITLE
Prevent throwing JSONParseException when the response is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed `CallbackStrategyTestHelper` and `ErrorsCollector` from `tests` [#2111](https://github.com/ruflin/Elastica/pull/2111)
 ### Fixed
 * Fixed `Query/Terms` terms phpdoc from `array<bool|float|int|string>` to `list<bool|float|int|string>` [#2118](https://github.com/ruflin/Elastica/pull/2118)
+* Fixed `Response` to prevent throwing JSONParseException when the response is empty.
 ### Security
 
 ## [7.2.0](https://github.com/ruflin/Elastica/compare/7.2.0...7.1.5)

--- a/src/Response.php
+++ b/src/Response.php
@@ -208,26 +208,7 @@ class Response
     public function getData()
     {
         if (null == $this->_response) {
-            $response = $this->_responseString;
-
-            try {
-                if ($this->getJsonBigintConversion()) {
-                    $response = JSON::parse($response, true, 512, \JSON_BIGINT_AS_STRING);
-                } else {
-                    $response = JSON::parse($response);
-                }
-            } catch (\JsonException $e) {
-                // leave response as is if parse fails
-            }
-
-            if (empty($response)) {
-                $response = [];
-            }
-
-            if (\is_string($response)) {
-                $response = ['message' => $response];
-            }
-
+            $response = $this->getResponseString();
             $this->_response = $response;
             $this->_responseString = '';
         }
@@ -356,5 +337,31 @@ class Response
     public function getJsonBigintConversion()
     {
         return $this->_jsonBigintConversion;
+    }
+
+    /**
+     * @return array|string[]
+     */
+    private function getResponseString()
+    {
+        $response = $this->_responseString;
+        if (empty($response)) {
+            return [];
+        }
+        try {
+            if ($this->getJsonBigintConversion()) {
+                $response = JSON::parse($response, true, 512, \JSON_BIGINT_AS_STRING);
+            } else {
+                $response = JSON::parse($response);
+            }
+        } catch (\JsonException $e) {
+            // leave response as is if parse fails
+        }
+
+        if (\is_string($response)) {
+            $response = ['message' => $response];
+        }
+
+        return $response;
     }
 }


### PR DESCRIPTION
I saw this issue when I wanted to check whether an index exists in the elastic.
Elastica uses HEAD requests to check whether the index exists or not, so the response body is empty. 
This issue is handled inside the code by try-catch (getData function). But there were two reasons for this PR:
1-  by this change, we can check if the response is empty, don't call the JSON parse function. So no exception will occur, and there isn't any need to catch it.
2- we use newrelic for distributed tracing and see many errors. ( newrelic agent collects all exceptions even though they are handled, and we want to keep this ability for better tracing )