### PR TITLE
Improve ResponseConverter to work with Elasticsearch Response class

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -27,7 +27,6 @@ use Elastica\Exception\InvalidException;
 use Elastica\Script\AbstractScript;
 use Psr\Http\Client\ClientInterface as HttpClientInterface;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -573,7 +572,7 @@ class Client implements ClientInterface
         return $this->_lastResponse;
     }
 
-    public function toElasticaResponse(Elasticsearch|ResponseInterface $elasticsearchResponse): Response
+    public function toElasticaResponse(Elasticsearch $elasticsearchResponse): Response
     {
         return ResponseConverter::toElastica($elasticsearchResponse);
     }

--- a/src/ResponseConverter.php
+++ b/src/ResponseConverter.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Elastica;
 
 use Elastic\Elasticsearch\Response\Elasticsearch;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * @author PK <projekty@pawelkeska.eu>
  */
 class ResponseConverter
 {
-    public static function toElastica(Elasticsearch|ResponseInterface $response): Response
+    private function __construct()
     {
-        if ($response instanceof Elasticsearch) {
-            return new Response($response->asString(), $response->getStatusCode());
-        }
+    }
 
-        return new Response((string) $response->getBody(), $response->getStatusCode());
+    public static function toElastica(Elasticsearch $response): Response
+    {
+        return new Response($response->asString(), $response->getStatusCode());
     }
 }


### PR DESCRIPTION
This PR a bit improves `ResponseConverter::toElasticaResponse` method and allows to pass `Elastic\Elasticsearch\Response\Elasticsearch` class only.

ResponseInterface was passed from tests only. 