### PR TITLE
Fix null client error in Bulk operations (#2219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 * `Elastica\Query\BoolQuery::toArray` no longer changes `$this->_params` to \stdClass when empty [#2241](https://github.com/ruflin/Elastica/pull/2241)
+* Fixed null client error in Bulk operations [#2219](https://github.com/ruflin/Elastica/pull/2219)
 ### Security
 
 ## [8.1.0](https://github.com/ruflin/Elastica/compare/8.0.0...8.1.0)

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -135,7 +135,7 @@ class Bulk
      */
     public function addDocument(Document $document, ?string $opType = null): self
     {
-        if (!$document->hasRetryOnConflict()) {
+        if (!$document->hasRetryOnConflict() && null !== $this->_client) {
             $retry = $this->_client->getConfigValue('retryOnConflict', 0);
 
             if ($retry > 0) {
@@ -167,7 +167,7 @@ class Bulk
      */
     public function addScript(AbstractScript $script, ?string $opType = null): self
     {
-        if (!$script->hasRetryOnConflict()) {
+        if (!$script->hasRetryOnConflict() && null !== $this->_client) {
             $retry = $this->_client->getConfigValue('retryOnConflict', 0);
 
             if ($retry > 0) {
@@ -346,8 +346,8 @@ class Bulk
 
                 if ($action instanceof AbstractDocumentAction) {
                     $data = $action->getData();
-                    if ($data instanceof Document && $data->isAutoPopulate()
-                        || $this->_client->getConfigValue(['document', 'autoPopulate'], false)
+                    if ($data instanceof Document && ($data->isAutoPopulate()
+                        || (null !== $this->_client && $this->_client->getConfigValue(['document', 'autoPopulate'], false)))
                     ) {
                         if (!$data->hasId() && isset($bulkResponseData['_id'])) {
                             $data->setId($bulkResponseData['_id']);

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -135,7 +135,7 @@ class Bulk
      */
     public function addDocument(Document $document, ?string $opType = null): self
     {
-        if (!$document->hasRetryOnConflict() && null !== $this->_client) {
+        if (null !== $this->_client && !$document->hasRetryOnConflict()) {
             $retry = $this->_client->getConfigValue('retryOnConflict', 0);
 
             if ($retry > 0) {
@@ -167,7 +167,7 @@ class Bulk
      */
     public function addScript(AbstractScript $script, ?string $opType = null): self
     {
-        if (!$script->hasRetryOnConflict() && null !== $this->_client) {
+        if (null !== $this->_client && !$script->hasRetryOnConflict()) {
             $retry = $this->_client->getConfigValue('retryOnConflict', 0);
 
             if ($retry > 0) {

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -792,7 +792,6 @@ class BulkTest extends BaseTest
         // Use reflection to simulate the scenario where _client might be null
         $reflection = new \ReflectionClass($bulk);
         $clientProperty = $reflection->getProperty('_client');
-        $clientProperty->setAccessible(true);
         $clientProperty->setValue($bulk, null);
 
         $document = new Document('1', ['name' => 'Test Document']);
@@ -814,7 +813,6 @@ class BulkTest extends BaseTest
         // Use reflection to simulate the scenario where _client might be null
         $reflection = new \ReflectionClass($bulk);
         $clientProperty = $reflection->getProperty('_client');
-        $clientProperty->setAccessible(true);
         $clientProperty->setValue($bulk, null);
 
         $script = new Script('ctx._source.name = params.name', ['name' => 'Test Script'], 'painless');

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -782,4 +782,48 @@ class BulkTest extends BaseTest
         $this->expectException(RequestEntityTooLargeException::class);
         $bulk->send();
     }
+
+    #[Group('unit')]
+    public function testAddDocumentWithNullClientDoesNotThrowError(): void
+    {
+        $clientMock = $this->createMock(Client::class);
+        $bulk = new Bulk($clientMock);
+
+        // Use reflection to simulate the scenario where _client might be null
+        $reflection = new \ReflectionClass($bulk);
+        $clientProperty = $reflection->getProperty('_client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($bulk, null);
+
+        $document = new Document('1', ['name' => 'Test Document']);
+
+        // This should not throw an error even when _client is null
+        $bulk->addDocument($document);
+
+        $actions = $bulk->getActions();
+        $this->assertCount(1, $actions);
+        $this->assertInstanceOf(AbstractDocument::class, $actions[0]);
+    }
+
+    #[Group('unit')]
+    public function testAddScriptWithNullClientDoesNotThrowError(): void
+    {
+        $clientMock = $this->createMock(Client::class);
+        $bulk = new Bulk($clientMock);
+
+        // Use reflection to simulate the scenario where _client might be null
+        $reflection = new \ReflectionClass($bulk);
+        $clientProperty = $reflection->getProperty('_client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($bulk, null);
+
+        $script = new Script('ctx._source.name = params.name', ['name' => 'Test Script'], 'painless');
+
+        // This should not throw an error even when _client is null
+        $bulk->addScript($script);
+
+        $actions = $bulk->getActions();
+        $this->assertCount(1, $actions);
+        $this->assertInstanceOf(AbstractDocument::class, $actions[0]);
+    }
 }


### PR DESCRIPTION
Add null checks before calling getConfigValue on _client in Bulk class to prevent "Call to a member function on null" errors in mocking scenarios and edge cases.

- Add null checks in addDocument() and addScript() methods
- Add null check in bulk response processing for autoPopulate feature
- Add comprehensive unit tests for null client scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)