### PR TITLE
Remove deprecations passing $options as int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `$origin` and `$scale` parameter types of `Elastica\Query\FunctionScore::addDecayFunction()` to allow `float|int|string` [#2144](https://github.com/ruflin/Elastica/pull/2144)
 * Changed `$key` parameter type of `Elastica\Multi\Search::addSearch()` to allow `int|string|null` [#2144](https://github.com/ruflin/Elastica/pull/2144)
 * Changed `$options` parameter type of `Elastica\Index::create()` to only allow `array<string, mixed>` [#2147](https://github.com/ruflin/Elastica/pull/2147)
+* Changed `$options` argument to not accept `int` in the following methods [#2148](https://github.com/ruflin/Elastica/pull/2148)
+  * `Elastica\SearchableInterface::search()`
+  * `Elastica\SearchableInterface::createSearch()`
+  * `Elastica\Search::search()`
+  * `Elastica\Search::createSearch()`
+  * `Elastica\Search::setOptionsAndQuery()`
+  * `Elastica\Index::search()`
+  * `Elastica\Index::createSearch()`
 ### Added
 * Added support for PHP 8.2 [#2136](https://github.com/ruflin/Elastica/pull/2136)
 ### Changed

--- a/src/Index.php
+++ b/src/Index.php
@@ -451,7 +451,7 @@ class Index implements SearchableInterface
     /**
      * {@inheritdoc}
      */
-    public function createSearch($query = '', $options = null, ?BuilderInterface $builder = null): Search
+    public function createSearch($query = '', ?array $options = null, ?BuilderInterface $builder = null): Search
     {
         $search = new Search($this->getClient(), $builder);
         $search->addIndex($this);
@@ -463,7 +463,7 @@ class Index implements SearchableInterface
     /**
      * {@inheritdoc}
      */
-    public function search($query = '', $options = null, string $method = Request::POST): ResultSet
+    public function search($query = '', ?array $options = null, string $method = Request::POST): ResultSet
     {
         $search = $this->createSearch($query, $options);
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -326,12 +326,12 @@ class Search
      *
      * @phpstan-param TCreateQueryArgs $query
      *
-     * @param array|int $options Limit or associative array of options (option=>value)
+     * @param array<string, mixed>|null $options associative array of options (option=>value)
      *
      * @throws InvalidException
      * @throws ResponseException
      */
-    public function search($query = '', $options = null, string $method = Request::POST): ResultSet
+    public function search($query = '', ?array $options = null, string $method = Request::POST): ResultSet
     {
         $this->setOptionsAndQuery($options, $query);
 
@@ -382,29 +382,28 @@ class Search
     }
 
     /**
-     * @param array|int                                                              $options
+     * @param array<string, mixed>|null                                              $options
      * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest|null $query
      *
      * @phpstan-param TCreateQueryArgs $query
      */
-    public function setOptionsAndQuery($options = null, $query = ''): self
+    public function setOptionsAndQuery(?array $options = null, $query = ''): self
     {
         if ('' !== $query) {
             $this->setQuery($query);
         }
 
-        if (\is_int($options)) {
-            \trigger_deprecation('ruflin/elastica', '7.1.3', 'Passing an int as 1st argument to "%s()" is deprecated, pass an array with the key "size" instead. It will be removed in 8.0.', __METHOD__);
-            $this->getQuery()->setSize($options);
-        } elseif (\is_array($options)) {
+        if (null !== $options) {
             if (isset($options['limit'])) {
                 $this->getQuery()->setSize($options['limit']);
                 unset($options['limit']);
             }
+
             if (isset($options['explain'])) {
                 $this->getQuery()->setExplain($options['explain']);
                 unset($options['explain']);
             }
+
             $this->setOptions($options);
         }
 

--- a/src/SearchableInterface.php
+++ b/src/SearchableInterface.php
@@ -35,10 +35,10 @@ interface SearchableInterface
      *
      * @phpstan-param TCreateQueryArgs $query
      *
-     * @param array|int|null $options Limit or associative array of options (option=>value)
-     * @param string         $method  Request method, see Request's constants
+     * @param array<string, mixed>|null $options associative array of options (option=>value)
+     * @param string                    $method  Request method, see Request's constants
      */
-    public function search($query = '', $options = null, string $method = Request::POST): ResultSet;
+    public function search($query = '', ?array $options = null, string $method = Request::POST): ResultSet;
 
     /**
      * Counts results for a query.
@@ -60,7 +60,7 @@ interface SearchableInterface
      *
      * @phpstan-param TCreateQueryArgs $query
      *
-     * @param array|int|null $options
+     * @param array<string, mixed>|null $options
      */
-    public function createSearch($query = '', $options = null): Search;
+    public function createSearch($query = '', ?array $options = null): Search;
 }

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -744,20 +744,6 @@ class IndexTest extends BaseTest
 
     /**
      * @group unit
-     * @group legacy
-     */
-    public function testLegacyCreateSearch(): void
-    {
-        $client = $this->createMock(Client::class);
-        $index = new Index($client, 'test');
-        $query = new QueryString('test');
-
-        $this->expectDeprecation('Since ruflin/elastica 7.1.3: Passing an int as 1st argument to "Elastica\Search::setOptionsAndQuery()" is deprecated, pass an array with the key "size" instead. It will be removed in 8.0.');
-        $index->createSearch($query, 5);
-    }
-
-    /**
-     * @group unit
      */
     public function testCreateSearch(): void
     {

--- a/tests/QueryBuilder/DSL/QueryTest.php
+++ b/tests/QueryBuilder/DSL/QueryTest.php
@@ -39,7 +39,6 @@ class QueryTest extends AbstractDSLTest
 
     /**
      * @group unit
-     * @group legacy
      */
     public function testInterface(): void
     {


### PR DESCRIPTION
The deprecation was only in `Search::setOptionsAndQuery()` method, but it affected the other ones.