### PR TITLE
fix: do not mutate BoolQuery instance in toArray method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* `Elastica\Query\BoolQuery::toArray` no longer changes `$this->_params` to \stdClass when empty [#2241](https://github.com/ruflin/Elastica/pull/2241)
 ### Security
 
 ## [8.1.0](https://github.com/ruflin/Elastica/compare/8.0.0...8.1.0)

--- a/src/Query/BoolQuery.php
+++ b/src/Query/BoolQuery.php
@@ -87,11 +87,15 @@ class BoolQuery extends AbstractQuery
 
     public function toArray(): array
     {
-        if (!$this->_params) {
-            $this->_params = new \stdClass();
+        $data = parent::toArray();
+
+        // When the query has no params, ensure that the query
+        // serializes into a JSON object instead of an empty array.
+        if (!$data[$this->_getBaseName()]) {
+            $data[$this->_getBaseName()] = new \stdClass();
         }
 
-        return parent::toArray();
+        return $data;
     }
 
     /**


### PR DESCRIPTION
Change the returned value of the `BoolQuery::toArray` method instead of mutating the instance.

Issue: https://github.com/ruflin/Elastica/issues/1450