### PR TITLE
Add missing @throws annotation to Client::request and related methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Added support for PHP 8.2 [#2136](https://github.com/ruflin/Elastica/pull/2136)
+* Added missing `@throws` annotations [#2152](https://github.com/ruflin/Elastica/pull/2152)
 ### Changed
 * Updated `php-cs-fixer` to `3.13.2` [#2143](https://github.com/ruflin/Elastica/pull/2143)
 * Modernize code using `match` expression [#2141](https://github.com/ruflin/Elastica/pull/2141)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Added support for PHP 8.2 [#2136](https://github.com/ruflin/Elastica/pull/2136)
-* Added missing `@throws` annotations [#2152](https://github.com/ruflin/Elastica/pull/2152)
+* Added missing `@throws` annotations to Client::request and related methods [#2152](https://github.com/ruflin/Elastica/pull/2152)
 ### Changed
 * Updated `php-cs-fixer` to `3.13.2` [#2143](https://github.com/ruflin/Elastica/pull/2143)
 * Modernize code using `match` expression [#2141](https://github.com/ruflin/Elastica/pull/2141)

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -10,8 +10,8 @@ use Elastica\Exception\Bulk\ResponseException as BulkResponseException;
 use Elastica\Exception\ClientException;
 use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
-use Elastica\Exception\ResponseException;
 use Elastica\Exception\RequestEntityTooLargeException;
+use Elastica\Exception\ResponseException;
 use Elastica\Script\AbstractScript;
 
 class Bulk

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -6,9 +6,11 @@ use Elastica\Bulk\Action;
 use Elastica\Bulk\Action\AbstractDocument as AbstractDocumentAction;
 use Elastica\Bulk\Response as BulkResponse;
 use Elastica\Bulk\ResponseSet;
-use Elastica\Exception\Bulk\ResponseException;
 use Elastica\Exception\Bulk\ResponseException as BulkResponseException;
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\ResponseException;
 use Elastica\Exception\RequestEntityTooLargeException;
 use Elastica\Script\AbstractScript;
 
@@ -274,6 +276,11 @@ class Bulk
         return $data;
     }
 
+    /**
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
+     */
     public function send(): ResponseSet
     {
         $response = $this->_client->request($this->getPath(), Request::POST, (string) $this, $this->_requestParams, Request::NDJSON_CONTENT_TYPE);
@@ -282,7 +289,7 @@ class Bulk
     }
 
     /**
-     * @throws ResponseException
+     * @throws BulkResponseException
      * @throws InvalidException
      */
     protected function _processResponse(Response $response): ResponseSet

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -280,6 +280,8 @@ class Bulk
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     * @throws BulkResponseException
+     * @throws InvalidException
      */
     public function send(): ResponseSet
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ namespace Elastica;
 
 use Elastica\Bulk\Action;
 use Elastica\Bulk\ResponseSet;
+use Elastica\Exception\Bulk\ResponseException as BulkResponseException;
 use Elastica\Exception\ClientException;
 use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
@@ -208,6 +209,10 @@ class Client
      * @param array|Document[] $docs Array of Elastica\Document
      *
      * @throws InvalidException If docs is empty
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
+     * @throws BulkResponseException
      */
     public function updateDocuments(array $docs, array $requestParams = []): ResponseSet
     {
@@ -237,6 +242,10 @@ class Client
      * @param array|Document[] $docs Array of Elastica\Document
      *
      * @throws InvalidException If docs is empty
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
+     * @throws BulkResponseException
      */
     public function addDocuments(array $docs, array $requestParams = []): ResponseSet
     {
@@ -329,6 +338,10 @@ class Client
      * @param array|Document[] $docs
      *
      * @throws InvalidException
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
+     * @throws BulkResponseException
      */
     public function deleteDocuments(array $docs, array $requestParams = []): ResponseSet
     {
@@ -442,6 +455,10 @@ class Client
      * @param bool|string  $routing Optional routing key for all ids
      *
      * @throws InvalidException
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
+     * @throws BulkResponseException
      */
     public function deleteIds(array $ids, $index, $routing = false): ResponseSet
     {
@@ -486,6 +503,9 @@ class Client
      *
      * @throws ResponseException
      * @throws InvalidException
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws BulkResponseException
      */
     public function bulk(array $params): ResponseSet
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -86,6 +86,10 @@ class Client
 
     /**
      * Get current version.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function getVersion(): string
     {
@@ -260,6 +264,10 @@ class Client
      * @param array                         $options array of query params to use for query. For possible options check es api
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function updateDocument($id, $data, $index, array $options = []): Response
     {
@@ -542,6 +550,10 @@ class Client
 
     /**
      * Makes calls to the elasticsearch server with usage official client Endpoint.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function requestEndpoint(AbstractEndpoint $endpoint): Response
     {
@@ -559,6 +571,10 @@ class Client
      * @param array $args OPTIONAL Optional arguments
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function forcemergeAll($args = []): Response
     {
@@ -572,6 +588,10 @@ class Client
      * Closes the given PointInTime.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html#close-point-in-time-api
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function closePointInTime(string $pointInTimeId): Response
     {
@@ -585,6 +605,10 @@ class Client
      * Refreshes all search indices.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function refreshAll(): Response
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -208,7 +208,7 @@ class Client
      *
      * @param array|Document[] $docs Array of Elastica\Document
      *
-     * @throws InvalidException If docs is empty
+     * @throws InvalidException      If docs is empty
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
@@ -241,7 +241,7 @@ class Client
      *
      * @param array|Document[] $docs Array of Elastica\Document
      *
-     * @throws InvalidException If docs is empty
+     * @throws InvalidException      If docs is empty
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -4,6 +4,9 @@ namespace Elastica;
 
 use Elastica\Cluster\Health;
 use Elastica\Cluster\Settings;
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
+use Elastica\Exception\ResponseException;
 use Elasticsearch\Endpoints\Cluster\State;
 
 /**
@@ -47,6 +50,10 @@ class Cluster
 
     /**
      * Refreshes all cluster information (state).
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function refresh(): void
     {

--- a/src/Cluster/Health.php
+++ b/src/Cluster/Health.php
@@ -4,6 +4,9 @@ namespace Elastica\Cluster;
 
 use Elastica\Client;
 use Elastica\Cluster\Health\Index;
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
+use Elastica\Exception\ResponseException;
 
 /**
  * Elastic cluster health.
@@ -175,6 +178,10 @@ class Health
 
     /**
      * Retrieves the health data from the cluster.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     protected function _retrieveHealthData(): array
     {

--- a/src/Index.php
+++ b/src/Index.php
@@ -3,6 +3,8 @@
 namespace Elastica;
 
 use Elastica\Bulk\ResponseSet;
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
 use Elastica\Exception\NotFoundException;
 use Elastica\Exception\ResponseException;
@@ -111,6 +113,10 @@ class Index implements SearchableInterface
 
     /**
      * Gets all mappings for the current index.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function getMapping(): array
     {
@@ -174,6 +180,10 @@ class Index implements SearchableInterface
      * @param array          $options Optional params
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function updateByQuery($query, AbstractScript $script, array $options = []): Response
     {
@@ -192,6 +202,10 @@ class Index implements SearchableInterface
 
     /**
      * Adds the given document to the search index.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function addDocument(Document $doc): Response
     {
@@ -260,8 +274,10 @@ class Index implements SearchableInterface
      * @param int|string $id      Document id
      * @param array      $options options for the get request
      *
-     * @throws ResponseException
      * @throws NotFoundException
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function getDocument($id, array $options = []): Document
     {
@@ -294,6 +310,10 @@ class Index implements SearchableInterface
      * Deletes a document by its unique identifier.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function deleteById(string $id, array $options = []): Response
     {
@@ -318,6 +338,10 @@ class Index implements SearchableInterface
      * @param array $options Optional params
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function deleteByQuery($query, array $options = []): Response
     {
@@ -334,6 +358,10 @@ class Index implements SearchableInterface
      * Opens a Point-in-Time on the index.
      *
      * @see: https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function openPointInTime(string $keepAlive): Response
     {
@@ -345,6 +373,10 @@ class Index implements SearchableInterface
 
     /**
      * Deletes the index.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function delete(): Response
     {
@@ -375,6 +407,10 @@ class Index implements SearchableInterface
      * @param array $args Additional arguments
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function forcemerge($args = []): Response
     {
@@ -388,6 +424,10 @@ class Index implements SearchableInterface
      * Refreshes the index.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function refresh(): Response
     {
@@ -403,6 +443,8 @@ class Index implements SearchableInterface
      * @param array $options Associative array of options (option=>value)
      *
      * @throws InvalidException
+     * @throws ClientException
+     * @throws ConnectionException
      * @throws ResponseException
      *
      * @return Response Server response
@@ -440,6 +482,10 @@ class Index implements SearchableInterface
 
     /**
      * Checks if the given index exists ans is created.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function exists(): bool
     {
@@ -484,6 +530,10 @@ class Index implements SearchableInterface
      * Opens an index.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function open(): Response
     {
@@ -494,6 +544,10 @@ class Index implements SearchableInterface
      * Closes the index.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function close(): Response
     {
@@ -522,6 +576,10 @@ class Index implements SearchableInterface
      * @param bool $replace If set, an existing alias will be replaced
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function addAlias(string $name, bool $replace = false): Response
     {
@@ -547,6 +605,10 @@ class Index implements SearchableInterface
      * Removes an alias pointing to the current index.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function removeAlias(string $name): Response
     {
@@ -561,6 +623,10 @@ class Index implements SearchableInterface
      * Returns all index aliases.
      *
      * @return string[]
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function getAliases(): array
     {
@@ -594,6 +660,10 @@ class Index implements SearchableInterface
      * Clears the cache of an index.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clearcache.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function clearCache(): Response
     {
@@ -608,6 +678,10 @@ class Index implements SearchableInterface
      * Flushes the index to storage.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function flush(array $options = []): Response
     {
@@ -623,6 +697,10 @@ class Index implements SearchableInterface
      * @param array $data Data array
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function setSettings(array $data): Response
     {
@@ -639,6 +717,10 @@ class Index implements SearchableInterface
      * @param string       $path   Path to call
      * @param string       $method Rest method to use (GET, POST, DELETE, PUT)
      * @param array|string $data   Arguments as array or encoded string
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function request(string $path, string $method, $data = [], array $queryParameters = []): Response
     {
@@ -649,6 +731,10 @@ class Index implements SearchableInterface
 
     /**
      * Makes calls to the elasticsearch server with usage official client Endpoint based on this index.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function requestEndpoint(AbstractEndpoint $endpoint): Response
     {
@@ -665,6 +751,10 @@ class Index implements SearchableInterface
      * @param array $args Additional arguments
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function analyze(array $body, $args = []): array
     {

--- a/src/Index.php
+++ b/src/Index.php
@@ -622,11 +622,11 @@ class Index implements SearchableInterface
     /**
      * Returns all index aliases.
      *
-     * @return string[]
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return string[]
      */
     public function getAliases(): array
     {

--- a/src/Index.php
+++ b/src/Index.php
@@ -3,6 +3,7 @@
 namespace Elastica;
 
 use Elastica\Bulk\ResponseSet;
+use Elastica\Exception\Bulk\ResponseException as BulkResponseException;
 use Elastica\Exception\ClientException;
 use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
@@ -158,6 +159,12 @@ class Index implements SearchableInterface
      * @param Document[] $docs    Array of Elastica\Document
      * @param array      $options Array of query params to use for query. For possible options check es api
      *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
+     * @throws BulkResponseException
+     * @throws InvalidException
+     *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
     public function updateDocuments(array $docs, array $options = []): ResponseSet
@@ -256,6 +263,12 @@ class Index implements SearchableInterface
      * @param array            $options Array of query params to use for query. For possible options check es api
      *
      * @return ResponseSet
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
+     * @throws BulkResponseException
+     * @throws InvalidException
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */
@@ -387,6 +400,12 @@ class Index implements SearchableInterface
      * Uses the "_bulk" endpoint to delete documents from the server.
      *
      * @param Document[] $docs Array of documents
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
+     * @throws BulkResponseException
+     * @throws InvalidException
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */

--- a/src/Index.php
+++ b/src/Index.php
@@ -262,13 +262,13 @@ class Index implements SearchableInterface
      * @param array|Document[] $docs    Array of Elastica\Document
      * @param array            $options Array of query params to use for query. For possible options check es api
      *
-     * @return ResponseSet
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
      * @throws BulkResponseException
      * @throws InvalidException
+     *
+     * @return ResponseSet
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
      */

--- a/src/Index/Settings.php
+++ b/src/Index/Settings.php
@@ -2,6 +2,8 @@
 
 namespace Elastica\Index;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\NotFoundException;
 use Elastica\Exception\ResponseException;
 use Elastica\Index as BaseIndex;
@@ -70,6 +72,10 @@ class Settings
      * @return array|int|string|null Settings data
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function get(string $setting = '', bool $includeDefaults = false)
     {
@@ -303,6 +309,10 @@ class Settings
      * @param array $data Arguments
      *
      * @return Response Response object
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function set(array $data): Response
     {
@@ -336,6 +346,10 @@ class Settings
      * @param string $method OPTIONAL Transfer method (default = \Elastica\Request::GET)
      *
      * @return Response Response object
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function request(array $data = [], string $method = Request::GET, array $queryParameters = []): Response
     {

--- a/src/Index/Settings.php
+++ b/src/Index/Settings.php
@@ -69,13 +69,13 @@ class Settings
      *
      * @param string $setting OPTIONAL Setting name to return
      *
-     * @return array|int|string|null Settings data
-     *
-     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return array|int|string|null Settings data
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
      */
     public function get(string $setting = '', bool $includeDefaults = false)
     {
@@ -308,11 +308,11 @@ class Settings
      *
      * @param array $data Arguments
      *
-     * @return Response Response object
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response Response object
      */
     public function set(array $data): Response
     {
@@ -345,11 +345,11 @@ class Settings
      * @param array  $data   OPTIONAL Data array
      * @param string $method OPTIONAL Transfer method (default = \Elastica\Request::GET)
      *
-     * @return Response Response object
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response Response object
      */
     public function request(array $data = [], string $method = Request::GET, array $queryParameters = []): Response
     {

--- a/src/IndexTemplate.php
+++ b/src/IndexTemplate.php
@@ -2,7 +2,10 @@
 
 namespace Elastica;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\ResponseException;
 
 /**
  * Elastica index template object.
@@ -46,6 +49,10 @@ class IndexTemplate
      * Deletes the index template.
      *
      * @return Response
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function delete()
     {
@@ -60,6 +67,10 @@ class IndexTemplate
      * @param array $args OPTIONAL Arguments to use
      *
      * @return Response
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function create(array $args = [])
     {
@@ -70,6 +81,10 @@ class IndexTemplate
      * Checks if the given index template is already created.
      *
      * @return bool
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function exists()
     {
@@ -105,6 +120,10 @@ class IndexTemplate
      * @param array  $data   OPTIONAL Arguments as array
      *
      * @return Response
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function request($method, $data = [])
     {

--- a/src/IndexTemplate.php
+++ b/src/IndexTemplate.php
@@ -48,11 +48,11 @@ class IndexTemplate
     /**
      * Deletes the index template.
      *
-     * @return Response
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response
      */
     public function delete()
     {
@@ -66,11 +66,11 @@ class IndexTemplate
      *
      * @param array $args OPTIONAL Arguments to use
      *
-     * @return Response
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response
      */
     public function create(array $args = [])
     {
@@ -80,11 +80,11 @@ class IndexTemplate
     /**
      * Checks if the given index template is already created.
      *
-     * @return bool
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return bool
      */
     public function exists()
     {
@@ -119,11 +119,11 @@ class IndexTemplate
      * @param string $method Rest method to use (GET, POST, DELETE, PUT)
      * @param array  $data   OPTIONAL Arguments as array
      *
-     * @return Response
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response
      */
     public function request($method, $data = [])
     {

--- a/src/Node/Info.php
+++ b/src/Node/Info.php
@@ -207,11 +207,11 @@ class Info
      *
      * @param array $params Params to return (default none). Possible options: settings, os, process, jvm, thread_pool, network, transport, http, plugin
      *
-     * @return Response Response object
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response Response object
      */
     public function refresh(array $params = []): Response
     {

--- a/src/Node/Info.php
+++ b/src/Node/Info.php
@@ -2,6 +2,9 @@
 
 namespace Elastica\Node;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
+use Elastica\Exception\ResponseException;
 use Elastica\Node as BaseNode;
 use Elastica\Response;
 use Elasticsearch\Endpoints\Nodes\Info as NodesInfo;
@@ -205,6 +208,10 @@ class Info
      * @param array $params Params to return (default none). Possible options: settings, os, process, jvm, thread_pool, network, transport, http, plugin
      *
      * @return Response Response object
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function refresh(array $params = []): Response
     {

--- a/src/Node/Stats.php
+++ b/src/Node/Stats.php
@@ -2,6 +2,9 @@
 
 namespace Elastica\Node;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
+use Elastica\Exception\ResponseException;
 use Elastica\Node as BaseNode;
 use Elastica\Response;
 use Elasticsearch\Endpoints\Nodes\Stats as NodesStats;
@@ -104,6 +107,10 @@ class Stats
      * Reloads all nodes information. Has to be called if informations changed.
      *
      * @return Response Response object
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function refresh(): Response
     {

--- a/src/Node/Stats.php
+++ b/src/Node/Stats.php
@@ -106,11 +106,11 @@ class Stats
     /**
      * Reloads all nodes information. Has to be called if informations changed.
      *
-     * @return Response Response object
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response Response object
      */
     public function refresh(): Response
     {

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -2,7 +2,10 @@
 
 namespace Elastica;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\ResponseException;
 use Elastica\Processor\AbstractProcessor;
 use Elasticsearch\Endpoints\AbstractEndpoint;
 use Elasticsearch\Endpoints\Ingest\DeletePipeline;
@@ -172,6 +175,10 @@ class Pipeline extends Param
 
     /**
      * Makes calls to the elasticsearch server with usage official client Endpoint based on this index.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function requestEndpoint(AbstractEndpoint $endpoint): Response
     {

--- a/src/Reindex.php
+++ b/src/Reindex.php
@@ -2,6 +2,9 @@
 
 namespace Elastica;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
+use Elastica\Exception\ResponseException;
 use Elastica\Query\AbstractQuery;
 use Elastica\Script\AbstractScript;
 use Elastica\Script\Script;
@@ -63,6 +66,11 @@ class Reindex extends Param
         $this->setParams($params);
     }
 
+    /**
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
+     */
     public function run(): Response
     {
         $body = $this->_getBody($this->_oldIndex, $this->_newIndex, $this->getParams());

--- a/src/Scroll.php
+++ b/src/Scroll.php
@@ -2,7 +2,10 @@
 
 namespace Elastica;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\ResponseException;
 
 /**
  * Scroll Iterator.
@@ -69,6 +72,10 @@ class Scroll implements \Iterator
      * Next scroll search.
      *
      * @see http://php.net/manual/en/iterator.next.php
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function next(): void
     {
@@ -112,6 +119,10 @@ class Scroll implements \Iterator
      * Initial scroll search.
      *
      * @see http://php.net/manual/en/iterator.rewind.php
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function rewind(): void
     {
@@ -132,6 +143,10 @@ class Scroll implements \Iterator
 
     /**
      * Cleares the search context on ES and marks this Scroll instance as finished.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function clear(): void
     {
@@ -149,6 +164,10 @@ class Scroll implements \Iterator
 
     /**
      * Prepares Scroll for next request.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     protected function _setScrollId(ResultSet $resultSet): void
     {

--- a/src/Search.php
+++ b/src/Search.php
@@ -2,6 +2,8 @@
 
 namespace Elastica;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\InvalidException;
 use Elastica\Exception\ResponseException;
 use Elastica\Query\AbstractQuery;
@@ -281,6 +283,8 @@ class Search
      * @param array<string, mixed>|null $options associative array of options (option=>value)
      *
      * @throws InvalidException
+     * @throws ClientException
+     * @throws ConnectionException
      * @throws ResponseException
      */
     public function search($query = '', ?array $options = null, string $method = Request::POST): ResultSet
@@ -310,6 +314,10 @@ class Search
      * @param bool                                   $fullResult By default only the total hit count is returned. If set to true, the full ResultSet including aggregations is returned
      *
      * @return int|ResultSet
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function count($query = '', bool $fullResult = false, string $method = Request::POST)
     {

--- a/src/Search.php
+++ b/src/Search.php
@@ -313,11 +313,11 @@ class Search
      * @param array|Query|Query\AbstractQuery|string $query
      * @param bool                                   $fullResult By default only the total hit count is returned. If set to true, the full ResultSet including aggregations is returned
      *
-     * @return int|ResultSet
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return int|ResultSet
      */
     public function count($query = '', bool $fullResult = false, string $method = Request::POST)
     {

--- a/src/SearchableInterface.php
+++ b/src/SearchableInterface.php
@@ -2,6 +2,10 @@
 
 namespace Elastica;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
+use Elastica\Exception\InvalidException;
+use Elastica\Exception\ResponseException;
 use Elastica\Query\AbstractQuery;
 use Elastica\Suggest\AbstractSuggest;
 
@@ -37,6 +41,11 @@ interface SearchableInterface
      *
      * @param array<string, mixed>|null $options associative array of options (option=>value)
      * @param string                    $method  Request method, see Request's constants
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws InvalidException
+     * @throws ResponseException
      */
     public function search($query = '', ?array $options = null, string $method = Request::POST): ResultSet;
 
@@ -52,6 +61,10 @@ interface SearchableInterface
      * @param string $method Request method, see Request's constants
      *
      * @return int number of documents matching the query
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function count($query = '', string $method = Request::POST);
 

--- a/src/SearchableInterface.php
+++ b/src/SearchableInterface.php
@@ -60,11 +60,11 @@ interface SearchableInterface
      *
      * @param string $method Request method, see Request's constants
      *
-     * @return int number of documents matching the query
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return int number of documents matching the query
      */
     public function count($query = '', string $method = Request::POST);
 

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -2,6 +2,8 @@
 
 namespace Elastica;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\NotFoundException;
 use Elastica\Exception\ResponseException;
 use Elasticsearch\Endpoints\Snapshot\Restore;
@@ -31,6 +33,10 @@ class Snapshot
      * @param array  $settings Additional repository settings. If type "fs" is used, the "location" setting must be provided.
      *
      * @return Response
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function registerRepository($name, $type, $settings = [])
     {
@@ -47,10 +53,12 @@ class Snapshot
      *
      * @param string $name the name of the desired repository
      *
-     * @throws Exception\ResponseException
-     * @throws Exception\NotFoundException
-     *
      * @return array
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws NotFoundException
+     * @throws ResponseException
      */
     public function getRepository($name)
     {
@@ -71,6 +79,10 @@ class Snapshot
      * Retrieve all repository records.
      *
      * @return array
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function getAllRepositories()
     {
@@ -86,6 +98,10 @@ class Snapshot
      * @param bool   $waitForCompletion if true, the request will not return until the snapshot operation is complete
      *
      * @return Response
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function createSnapshot($repository, $name, $options = [], $waitForCompletion = false)
     {
@@ -98,10 +114,12 @@ class Snapshot
      * @param string $repository the name of the repository from which to retrieve the snapshot
      * @param string $name       the name of the desired snapshot
      *
-     * @throws Exception\ResponseException
-     * @throws Exception\NotFoundException
-     *
      * @return array
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws NotFoundException
+     * @throws ResponseException
      */
     public function getSnapshot($repository, $name)
     {
@@ -124,6 +142,10 @@ class Snapshot
      * @param string $repository the repository name
      *
      * @return array
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function getAllSnapshots($repository)
     {
@@ -137,6 +159,10 @@ class Snapshot
      * @param string $name       the name of the snapshot to be deleted
      *
      * @return Response
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function deleteSnapshot($repository, $name)
     {
@@ -152,6 +178,10 @@ class Snapshot
      * @param bool   $waitForCompletion if true, the request will not return until the restore operation is complete
      *
      * @return Response
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function restoreSnapshot($repository, $name, $options = [], $waitForCompletion = false)
     {
@@ -176,6 +206,10 @@ class Snapshot
      * @param array  $query  query string parameters
      *
      * @return Response
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function request($path, $method = Request::GET, $data = [], array $query = [])
     {

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -32,11 +32,11 @@ class Snapshot
      * @param string $type     the repository type ("fs" for file system)
      * @param array  $settings Additional repository settings. If type "fs" is used, the "location" setting must be provided.
      *
-     * @return Response
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response
      */
     public function registerRepository($name, $type, $settings = [])
     {
@@ -53,12 +53,12 @@ class Snapshot
      *
      * @param string $name the name of the desired repository
      *
-     * @return array
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws NotFoundException
      * @throws ResponseException
+     *
+     * @return array
      */
     public function getRepository($name)
     {
@@ -78,11 +78,11 @@ class Snapshot
     /**
      * Retrieve all repository records.
      *
-     * @return array
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return array
      */
     public function getAllRepositories()
     {
@@ -97,11 +97,11 @@ class Snapshot
      * @param array  $options           optional settings for this snapshot
      * @param bool   $waitForCompletion if true, the request will not return until the snapshot operation is complete
      *
-     * @return Response
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response
      */
     public function createSnapshot($repository, $name, $options = [], $waitForCompletion = false)
     {
@@ -114,12 +114,12 @@ class Snapshot
      * @param string $repository the name of the repository from which to retrieve the snapshot
      * @param string $name       the name of the desired snapshot
      *
-     * @return array
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws NotFoundException
      * @throws ResponseException
+     *
+     * @return array
      */
     public function getSnapshot($repository, $name)
     {
@@ -141,11 +141,11 @@ class Snapshot
      *
      * @param string $repository the repository name
      *
-     * @return array
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return array
      */
     public function getAllSnapshots($repository)
     {
@@ -158,11 +158,11 @@ class Snapshot
      * @param string $repository the repository in which the snapshot resides
      * @param string $name       the name of the snapshot to be deleted
      *
-     * @return Response
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response
      */
     public function deleteSnapshot($repository, $name)
     {
@@ -177,11 +177,11 @@ class Snapshot
      * @param array  $options           options for the restore operation
      * @param bool   $waitForCompletion if true, the request will not return until the restore operation is complete
      *
-     * @return Response
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response
      */
     public function restoreSnapshot($repository, $name, $options = [], $waitForCompletion = false)
     {
@@ -205,11 +205,11 @@ class Snapshot
      * @param array  $data   request body data
      * @param array  $query  query string parameters
      *
-     * @return Response
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Response
      */
     public function request($path, $method = Request::GET, $data = [], array $query = [])
     {

--- a/src/Status.php
+++ b/src/Status.php
@@ -2,6 +2,8 @@
 
 namespace Elastica;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
 use Elastica\Exception\ResponseException;
 use Elasticsearch\Endpoints\Indices\Alias\Get;
 use Elasticsearch\Endpoints\Indices\GetAlias;
@@ -92,6 +94,10 @@ class Status
      * Returns an array with all indices that the given alias name points to.
      *
      * @return Index[]
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function getIndicesWithAlias(string $alias)
     {
@@ -147,6 +153,10 @@ class Status
 
     /**
      * Refresh status object.
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function refresh(): void
     {

--- a/src/Status.php
+++ b/src/Status.php
@@ -93,11 +93,11 @@ class Status
     /**
      * Returns an array with all indices that the given alias name points to.
      *
-     * @return Index[]
-     *
      * @throws ClientException
      * @throws ConnectionException
      * @throws ResponseException
+     *
+     * @return Index[]
      */
     public function getIndicesWithAlias(string $alias)
     {

--- a/src/Task.php
+++ b/src/Task.php
@@ -2,6 +2,9 @@
 
 namespace Elastica;
 
+use Elastica\Exception\ClientException;
+use Elastica\Exception\ConnectionException;
+use Elastica\Exception\ResponseException;
 use Elasticsearch\Endpoints\Tasks;
 
 /**
@@ -83,6 +86,10 @@ class Task extends Param
      * Refresh task status.
      *
      * @param array<string, mixed> $options
+     *
+     * @throws ClientException
+     * @throws ConnectionException
+     * @throws ResponseException
      */
     public function refresh(array $options = []): void
     {
@@ -102,6 +109,9 @@ class Task extends Param
         return true === $data['completed'];
     }
 
+    /**
+     * @throws \Exception
+     */
     public function cancel(): Response
     {
         if ('' === $this->_id) {


### PR DESCRIPTION
When using `PHPStan`, it can report exceptions which are not caught if and only if the library is correctly using the `@throws` annotations. Same for `PHPStorm`.

The `Client::request` method is throwing ConnectionException, ClientException and ResponseException, so it should be propagated to the phpdoc of method using `Client::request` in order to help the developper to catch such exceptions.