### PR TITLE
Allow base url without ending slash

### DIFF
--- a/src/Transport/Http.php
+++ b/src/Transport/Http.php
@@ -65,7 +65,10 @@ class Http extends AbstractTransport
             $requestPath = Util::escapeDateMath($requestPath);
         }
 
-        $baseUri .= $requestPath;
+        if ($requestPath !== '') {
+            $baseUri = rtrim('/', '');
+            $baseUri .= '/' . $requestPath;
+        }
 
         $query = $request->getQuery();
 


### PR DESCRIPTION
_Accept both with and without trailing slash URL as Elastic source._

I have spent few time to find out what is wrong with Elastic URL `https://foo:bar@elastic-dev.example.com`, getting error `Couldn't resolve host`
```
./bin/console fos:elastica:create

Creating bitbag_shop_product

In Http.php line 186:
                         
  Couldn't resolve host  
                         

fos:elastica:create [--index [INDEX]] [--no-alias]
```

Reason was missing trailing slash in URL, leading into invalid URL `https://foo:bar@elastic-dev.example.combitbag_shop_product` instead of correct `https://foo:bar@elastic-dev.example.com/bitbag_shop_product`

Suggested change ensures slash between base URL and request path (Elastic index name in this case).