### PR TITLE
Add component and legacy Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Backward Compatibility Breaks
 ### Added
+* Added support for Component Template [#2257](https://github.com/ruflin/Elastica/pull/2257)
+* Added support for Index Template, using `useLegacy = false`  [#2257](https://github.com/ruflin/Elastica/pull/2257)
+* Added Template class to target only legacy Template [#2257](https://github.com/ruflin/Elastica/pull/2257)
 ### Changed
 ### Deprecated
+* Deprecated `Elastica\Template` because it's deprecated since version 7.8 on ElasticSearch [#2257](https://github.com/ruflin/Elastica/pull/2257)
 ### Removed
 ### Fixed
 * `Elastica\Query\BoolQuery::toArray` no longer changes `$this->_params` to \stdClass when empty [#2241](https://github.com/ruflin/Elastica/pull/2241)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Backward Compatibility Breaks
 ### Added
+* Added support for PHP 8.5 [#2254](https://github.com/ruflin/Elastica/pull/2254)
 * Added support for Component Template [#2257](https://github.com/ruflin/Elastica/pull/2257)
 * Added support for Index Template, using `useLegacy = false`  [#2257](https://github.com/ruflin/Elastica/pull/2257)
 * Added Template class to target only legacy Template [#2257](https://github.com/ruflin/Elastica/pull/2257)
-* Added support for PHP 8.5 [#2254](https://github.com/ruflin/Elastica/pull/2254)
 ### Changed
 ### Deprecated
 * Deprecated `Elastica\Template` because it's deprecated since version 7.8 on ElasticSearch [#2257](https://github.com/ruflin/Elastica/pull/2257)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -101,9 +101,19 @@ parameters:
 			path: tests/DocumentTest.php
 
 		-
+			message: "#^Parameter \\#2 \\$name of class Elastica\\\\ComponentTemplate constructor expects string, null given\\.$#"
+			count: 1
+			path: tests/ComponentTemplateTest.php
+
+		-
 			message: "#^Parameter \\#2 \\$name of class Elastica\\\\IndexTemplate constructor expects string, null given\\.$#"
 			count: 1
 			path: tests/IndexTemplateTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$name of class Elastica\\\\Template constructor expects string, null given\\.$#"
+			count: 1
+			path: tests/TemplateTest.php
 
 		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"

--- a/src/ComponentTemplate.php
+++ b/src/ComponentTemplate.php
@@ -12,18 +12,16 @@ use Elastica\Exception\ClientException;
 use Elastica\Exception\InvalidException;
 
 /**
- * Elastica index template object.
- *
- * @author Dmitry Balabka <dmitry.balabka@gmail.com>
+ * Elastica component template object.
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
  */
-class IndexTemplate
+class ComponentTemplate
 {
     /**
-     * Index template name.
+     * Component template name.
      *
-     * @var string Index pattern
+     * @var string
      */
     protected $_name;
 
@@ -33,45 +31,24 @@ class IndexTemplate
     protected $_client;
 
     /**
-     * Indicates if we should use the legacy template API.
+     * Creates a new component template object.
      *
-     * @var bool
-     */
-    protected $_useLegacy;
-
-    /**
-     * Legacy template object if using the legacy API.
-     *
-     * @var Template
-     */
-    protected $_legacyTemplate;
-
-    /**
-     * Creates a new index template object.
-     *
-     * @param string $name Index template name
+     * @param string $name Component template name
      *
      * @throws InvalidException
      */
-    public function __construct(Client $client, $name, $useLegacy = true)
+    public function __construct(Client $client, $name)
     {
-        $this->_useLegacy = $useLegacy;
-        if ($useLegacy) {
-            $this->_legacyTemplate = new Template($client, $name);
-
-            return;
-        }
-
         $this->_client = $client;
 
         if (!\is_scalar($name)) {
-            throw new InvalidException('Index template should be a scalar type');
+            throw new InvalidException('Component template should be a scalar type');
         }
         $this->_name = (string) $name;
     }
 
     /**
-     * Deletes the index template.
+     * Deletes the component template.
      *
      * @throws MissingParameterException if a required parameter is missing
      * @throws NoNodeAvailableException  if all the hosts are offline
@@ -81,17 +58,13 @@ class IndexTemplate
      */
     public function delete(): Response
     {
-        if ($this->_useLegacy) {
-            return $this->_legacyTemplate->delete();
-        }
-
         return $this->_client->toElasticaResponse(
-            $this->_client->indices()->deleteTemplate(['name' => $this->getName()])
+            $this->_client->cluster()->deleteComponentTemplate(['name' => $this->getName()])
         );
     }
 
     /**
-     * Creates a new index template with the given arguments.
+     * Creates a new component template with the given arguments.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
      *
@@ -105,17 +78,13 @@ class IndexTemplate
      */
     public function create(array $args = []): Response
     {
-        if ($this->_useLegacy) {
-            return $this->_legacyTemplate->create($args);
-        }
-
         return $this->_client->toElasticaResponse(
-            $this->_client->indices()->putTemplate(['name' => $this->getName(), 'body' => $args])
+            $this->_client->cluster()->putComponentTemplate(['name' => $this->getName(), 'body' => $args])
         );
     }
 
     /**
-     * Checks if the given index template is already created.
+     * Checks if the given component template is already created.
      *
      * @throws MissingParameterException if a required parameter is missing
      * @throws NoNodeAvailableException  if all the hosts are offline
@@ -125,35 +94,24 @@ class IndexTemplate
      */
     public function exists(): bool
     {
-        if ($this->_useLegacy) {
-            return $this->_legacyTemplate->exists();
-        }
-        $response = $this->_client->indices()->existsTemplate(['name' => $this->getName()]);
+        $response = $this->_client->cluster()->existsComponentTemplate(['name' => $this->getName()]);
 
         return 200 === $response->getStatusCode();
     }
 
     /**
-     * Returns the index template name.
+     * Returns the component template name.
      */
     public function getName(): string
     {
-        if ($this->_useLegacy) {
-            return $this->_legacyTemplate->getName();
-        }
-
         return $this->_name;
     }
 
     /**
-     * Returns index template client.
+     * Returns component template client.
      */
     public function getClient(): Client
     {
-        if ($this->_useLegacy) {
-            return $this->_legacyTemplate->getClient();
-        }
-
         return $this->_client;
     }
 }

--- a/src/IndexTemplate.php
+++ b/src/IndexTemplate.php
@@ -86,7 +86,7 @@ class IndexTemplate
         }
 
         return $this->_client->toElasticaResponse(
-            $this->_client->indices()->deleteTemplate(['name' => $this->getName()])
+            $this->_client->indices()->deleteIndexTemplate(['name' => $this->getName()])
         );
     }
 
@@ -110,7 +110,7 @@ class IndexTemplate
         }
 
         return $this->_client->toElasticaResponse(
-            $this->_client->indices()->putTemplate(['name' => $this->getName(), 'body' => $args])
+            $this->_client->indices()->putIndexTemplate(['name' => $this->getName(), 'body' => $args])
         );
     }
 
@@ -128,7 +128,7 @@ class IndexTemplate
         if ($this->_useLegacy) {
             return $this->_legacyTemplate->exists();
         }
-        $response = $this->_client->indices()->existsTemplate(['name' => $this->getName()]);
+        $response = $this->_client->indices()->existsIndexTemplate(['name' => $this->getName()]);
 
         return 200 === $response->getStatusCode();
     }

--- a/src/Template.php
+++ b/src/Template.php
@@ -12,13 +12,14 @@ use Elastica\Exception\ClientException;
 use Elastica\Exception\InvalidException;
 
 /**
- * Elastica index template object.
+ * Elastica legacy index template object.
  *
  * @author Dmitry Balabka <dmitry.balabka@gmail.com>
  *
+ * @deprecated _template have been deprecated in Elasticsearch 7.8 and will be removed in a future version. You should use the IndexTemplate class instead.
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
  */
-class IndexTemplate
+class Template
 {
     /**
      * Index template name.
@@ -33,35 +34,14 @@ class IndexTemplate
     protected $_client;
 
     /**
-     * Indicates if we should use the legacy template API.
-     *
-     * @var bool
-     */
-    protected $_useLegacy;
-
-    /**
-     * Legacy template object if using the legacy API.
-     *
-     * @var Template
-     */
-    protected $_legacyTemplate;
-
-    /**
      * Creates a new index template object.
      *
      * @param string $name Index template name
      *
      * @throws InvalidException
      */
-    public function __construct(Client $client, $name, $useLegacy = true)
+    public function __construct(Client $client, $name)
     {
-        $this->_useLegacy = $useLegacy;
-        if ($useLegacy) {
-            $this->_legacyTemplate = new Template($client, $name);
-
-            return;
-        }
-
         $this->_client = $client;
 
         if (!\is_scalar($name)) {
@@ -81,10 +61,6 @@ class IndexTemplate
      */
     public function delete(): Response
     {
-        if ($this->_useLegacy) {
-            return $this->_legacyTemplate->delete();
-        }
-
         return $this->_client->toElasticaResponse(
             $this->_client->indices()->deleteTemplate(['name' => $this->getName()])
         );
@@ -105,10 +81,6 @@ class IndexTemplate
      */
     public function create(array $args = []): Response
     {
-        if ($this->_useLegacy) {
-            return $this->_legacyTemplate->create($args);
-        }
-
         return $this->_client->toElasticaResponse(
             $this->_client->indices()->putTemplate(['name' => $this->getName(), 'body' => $args])
         );
@@ -125,9 +97,6 @@ class IndexTemplate
      */
     public function exists(): bool
     {
-        if ($this->_useLegacy) {
-            return $this->_legacyTemplate->exists();
-        }
         $response = $this->_client->indices()->existsTemplate(['name' => $this->getName()]);
 
         return 200 === $response->getStatusCode();
@@ -138,10 +107,6 @@ class IndexTemplate
      */
     public function getName(): string
     {
-        if ($this->_useLegacy) {
-            return $this->_legacyTemplate->getName();
-        }
-
         return $this->_name;
     }
 
@@ -150,10 +115,6 @@ class IndexTemplate
      */
     public function getClient(): Client
     {
-        if ($this->_useLegacy) {
-            return $this->_legacyTemplate->getClient();
-        }
-
         return $this->_client;
     }
 }

--- a/src/Template.php
+++ b/src/Template.php
@@ -24,7 +24,7 @@ class Template
     /**
      * Index template name.
      *
-     * @var string Index pattern
+     * @var string Template name
      */
     protected $_name;
 

--- a/tests/ComponentTemplateTest.php
+++ b/tests/ComponentTemplateTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elastica\Test;
+
+use Elastic\Elasticsearch\Exception\ClientResponseException;
+use Elastica\ComponentTemplate;
+use Elastica\Exception\InvalidException;
+use Elastica\Test\Base as BaseTest;
+
+/**
+ * ComponentTemplate class tests.
+ *
+ * @internal
+ */
+class ComponentTemplateTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testInstantiate(): void
+    {
+        $name = 'component_template1';
+        $client = $this->_getClient();
+        $template = new ComponentTemplate($client, $name);
+
+        $this->assertSame($client, $template->getClient());
+        $this->assertEquals($name, $template->getName());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testIncorrectInstantiate(): void
+    {
+        $this->expectException(InvalidException::class);
+
+        $client = $this->_getClient();
+        new ComponentTemplate($client, null);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testCreateTemplate(): void
+    {
+        $componentTemplateArgs = [
+            'template' => [
+                'mappings' => [
+                    'properties' => [
+                        '@timestamp' => [
+                            'type' => 'date',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $name = 'component_template1';
+        $template = new ComponentTemplate($this->_getClient(), $name);
+        $template->create($componentTemplateArgs);
+        $this->assertTrue($template->exists());
+        $template->delete();
+        $this->assertFalse($template->exists());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testCreateAlreadyExistsTemplateException(): void
+    {
+        $templateArgs = [
+            'template' => [
+                'mappings' => [
+                    'properties' => [
+                        '@timestamp' => [
+                            'type' => 'date',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $name = 'component_template1';
+        $template = new ComponentTemplate($this->_getClient(), $name);
+        $template->create($templateArgs);
+        try {
+            $template->create($templateArgs);
+        } catch (ClientResponseException $e) {
+            $error = \json_decode((string) $e->getResponse()->getBody(), true)['error']['root_cause'][0] ?? null;
+
+            $this->assertNotEquals('index_template_already_exists_exception', $error['type']);
+            $this->assertEquals('resource_already_exists_exception', $error['type']);
+            $this->assertEquals(400, $e->getResponse()->getStatusCode());
+        }
+    }
+}

--- a/tests/ComponentTemplateTest.php
+++ b/tests/ComponentTemplateTest.php
@@ -69,7 +69,7 @@ class ComponentTemplateTest extends BaseTest
      */
     public function testCreateAlreadyExistsTemplateException(): void
     {
-        $templateArgs = [
+        $componentTemplateArgs = [
             'template' => [
                 'mappings' => [
                     'properties' => [
@@ -82,9 +82,9 @@ class ComponentTemplateTest extends BaseTest
         ];
         $name = 'component_template1';
         $template = new ComponentTemplate($this->_getClient(), $name);
-        $template->create($templateArgs);
+        $template->create($componentTemplateArgs);
         try {
-            $template->create($templateArgs);
+            $template->create($componentTemplateArgs);
         } catch (ClientResponseException $e) {
             $error = \json_decode((string) $e->getResponse()->getBody(), true)['error']['root_cause'][0] ?? null;
 

--- a/tests/IndexTemplateTest.php
+++ b/tests/IndexTemplateTest.php
@@ -117,7 +117,7 @@ class IndexTemplateTest extends BaseTest
                 'settings' => [
                     'number_of_shards' => 1,
                 ],
-            ]
+            ],
         ];
         $name = 'index_template1';
         $indexTemplate = new IndexTemplate($this->_getClient(), $name, false);

--- a/tests/IndexTemplateTest.php
+++ b/tests/IndexTemplateTest.php
@@ -12,8 +12,6 @@ use Elastica\Test\Base as BaseTest;
 /**
  * IndexTemplate class tests.
  *
- * @author Dmitry Balabka <dmitry.balabka@intexsys.lv>
- *
  * @internal
  */
 class IndexTemplateTest extends BaseTest
@@ -45,6 +43,25 @@ class IndexTemplateTest extends BaseTest
     /**
      * @group functional
      */
+    public function testLegacyCreateTemplate(): void
+    {
+        $template = [
+            'index_patterns' => 'te*',
+            'settings' => [
+                'number_of_shards' => 1,
+            ],
+        ];
+        $name = 'index_legacy_template1';
+        $indexTemplate = new IndexTemplate($this->_getClient(), $name);
+        $indexTemplate->create($template);
+        $this->assertTrue($indexTemplate->exists());
+        $indexTemplate->delete();
+        $this->assertFalse($indexTemplate->exists());
+    }
+
+    /**
+     * @group functional
+     */
     public function testCreateTemplate(): void
     {
         $template = [
@@ -54,11 +71,36 @@ class IndexTemplateTest extends BaseTest
             ],
         ];
         $name = 'index_template1';
-        $indexTemplate = new IndexTemplate($this->_getClient(), $name);
+        $indexTemplate = new IndexTemplate($this->_getClient(), $name, false);
         $indexTemplate->create($template);
         $this->assertTrue($indexTemplate->exists());
         $indexTemplate->delete();
         $this->assertFalse($indexTemplate->exists());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testLegacyCreateAlreadyExistsTemplateException(): void
+    {
+        $template = [
+            'index_patterns' => 'te*',
+            'settings' => [
+                'number_of_shards' => 1,
+            ],
+        ];
+        $name = 'index_legacy_template1';
+        $indexTemplate = new IndexTemplate($this->_getClient(), $name);
+        $indexTemplate->create($template);
+        try {
+            $indexTemplate->create($template);
+        } catch (ClientResponseException $e) {
+            $error = \json_decode((string) $e->getResponse()->getBody(), true)['error']['root_cause'][0] ?? null;
+
+            $this->assertNotEquals('index_template_already_exists_exception', $error['type']);
+            $this->assertEquals('resource_already_exists_exception', $error['type']);
+            $this->assertEquals(400, $e->getResponse()->getStatusCode());
+        }
     }
 
     /**
@@ -72,8 +114,8 @@ class IndexTemplateTest extends BaseTest
                 'number_of_shards' => 1,
             ],
         ];
-        $name = 'index_template1';
-        $indexTemplate = new IndexTemplate($this->_getClient(), $name);
+        $name = 'index_legacy_template1';
+        $indexTemplate = new IndexTemplate($this->_getClient(), $name, false);
         $indexTemplate->create($template);
         try {
             $indexTemplate->create($template);

--- a/tests/IndexTemplateTest.php
+++ b/tests/IndexTemplateTest.php
@@ -8,6 +8,7 @@ use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Elastica\Exception\InvalidException;
 use Elastica\IndexTemplate;
 use Elastica\Test\Base as BaseTest;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * IndexTemplate class tests.
@@ -23,7 +24,7 @@ class IndexTemplateTest extends BaseTest
     {
         $name = 'index_template1';
         $client = $this->_getClient();
-        $indexTemplate = new IndexTemplate($client, $name);
+        $indexTemplate = new IndexTemplate($client, $name, false);
 
         $this->assertSame($client, $indexTemplate->getClient());
         $this->assertEquals($name, $indexTemplate->getName());
@@ -37,7 +38,7 @@ class IndexTemplateTest extends BaseTest
         $this->expectException(InvalidException::class);
 
         $client = $this->_getClient();
-        new IndexTemplate($client, null);
+        new IndexTemplate($client, null, false);
     }
 
     /**
@@ -46,7 +47,7 @@ class IndexTemplateTest extends BaseTest
     public function testLegacyCreateTemplate(): void
     {
         $template = [
-            'index_patterns' => 'te*',
+            'index_patterns' => 'legacyte*',
             'settings' => [
                 'number_of_shards' => 1,
             ],
@@ -66,8 +67,10 @@ class IndexTemplateTest extends BaseTest
     {
         $template = [
             'index_patterns' => 'te*',
-            'settings' => [
-                'number_of_shards' => 1,
+            'template' => [
+                'settings' => [
+                    'number_of_shards' => 1,
+                ],
             ],
         ];
         $name = 'index_template1';
@@ -84,7 +87,7 @@ class IndexTemplateTest extends BaseTest
     public function testLegacyCreateAlreadyExistsTemplateException(): void
     {
         $template = [
-            'index_patterns' => 'te*',
+            'index_patterns' => 'legacyte*',
             'settings' => [
                 'number_of_shards' => 1,
             ],

--- a/tests/IndexTemplateTest.php
+++ b/tests/IndexTemplateTest.php
@@ -113,9 +113,11 @@ class IndexTemplateTest extends BaseTest
     {
         $template = [
             'index_patterns' => 'te*',
-            'settings' => [
-                'number_of_shards' => 1,
-            ],
+            'template' => [
+                'settings' => [
+                    'number_of_shards' => 1,
+                ],
+            ]
         ];
         $name = 'index_template1';
         $indexTemplate = new IndexTemplate($this->_getClient(), $name, false);

--- a/tests/IndexTemplateTest.php
+++ b/tests/IndexTemplateTest.php
@@ -114,7 +114,7 @@ class IndexTemplateTest extends BaseTest
                 'number_of_shards' => 1,
             ],
         ];
-        $name = 'index_legacy_template1';
+        $name = 'index_template1';
         $indexTemplate = new IndexTemplate($this->_getClient(), $name, false);
         $indexTemplate->create($template);
         try {

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elastica\Test;
+
+use Elastic\Elasticsearch\Exception\ClientResponseException;
+use Elastica\Exception\InvalidException;
+use Elastica\Template;
+use Elastica\Test\Base as BaseTest;
+
+/**
+ * Template class tests.
+ *
+ * @author Dmitry Balabka <dmitry.balabka@intexsys.lv>
+ *
+ * @internal
+ */
+class TemplateTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testInstantiate(): void
+    {
+        $name = 'template1';
+        $client = $this->_getClient();
+        $template = new Template($client, $name);
+
+        $this->assertSame($client, $template->getClient());
+        $this->assertEquals($name, $template->getName());
+    }
+
+    /**
+     * @group unit
+     */
+    public function testIncorrectInstantiate(): void
+    {
+        $this->expectException(InvalidException::class);
+
+        $client = $this->_getClient();
+        new Template($client, null);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testCreateTemplate(): void
+    {
+        $templateArgs = [
+            'index_patterns' => 'te*',
+            'settings' => [
+                'number_of_shards' => 1,
+            ],
+        ];
+        $name = 'template1';
+        $template = new Template($this->_getClient(), $name);
+        $template->create($templateArgs);
+        $this->assertTrue($template->exists());
+        $template->delete();
+        $this->assertFalse($template->exists());
+    }
+
+    /**
+     * @group functional
+     */
+    public function testCreateAlreadyExistsTemplateException(): void
+    {
+        $templateArgs = [
+            'index_patterns' => 'te*',
+            'settings' => [
+                'number_of_shards' => 1,
+            ],
+        ];
+        $name = 'template1';
+        $template = new Template($this->_getClient(), $name);
+        $template->create($templateArgs);
+        try {
+            $template->create($templateArgs);
+        } catch (ClientResponseException $e) {
+            $error = \json_decode((string) $e->getResponse()->getBody(), true)['error']['root_cause'][0] ?? null;
+
+            $this->assertNotEquals('index_template_already_exists_exception', $error['type']);
+            $this->assertEquals('resource_already_exists_exception', $error['type']);
+            $this->assertEquals(400, $e->getResponse()->getStatusCode());
+        }
+    }
+}

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -8,6 +8,7 @@ use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Elastica\Exception\InvalidException;
 use Elastica\Template;
 use Elastica\Test\Base as BaseTest;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Template class tests.
@@ -48,7 +49,7 @@ class TemplateTest extends BaseTest
     public function testCreateTemplate(): void
     {
         $templateArgs = [
-            'index_patterns' => 'te*',
+            'index_patterns' => 'oldte*',
             'settings' => [
                 'number_of_shards' => 1,
             ],
@@ -67,7 +68,7 @@ class TemplateTest extends BaseTest
     public function testCreateAlreadyExistsTemplateException(): void
     {
         $templateArgs = [
-            'index_patterns' => 'te*',
+            'index_patterns' => 'oldte*',
             'settings' => [
                 'number_of_shards' => 1,
             ],


### PR DESCRIPTION
Folowing #2250 

This is the update for 8.x version which **don't** add Breaking change.

When using IndexTemplate, it has the `useLgeacy` set to true.
In this case `IndexTemplate` uses the new `Template` class.

The new `Template` is marked deprecated because [ElasticSearch did so in 7.8 version](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-template)

This PR also add a `ComponentTemplate`.

Please note that `exists` function implemented in https://github.com/elastic/elasticsearch-php does not work correctly.
Here is the corresponding issue:
https://github.com/elastic/elasticsearch-php/issues/1458