### PR TITLE
[6.x] Allow psr/log v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.0||^8.0",
         "ext-json": "*",
-        "psr/log": "~1.0",
+        "psr/log": "^1.0||^2.0||^3.0",
         "elasticsearch/elasticsearch": "^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Seems [we allow psr/log v2 or v3](https://github.com/ruflin/Elastica/pull/1971) to elastica v7+. This is a backport support for elastica v6. No changes from the code itself is necessary.