### PR TITLE
Support multi match type 'bool_prefix'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Backward Compatibility Breaks
 
 ### Added
+* Added support for the multi-match query type `bool_prefix` [#2220](https://github.com/ruflin/Elastica/pull/2220)
 
 ### Changed
 

--- a/src/Query/MultiMatch.php
+++ b/src/Query/MultiMatch.php
@@ -20,6 +20,7 @@ class MultiMatch extends AbstractQuery
     public const TYPE_CROSS_FIELDS = 'cross_fields';
     public const TYPE_PHRASE = 'phrase';
     public const TYPE_PHRASE_PREFIX = 'phrase_prefix';
+    public const TYPE_BOOL_PREFIX = 'bool_prefix';
 
     public const OPERATOR_OR = 'or';
     public const OPERATOR_AND = 'and';

--- a/tests/Query/MultiMatchTest.php
+++ b/tests/Query/MultiMatchTest.php
@@ -55,7 +55,7 @@ class MultiMatchTest extends BaseTest
     /**
      * @group functional
      */
-    public function testType(): void
+    public function testTypePhrasePrefix(): void
     {
         $multiMatch = new MultiMatch();
         $multiMatch->setQuery('Trist');
@@ -64,6 +64,20 @@ class MultiMatchTest extends BaseTest
         $resultSet = $this->_getResults($multiMatch);
 
         $this->assertEquals(1, $resultSet->count());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testTypeBoolPrefix(): void
+    {
+        $multiMatch = new MultiMatch();
+        $multiMatch->setQuery('Main');
+        $multiMatch->setFields(['full_name', 'name']);
+        $multiMatch->setType(MultiMatch::TYPE_BOOL_PREFIX);
+        $resultSet = $this->_getResults($multiMatch);
+
+        $this->assertEquals(2, $resultSet->count());
     }
 
     /**


### PR DESCRIPTION
Adds support for the multi match query type `bool_prefix` [1]

[1] https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html#multi-match-types