### PR TITLE
Remove deprecated index creation options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed return type of `Elastica\Cluster\Health::getActiveShardsPercentAsNumber()` method to `float` [#2144](https://github.com/ruflin/Elastica/pull/2144)
 * Changed `$origin` and `$scale` parameter types of `Elastica\Query\FunctionScore::addDecayFunction()` to allow `float|int|string` [#2144](https://github.com/ruflin/Elastica/pull/2144)
 * Changed `$key` parameter type of `Elastica\Multi\Search::addSearch()` to allow `int|string|null` [#2144](https://github.com/ruflin/Elastica/pull/2144)
+* Changed `$options` parameter type of `Elastica\Index::create()` to only allow `array<string, mixed>` [#2147](https://github.com/ruflin/Elastica/pull/2147)
 ### Added
 * Added support for PHP 8.2 [#2136](https://github.com/ruflin/Elastica/pull/2136)
 ### Changed

--- a/src/Index.php
+++ b/src/Index.php
@@ -399,30 +399,16 @@ class Index implements SearchableInterface
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
      *
-     * @param array      $args    Additional arguments to pass to the Create endpoint
-     * @param array|bool $options OPTIONAL
-     *                            bool=> Deletes index first if already exists (default = false).
-     *                            array => Associative array of options (option=>value)
+     * @param array $args    Additional arguments to pass to the Create endpoint
+     * @param array $options Associative array of options (option=>value)
      *
      * @throws InvalidException
      * @throws ResponseException
      *
      * @return Response Server response
      */
-    public function create(array $args = [], $options = null): Response
+    public function create(array $args = [], array $options = []): Response
     {
-        if (null === $options) {
-            if (\func_num_args() >= 2) {
-                \trigger_deprecation('ruflin/elastica', '7.1.0', 'Passing null as 2nd argument to "%s()" is deprecated, avoid passing this argument or pass an array instead. It will be removed in 8.0.', __METHOD__);
-            }
-            $options = [];
-        } elseif (\is_bool($options)) {
-            \trigger_deprecation('ruflin/elastica', '7.1.0', 'Passing a bool as 2nd argument to "%s()" is deprecated, pass an array with the key "recreate" instead. It will be removed in 8.0.', __METHOD__);
-            $options = ['recreate' => $options];
-        } elseif (!\is_array($options)) {
-            throw new \TypeError(\sprintf('Argument 2 passed to "%s()" must be of type array|bool|null, %s given.', __METHOD__, \is_object($options) ? \get_class($options) : \gettype($options)));
-        }
-
         $endpoint = new Create();
         $invalidOptions = \array_diff(\array_keys($options), $allowedOptions = \array_merge($endpoint->getParamWhitelist(), [
             'recreate',

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -728,27 +728,6 @@ class IndexTest extends BaseTest
     }
 
     /**
-     * @group functional
-     * @group legacy
-     */
-    public function testLegacyCreate(): void
-    {
-        $client = $this->_getClient();
-        $indexName = 'test';
-        $index = $client->getIndex($indexName);
-
-        $this->expectDeprecation('Since ruflin/elastica 7.1.0: Passing null as 2nd argument to "Elastica\Index::create()" is deprecated, avoid passing this argument or pass an array instead. It will be removed in 8.0.');
-        $index->create([], null);
-        $status = new Status($client);
-        $this->assertTrue($status->indexExists($indexName));
-
-        $this->expectDeprecation('Since ruflin/elastica 7.1.0: Passing a bool as 2nd argument to "Elastica\Index::create()" is deprecated, pass an array with the key "recreate" instead. It will be removed in 8.0.');
-        $index->create([], true);
-        $status = new Status($client);
-        $this->assertTrue($status->indexExists($indexName));
-    }
-
-    /**
      * @group unit
      */
     public function testCreateWithInvalidOption(): void

--- a/tests/Transport/TransportBenchmarkTest.php
+++ b/tests/Transport/TransportBenchmarkTest.php
@@ -173,7 +173,7 @@ class TransportBenchmarkTest extends BaseTest
     {
         $client = $this->_getClient($config);
         $index = $client->getIndex('benchmark'.self::buildUniqueId());
-        $index->create(['index' => ['number_of_shards' => 1, 'number_of_replicas' => 0]], true);
+        $index->create(['index' => ['number_of_shards' => 1, 'number_of_replicas' => 0]], ['recreate' => true]);
 
         return $index;
     }


### PR DESCRIPTION
Replaces https://github.com/ruflin/Elastica/pull/2134

Using the work done in https://github.com/ruflin/Elastica/pull/2134 and fixed issues found by phpstan