### PR TITLE
Fix types order to work with psalm + expand aggs type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* Fix types order in `Elastica\Query` to work with psalm
 ### Security
 
 ## [7.3.0](https://github.com/ruflin/Elastica/compare/7.3.0...7.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-* Fix types order in `Elastica\Query` to work with psalm
+* Fix types order in `Elastica\Query` to work with psalm & expand the `aggs` type to include raw arrays
 ### Security
 
 ## [7.3.0](https://github.com/ruflin/Elastica/compare/7.3.0...7.2.0)

--- a/src/Query.php
+++ b/src/Query.php
@@ -20,8 +20,23 @@ use Elastica\Suggest\AbstractSuggest;
  * @author Nicolas Ruflin <spam@ruflin.com>
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html
- * @phpstan-type TCreateQueryArgs = TCreateQueryArgsMatching|AbstractSuggest|Collapse|Suggest
- * @phpstan-type TCreateQueryArgsMatching = AbstractQuery|TRawQuery|self|string|null
+ * @todo: improve THighlightArgs https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
+ * @phpstan-type THighlightArgs = array<mixed>
+ * @phpstan-type TStoredFields = list<string>
+ * @todo: improve TDocValueFields https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-docvalue-fields
+ * @phpstan-type TDocValueFields = array<mixed>
+ * @phpstan-type TRescoreArgs = QueryRescore|list<QueryRescore>
+ * @phpstan-type TSourceArgs = non-empty-string|list<non-empty-string>|array{includes?: list<non-empty-string>, excludes?: list<non-empty-string>}|false
+ * @phpstan-type TSortArrayArg = array<string, string>|array<string, array{
+ *     order?: non-empty-string,
+ *     mode?: non-empty-string,
+ *     numeric_type?: non-empty-string,
+ *     nested?: array{path: non-empty-string, filter?: array<mixed>, max_children?: int, nested?: array<mixed>},
+ *     missing?: non-empty-string,
+ *     unmapped_type?: non-empty-string,
+ * }>|array{_geo_distance: array<string, mixed>}
+ * @phpstan-type TSortArg = non-empty-string|TSortArrayArg
+ * @phpstan-type TSortArgs = list<TSortArg>|TSortArrayArg
  * @phpstan-type TRawQuery = array{
  *     _source?: TSourceArgs,
  *     aggs?: list<AbstractAggregation>,
@@ -46,23 +61,8 @@ use Elastica\Suggest\AbstractSuggest;
  *     track_total_hits?: bool|int,
  *     version?: bool,
  * }
- * @phpstan-type TSortArgs = list<TSortArg>|TSortArrayArg
- * @phpstan-type TSortArg = non-empty-string|TSortArrayArg
- * @phpstan-type TSortArrayArg = array<string, string>|array<string, array{
- *     order?: non-empty-string,
- *     mode?: non-empty-string,
- *     numeric_type?: non-empty-string,
- *     nested?: array{path: non-empty-string, filter?: array<mixed>, max_children?: int, nested?: array<mixed>},
- *     missing?: non-empty-string,
- *     unmapped_type?: non-empty-string,
- * }>|array{_geo_distance: array<string, mixed>}
- * @todo: improve THighlightArgs https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html
- * @phpstan-type THighlightArgs = array<mixed>
- * @phpstan-type TStoredFields = list<string>
- * @todo: improve TDocValueFields https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#request-body-search-docvalue-fields
- * @phpstan-type TDocValueFields = array<mixed>
- * @phpstan-type TRescoreArgs = QueryRescore|list<QueryRescore>
- * @phpstan-type TSourceArgs = non-empty-string|list<non-empty-string>|array{includes?: list<non-empty-string>, excludes?: list<non-empty-string>}|false
+ * @phpstan-type TCreateQueryArgsMatching = AbstractQuery|TRawQuery|self|string|null
+ * @phpstan-type TCreateQueryArgs = TCreateQueryArgsMatching|AbstractSuggest|Collapse|Suggest
  */
 class Query extends Param
 {

--- a/src/Query.php
+++ b/src/Query.php
@@ -39,7 +39,7 @@ use Elastica\Suggest\AbstractSuggest;
  * @phpstan-type TSortArgs = list<TSortArg>|TSortArrayArg
  * @phpstan-type TRawQuery = array{
  *     _source?: TSourceArgs,
- *     aggs?: list<AbstractAggregation>,
+ *     aggs?: list<AbstractAggregation>|array<string, array<string, array<string, mixed>>>,
  *     collapse?: Collapse,
  *     docvalue_fields?: TDocValueFields,
  *     explain?: bool,


### PR DESCRIPTION
Followup to #2102

I've encountered two problems with the current annotations:

1) [pslam](https://psalm.dev/) is dependent on the order in which the types are declared, eg you can't reference a type that's declared afterwards:
  a) works: https://psalm.dev/r/f51e255c5c
  b) doesn't work: https://psalm.dev/r/062e88cf37

   Since psalm reads `@phpstan-*` annotations as well, I've started getting a lot of errors when running the tool.

2) `aggs` can be a multidimensional array as well, eg:

   ```php
   $result = $index->search([
       'aggs' => [
           'agg-name' => [
               'terms' => ['field' => 'field-name'],
           ],
       ],
   ]);
   ```