### PR TITLE
Apply RetryOnConflict on Bulk documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Backward Compatibility Breaks
 ### Added
+* If not expicitly set, use `retry_on_conflict` from Client configuration in Bulk updates [#2184](https://github.com/ruflin/Elastica/pull/2184)
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -131,8 +131,8 @@ class Bulk
      */
     public function addDocument(Document $document, ?string $opType = null): self
     {
-        if ($this->_client->getConnection()->hasParam('retryOnConflict')) {
-            $document->setRetryOnConflict($this->_client->getConnection()->getParam('retryOnConflict'));
+        if (!$document->hasRetryOnConflict() && $this->_client->hasConnection() && ($retry = $this->_client->getConnection()->getParam('retryOnConflict')) > 0) {
+            $document->setRetryOnConflict($retry);
         }
 
         $action = AbstractDocumentAction::create($document, $opType);
@@ -159,6 +159,10 @@ class Bulk
      */
     public function addScript(AbstractScript $script, ?string $opType = null): self
     {
+        if (!$script->hasRetryOnConflict() && $this->_client->hasConnection() && ($retry = $this->_client->getConnection()->getParam('retryOnConflict')) > 0) {
+            $script->setRetryOnConflict($retry);
+        }
+
         $action = AbstractDocumentAction::create($script, $opType);
 
         return $this->addAction($action);

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -131,7 +131,7 @@ class Bulk
      */
     public function addDocument(Document $document, ?string $opType = null): self
     {
-        if (!$document->hasRetryOnConflict() && $this->_client->hasConnection() && ($retry = $this->_client->getConnection()->getParam('retryOnConflict')) > 0) {
+        if (!$document->hasRetryOnConflict() && $this->_client->hasConnection() && $this->_client->getConnection()->hasParam('retryOnConflict') && ($retry = $this->_client->getConnection()->getParam('retryOnConflict')) > 0) {
             $document->setRetryOnConflict($retry);
         }
 
@@ -159,7 +159,7 @@ class Bulk
      */
     public function addScript(AbstractScript $script, ?string $opType = null): self
     {
-        if (!$script->hasRetryOnConflict() && $this->_client->hasConnection() && ($retry = $this->_client->getConnection()->getParam('retryOnConflict')) > 0) {
+        if (!$script->hasRetryOnConflict() && $this->_client->hasConnection() && $this->_client->getConnection()->hasParam('retryOnConflict') && ($retry = $this->_client->getConnection()->getParam('retryOnConflict')) > 0) {
             $script->setRetryOnConflict($retry);
         }
 

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -131,6 +131,10 @@ class Bulk
      */
     public function addDocument(Document $document, ?string $opType = null): self
     {
+        if ($this->_client->getConnection()->hasParam('retryOnConflict')) {
+            $document->setRetryOnConflict($this->_client->getConnection()->getParam('retryOnConflict'));
+        }
+
         $action = AbstractDocumentAction::create($document, $opType);
 
         return $this->addAction($action);

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -725,7 +725,6 @@ JSON;
 
         $metadata = $actions[0]->getMetadata();
         $this->assertEquals(5, $metadata['retry_on_conflict']);
-
     }
 
     /**

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -702,6 +702,30 @@ JSON;
 
         $metadata = $actions[0]->getMetadata();
         $this->assertEquals(5, $metadata['retry_on_conflict']);
+
+        // Test retry via client
+        $client->getConnection()->setParam('retryOnConflict', 5);
+        $doc2 = new Document('2', ['name' => 'Invisible Woman']);
+        $doc2->setOpType(Action::OP_TYPE_UPDATE);
+
+        $bulk = new Bulk($client);
+        $bulk->addDocument($doc2);
+
+        $actions = $bulk->getActions();
+
+        $metadata = $actions[0]->getMetadata();
+        $this->assertEquals(5, $metadata['retry_on_conflict']);
+
+        $script = new Script('');
+
+        $bulk = new Bulk($client);
+        $bulk->addScript($script);
+
+        $actions = $bulk->getActions();
+
+        $metadata = $actions[0]->getMetadata();
+        $this->assertEquals(5, $metadata['retry_on_conflict']);
+
     }
 
     /**


### PR DESCRIPTION
This PR is created to solve the issue on the missing RetryOnConflict (retry_on_conflict) metadata attribute when adding documents in bulk (detailed at https://github.com/ruflin/Elastica/issues/2182)
