### PR TITLE
Allow psr/log 2.0 + 3.0 in 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file based on the
 ### Backward Compatibility Breaks
 ### Bugfixes
 ### Added
+* Added support for `psr/log` 2.0 and 3.0 [#2244](https://github.com/ruflin/Elastica/pull/2244)
 ### Improvements
 * Solve PHP 8.1 deprecations for every class implementing Countable, Iterator or ArrayAccess [#2061](https://github.com/ruflin/Elastica/pull/2061)
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.0||^8.0",
         "ext-json": "*",
-        "psr/log": "~1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "elasticsearch/elasticsearch": "^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Backport #1971 to 6.x