### PR TITLE
Update PHP-CS-Fixer to the latest version and enable parallelization

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -14,11 +14,11 @@ jobs:
           php-version: '8.0'
           coverage: 'none'
           extensions: 'json, mbstring, tokenizer'
-          tools: 'composer-normalize:2.28.0, php-cs-fixer:3.13.2'
+          tools: 'composer-normalize:2.28.0, php-cs-fixer:3.59.3'
 
       - name: 'Check PHP code'
         run: |
-          php-cs-fixer fix --diff --dry-run --allow-risky=yes --using-cache=no
+          php-cs-fixer fix --diff --dry-run --allow-risky=yes --using-cache=no --show-progress=dots
 
       - name: 'Check composer.json'
         run: |

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,6 +8,7 @@ $finder = (new PhpCsFixer\Finder())
 ;
 
 return (new PhpCsFixer\Config())
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setFinder($finder)
     ->setRules([
         '@PHP80Migration' => true,
@@ -33,5 +34,9 @@ return (new PhpCsFixer\Config())
         'static_lambda' => true,
         'ternary_to_null_coalescing' => true,
         'visibility_required' => ['elements' => ['property', 'method', 'const']],
+        'fully_qualified_strict_types' => [
+            'import_symbols' => true,
+        ],
+        'string_implicit_backslashes' => false,
     ])
 ;

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ install-tools: install-phpcs
 
 .PHONY: run-phpcs
 run-phpcs: install-phpcs
-	tools/php-cs-fixer.phar fix --diff --dry-run --allow-risky=yes -v
+	tools/php-cs-fixer.phar fix --diff --dry-run --allow-risky=yes -v --show-progress=dots
 
 .PHONY: fix-phpcs
 fix-phpcs: install-phpcs
-	tools/php-cs-fixer.phar fix --allow-risky=yes -v
+	tools/php-cs-fixer.phar fix --allow-risky=yes -v --show-progress=dots
 
 .PHONY: run-phpunit
 run-phpunit: composer-install

--- a/phive.xml
+++ b/phive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.0" installed="3.9.5" location="./tools/php-cs-fixer.phar" copy="true"/>
+  <phar name="php-cs-fixer" version="^3.0" installed="3.59.3" location="./tools/php-cs-fixer.phar" copy="true"/>
   <phar name="php-coveralls" version="^2.2" installed="2.2.0" location="./tools/php-coveralls.phar" copy="true"/>
 </phive>

--- a/src/Aggregation/AbstractSimpleAggregation.php
+++ b/src/Aggregation/AbstractSimpleAggregation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Elastica\Aggregation;
 
 use Elastica\Exception\InvalidException;
+use Elastica\Script\AbstractScript;
 
 abstract class AbstractSimpleAggregation extends AbstractAggregation
 {
@@ -23,7 +24,7 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
     /**
      * Set a script for this aggregation.
      *
-     * @param \Elastica\Script\AbstractScript|string $script
+     * @param AbstractScript|string $script
      *
      * @return $this
      */
@@ -32,9 +33,6 @@ abstract class AbstractSimpleAggregation extends AbstractAggregation
         return $this->setParam('script', $script);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         if (!$this->hasParam('field') && !$this->hasParam('script')) {

--- a/src/Aggregation/ReverseNested.php
+++ b/src/Aggregation/ReverseNested.php
@@ -34,9 +34,6 @@ class ReverseNested extends AbstractAggregation
         return $this->setParam('path', $path);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         $array = parent::toArray();

--- a/src/Aggregation/Traits/MissingTrait.php
+++ b/src/Aggregation/Traits/MissingTrait.php
@@ -9,8 +9,6 @@ trait MissingTrait
     /**
      * Defines how documents that are missing a value should be treated.
      *
-     * @param mixed $missing
-     *
      * @return $this
      */
     public function setMissing($missing): self

--- a/src/Aggregation/WeightedAvg.php
+++ b/src/Aggregation/WeightedAvg.php
@@ -16,7 +16,7 @@ class WeightedAvg extends AbstractAggregation
     /**
      * Set the value for this aggregation.
      *
-     * @param mixed $missing
+     * @param mixed|null $missing
      *
      * @return $this
      */
@@ -52,7 +52,7 @@ class WeightedAvg extends AbstractAggregation
     /**
      * Set the weight for this aggregation.
      *
-     * @param mixed $missing
+     * @param mixed|null $missing
      *
      * @return $this
      */
@@ -99,8 +99,6 @@ class WeightedAvg extends AbstractAggregation
 
     /**
      * Set the value_type for this aggregation.
-     *
-     * @param mixed $valueType
      *
      * @return $this
      */

--- a/src/Bulk/Action/DeleteDocument.php
+++ b/src/Bulk/Action/DeleteDocument.php
@@ -13,9 +13,6 @@ class DeleteDocument extends AbstractDocument
      */
     protected $_opType = self::OP_TYPE_DELETE;
 
-    /**
-     * {@inheritdoc}
-     */
     protected function _getMetadata(AbstractUpdateAction $action): array
     {
         return $action->getOptions([

--- a/src/Bulk/Action/IndexDocument.php
+++ b/src/Bulk/Action/IndexDocument.php
@@ -14,9 +14,6 @@ class IndexDocument extends AbstractDocument
      */
     protected $_opType = self::OP_TYPE_INDEX;
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDocument(Document $document): AbstractDocument
     {
         parent::setDocument($document);
@@ -26,9 +23,6 @@ class IndexDocument extends AbstractDocument
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function _getMetadata(AbstractUpdateAction $action): array
     {
         return $action->getOptions([

--- a/src/Bulk/Action/UpdateDocument.php
+++ b/src/Bulk/Action/UpdateDocument.php
@@ -14,9 +14,6 @@ class UpdateDocument extends IndexDocument
      */
     protected $_opType = self::OP_TYPE_UPDATE;
 
-    /**
-     * {@inheritdoc}
-     */
     public function setDocument(Document $document): AbstractDocument
     {
         parent::setDocument($document);
@@ -38,9 +35,6 @@ class UpdateDocument extends IndexDocument
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setScript(AbstractScript $script): AbstractDocument
     {
         parent::setScript($script);

--- a/src/Bulk/ResponseSet.php
+++ b/src/Bulk/ResponseSet.php
@@ -93,41 +93,26 @@ class ResponseSet extends BaseResponse implements \Iterator, \Countable
         return $this->_bulkResponses[$this->key()];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function next(): void
     {
         ++$this->_position;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function key(): int
     {
         return $this->_position;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function valid(): bool
     {
         return isset($this->_bulkResponses[$this->key()]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function rewind(): void
     {
         $this->_position = 0;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function count(): int
     {
         return \count($this->_bulkResponses);

--- a/src/Client.php
+++ b/src/Client.php
@@ -68,41 +68,26 @@ class Client implements ClientInterface
         $this->_transport = $this->_buildTransport($this->getConfig());
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getLogger(): LoggerInterface
     {
         return $this->_logger;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTransport(): Transport
     {
         return $this->_transport;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setAsync(bool $async): self
     {
         throw new \Exception('Not supported');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAsync(): bool
     {
         throw new \Exception('Not supported');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setElasticMetaHeader(bool $active): self
     {
         $this->elasticMetaHeader = $active;
@@ -110,25 +95,16 @@ class Client implements ClientInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getElasticMetaHeader(): bool
     {
         return $this->elasticMetaHeader;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setResponseException(bool $active): self
     {
         throw new \Exception('Not supported');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getResponseException(): bool
     {
         throw new \Exception('Not supported');
@@ -192,8 +168,6 @@ class Client implements ClientInterface
     /**
      * @param array|string $keys    config key or path of config keys
      * @param mixed        $default default value will be returned if key was not found
-     *
-     * @return mixed
      */
     public function getConfigValue($keys, $default = null)
     {

--- a/src/Cluster/Settings.php
+++ b/src/Cluster/Settings.php
@@ -103,8 +103,6 @@ class Settings
 
     /**
      * Sets persistent setting.
-     *
-     * @param mixed $value
      */
     public function setPersistent(string $key, $value): Response
     {
@@ -119,8 +117,6 @@ class Settings
 
     /**
      * Sets transient settings.
-     *
-     * @param mixed $value
      */
     public function setTransient(string $key, $value): Response
     {

--- a/src/Document.php
+++ b/src/Document.php
@@ -49,17 +49,11 @@ class Document extends AbstractUpdateAction
         $this->setIndex($index);
     }
 
-    /**
-     * @return mixed
-     */
     public function __get(string $key)
     {
         return $this->get($key);
     }
 
-    /**
-     * @param mixed $value
-     */
     public function __set(string $key, $value): void
     {
         $this->set($key, $value);
@@ -78,11 +72,7 @@ class Document extends AbstractUpdateAction
     /**
      * Get the value of the given field.
      *
-     * @param mixed $key
-     *
      * @throws InvalidException If the given field does not exist
-     *
-     * @return mixed
      */
     public function get($key)
     {
@@ -95,8 +85,6 @@ class Document extends AbstractUpdateAction
 
     /**
      * Set the value of the given field.
-     *
-     * @param mixed $value
      *
      * @throws InvalidException if the current document is a serialized data
      */

--- a/src/Index.php
+++ b/src/Index.php
@@ -518,9 +518,6 @@ class Index implements SearchableInterface
         return 200 === $response->getStatusCode();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function createSearch($query = '', ?array $options = null, ?BuilderInterface $builder = null): Search
     {
         $search = new Search($this->getClient(), $builder);
@@ -530,9 +527,6 @@ class Index implements SearchableInterface
         return $search;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function search($query = '', ?array $options = null, string $method = Request::POST): ResultSet
     {
         $search = $this->createSearch($query, $options);
@@ -540,9 +534,6 @@ class Index implements SearchableInterface
         return $search->search('', null, $method);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function count($query = '', string $method = Request::POST): int
     {
         $search = $this->createSearch($query);

--- a/src/Multi/ResultSet.php
+++ b/src/Multi/ResultSet.php
@@ -75,79 +75,48 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @return mixed
-     */
     #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_resultSets[$this->key()];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function next(): void
     {
         ++$this->_position;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function key(): int
     {
         return $this->_position;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function valid(): bool
     {
         return isset($this->_resultSets[$this->key()]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function rewind(): void
     {
         $this->_position = 0;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function count(): int
     {
         return \count($this->_resultSets);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function offsetExists($offset): bool
     {
         return isset($this->_resultSets[$offset]);
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @return mixed
-     */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->_resultSets[$offset] ?? null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function offsetSet($offset, $value): void
     {
         if (null === $offset) {
@@ -157,9 +126,6 @@ class ResultSet implements \Iterator, \ArrayAccess, \Countable
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function offsetUnset($offset): void
     {
         unset($this->_resultSets[$offset]);

--- a/src/Param.php
+++ b/src/Param.php
@@ -138,8 +138,6 @@ class Param implements ArrayableInterface, \Countable
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @return int
      */
     #[\ReturnTypeWillChange]
@@ -186,7 +184,6 @@ class Param implements ArrayableInterface, \Countable
      * Sets params not inside params array.
      *
      * @param string $key
-     * @param mixed  $value
      *
      * @return $this
      */

--- a/src/Processor/SetProcessor.php
+++ b/src/Processor/SetProcessor.php
@@ -18,9 +18,6 @@ class SetProcessor extends AbstractProcessor
 
     public const DEFAULT_OVERRIDE_VALUE = true;
 
-    /**
-     * @param mixed $value
-     */
     public function __construct(string $field, $value)
     {
         $this->setField($field);
@@ -29,8 +26,6 @@ class SetProcessor extends AbstractProcessor
 
     /**
      * Set field value.
-     *
-     * @param mixed $value
      *
      * @return $this
      */

--- a/src/Query/AbstractGeoDistance.php
+++ b/src/Query/AbstractGeoDistance.php
@@ -145,9 +145,6 @@ abstract class AbstractGeoDistance extends AbstractQuery
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         $this->setParam($this->_key, $this->_getLocationData());

--- a/src/Query/BoolQuery.php
+++ b/src/Query/BoolQuery.php
@@ -85,9 +85,6 @@ class BoolQuery extends AbstractQuery
         return $this->setParam('minimum_should_match', $minimum);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         if (!$this->_params) {

--- a/src/Query/CombinedFields.php
+++ b/src/Query/CombinedFields.php
@@ -56,8 +56,6 @@ class CombinedFields extends AbstractQuery
     /**
      * Set field minimum should match for Match Query.
      *
-     * @param mixed $minimumShouldMatch
-     *
      * @return $this
      */
     public function setMinimumShouldMatch($minimumShouldMatch): self

--- a/src/Query/FunctionScore.php
+++ b/src/Query/FunctionScore.php
@@ -294,9 +294,6 @@ class FunctionScore extends AbstractQuery
         return $this->setParam('min_score', $minScore);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         if (0 < \count($this->_functions)) {

--- a/src/Query/GeoDistance.php
+++ b/src/Query/GeoDistance.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Elastica\Query;
 
+use Elastica\Exception\InvalidException;
+
 /**
  * Geo distance query.
  *
@@ -23,7 +25,7 @@ class GeoDistance extends AbstractGeoDistance
      * @param array|string $location Location as array or geohash: array('lat' => 48.86, 'lon' => 2.35) OR 'drm3btev3e86'
      * @param string       $distance Distance
      *
-     * @throws \Elastica\Exception\InvalidException
+     * @throws InvalidException
      */
     public function __construct(string $key, $location, string $distance)
     {

--- a/src/Query/GeoPolygon.php
+++ b/src/Query/GeoPolygon.php
@@ -39,9 +39,6 @@ class GeoPolygon extends AbstractQuery
         $this->_points = $points;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         return [
@@ -53,9 +50,6 @@ class GeoPolygon extends AbstractQuery
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function count(): int
     {
         return \count($this->_points);

--- a/src/Query/GeoShapePreIndexed.php
+++ b/src/Query/GeoShapePreIndexed.php
@@ -56,9 +56,6 @@ class GeoShapePreIndexed extends AbstractGeoShape
         $this->_indexedPath = $indexedPath;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         return [

--- a/src/Query/GeoShapeProvided.php
+++ b/src/Query/GeoShapeProvided.php
@@ -52,9 +52,6 @@ class GeoShapeProvided extends AbstractGeoShape
         $this->_coordinates = $coordinates;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         return [

--- a/src/Query/HasChild.php
+++ b/src/Query/HasChild.php
@@ -78,9 +78,6 @@ class HasChild extends AbstractQuery
         return $this->setParam('inner_hits', $innerHits);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         $array = parent::toArray();

--- a/src/Query/HasParent.php
+++ b/src/Query/HasParent.php
@@ -66,9 +66,6 @@ class HasParent extends AbstractQuery
         return $this->setParam('_scope', $scope);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         $array = parent::toArray();

--- a/src/Query/Ids.php
+++ b/src/Query/Ids.php
@@ -57,9 +57,6 @@ class Ids extends AbstractQuery
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         return ['ids' => $this->_params];

--- a/src/Query/InnerHits.php
+++ b/src/Query/InnerHits.php
@@ -16,9 +16,6 @@ use Elastica\Script\ScriptFields;
  */
 class InnerHits extends AbstractQuery
 {
-    /**
-     * {@inheritdoc}
-     */
     public function toArray()
     {
         $array = parent::toArray();

--- a/src/Query/MatchPhrase.php
+++ b/src/Query/MatchPhrase.php
@@ -14,9 +14,6 @@ namespace Elastica\Query;
  */
 class MatchPhrase extends AbstractQuery
 {
-    /**
-     * @param mixed $values
-     */
     public function __construct(?string $field = null, $values = null)
     {
         if (null !== $field && null !== $values) {
@@ -26,8 +23,6 @@ class MatchPhrase extends AbstractQuery
 
     /**
      * Sets a param for the message array.
-     *
-     * @param mixed $values
      *
      * @return $this
      */

--- a/src/Query/MatchQuery.php
+++ b/src/Query/MatchQuery.php
@@ -22,9 +22,6 @@ class MatchQuery extends AbstractQuery
 
     public const FUZZINESS_AUTO = 'AUTO';
 
-    /**
-     * @param mixed $values
-     */
     public function __construct(?string $field = null, $values = null)
     {
         if (null !== $field && null !== $values) {
@@ -34,8 +31,6 @@ class MatchQuery extends AbstractQuery
 
     /**
      * Sets a param for the message array.
-     *
-     * @param mixed $values
      *
      * @return $this
      */
@@ -120,8 +115,6 @@ class MatchQuery extends AbstractQuery
 
     /**
      * Set field fuzziness.
-     *
-     * @param mixed $fuzziness
      *
      * @return $this
      */

--- a/src/Query/MoreLikeThis.php
+++ b/src/Query/MoreLikeThis.php
@@ -157,9 +157,6 @@ class MoreLikeThis extends AbstractQuery
         return $this->setParam('minimum_should_match', $minimumShouldMatch);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         $array = parent::toArray();

--- a/src/Query/MultiMatch.php
+++ b/src/Query/MultiMatch.php
@@ -93,8 +93,6 @@ class MultiMatch extends AbstractQuery
     /**
      * Set field minimum should match for Match Query.
      *
-     * @param mixed $minimumShouldMatch
-     *
      * @return $this
      */
     public function setMinimumShouldMatch($minimumShouldMatch): self

--- a/src/Query/QueryString.php
+++ b/src/Query/QueryString.php
@@ -225,9 +225,6 @@ class QueryString extends AbstractQuery
         return $this->setParam('time_zone', $timezone);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         return ['query_string' => \array_merge(['query' => $this->_queryString], $this->getParams())];

--- a/src/Query/Script.php
+++ b/src/Query/Script.php
@@ -40,9 +40,6 @@ class Script extends AbstractQuery
         return $this->setParam('script', BaseScript::create($script));
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         $array = parent::toArray();

--- a/src/Query/Simple.php
+++ b/src/Query/Simple.php
@@ -38,9 +38,6 @@ class Simple extends AbstractQuery
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         return $this->_query;

--- a/src/QueryBuilder/DSL/Query.php
+++ b/src/QueryBuilder/DSL/Query.php
@@ -73,7 +73,7 @@ class Query implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
      *
-     * @param mixed $values
+     * @param mixed|null $values
      */
     public function match(?string $field = null, $values = null): MatchQuery
     {

--- a/src/QueryBuilder/Facade.php
+++ b/src/QueryBuilder/Facade.php
@@ -36,8 +36,6 @@ class Facade
      * Executes DSL methods.
      *
      * @throws QueryBuilderException
-     *
-     * @return mixed
      */
     public function __call(string $name, array $arguments)
     {

--- a/src/Result.php
+++ b/src/Result.php
@@ -234,8 +234,6 @@ class Result
 
     /**
      * Sets a parameter on the hit.
-     *
-     * @param mixed $value
      */
     public function setParam(string $param, $value): void
     {

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -126,7 +126,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @param string $name the name of the desired aggregation
      *
-     * @throws Exception\InvalidException if an aggregation by the given name cannot be found
+     * @throws InvalidException if an aggregation by the given name cannot be found
      */
     public function getAggregation(string $name): array
     {
@@ -295,7 +295,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      *
      * @param int $offset
      *
-     * @throws Exception\InvalidException If offset doesn't exist
+     * @throws InvalidException If offset doesn't exist
      */
     public function offsetGet($offset): Result
     {
@@ -314,7 +314,7 @@ class ResultSet implements \Iterator, \Countable, \ArrayAccess
      * @param int    $offset
      * @param Result $value
      *
-     * @throws Exception\InvalidException
+     * @throws InvalidException
      */
     public function offsetSet($offset, $value): void
     {

--- a/src/ResultSet/ChainProcessor.php
+++ b/src/ResultSet/ChainProcessor.php
@@ -25,9 +25,6 @@ class ChainProcessor implements ProcessorInterface
         $this->processors = $processors;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function process(ResultSet $resultSet): void
     {
         foreach ($this->processors as $processor) {

--- a/src/Script/AbstractScript.php
+++ b/src/Script/AbstractScript.php
@@ -93,9 +93,6 @@ abstract class AbstractScript extends AbstractUpdateAction
         return $this->_lang;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         $array = $this->getScriptTypeArray();

--- a/src/Script/Script.php
+++ b/src/Script/Script.php
@@ -43,9 +43,6 @@ class Script extends AbstractScript
         return $this->_scriptCode;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getScriptTypeArray(): array
     {
         return ['source' => $this->_scriptCode];

--- a/src/Script/ScriptId.php
+++ b/src/Script/ScriptId.php
@@ -41,9 +41,6 @@ class ScriptId extends AbstractScript
         return $this->_scriptId;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getScriptTypeArray(): array
     {
         return ['id' => $this->_scriptId];

--- a/src/Search.php
+++ b/src/Search.php
@@ -148,9 +148,6 @@ class Search
         return $this;
     }
 
-    /**
-     * @param mixed $value
-     */
     public function setOption(string $key, $value): self
     {
         $this->validateOption($key);
@@ -178,9 +175,6 @@ class Search
         return $this;
     }
 
-    /**
-     * @param mixed $value
-     */
     public function addOption(string $key, $value): self
     {
         $this->validateOption($key);
@@ -197,8 +191,6 @@ class Search
 
     /**
      * @throws InvalidException if the given key does not exists as an option
-     *
-     * @return mixed
      */
     public function getOption(string $key)
     {
@@ -319,8 +311,8 @@ class Search
     }
 
     /**
-     * @param array|Query|Query\AbstractQuery|string $query
-     * @param bool                                   $fullResult By default only the total hit count is returned. If set to true, the full ResultSet including aggregations is returned
+     * @param AbstractQuery|array|Query|string $query
+     * @param bool                             $fullResult By default only the total hit count is returned. If set to true, the full ResultSet including aggregations is returned
      *
      * @throws NoNodeAvailableException if all the hosts are offline
      * @throws ClientResponseException  if the status code of response is 4xx

--- a/src/Suggest.php
+++ b/src/Suggest.php
@@ -40,7 +40,7 @@ class Suggest extends Param
     /**
      * @param AbstractSuggest|Suggest $suggestion
      *
-     * @throws Exception\NotImplementedException
+     * @throws NotImplementedException
      */
     public static function create($suggestion): self
     {
@@ -51,9 +51,6 @@ class Suggest extends Param
         };
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         $array = parent::toArray();

--- a/src/Suggest/Phrase.php
+++ b/src/Suggest/Phrase.php
@@ -146,9 +146,6 @@ class Phrase extends AbstractSuggest
         return $this->addParam('candidate_generator', $generator);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray(): array
     {
         $array = parent::toArray();

--- a/tests/Aggregation/TopHitsTest.php
+++ b/tests/Aggregation/TopHitsTest.php
@@ -255,8 +255,6 @@ class TopHitsTest extends BaseAggregationTest
      * @group functional
      *
      * @dataProvider limitedSourceProvider
-     *
-     * @param mixed $source
      */
     public function testAggregateWithLimitedSource($source): void
     {

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -281,9 +281,6 @@ class BulkTest extends BaseTest
      * @group unit
      *
      * @dataProvider invalidRawDataProvider
-     *
-     * @param mixed $rawData
-     * @param mixed $failMessage
      */
     public function testInvalidRawData($rawData, $failMessage): void
     {

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -885,9 +885,6 @@ class ClientFunctionalTest extends BaseTest
 
     /**
      * @dataProvider endpointQueryRequestDataProvider
-     *
-     * @param mixed $query
-     * @param mixed $totalHits
      */
     public function testEndpointQueryRequest($query, $totalHits): void
     {

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -634,8 +634,6 @@ class QueryTest extends BaseTest
      * @group functional
      *
      * @dataProvider provideSetTrackTotalHitsInvalidValue
-     *
-     * @param mixed $value
      */
     public function testSetTrackTotalHitsInvalidValue($value): void
     {

--- a/tests/ResultSet/ProcessingBuilderTest.php
+++ b/tests/ResultSet/ProcessingBuilderTest.php
@@ -11,6 +11,7 @@ use Elastica\ResultSet\BuilderInterface;
 use Elastica\ResultSet\ProcessingBuilder;
 use Elastica\ResultSet\ProcessorInterface;
 use Elastica\Test\Base as BaseTest;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @group unit
@@ -25,12 +26,12 @@ class ProcessingBuilderTest extends BaseTest
     private $builder;
 
     /**
-     * @var BuilderInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var BuilderInterface|MockObject
      */
     private $innerBuilder;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|ProcessorInterface
+     * @var MockObject|ProcessorInterface
      */
     private $processor;
 

--- a/tests/Script/ScriptIdTest.php
+++ b/tests/Script/ScriptIdTest.php
@@ -119,8 +119,6 @@ class ScriptIdTest extends BaseTest
      * @group unit
      *
      * @dataProvider dataProviderCreateInvalid
-     *
-     * @param mixed $data
      */
     public function testCreateInvalid($data): void
     {

--- a/tests/Script/ScriptTest.php
+++ b/tests/Script/ScriptTest.php
@@ -119,8 +119,6 @@ class ScriptTest extends BaseTest
      * @group unit
      *
      * @dataProvider dataProviderCreateInvalid
-     *
-     * @param mixed $data
      */
     public function testCreateInvalid($data): void
     {

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -16,9 +16,6 @@ class UtilTest extends BaseTest
      * @group unit
      *
      * @dataProvider getIsDateMathEscapedPairs
-     *
-     * @param mixed $requestUri
-     * @param mixed $expectedIsEscaped
      */
     public function testIsDateMathEscaped($requestUri, $expectedIsEscaped): void
     {
@@ -42,9 +39,6 @@ class UtilTest extends BaseTest
      * @group unit
      *
      * @dataProvider getEscapeDateMathPairs
-     *
-     * @param mixed $requestUri
-     * @param mixed $expectedEscapedRequestUri
      */
     public function testEscapeDateMath($requestUri, $expectedEscapedRequestUri): void
     {
@@ -77,9 +71,6 @@ class UtilTest extends BaseTest
      * @group unit
      *
      * @dataProvider getEscapeTermPairs
-     *
-     * @param mixed $unescaped
-     * @param mixed $escaped
      */
     public function testEscapeTerm($unescaped, $escaped): void
     {
@@ -102,9 +93,6 @@ class UtilTest extends BaseTest
      * @group unit
      *
      * @dataProvider getReplaceBooleanWordsPairs
-     *
-     * @param mixed $before
-     * @param mixed $after
      */
     public function testReplaceBooleanWords($before, $after): void
     {


### PR DESCRIPTION
This PR updates PHP-CS-Fixer and enable parallelization.

Rules list which were applied:
```
  1) src/Query/GeoShapeProvided.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
   2) src/Query/HasParent.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
   3) src/Query/Simple.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
   4) src/Query/GeoPolygon.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
   5) src/Query/BoolQuery.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
   6) src/Query/QueryString.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
   7) src/Query/GeoDistance.php (fully_qualified_strict_types, blank_line_after_namespace)
   8) src/Query/MultiMatch.php (no_superfluous_phpdoc_tags, phpdoc_trim_consecutive_blank_line_separation)
   9) src/Query/MoreLikeThis.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  10) src/Query/MatchPhrase.php (no_superfluous_phpdoc_tags, no_empty_phpdoc, phpdoc_trim_consecutive_blank_line_separation)
  11) src/Aggregation/WeightedAvg.php (no_superfluous_phpdoc_tags, phpdoc_trim_consecutive_blank_line_separation)
  12) src/Aggregation/ReverseNested.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  13) src/Aggregation/Traits/MissingTrait.php (no_superfluous_phpdoc_tags, phpdoc_trim_consecutive_blank_line_separation)
  14) src/Query/FunctionScore.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  15) src/Query/AbstractGeoDistance.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  16) src/Query/InnerHits.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  17) src/Query/CombinedFields.php (no_superfluous_phpdoc_tags, phpdoc_trim_consecutive_blank_line_separation)
  18) src/Query/MatchQuery.php (no_superfluous_phpdoc_tags, no_empty_phpdoc, phpdoc_trim_consecutive_blank_line_separation)
  19) src/Query/Script.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  20) src/Query/GeoShapePreIndexed.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  21) src/Multi/ResultSet.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  22) src/Util.php (string_implicit_backslashes)
  23) src/Bulk/ResponseSet.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  24) src/Bulk/Action/IndexDocument.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  25) src/Bulk/Action/DeleteDocument.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  26) src/Bulk/Action/UpdateDocument.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  27) src/Index.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  28) src/QueryBuilder/Facade.php (no_superfluous_phpdoc_tags, phpdoc_trim)
  29) src/QueryBuilder/DSL/Query.php (no_superfluous_phpdoc_tags, phpdoc_trim)
  30) src/Aggregation/AbstractSimpleAggregation.php (fully_qualified_strict_types, no_superfluous_phpdoc_tags, no_empty_phpdoc)
  31) src/Param.php (no_superfluous_phpdoc_tags, phpdoc_trim)
  32) src/Suggest.php (fully_qualified_strict_types, no_superfluous_phpdoc_tags, no_empty_phpdoc)
  33) src/Script/AbstractScript.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  34) src/Script/Script.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  35) src/Script/ScriptId.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  36) src/Suggest/Phrase.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  37) tests/UtilTest.php (string_implicit_backslashes, no_superfluous_phpdoc_tags, phpdoc_trim)
  38) tests/Aggregation/TopHitsTest.php (no_superfluous_phpdoc_tags, phpdoc_trim)
  39) tests/QueryTest.php (no_superfluous_phpdoc_tags, phpdoc_trim)
  40) tests/ResultSet/ProcessingBuilderTest.php (fully_qualified_strict_types)
  41) src/Query/Ids.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  42) src/Query/HasChild.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  43) src/Result.php (no_superfluous_phpdoc_tags, phpdoc_trim)
  44) src/Document.php (no_superfluous_phpdoc_tags, no_empty_phpdoc, phpdoc_trim, phpdoc_trim_consecutive_blank_line_separation)
  45) src/Processor/SetProcessor.php (no_superfluous_phpdoc_tags, no_empty_phpdoc, phpdoc_trim_consecutive_blank_line_separation)
  46) src/ResultSet/ChainProcessor.php (no_superfluous_phpdoc_tags, no_empty_phpdoc)
  47) src/Search.php (fully_qualified_strict_types, no_superfluous_phpdoc_tags, no_empty_phpdoc, phpdoc_types_order, phpdoc_trim, phpdoc_align)
  48) src/Client.php (no_superfluous_phpdoc_tags, no_empty_phpdoc, phpdoc_trim)
  49) src/Cluster/Settings.php (no_superfluous_phpdoc_tags, phpdoc_trim)
  50) src/ResultSet.php (fully_qualified_strict_types)
  51) tests/BulkTest.php (no_superfluous_phpdoc_tags, phpdoc_trim)
  52) tests/Exception/AbstractExceptionTest.php (string_implicit_backslashes)
  53) tests/ClientFunctionalTest.php (no_superfluous_phpdoc_tags, phpdoc_trim)
  54) tests/Script/ScriptTest.php (no_superfluous_phpdoc_tags, phpdoc_trim)
  55) tests/Script/ScriptIdTest.php (no_superfluous_phpdoc_tags, phpdoc_trim)
```

All rules are default one now and are part of `@PhpCsFixer`, except `fully_qualified_strict_types`. 
I enabled it in a purpose. I'm planning to upgrade PHPUnit to 10.5 and migrate from doc blocks to attributes with the help of `rectorphp`.
So this rule will help me to fix code like:
```
#[\PHPUnit\Framework\Attributes\Group('unit')]
```
to be
```
use  PHPUnit\Framework\Attributes\Group;

#[Group('unit')]
```

Benefits of enabling parallelization:
```diff
- Found 0 of 425 files that can be fixed in 10.818 seconds, 22.000 MB memory used
+ Found 0 of 425 files that can be fixed in 5.513 seconds, 18.00 MB memory used
```