### PR TITLE
Add intstructions for Github Copilot

### DIFF
--- a/.github/copilot/copilot-setup-steps.yaml
+++ b/.github/copilot/copilot-setup-steps.yaml
@@ -1,0 +1,23 @@
+# This file contains recommended steps for setting up the Elastica project.
+
+steps:
+  - name: "Install dependencies"
+    description: "Install the project's dependencies using Composer."
+    run: "make composer-install"
+    optional: false
+
+  - name: "Run tests"
+    description: "Run the test suite using PHPUnit."
+    run: "make run-phpunit"
+    optional: true
+
+  - name: "Check code style"
+    description: "Check for code style violations using php-cs-fixer."
+    run: "make run-phpcs"
+    optional: true
+
+  - name: "Fix code style"
+    description: "Automatically fix code style violations."
+    run: "make fix-phpcs"
+    optional: true
+

--- a/.github/copilot/instructions.md
+++ b/.github/copilot/instructions.md
@@ -11,7 +11,7 @@ This file contains custom instructions for GitHub Copilot. It is used to provide
 - The project uses phpstan for static analysis.
 - The project uses a Makefile for common tasks.
 - The project uses composer for dependencies
-- The code is compatible with Elastisearch 9.0 or newer
+- The code is compatible with Elasticsearch 9.0 or newer
 - Each code change has an entry in the `CHANGELOG.md` file. Exceptions are changes to tests.
 
 

--- a/.github/copilot/instructions.md
+++ b/.github/copilot/instructions.md
@@ -1,0 +1,42 @@
+# Custom instructions for GitHub Copilot
+
+This file contains custom instructions for GitHub Copilot. It is used to provide guidance to Copilot on how to behave when it is used in this repository.
+
+## General instructions
+
+- This is an open-source project. All contributions are welcome.
+- The project is written in PHP.
+- The project uses PHPUnit for testing.
+- The project uses php-cs-fixer for code style.
+- The project uses phpstan for static analysis.
+- The project uses a Makefile for common tasks.
+- The project uses composer for dependencies
+- The code is compatible with Elastisearch 9.0 or newer
+- Each code change has an entry in the `CHANGELOG.md` file. Exceptions are changes to tests.
+
+
+## PHP instructions
+
+- All code must be compatible with PHP 8.1 or higher.
+- All code must be PSR-2 compliant.
+- All classes must be in the `Elastica` namespace.
+- All classes must be final, unless they are meant to be extended.
+- All methods must have a return type.
+- All properties must have a type.
+- All parameters must have a type.
+- All functions must have a docblock.
+- All classes must have a docblock.
+- All properties must have a docblock.
+- All methods must have a docblock.
+- All docs for a method that calls an Elasticsearch API, a link to the Elasticsearch API docs must exist
+
+## Testing instructions
+
+- All code must be tested with PHPUnit.
+- All tests must be in the `tests` directory.
+- All tests must be in the `Elastica\Test` namespace.
+- All test classes must extend `Elastica\Test\Base`.
+- All test methods must start with `test`.
+- All test methods must have a `@covers` annotation.
+- All test methods must have a `@group` annotation.
+- For all methods, a `@group unit` and `@group functional` should exist

--- a/.github/copilot/instructions.md
+++ b/.github/copilot/instructions.md
@@ -28,7 +28,7 @@ This file contains custom instructions for GitHub Copilot. It is used to provide
 - All classes must have a docblock.
 - All properties must have a docblock.
 - All methods must have a docblock.
-- All docs for a method that calls an Elasticsearch API, a link to the Elasticsearch API docs must exist
+- For all methods that call an Elasticsearch API, a link to the Elasticsearch API docs must exist in the documentation.
 
 ## Testing instructions
 

--- a/.github/copilot/prompts/explain-code.prompt.md
+++ b/.github/copilot/prompts/explain-code.prompt.md
@@ -1,0 +1,13 @@
+---
+name: "Explain the code"
+description: "Explain the selected code."
+---
+Explain the following PHP code:
+
+```php
+{{selection}}
+```
+
+What is its purpose? How does it work?
+Are there any potential issues or edge cases to consider?
+

--- a/.github/copilot/prompts/new-test.prompt.md
+++ b/.github/copilot/prompts/new-test.prompt.md
@@ -1,0 +1,10 @@
+---
+name: "Create a new test"
+description: "Create a new PHPUnit test file for a class."
+---
+Create a new PHPUnit test file for the class `{{selection}}`.
+
+The test class should be in the `Elastica\Test` namespace and extend `Elastica\Test\Base`.
+It should have a `setUp()` method to initialize the object under test.
+Add a basic test case to verify that the object can be instantiated.
+


### PR DESCRIPTION
To make it easier for developers to use Github Copilot, this is adding files for Github Copilot.

This is an initial experiment to see how well Copilot can assist with code explanations and test generation for this repository. Contributions for other AI tools are welcome.