### PR TITLE
fix some types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `Elastica\Aggregation\SerialDiff`: The second argument (`string $bucketsPath`) is now mandatory
   * `Elastica\Aggregation\StatsBucket`: The second argument (`string $bucketsPath`) is now mandatory
   * `Elastica\Aggregation\SumBucket`: The second argument (`string $bucketsPath`) is now mandatory
-
+* Changed return type of `Elastica\Cluster\Health::getActiveShardsPercentAsNumber()` method to `float` [#2144](https://github.com/ruflin/Elastica/pull/2144)
+* Changed `$origin` and `$scale` parameter types of `Elastica\Query\FunctionScore::addDecayFunction()` to allow `float|int|string` [#2144](https://github.com/ruflin/Elastica/pull/2144)
+* Changed `$key` parameter type of `Elastica\Multi\Search::addSearch()` to allow `int|string|null` [#2144](https://github.com/ruflin/Elastica/pull/2144)
 ### Added
 * Added support for PHP 8.2 [#2136](https://github.com/ruflin/Elastica/pull/2136)
 ### Changed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,21 +136,6 @@ parameters:
 			path: tests/Multi/SearchTest.php
 
 		-
-			message: "#^Parameter \\#3 \\$origin of method Elastica\\\\Query\\\\FunctionScore\\:\\:addDecayFunction\\(\\) expects string, int given\\.$#"
-			count: 4
-			path: tests/Query/FunctionScoreTest.php
-
-		-
-			message: "#^Parameter \\#4 \\$scale of method Elastica\\\\Query\\\\FunctionScore\\:\\:addDecayFunction\\(\\) expects string, float given\\.$#"
-			count: 2
-			path: tests/Query/FunctionScoreTest.php
-
-		-
-			message: "#^Parameter \\#4 \\$scale of method Elastica\\\\Query\\\\FunctionScore\\:\\:addDecayFunction\\(\\) expects string, int given\\.$#"
-			count: 2
-			path: tests/Query/FunctionScoreTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$clauses of class Elastica\\\\Query\\\\SpanNear constructor expects array\\<Elastica\\\\Query\\\\AbstractSpanQuery\\>, array\\<int, Elastica\\\\Query\\\\Term\\> given\\.$#"
 			count: 1
 			path: tests/Query/SpanNearTest.php

--- a/src/Cluster/Health.php
+++ b/src/Cluster/Health.php
@@ -153,7 +153,7 @@ class Health
         return $this->_data['task_max_waiting_in_queue_millis'];
     }
 
-    public function getActiveShardsPercentAsNumber(): int
+    public function getActiveShardsPercentAsNumber(): float
     {
         return $this->_data['active_shards_percent_as_number'];
     }

--- a/src/Multi/Search.php
+++ b/src/Multi/Search.php
@@ -70,7 +70,7 @@ class Search
     /**
      * @return $this
      */
-    public function addSearch(BaseSearch $search, ?string $key = null): self
+    public function addSearch(BaseSearch $search, int|string|null $key = null): self
     {
         if ($key) {
             $this->_searches[$key] = $search;

--- a/src/Query/FunctionScore.php
+++ b/src/Query/FunctionScore.php
@@ -110,12 +110,10 @@ class FunctionScore extends AbstractQuery
     /**
      * Add a decay function to the query.
      *
-     * TODO: Change "$origin" and "$scale" parameter types to allow "float|int|string".
-     *
      * @param string             $function       see DECAY_* constants for valid options
      * @param string             $field          the document field on which to perform the decay function
-     * @param string             $origin         the origin value for this decay function
-     * @param string             $scale          a scale to define the rate of decay for this function
+     * @param float|int|string   $origin         the origin value for this decay function
+     * @param float|int|string   $scale          a scale to define the rate of decay for this function
      * @param string|null        $offset         If defined, this function will only be computed for documents with a distance from the origin greater than this value
      * @param float|null         $decay          optionally defines how documents are scored at the distance given by the $scale parameter
      * @param float|null         $weight         optional factor by which to multiply the score at the value provided by the $scale parameter
@@ -127,8 +125,8 @@ class FunctionScore extends AbstractQuery
     public function addDecayFunction(
         string $function,
         string $field,
-        string $origin,
-        string $scale,
+        float|int|string $origin,
+        float|int|string $scale,
         ?string $offset = null,
         ?float $decay = null,
         ?float $weight = null,

--- a/tests/Cluster/HealthTest.php
+++ b/tests/Cluster/HealthTest.php
@@ -180,7 +180,7 @@ class HealthTest extends BaseTest
      */
     public function testActiveShardsPercentAsNumber(): void
     {
-        $this->assertEquals(50, $this->_health->getActiveShardsPercentAsNumber());
+        $this->assertEquals(50.0, $this->_health->getActiveShardsPercentAsNumber());
     }
 
     /**

--- a/tests/QueryBuilder/DSL/QueryTest.php
+++ b/tests/QueryBuilder/DSL/QueryTest.php
@@ -60,7 +60,7 @@ class QueryTest extends AbstractDSLTest
         $this->_assertImplemented($queryDSL, 'more_like_this', Query\MoreLikeThis::class, []);
         $this->_assertImplemented($queryDSL, 'multi_match', Query\MultiMatch::class, []);
         $this->_assertImplemented($queryDSL, 'nested', Query\Nested::class, []);
-        $this->_assertImplemented($queryDSL, 'parent_id', Query\ParentId::class, ['test', 1]);
+        $this->_assertImplemented($queryDSL, 'parent_id', Query\ParentId::class, ['test', '1']);
         $this->_assertImplemented($queryDSL, 'prefix', Query\Prefix::class, []);
         $this->_assertImplemented($queryDSL, 'query_string', Query\QueryString::class, []);
         $this->_assertImplemented($queryDSL, 'range', Query\Range::class, ['field', []]);


### PR DESCRIPTION
I was trying to use strict types and some issues appeared:

- `active_shards_percent_as_number` returns a `float` according to https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html#cluster-health-api-response-body
- `Elastica\Multi\Search:: addSearch()` `$key` parameter could be an `int` if no key is specified when calling `addSearches` or `setSearches`.