### PR TITLE
Add support for the Combined Fields query type (to 8.x branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added ElasticSearch 8.x to CI [#2123](https://github.com/ruflin/Elastica/pull/2123)
 * Added more versions of ElasticSearch to CI [#2155](https://github.com/ruflin/Elastica/pull/2155)
 * If not expicitly set, use `retry_on_conflict` from Client configuration in Bulk updates (ported from 7.x [#2184](https://github.com/ruflin/Elastica/pull/2184))
+* Added support for the Combined Fields query type [#2195](https://github.com/ruflin/Elastica/issues/2195)
 ### Changed
 * Updated `php-cs-fixer` to `3.13.2` [#2143](https://github.com/ruflin/Elastica/pull/2143)
 * Modernize code using `match` expression [#2141](https://github.com/ruflin/Elastica/pull/2141)

--- a/src/Query/CombinedFields.php
+++ b/src/Query/CombinedFields.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Elastica\Query;
+
+/**
+ * Combined fields query.
+ *
+ * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-combined-fields-query.html
+ */
+class CombinedFields extends AbstractQuery
+{
+    public const OPERATOR_OR = 'or';
+    public const OPERATOR_AND = 'and';
+
+    public const ZERO_TERM_NONE = 'none';
+    public const ZERO_TERM_ALL = 'all';
+
+    /**
+     * Sets the query.
+     *
+     * @param string $query Query
+     *
+     * @return $this
+     */
+    public function setQuery(string $query = ''): self
+    {
+        return $this->setParam('query', $query);
+    }
+
+    /**
+     * Sets Fields to be used in the query.
+     *
+     * @param array $fields Fields
+     *
+     * @return $this
+     */
+    public function setFields(array $fields = []): self
+    {
+        return $this->setParam('fields', $fields);
+    }
+
+    /**
+     * Sets operator for Match Query.
+     *
+     * If not set, defaults to 'or'
+     *
+     * @return $this
+     */
+    public function setOperator(string $operator = self::OPERATOR_OR): self
+    {
+        return $this->setParam('operator', $operator);
+    }
+
+    /**
+     * Set field minimum should match for Match Query.
+     *
+     * @param mixed $minimumShouldMatch
+     *
+     * @return $this
+     */
+    public function setMinimumShouldMatch($minimumShouldMatch): self
+    {
+        return $this->setParam('minimum_should_match', $minimumShouldMatch);
+    }
+
+    /**
+     * Set zero terms query for Match Query.
+     *
+     * If not set, default to 'none'
+     *
+     * @return $this
+     */
+    public function setZeroTermsQuery(string $zeroTermQuery = self::ZERO_TERM_NONE): self
+    {
+        return $this->setParam('zero_terms_query', $zeroTermQuery);
+    }
+}

--- a/tests/Query/CombinedFieldsQueryTest.php
+++ b/tests/Query/CombinedFieldsQueryTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Elastica\Test\Query;
+
+use Elastica\Document;
+use Elastica\Index;
+use Elastica\Mapping;
+use Elastica\Query;
+use Elastica\Query\CombinedFields;
+use Elastica\ResultSet;
+use Elastica\Test\Base as BaseTest;
+
+/**
+ * @internal
+ */
+class CombinedFieldsQueryTest extends BaseTest
+{
+    private static $data = [
+        ['id' => 1, 'title' => 'Rodolfo', 'body' => 'Moraes',   'abstract' => 'Lorem'],
+        ['id' => 2, 'title' => 'Tristan', 'body' => 'Maindron', 'abstract' => 'Dolor'],
+        ['id' => 3, 'title' => 'Monique', 'body' => 'Maindron', 'abstract' => 'Ipsum'],
+        ['id' => 4, 'title' => 'John',    'body' => 'not Doe',  'abstract' => 'Consectetur'],
+    ];
+
+    /**
+     * @group functional
+     */
+    public function testMinimumShouldMatch(): void
+    {
+        // Note that the OR operator is the default.
+        $combinedFields = new CombinedFields();
+        $combinedFields->setQuery('Tristan Maindron');
+        $combinedFields->setFields(['title', 'body', 'abstract']);
+        $combinedFields->setMinimumShouldMatch('2<100%');
+        $resultSet = $this->_getResults($combinedFields);
+
+        $this->assertEquals(1, $resultSet->count());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testAndOperator(): void
+    {
+        $combinedFields = new CombinedFields();
+        $combinedFields->setQuery('Monique Maindron');
+        $combinedFields->setFields(['title', 'body', 'abstract']);
+        $combinedFields->setOperator(CombinedFields::OPERATOR_AND);
+        $resultSet = $this->_getResults($combinedFields);
+
+        $this->assertEquals(1, $resultSet->count());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testZeroTerm(): void
+    {
+        $combinedFields = new CombinedFields();
+        $combinedFields->setQuery('not'); // This is a stopword.
+        $combinedFields->setFields(['title', 'body', 'abstract']);
+        $combinedFields->setZeroTermsQuery(CombinedFields::ZERO_TERM_NONE);
+        $resultSet = $this->_getResults($combinedFields);
+
+        $this->assertEquals(1, $resultSet->count());
+
+        $combinedFields->setZeroTermsQuery(CombinedFields::ZERO_TERM_ALL);
+        $resultSet = $this->_getResults($combinedFields);
+
+        $this->assertEquals(1, $resultSet->count());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testBaseCombinedFields(): void
+    {
+        $combinedFields = new CombinedFields();
+        $combinedFields->setQuery('Rodolfo Moraes');
+        $combinedFields->setFields(['title', 'body', 'abstract']);
+        $resultSet = $this->_getResults($combinedFields);
+
+        $this->assertEquals(1, $resultSet->count());
+
+        $combinedFields = new CombinedFields();
+        $combinedFields->setQuery('Doe John');
+        $combinedFields->setFields(['title', 'body', 'abstract']);
+        $resultSet = $this->_getResults($combinedFields);
+
+        $this->assertEquals(1, $resultSet->count());
+
+        $combinedFields = new CombinedFields();
+        $combinedFields->setQuery('John Doe Consectetur');
+        $combinedFields->setFields(['title', 'body', 'abstract']);
+        $resultSet = $this->_getResults($combinedFields);
+
+        $this->assertEquals(1, $resultSet->count());
+    }
+
+    /**
+     * Executes the query with the current multimatch.
+     */
+    private function _getResults(CombinedFields $combinedFields): ResultSet
+    {
+        return $this->_generateIndex()->search(new Query($combinedFields));
+    }
+
+    /**
+     * Builds an index for testing.
+     */
+    private function _generateIndex(): Index
+    {
+        $client = $this->_getClient();
+        $index = $client->getIndex('test');
+
+        $mapping = new Mapping([
+            'title' => ['type' => 'text', 'analyzer' => 'noStops'],
+            'body' => ['type' => 'text', 'analyzer' => 'noStops'],
+            'abstract' => ['type' => 'text', 'analyzer' => 'noStops'],
+        ]);
+
+        $index->create(
+            [
+                'settings' => [
+                    'analysis' => [
+                        'analyzer' => [
+                            'noStops' => [
+                                'type' => 'standard',
+                                'stopwords' => '_none_',
+                            ],
+                            'stops' => [
+                                'type' => 'standard',
+                                'stopwords' => ['not'],
+                            ],
+                        ],
+                    ],
+                ],
+                'mappings' => $mapping->toArray(),
+            ],
+            [
+                'recreate' => true,
+            ]
+        );
+
+        foreach (self::$data as $key => $docData) {
+            $index->addDocument(new Document($key, $docData));
+        }
+
+        // Refresh index
+        $index->refresh();
+
+        return $index;
+    }
+}


### PR DESCRIPTION
The Combined Fields query was introduced in ElasticSearch 7.13.

See
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-combined-fields-query.html for more information.

Fixes #2195