### PR TITLE
Support git worktree inside the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ atlassian-ide-plugin.xml
 /nbproject
 /tools
 /vendor
+/_worktrees
 
 composer.lock
 composer.phar


### PR DESCRIPTION
To support working actively on multipel branches, especially having AI working on multiple branches in parallel, _worktrees is added to .gitignore

Example to create new branch in _worktrees:

```
git worktree add -b my-branch _worktrees/my-branch
```