### PR TITLE
Deprecate constructing BucketScript and BucketSelector with invalid data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Deprecated
+* Deprecated not passing a `buckets_path` and `script` when constructing `Elastica\Aggregation\BucketScript` and `Elastica\Aggregation\BucketSelector`
 ### Removed
 ### Fixed
 * Fix types order in `Elastica\Query` to work with psalm & expand the `aggs` type to include raw arrays

--- a/src/Aggregation/BucketScript.php
+++ b/src/Aggregation/BucketScript.php
@@ -19,10 +19,18 @@ class BucketScript extends AbstractAggregation implements GapPolicyInterface
 
         if (null !== $bucketsPath) {
             $this->setBucketsPath($bucketsPath);
+        } elseif (\func_num_args() >= 2) {
+            \trigger_deprecation('ruflin/elastica', '7.4.0', 'Passing null as 2nd argument to "%s()" is deprecated, pass an array instead. It will be mandatory in 8.0.', __METHOD__);
+        } else {
+            \trigger_deprecation('ruflin/elastica', '7.4.0', 'Not passing a 2nd argument to "%s()" is deprecated, pass an array instead. It will be mandatory in 8.0.', __METHOD__);
         }
 
         if (null !== $script) {
             $this->setScript($script);
+        } elseif (\func_num_args() >= 3) {
+            \trigger_deprecation('ruflin/elastica', '7.4.0', 'Passing null as 3rd argument to "%s()" is deprecated, pass a string instead. It will be mandatory in 8.0.', __METHOD__);
+        } else {
+            \trigger_deprecation('ruflin/elastica', '7.4.0', 'Not passing a 3rd argument to "%s()" is deprecated, pass a string instead. It will be mandatory in 8.0.', __METHOD__);
         }
     }
 

--- a/src/Aggregation/BucketSelector.php
+++ b/src/Aggregation/BucketSelector.php
@@ -17,10 +17,18 @@ class BucketSelector extends AbstractSimpleAggregation implements GapPolicyInter
 
         if (null !== $bucketsPath) {
             $this->setBucketsPath($bucketsPath);
+        } elseif (\func_num_args() >= 2) {
+            \trigger_deprecation('ruflin/elastica', '7.4.0', 'Passing null as 2nd argument to "%s()" is deprecated, pass an array instead. It will be mandatory in 8.0.', __METHOD__);
+        } else {
+            \trigger_deprecation('ruflin/elastica', '7.4.0', 'Not passing a 2nd argument to "%s()" is deprecated, pass an array instead. It will be mandatory in 8.0.', __METHOD__);
         }
 
         if (null !== $script) {
             $this->setScript($script);
+        } elseif (\func_num_args() >= 3) {
+            \trigger_deprecation('ruflin/elastica', '7.4.0', 'Passing null as 3rd argument to "%s()" is deprecated, pass a string instead. It will be mandatory in 8.0.', __METHOD__);
+        } else {
+            \trigger_deprecation('ruflin/elastica', '7.4.0', 'Not passing a 3rd argument to "%s()" is deprecated, pass a string instead. It will be mandatory in 8.0.', __METHOD__);
         }
     }
 

--- a/tests/Aggregation/BucketScriptTest.php
+++ b/tests/Aggregation/BucketScriptTest.php
@@ -49,6 +49,7 @@ class BucketScriptTest extends BaseAggregationTest
 
     /**
      * @group unit
+     * @group legacy
      */
     public function testConstructThroughSetters(): void
     {
@@ -83,6 +84,7 @@ class BucketScriptTest extends BaseAggregationTest
 
     /**
      * @group unit
+     * @group legacy
      */
     public function testToArrayInvalidBucketsPath(): void
     {
@@ -94,6 +96,7 @@ class BucketScriptTest extends BaseAggregationTest
 
     /**
      * @group unit
+     * @group legacy
      */
     public function testToArrayInvalidScript(): void
     {

--- a/tests/QueryBuilder/DSL/AggregationTest.php
+++ b/tests/QueryBuilder/DSL/AggregationTest.php
@@ -66,7 +66,7 @@ class AggregationTest extends AbstractDSLTest
         $this->_assertImplemented($aggregationDSL, 'terms', Aggregation\Terms::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'top_hits', Aggregation\TopHits::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'value_count', Aggregation\ValueCount::class, ['name', 'field']);
-        $this->_assertImplemented($aggregationDSL, 'bucket_script', Aggregation\BucketScript::class, ['name']);
+        $this->_assertImplemented($aggregationDSL, 'bucket_script', Aggregation\BucketScript::class, ['name', [], 'script']);
         $this->_assertImplemented($aggregationDSL, 'serial_diff', Aggregation\SerialDiff::class, ['name', 'buckets_path']);
         $this->_assertImplemented($aggregationDSL, 'adjacency_matrix', Aggregation\AdjacencyMatrix::class, ['name']);
         $this->_assertImplemented($aggregationDSL, 'sampler', Aggregation\Sampler::class, ['name']);


### PR DESCRIPTION
Reference: https://github.com/ruflin/Elastica/pull/2138#discussion_r1060332200

These parameters will be mandatory in 8.0