### PR TITLE
Send scroll_id in body for clearScroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `Elastica\Connection\Strategy\StrategyInterface`
 * Removed `Elastica\Client::setLogger()` method [#2148](https://github.com/ruflin/Elastica/pull/2148)
 * Enabled `strict_types` on all classes [#2190](https://github.com/ruflin/Elastica/pull/2190)
+* Changed `Elastica\Scroll:clear` to use `scroll_id` body parameter instead of url parameter [#2211](https://github.com/ruflin/Elastica/pull/2211)
 
 
 ### Added

--- a/src/Scroll.php
+++ b/src/Scroll.php
@@ -159,7 +159,7 @@ class Scroll implements \Iterator
     {
         if (null !== $this->_nextScrollId) {
             $this->_search->getClient()->clearScroll(
-                [Search::OPTION_SCROLL_ID => [$this->_nextScrollId]]
+                ['body' => [Search::OPTION_SCROLL_ID => [$this->_nextScrollId]]]
             );
 
             // Reset scroll ID so valid() returns false.


### PR DESCRIPTION
Sending the scroll_id in the url is [deprecated since 7.0](https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html#clear-scroll-api-path-params) and it's what elasticsearch-php clearScroll does when passing a "scroll_id" parameter. It should be passed in the body instead to prevent errors with big ids.