### PR TITLE
Fix Elasticsearch cluster discovery configuration to ensure green health status

### DIFF
--- a/docker/docker-compose.es.yml
+++ b/docker/docker-compose.es.yml
@@ -9,8 +9,8 @@ services:
         environment: &environment
             node.name: es01
             cluster.name: es-docker-cluster
-            cluster.initial_master_nodes: es01
-            discovery.seed_hosts: es01
+            cluster.initial_master_nodes: es01,es02
+            discovery.seed_hosts: es01,es02
             bootstrap.memory_lock: 'true'
             xpack.security.enabled: 'false'
             action.destructive_requires_name: 'false'


### PR DESCRIPTION
Update docker-compose.es.yml to include both es01 and es02 nodes in cluster.initial_master_nodes and discovery.seed_hosts settings. This ensures proper cluster formation where both nodes can discover each other, preventing yellow health status that occurs when replicas cannot be properly assigned due to incomplete cluster membership.

Fixes ClusterTest::testGetHealth which expects green status but was failing with yellow.
