### PR TITLE
Update docker compose files to follow new recommendations, use latest…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,8 @@
 /.php-cs-fixer.dist.php export-ignore
 /CHANGELOG.md merge=union
 /CONTRIBUTING.md export-ignore
+/CLAUDE.md export-ignore
+/GEMINI.md export-ignore
 /UPGRADE-8.0.md export-ignore
 /codecov.yml export-ignore
 /docker export-ignore

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -28,7 +28,6 @@ jobs:
     runs-on: 'ubuntu-24.04'
     name: 'PHPUnit (PHP ${{ matrix.php }}, ES ${{ matrix.elasticsearch }})'
     timeout-minutes: 10
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         php:
@@ -37,12 +36,10 @@ jobs:
           - '8.3'
           - '8.4'
           - '8.5'
-        experimental:
-          - false
         dependencies:
           - 'highest'
         elasticsearch:
-          - '9.0.4'
+          - '9.1.0'
       fail-fast: false
     steps:
       - name: 'Checkout'
@@ -74,7 +71,7 @@ jobs:
           sudo sysctl -w vm.swappiness=1
           sudo sysctl -w fs.file-max=262144
           sudo sysctl -w vm.max_map_count=262144
-          docker compose --file=docker/docker-compose.proxy.yml --file=docker/docker-compose.es.yml up --detach
+          docker compose --file=docker/compose.proxy.yaml --file=docker/compose.es.yaml up --detach
 
           docker run --rm --network=docker_elastic curlimages/curl --max-time 120 --retry-max-time 120 --retry 120 --retry-delay 5 --retry-all-errors --show-error --silent http://es01:9200
           docker run --rm --network=docker_elastic curlimages/curl --max-time 120 --retry-max-time 120 --retry 120 --retry-delay 5 --retry-all-errors --show-error --silent http://es02:9200
@@ -93,7 +90,7 @@ jobs:
       - name: Elasticsearch Logs
         if: always()
         run: |
-          docker compose --file=docker/docker-compose.proxy.yml --file=docker/docker-compose.es.yml logs es01 es02
+          docker compose --file=docker/compose.proxy.yaml --file=docker/compose.es.yaml logs es01 es02
 
   phpstan:
     runs-on: 'ubuntu-24.04'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-DOCKER_COMPOSE_OPTIONS	= --project-name=elastica --file=docker/docker-compose.yml --file=docker/docker-compose.proxy.yml --file=docker/docker-compose.es.yml
-DOCKER_COMPOSE_CMD := $(shell if [ ! -z "`docker compose version`" ]; then echo "docker compose"; else echo "docker-compose"; fi 2>/dev/null)
+DOCKER_COMPOSE_OPTIONS	= --project-name=elastica --file=docker/compose.yaml --file=docker/compose.proxy.yaml --file=docker/compose.es.yaml
 
 .PHONY: clean
 clean:
@@ -85,35 +84,35 @@ fix-phpstan-baseline: composer-install
 
 .PHONY: docker-start
 docker-start:
-	${DOCKER_COMPOSE_CMD} ${DOCKER_COMPOSE_OPTIONS} up ${DOCKER_OPTIONS}
+	docker compose ${DOCKER_COMPOSE_OPTIONS} up ${DOCKER_OPTIONS}
 
 .PHONY: docker-stop
 docker-stop:
-	${DOCKER_COMPOSE_CMD} ${DOCKER_COMPOSE_OPTIONS} down
+	docker compose ${DOCKER_COMPOSE_OPTIONS} down
 
 .PHONY: docker-run-phpunit
 docker-run-phpunit:
-	${DOCKER_COMPOSE_CMD} ${DOCKER_COMPOSE_OPTIONS} exec php env TERM=xterm-256color make run-phpunit PHPUNIT_OPTIONS=${PHPUNIT_OPTIONS}
+	docker compose ${DOCKER_COMPOSE_OPTIONS} exec php env TERM=xterm-256color make run-phpunit PHPUNIT_OPTIONS=${PHPUNIT_OPTIONS}
 
 .PHONY: docker-run-phpcs
 docker-run-phpcs:
-	${DOCKER_COMPOSE_CMD} ${DOCKER_COMPOSE_OPTIONS} exec php env TERM=xterm-256color make run-phpcs
+	docker compose ${DOCKER_COMPOSE_OPTIONS} exec php env TERM=xterm-256color make run-phpcs
 
 .PHONY: docker-fix-phpcs
 docker-fix-phpcs:
-	${DOCKER_COMPOSE_CMD} ${DOCKER_COMPOSE_OPTIONS} exec php env TERM=xterm-256color make fix-phpcs
+	docker compose ${DOCKER_COMPOSE_OPTIONS} exec php env TERM=xterm-256color make fix-phpcs
 
 .PHONY: docker-run-phpstan
 docker-run-phpstan:
-	${DOCKER_COMPOSE_CMD} ${DOCKER_COMPOSE_OPTIONS} exec php env TERM=xterm-256color vendor/bin/phpstan analyse --no-progress --no-interaction --memory-limit=1G
+	docker compose ${DOCKER_COMPOSE_OPTIONS} exec php env TERM=xterm-256color vendor/bin/phpstan analyse --no-progress --no-interaction --memory-limit=1G
 
 .PHONY: docker-fix-phpstan-baseline
 docker-fix-phpstan-baseline:
-	${DOCKER_COMPOSE_CMD} ${DOCKER_COMPOSE_OPTIONS} exec php env TERM=xterm-256color vendor/bin/phpstan analyse --no-progress --no-interaction --generate-baseline phpstan-baseline.neon --memory-limit=1G
+	docker compose ${DOCKER_COMPOSE_OPTIONS} exec php env TERM=xterm-256color vendor/bin/phpstan analyse --no-progress --no-interaction --generate-baseline phpstan-baseline.neon --memory-limit=1G
 
 .PHONY: docker-shell
 docker-shell:
-	${DOCKER_COMPOSE_CMD} ${DOCKER_COMPOSE_OPTIONS} exec php sh
+	docker compose ${DOCKER_COMPOSE_OPTIONS} exec php sh
 
 ## Additional commands
 

--- a/docker/compose.es.yaml
+++ b/docker/compose.es.yaml
@@ -1,11 +1,7 @@
-version: '3.8'
-
 services:
     es01:
         container_name: es01
-        image: &image docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-9.0.4}
-        command: &command >
-            /bin/sh -c "(./bin/elasticsearch-plugin list | grep -q ingest-attachment || ./bin/elasticsearch-plugin install --batch ingest-attachment) && /usr/local/bin/docker-entrypoint.sh"
+        image: &image docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-9.1.0}
         environment: &environment
             node.name: es01
             cluster.name: es-docker-cluster
@@ -31,7 +27,6 @@ services:
     es02:
         container_name: es02
         image: *image
-        command: *command
         environment:
             <<: *environment
             node.name: es02

--- a/docker/compose.proxy.yaml
+++ b/docker/compose.proxy.yaml
@@ -1,9 +1,7 @@
-version: '3.4'
-
 services:
     proxy:
         container_name: proxy
-        image: nginx:1.17-alpine
+        image: nginx:1.28-alpine
         volumes:
             - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
         ports:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,13 +1,11 @@
-version: '3.4'
-
-# This is a docker-compose template file for running docker's containers locally.
-# It must be combined with `docker-compose.es.yml`
+# This is a docker compose template file for running docker's containers locally.
+# It must be combined with `compose.es.yaml`
 # See: docker-start unit in Makefile
 
 services:
     php:
         container_name: php
-        build: 
+        build:
             dockerfile: php/Dockerfile
         volumes:
             - ../:/var/www/html
@@ -17,7 +15,7 @@ services:
             - ES_HOST=es01
             - PROXY_HOST=proxy
             - ES_VERSION=${ES_VERSION}
-        stdin_open: true 
+        stdin_open: true
         tty: true
 
 networks:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,8 +1,10 @@
-FROM php:8.1-alpine
+ARG PHP_VERSION=8.1
+
+FROM php:${PHP_VERSION}-alpine
 
 WORKDIR /var/www/html
 
-COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY --from=composer/composer:2.8-bin /composer /usr/bin/composer
 
 # Install requried packages for running Make and Phive
 RUN apk add make gnupg ncurses
@@ -10,6 +12,3 @@ RUN apk add make gnupg ncurses
 # Allow php to run with an
 RUN adduser phpuser -u 1000 -D -g ""
 USER phpuser
-
-# Config allow-plugin.symfony.Flex on PHPUser context
-RUN composer global config allow-plugins.symfony/flex false


### PR DESCRIPTION
This PR do:
- renames docker-compose.yml to the new docker official recommendations:
> This is the officially recommended and preferred file name for Docker Compose configuration files since Docker Compose version 1.28.6 (released in March 2021). It aligns with the newer docker compose CLI command (Compose V2), which is the current standard.

- Removes `version` key as it was deprecated while ago
- Uses docker compose (V2) and drops support for the V1