### PR TITLE
Fix PHPStan conditional return type on Search::count

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -318,6 +318,8 @@ class Search
      * @throws ResponseException
      *
      * @return int|ResultSet
+     *
+     * @phpstan-return ($fullResult is false ? int : ResultSet)
      */
     public function count($query = '', bool $fullResult = false, string $method = Request::POST)
     {


### PR DESCRIPTION
When using `Search::count method`, PHPstan warns about using the result as an integer because it could also be a ResultSet.

This PR add a conditional return type depending on `$fullResult` param.