### PR TITLE
Remove aggregation deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `Elastica\Result::getType()`
   * `Elastica\Suggest\Phrase::addCandidateGenerator()` -> use `Elastica\Suggest\Phrase::addDirectGenerator()` instead
   * `Elastica\Util::getParamName()`
+* Changed following aggregation constructors [#2138](https://github.com/ruflin/Elastica/pull/2138)
+  * `Elastica\Aggregation\AvgBucket`: The second argument `$bucketsPath` is now mandatory
+  * `Elastica\Aggregation\BucketScript`: The second (`array $bucketsPath`) and the third (`string $script`) argument are now mandatory
+  * `Elastica\Aggregation\BucketSelector`: The second (`array $bucketsPath`) and the third (`string $script`) argument are now mandatory
+  * `Elastica\Aggregation\Derivative`: The second argument (`string $bucketsPath`) is now mandatory
+  * `Elastica\Aggregation\NormalizeAggregation`: The second (`string $bucketsPath`) and the third (`string $method`) argument are now mandatory
+  * `Elastica\Aggregation\PercentilesBucket`: The second argument (`string $bucketsPath`) is now mandatory
+  * `Elastica\Aggregation\SerialDiff`: The second argument (`string $bucketsPath`) is now mandatory
+  * `Elastica\Aggregation\StatsBucket`: The second argument (`string $bucketsPath`) is now mandatory
+  * `Elastica\Aggregation\SumBucket`: The second argument (`string $bucketsPath`) is now mandatory
+
 ### Added
 * Added support for PHP 8.2 [#2136](https://github.com/ruflin/Elastica/pull/2136)
 ### Changed

--- a/src/Aggregation/AvgBucket.php
+++ b/src/Aggregation/AvgBucket.php
@@ -2,8 +2,6 @@
 
 namespace Elastica\Aggregation;
 
-use Elastica\Exception\InvalidException;
-
 /**
  * Class AvgBucket.
  *
@@ -16,17 +14,11 @@ class AvgBucket extends AbstractAggregation implements GapPolicyInterface
 
     public const DEFAULT_FORMAT_VALUE = null;
 
-    public function __construct(string $name, ?string $bucketsPath = null)
+    public function __construct(string $name, string $bucketsPath)
     {
         parent::__construct($name);
 
-        if (null !== $bucketsPath) {
-            $this->setBucketsPath($bucketsPath);
-        } elseif (\func_num_args() >= 2) {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Passing null as 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        } else {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Not passing a 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        }
+        $this->setBucketsPath($bucketsPath);
     }
 
     /**
@@ -37,17 +29,5 @@ class AvgBucket extends AbstractAggregation implements GapPolicyInterface
     public function setFormat(?string $format = null): self
     {
         return $this->setParam('format', $format);
-    }
-
-    /**
-     * @throws InvalidException If buckets path or script is not set
-     */
-    public function toArray(): array
-    {
-        if (!$this->hasParam('buckets_path')) {
-            throw new InvalidException('Buckets path is required');
-        }
-
-        return parent::toArray();
     }
 }

--- a/src/Aggregation/BucketScript.php
+++ b/src/Aggregation/BucketScript.php
@@ -2,8 +2,6 @@
 
 namespace Elastica\Aggregation;
 
-use Elastica\Exception\InvalidException;
-
 /**
  * Class BucketScript.
  *
@@ -13,17 +11,12 @@ class BucketScript extends AbstractAggregation implements GapPolicyInterface
 {
     use Traits\GapPolicyTrait;
 
-    public function __construct(string $name, ?array $bucketsPath = null, ?string $script = null)
+    public function __construct(string $name, array $bucketsPath, string $script)
     {
         parent::__construct($name);
 
-        if (null !== $bucketsPath) {
-            $this->setBucketsPath($bucketsPath);
-        }
-
-        if (null !== $script) {
-            $this->setScript($script);
-        }
+        $this->setBucketsPath($bucketsPath);
+        $this->setScript($script);
     }
 
     /**
@@ -54,20 +47,5 @@ class BucketScript extends AbstractAggregation implements GapPolicyInterface
     public function setFormat(?string $format = null): self
     {
         return $this->setParam('format', $format);
-    }
-
-    /**
-     * @throws InvalidException If buckets path or script is not set
-     */
-    public function toArray(): array
-    {
-        if (!$this->hasParam('buckets_path')) {
-            throw new InvalidException('Buckets path is required');
-        }
-        if (!$this->hasParam('script')) {
-            throw new InvalidException('Script parameter is required');
-        }
-
-        return parent::toArray();
     }
 }

--- a/src/Aggregation/BucketSelector.php
+++ b/src/Aggregation/BucketSelector.php
@@ -11,17 +11,12 @@ class BucketSelector extends AbstractSimpleAggregation implements GapPolicyInter
 {
     use Traits\GapPolicyTrait;
 
-    public function __construct(string $name, ?array $bucketsPath = null, ?string $script = null)
+    public function __construct(string $name, array $bucketsPath, string $script)
     {
         parent::__construct($name);
 
-        if (null !== $bucketsPath) {
-            $this->setBucketsPath($bucketsPath);
-        }
-
-        if (null !== $script) {
-            $this->setScript($script);
-        }
+        $this->setBucketsPath($bucketsPath);
+        $this->setScript($script);
     }
 
     /**

--- a/src/Aggregation/Derivative.php
+++ b/src/Aggregation/Derivative.php
@@ -2,8 +2,6 @@
 
 namespace Elastica\Aggregation;
 
-use Elastica\Exception\InvalidException;
-
 /**
  * Class Derivative.
  *
@@ -14,17 +12,11 @@ class Derivative extends AbstractAggregation implements GapPolicyInterface
     use Traits\BucketsPathTrait;
     use Traits\GapPolicyTrait;
 
-    public function __construct(string $name, ?string $bucketsPath = null)
+    public function __construct(string $name, string $bucketsPath)
     {
         parent::__construct($name);
 
-        if (null !== $bucketsPath) {
-            $this->setBucketsPath($bucketsPath);
-        } elseif (\func_num_args() >= 2) {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Passing null as 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        } else {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Not passing a 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        }
+        $this->setBucketsPath($bucketsPath);
     }
 
     /**
@@ -35,17 +27,5 @@ class Derivative extends AbstractAggregation implements GapPolicyInterface
     public function setFormat(string $format): self
     {
         return $this->setParam('format', $format);
-    }
-
-    /**
-     * @throws InvalidException If buckets path or script is not set
-     */
-    public function toArray(): array
-    {
-        if (!$this->hasParam('buckets_path')) {
-            throw new InvalidException('Buckets path is required');
-        }
-
-        return parent::toArray();
     }
 }

--- a/src/Aggregation/NormalizeAggregation.php
+++ b/src/Aggregation/NormalizeAggregation.php
@@ -2,8 +2,6 @@
 
 namespace Elastica\Aggregation;
 
-use Elastica\Exception\InvalidException;
-
 /**
  * Class NormalizeAggregation.
  *
@@ -13,25 +11,12 @@ class NormalizeAggregation extends AbstractAggregation
 {
     use Traits\BucketsPathTrait;
 
-    public function __construct(string $name, ?string $bucketsPath = null, ?string $method = null)
+    public function __construct(string $name, string $bucketsPath, string $method)
     {
         parent::__construct($name);
 
-        if (null !== $bucketsPath) {
-            $this->setBucketsPath($bucketsPath);
-        } elseif (\func_num_args() >= 2) {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Passing null as 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        } else {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Not passing a 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        }
-
-        if (null !== $method) {
-            $this->setMethod($method);
-        } elseif (\func_num_args() >= 3) {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Passing null as 3rd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        } else {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Not passing a 3rd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        }
+        $this->setBucketsPath($bucketsPath);
+        $this->setMethod($method);
     }
 
     /**
@@ -52,21 +37,5 @@ class NormalizeAggregation extends AbstractAggregation
     public function setFormat(string $format): self
     {
         return $this->setParam('format', $format);
-    }
-
-    /**
-     * @throws InvalidException If buckets path or method are not set
-     */
-    public function toArray(): array
-    {
-        if (!$this->hasParam('buckets_path')) {
-            throw new InvalidException('Buckets path is required');
-        }
-
-        if (!$this->hasParam('method')) {
-            throw new InvalidException('Method parameter is required');
-        }
-
-        return parent::toArray();
     }
 }

--- a/src/Aggregation/PercentilesBucket.php
+++ b/src/Aggregation/PercentilesBucket.php
@@ -2,8 +2,6 @@
 
 namespace Elastica\Aggregation;
 
-use Elastica\Exception\InvalidException;
-
 /**
  * Class PercentilesBucket.
  *
@@ -15,29 +13,11 @@ class PercentilesBucket extends AbstractAggregation implements GapPolicyInterfac
     use Traits\GapPolicyTrait;
     use Traits\KeyedTrait;
 
-    public function __construct(string $name, ?string $bucketsPath = null)
+    public function __construct(string $name, string $bucketsPath)
     {
         parent::__construct($name);
 
-        if (null !== $bucketsPath) {
-            $this->setBucketsPath($bucketsPath);
-        } elseif (\func_num_args() >= 2) {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Passing null as 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        } else {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Not passing a 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        }
-    }
-
-    /**
-     * @throws InvalidException If buckets path or script is not set
-     */
-    public function toArray(): array
-    {
-        if (!$this->hasParam('buckets_path')) {
-            throw new InvalidException('Buckets path is required');
-        }
-
-        return parent::toArray();
+        $this->setBucketsPath($bucketsPath);
     }
 
     /**

--- a/src/Aggregation/SerialDiff.php
+++ b/src/Aggregation/SerialDiff.php
@@ -2,8 +2,6 @@
 
 namespace Elastica\Aggregation;
 
-use Elastica\Exception\InvalidException;
-
 /**
  * Class SerialDiff.
  *
@@ -15,17 +13,11 @@ class SerialDiff extends AbstractAggregation implements GapPolicyInterface
 
     public const DEFAULT_GAP_POLICY_VALUE = GapPolicyInterface::INSERT_ZEROS;
 
-    public function __construct(string $name, ?string $bucketsPath = null)
+    public function __construct(string $name, string $bucketsPath)
     {
         parent::__construct($name);
 
-        if (null !== $bucketsPath) {
-            $this->setBucketsPath($bucketsPath);
-        } elseif (\func_num_args() >= 2) {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Passing null as 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        } else {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Not passing a 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        }
+        $this->setBucketsPath($bucketsPath);
     }
 
     /**
@@ -56,17 +48,5 @@ class SerialDiff extends AbstractAggregation implements GapPolicyInterface
     public function setFormat(?string $format = null): self
     {
         return $this->setParam('format', $format);
-    }
-
-    /**
-     * @throws InvalidException If buckets path is not set
-     */
-    public function toArray(): array
-    {
-        if (!$this->hasParam('buckets_path')) {
-            throw new InvalidException('Buckets path is required');
-        }
-
-        return parent::toArray();
     }
 }

--- a/src/Aggregation/StatsBucket.php
+++ b/src/Aggregation/StatsBucket.php
@@ -2,8 +2,6 @@
 
 namespace Elastica\Aggregation;
 
-use Elastica\Exception\InvalidException;
-
 /**
  * Class StatsBucket.
  *
@@ -14,17 +12,11 @@ class StatsBucket extends AbstractAggregation implements GapPolicyInterface
     use Traits\BucketsPathTrait;
     use Traits\GapPolicyTrait;
 
-    public function __construct(string $name, ?string $bucketsPath = null)
+    public function __construct(string $name, string $bucketsPath)
     {
         parent::__construct($name);
 
-        if (null !== $bucketsPath) {
-            $this->setBucketsPath($bucketsPath);
-        } elseif (\func_num_args() >= 2) {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Passing null as 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        } else {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Not passing a 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        }
+        $this->setBucketsPath($bucketsPath);
     }
 
     /**
@@ -35,17 +27,5 @@ class StatsBucket extends AbstractAggregation implements GapPolicyInterface
     public function setFormat(string $format): self
     {
         return $this->setParam('format', $format);
-    }
-
-    /**
-     * @throws InvalidException If buckets path or script is not set
-     */
-    public function toArray(): array
-    {
-        if (!$this->hasParam('buckets_path')) {
-            throw new InvalidException('Buckets path is required');
-        }
-
-        return parent::toArray();
     }
 }

--- a/src/Aggregation/SumBucket.php
+++ b/src/Aggregation/SumBucket.php
@@ -2,8 +2,6 @@
 
 namespace Elastica\Aggregation;
 
-use Elastica\Exception\InvalidException;
-
 /**
  * Class SumBucket.
  *
@@ -14,17 +12,11 @@ class SumBucket extends AbstractAggregation implements GapPolicyInterface
     use Traits\BucketsPathTrait;
     use Traits\GapPolicyTrait;
 
-    public function __construct(string $name, ?string $bucketsPath = null)
+    public function __construct(string $name, string $bucketsPath)
     {
         parent::__construct($name);
 
-        if (null !== $bucketsPath) {
-            $this->setBucketsPath($bucketsPath);
-        } elseif (\func_num_args() >= 2) {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Passing null as 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        } else {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Not passing a 2nd argument to "%s()" is deprecated, pass a string instead. It will be removed in 8.0.', __METHOD__);
-        }
+        $this->setBucketsPath($bucketsPath);
     }
 
     /**
@@ -35,17 +27,5 @@ class SumBucket extends AbstractAggregation implements GapPolicyInterface
     public function setFormat(string $format): self
     {
         return $this->setParam('format', $format);
-    }
-
-    /**
-     * @throws InvalidException If buckets path or script is not set
-     */
-    public function toArray(): array
-    {
-        if (!$this->hasParam('buckets_path')) {
-            throw new InvalidException('Buckets path is required');
-        }
-
-        return parent::toArray();
     }
 }

--- a/src/QueryBuilder/DSL/Aggregation.php
+++ b/src/QueryBuilder/DSL/Aggregation.php
@@ -99,7 +99,7 @@ class Aggregation implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-sum-bucket-aggregation.html
      */
-    public function sum_bucket(string $name, ?string $bucketsPath = null): SumBucket
+    public function sum_bucket(string $name, string $bucketsPath): SumBucket
     {
         return new SumBucket($name, $bucketsPath);
     }
@@ -119,7 +119,7 @@ class Aggregation implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-avg-bucket-aggregation.html
      */
-    public function avg_bucket(string $name, ?string $bucketsPath = null): AvgBucket
+    public function avg_bucket(string $name, string $bucketsPath): AvgBucket
     {
         return new AvgBucket($name, $bucketsPath);
     }
@@ -137,7 +137,7 @@ class Aggregation implements DSL
     /**
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-stats-bucket-aggregation.html
      */
-    public function stats_bucket(string $name, ?string $bucketsPath = null): StatsBucket
+    public function stats_bucket(string $name, string $bucketsPath): StatsBucket
     {
         return new StatsBucket($name, $bucketsPath);
     }
@@ -180,10 +180,10 @@ class Aggregation implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-percentiles-bucket-aggregation.html
      *
-     * @param string      $name        the name of this aggregation
-     * @param string|null $bucketsPath the field on which to perform this aggregation
+     * @param string $name        the name of this aggregation
+     * @param string $bucketsPath the field on which to perform this aggregation
      */
-    public function percentiles_bucket(string $name, ?string $bucketsPath = null): PercentilesBucket
+    public function percentiles_bucket(string $name, string $bucketsPath): PercentilesBucket
     {
         return new PercentilesBucket($name, $bucketsPath);
     }
@@ -431,7 +431,7 @@ class Aggregation implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-bucket-script-aggregation.html
      */
-    public function bucket_script(string $name, ?array $bucketsPath = null, ?string $script = null): BucketScript
+    public function bucket_script(string $name, array $bucketsPath, string $script): BucketScript
     {
         return new BucketScript($name, $bucketsPath, $script);
     }
@@ -441,7 +441,7 @@ class Aggregation implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-serialdiff-aggregation.html
      */
-    public function serial_diff(string $name, ?string $bucketsPath = null): SerialDiff
+    public function serial_diff(string $name, string $bucketsPath): SerialDiff
     {
         return new SerialDiff($name, $bucketsPath);
     }
@@ -469,7 +469,7 @@ class Aggregation implements DSL
     /**
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-derivative-aggregation.html
      */
-    public function derivative(string $name, ?string $bucketsPath = null): Derivative
+    public function derivative(string $name, string $bucketsPath): Derivative
     {
         return new Derivative($name, $bucketsPath);
     }
@@ -509,7 +509,7 @@ class Aggregation implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-normalize-aggregation.html
      */
-    public function normalize(string $name, ?string $bucketsPath = null, ?string $method = null): NormalizeAggregation
+    public function normalize(string $name, string $bucketsPath, string $method): NormalizeAggregation
     {
         return new NormalizeAggregation($name, $bucketsPath, $method);
     }

--- a/tests/Aggregation/AvgBucketTest.php
+++ b/tests/Aggregation/AvgBucketTest.php
@@ -7,18 +7,14 @@ use Elastica\Aggregation\AvgBucket;
 use Elastica\Aggregation\GapPolicyInterface;
 use Elastica\Aggregation\Terms;
 use Elastica\Document;
-use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @internal
  */
 class AvgBucketTest extends BaseAggregationTest
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @group functional
      */
@@ -65,40 +61,6 @@ class AvgBucketTest extends BaseAggregationTest
         ];
 
         $this->assertEquals($expected, $aggregation->toArray());
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNoBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Not passing a 2nd argument to "Elastica\Aggregation\AvgBucket::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new AvgBucket('avg_bucket');
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNullBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Passing null as 2nd argument to "Elastica\Aggregation\AvgBucket::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new AvgBucket('avg_bucket', null);
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyToArrayWithNoBucketsPath(): void
-    {
-        $this->expectException(InvalidException::class);
-        $this->expectExceptionMessage('Buckets path is required');
-
-        (new AvgBucket('avg_bucket'))->toArray();
     }
 
     private function getIndexForTest(): Index

--- a/tests/Aggregation/BucketScriptTest.php
+++ b/tests/Aggregation/BucketScriptTest.php
@@ -7,7 +7,6 @@ use Elastica\Aggregation\GapPolicyInterface;
 use Elastica\Aggregation\Histogram;
 use Elastica\Aggregation\Max;
 use Elastica\Document;
-use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
 
@@ -52,15 +51,13 @@ class BucketScriptTest extends BaseAggregationTest
      */
     public function testConstructThroughSetters(): void
     {
-        $serialDiffAgg = new BucketScript('bucket_scripted');
+        $serialDiffAgg = new BucketScript('bucket_scripted', [
+            'x' => 'agg_max',
+            'y' => 'agg_sum',
+            'z' => 'agg_min',
+        ], 'x / y * z');
 
         $serialDiffAgg
-            ->setScript('x / y * z')
-            ->setBucketsPath([
-                'x' => 'agg_max',
-                'y' => 'agg_sum',
-                'z' => 'agg_min',
-            ])
             ->setFormat('test_format')
             ->setGapPolicy(GapPolicyInterface::INSERT_ZEROS)
         ;
@@ -79,28 +76,6 @@ class BucketScriptTest extends BaseAggregationTest
         ];
 
         $this->assertEquals($expected, $serialDiffAgg->toArray());
-    }
-
-    /**
-     * @group unit
-     */
-    public function testToArrayInvalidBucketsPath(): void
-    {
-        $this->expectException(InvalidException::class);
-
-        $serialDiffAgg = new BucketScript('bucket_scripted');
-        $serialDiffAgg->toArray();
-    }
-
-    /**
-     * @group unit
-     */
-    public function testToArrayInvalidScript(): void
-    {
-        $this->expectException(InvalidException::class);
-
-        $serialDiffAgg = new BucketScript('bucket_scripted', ['path' => 'agg']);
-        $serialDiffAgg->toArray();
     }
 
     protected function _getIndexForTest(): Index

--- a/tests/Aggregation/DerivativeTest.php
+++ b/tests/Aggregation/DerivativeTest.php
@@ -8,37 +8,12 @@ use Elastica\Aggregation\Max;
 use Elastica\Document;
 use Elastica\Index;
 use Elastica\Query;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @internal
  */
 class DerivativeTest extends BaseAggregationTest
 {
-    use ExpectDeprecationTrait;
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNoBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Not passing a 2nd argument to "Elastica\Aggregation\Derivative::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new Derivative('derivative');
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNullBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Passing null as 2nd argument to "Elastica\Aggregation\Derivative::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new Derivative('derivative', null);
-    }
-
     /**
      * @group unit
      */

--- a/tests/Aggregation/NormalizeAggregationTest.php
+++ b/tests/Aggregation/NormalizeAggregationTest.php
@@ -6,18 +6,14 @@ use Elastica\Aggregation\DateHistogram;
 use Elastica\Aggregation\NormalizeAggregation;
 use Elastica\Aggregation\Sum;
 use Elastica\Document;
-use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @internal
  */
 class NormalizeAggregationTest extends BaseAggregationTest
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @group unit
      */
@@ -58,64 +54,6 @@ class NormalizeAggregationTest extends BaseAggregationTest
         ;
 
         $this->assertEquals($expected, $dateHistogramAgg->toArray());
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNoBucketsPathAndNoMethod(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Not passing a 2nd argument to "Elastica\Aggregation\NormalizeAggregation::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Not passing a 3rd argument to "Elastica\Aggregation\NormalizeAggregation::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new NormalizeAggregation('normalize_agg');
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNullBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Passing null as 2nd argument to "Elastica\Aggregation\NormalizeAggregation::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new NormalizeAggregation('normalize_agg', null, 'method');
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNullMethod(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Passing null as 3rd argument to "Elastica\Aggregation\NormalizeAggregation::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new NormalizeAggregation('normalize_agg', 'buckets_path', null);
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyToArrayWithNoBucketsPath(): void
-    {
-        $this->expectException(InvalidException::class);
-        $this->expectExceptionMessage('Buckets path is required');
-
-        (new NormalizeAggregation('normalize_agg'))->toArray();
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testToArrayInvalidMethod(): void
-    {
-        $this->expectException(InvalidException::class);
-        $this->expectExceptionMessage('Method parameter is required');
-
-        (new NormalizeAggregation('normalize_agg', 'buckets_path'))->toArray();
     }
 
     /**

--- a/tests/Aggregation/PercentilesBucketTest.php
+++ b/tests/Aggregation/PercentilesBucketTest.php
@@ -7,18 +7,14 @@ use Elastica\Aggregation\GapPolicyInterface;
 use Elastica\Aggregation\PercentilesBucket;
 use Elastica\Aggregation\Terms;
 use Elastica\Document;
-use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @internal
  */
 class PercentilesBucketTest extends BaseAggregationTest
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @group functional
      */
@@ -74,40 +70,6 @@ class PercentilesBucketTest extends BaseAggregationTest
         ];
 
         $this->assertEquals($expected, $aggregation->toArray());
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNoBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Not passing a 2nd argument to "Elastica\Aggregation\PercentilesBucket::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new PercentilesBucket('percentiles_bucket');
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNullBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Passing null as 2nd argument to "Elastica\Aggregation\PercentilesBucket::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new PercentilesBucket('percentiles_bucket', null);
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyToArrayWithNoBucketsPath(): void
-    {
-        $this->expectException(InvalidException::class);
-        $this->expectExceptionMessage('Buckets path is required');
-
-        (new PercentilesBucket('percentiles_bucket'))->toArray();
     }
 
     private function getIndexForTest(): Index

--- a/tests/Aggregation/SerialDiffTest.php
+++ b/tests/Aggregation/SerialDiffTest.php
@@ -7,19 +7,15 @@ use Elastica\Aggregation\GapPolicyInterface;
 use Elastica\Aggregation\Max;
 use Elastica\Aggregation\SerialDiff;
 use Elastica\Document;
-use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Mapping;
 use Elastica\Query;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @internal
  */
 class SerialDiffTest extends BaseAggregationTest
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @group functional
      */
@@ -63,40 +59,6 @@ class SerialDiffTest extends BaseAggregationTest
         ];
 
         $this->assertEquals($expected, $aggregation->toArray());
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNoBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Not passing a 2nd argument to "Elastica\Aggregation\SerialDiff::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new SerialDiff('serial_diff');
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNullBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Passing null as 2nd argument to "Elastica\Aggregation\SerialDiff::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new SerialDiff('serial_diff', null);
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyToArrayWithNoBucketsPath(): void
-    {
-        $this->expectException(InvalidException::class);
-        $this->expectExceptionMessage('Buckets path is required');
-
-        (new SerialDiff('serial_diff'))->toArray();
     }
 
     private function getIndexForTest(): Index

--- a/tests/Aggregation/StatsBucketTest.php
+++ b/tests/Aggregation/StatsBucketTest.php
@@ -7,18 +7,14 @@ use Elastica\Aggregation\Histogram;
 use Elastica\Aggregation\Max;
 use Elastica\Aggregation\StatsBucket;
 use Elastica\Document;
-use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @internal
  */
 class StatsBucketTest extends BaseAggregationTest
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @group functional
      */
@@ -65,40 +61,6 @@ class StatsBucketTest extends BaseAggregationTest
         ];
 
         $this->assertEquals($expected, $aggregation->toArray());
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNoBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Not passing a 2nd argument to "Elastica\Aggregation\StatsBucket::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new StatsBucket('stats_bucket');
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNullBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Passing null as 2nd argument to "Elastica\Aggregation\StatsBucket::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new StatsBucket('stats_bucket', null);
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyToArrayWithNoBucketsPath(): void
-    {
-        $this->expectException(InvalidException::class);
-        $this->expectExceptionMessage('Buckets path is required');
-
-        (new StatsBucket('stats_bucket'))->toArray();
     }
 
     private function getIndexForTest(): Index

--- a/tests/Aggregation/SumBucketTest.php
+++ b/tests/Aggregation/SumBucketTest.php
@@ -7,18 +7,14 @@ use Elastica\Aggregation\Sum;
 use Elastica\Aggregation\SumBucket;
 use Elastica\Aggregation\Terms;
 use Elastica\Document;
-use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Query;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @internal
  */
 class SumBucketTest extends BaseAggregationTest
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @group functional
      */
@@ -65,40 +61,6 @@ class SumBucketTest extends BaseAggregationTest
         ];
 
         $this->assertEquals($expected, $aggregation->toArray());
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNoBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Not passing a 2nd argument to "Elastica\Aggregation\SumBucket::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new SumBucket('sum_bucket');
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyConstructWithNullBucketsPath(): void
-    {
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Passing null as 2nd argument to "Elastica\Aggregation\SumBucket::__construct()" is deprecated, pass a string instead. It will be removed in 8.0.');
-
-        new SumBucket('sum_bucket', null);
-    }
-
-    /**
-     * @group unit
-     * @group legacy
-     */
-    public function testLegacyToArrayWithNoBucketsPath(): void
-    {
-        $this->expectException(InvalidException::class);
-        $this->expectExceptionMessage('Buckets path is required');
-
-        (new SumBucket('sum_bucket'))->toArray();
     }
 
     private function getIndexForTest(): Index

--- a/tests/QueryBuilder/DSL/AggregationTest.php
+++ b/tests/QueryBuilder/DSL/AggregationTest.php
@@ -5,15 +5,12 @@ namespace Elastica\Test\QueryBuilder\DSL;
 use Elastica\Aggregation;
 use Elastica\Query\Exists;
 use Elastica\QueryBuilder\DSL;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @internal
  */
 class AggregationTest extends AbstractDSLTest
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @group unit
      */
@@ -66,7 +63,7 @@ class AggregationTest extends AbstractDSLTest
         $this->_assertImplemented($aggregationDSL, 'terms', Aggregation\Terms::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'top_hits', Aggregation\TopHits::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'value_count', Aggregation\ValueCount::class, ['name', 'field']);
-        $this->_assertImplemented($aggregationDSL, 'bucket_script', Aggregation\BucketScript::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'bucket_script', Aggregation\BucketScript::class, ['name', [], 'script']);
         $this->_assertImplemented($aggregationDSL, 'serial_diff', Aggregation\SerialDiff::class, ['name', 'buckets_path']);
         $this->_assertImplemented($aggregationDSL, 'adjacency_matrix', Aggregation\AdjacencyMatrix::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'sampler', Aggregation\Sampler::class, ['name']);


### PR DESCRIPTION
I would go a step further (in another PR) and remove setters or make them private for mandatory data passed in the constructor like `setBucketsPath()` or `setScript()`.

