### PR TITLE
Add component and legacy Template, update IndexTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/ruflin/Elastica/compare/8.x...9.x)
+### Backward Compatibility Breaks
+* `Elastica\IndexTemplate` now works only with new `_index_template` API. You should use `Elastica\Template` to use the deprecated API [#2274](https://github.com/ruflin/Elastica/pull/2274)
+### Added
+* Added support for Component Template [#2274](https://github.com/ruflin/Elastica/pull/2274)
+* Added support for Index Template  [#2274](https://github.com/ruflin/Elastica/pull/2274)
+* Added Template class to target only legacy Template [#2274](https://github.com/ruflin/Elastica/pull/2274)
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/8.1.0...8.x)
 
 ### Backward Compatibility Breaks

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -151,10 +151,20 @@ parameters:
 			path: tests/DocumentTest.php
 
 		-
+			message: '#^Parameter \#2 \$name of class Elastica\\ComponentTemplate constructor expects string, null given\.$#'
+			count: 1
+			path: tests/ComponentTemplateTest.php
+
+		-
 			message: '#^Parameter \#2 \$name of class Elastica\\IndexTemplate constructor expects string, null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: tests/IndexTemplateTest.php
+
+		-
+			message: '#^Parameter \#2 \$name of class Elastica\\Template constructor expects string, null given\.$#'
+			count: 1
+			path: tests/TemplateTest.php
 
 		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'

--- a/src/ComponentTemplate.php
+++ b/src/ComponentTemplate.php
@@ -12,16 +12,16 @@ use Elastica\Exception\ClientException;
 use Elastica\Exception\InvalidException;
 
 /**
- * Elastica index template object.
+ * Elastica component template object.
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
  */
-class IndexTemplate
+class ComponentTemplate
 {
     /**
-     * Index template name.
+     * Component template name.
      *
-     * @var string Index template name
+     * @var string Component template name
      */
     protected $_name;
 
@@ -31,9 +31,9 @@ class IndexTemplate
     protected $_client;
 
     /**
-     * Creates a new index template object.
+     * Creates a new component template object.
      *
-     * @param string $name Index template name
+     * @param string $name Component template name
      *
      * @throws InvalidException
      */
@@ -42,13 +42,13 @@ class IndexTemplate
         $this->_client = $client;
 
         if (!\is_scalar($name)) {
-            throw new InvalidException('Index template should be a scalar type');
+            throw new InvalidException('Component template should be a scalar type');
         }
         $this->_name = (string) $name;
     }
 
     /**
-     * Deletes the index template.
+     * Deletes the component template.
      *
      * @throws MissingParameterException if a required parameter is missing
      * @throws NoNodeAvailableException  if all the hosts are offline
@@ -59,12 +59,12 @@ class IndexTemplate
     public function delete(): Response
     {
         return $this->_client->toElasticaResponse(
-            $this->_client->indices()->deleteIndexTemplate(['name' => $this->getName()])
+            $this->_client->cluster()->deleteComponentTemplate(['name' => $this->getName()])
         );
     }
 
     /**
-     * Creates a new index template with the given arguments.
+     * Creates a new component template with the given arguments.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
      *
@@ -79,12 +79,12 @@ class IndexTemplate
     public function create(array $args = []): Response
     {
         return $this->_client->toElasticaResponse(
-            $this->_client->indices()->putIndexTemplate(['name' => $this->getName(), 'body' => $args])
+            $this->_client->cluster()->putComponentTemplate(['name' => $this->getName(), 'body' => $args])
         );
     }
 
     /**
-     * Checks if the given index template is already created.
+     * Checks if the given component template is already created.
      *
      * @throws MissingParameterException if a required parameter is missing
      * @throws NoNodeAvailableException  if all the hosts are offline
@@ -94,13 +94,13 @@ class IndexTemplate
      */
     public function exists(): bool
     {
-        $response = $this->_client->indices()->existsIndexTemplate(['name' => $this->getName()]);
+        $response = $this->_client->cluster()->existsComponentTemplate(['name' => $this->getName()]);
 
         return 200 === $response->getStatusCode();
     }
 
     /**
-     * Returns the index template name.
+     * Returns the component template name.
      */
     public function getName(): string
     {
@@ -108,7 +108,7 @@ class IndexTemplate
     }
 
     /**
-     * Returns index template client.
+     * Returns component template client.
      */
     public function getClient(): Client
     {

--- a/src/Template.php
+++ b/src/Template.php
@@ -12,16 +12,19 @@ use Elastica\Exception\ClientException;
 use Elastica\Exception\InvalidException;
 
 /**
- * Elastica index template object.
+ * Elastica legacy index template object.
  *
+ * @author Dmitry Balabka <dmitry.balabka@gmail.com>
+ *
+ * @deprecated _template have been deprecated in Elasticsearch 7.8 and will be removed in a future version. You should use the IndexTemplate class instead.
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
  */
-class IndexTemplate
+class Template
 {
     /**
-     * Index template name.
+     * Template name.
      *
-     * @var string Index template name
+     * @var string Template name
      */
     protected $_name;
 
@@ -59,7 +62,7 @@ class IndexTemplate
     public function delete(): Response
     {
         return $this->_client->toElasticaResponse(
-            $this->_client->indices()->deleteIndexTemplate(['name' => $this->getName()])
+            $this->_client->indices()->deleteTemplate(['name' => $this->getName()])
         );
     }
 
@@ -79,7 +82,7 @@ class IndexTemplate
     public function create(array $args = []): Response
     {
         return $this->_client->toElasticaResponse(
-            $this->_client->indices()->putIndexTemplate(['name' => $this->getName(), 'body' => $args])
+            $this->_client->indices()->putTemplate(['name' => $this->getName(), 'body' => $args])
         );
     }
 
@@ -94,7 +97,7 @@ class IndexTemplate
      */
     public function exists(): bool
     {
-        $response = $this->_client->indices()->existsIndexTemplate(['name' => $this->getName()]);
+        $response = $this->_client->indices()->existsTemplate(['name' => $this->getName()]);
 
         return 200 === $response->getStatusCode();
     }

--- a/tests/ComponentTemplateTest.php
+++ b/tests/ComponentTemplateTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elastica\Test;
+
+use Elastic\Elasticsearch\Exception\ClientResponseException;
+use Elastica\ComponentTemplate;
+use Elastica\Exception\InvalidException;
+use Elastica\Test\Base as BaseTest;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * ComponentTemplate class tests.
+ *
+ * @internal
+ */
+class ComponentTemplateTest extends BaseTest
+{
+    #[Group('unit')]
+    public function testInstantiate(): void
+    {
+        $name = 'component_template1';
+        $client = $this->_getClient();
+        $template = new ComponentTemplate($client, $name);
+
+        $this->assertSame($client, $template->getClient());
+        $this->assertEquals($name, $template->getName());
+    }
+
+    #[Group('unit')]
+    public function testIncorrectInstantiate(): void
+    {
+        $this->expectException(InvalidException::class);
+
+        $client = $this->_getClient();
+        new ComponentTemplate($client, null);
+    }
+
+    #[Group('functional')]
+    public function testCreateTemplate(): void
+    {
+        $componentTemplateArgs = [
+            'template' => [
+                'mappings' => [
+                    'properties' => [
+                        '@timestamp' => [
+                            'type' => 'date',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $name = 'component_template1';
+        $template = new ComponentTemplate($this->_getClient(), $name);
+        $template->create($componentTemplateArgs);
+        $this->assertTrue($template->exists());
+        $template->delete();
+        $this->assertFalse($template->exists());
+    }
+
+    #[Group('functional')]
+    public function testCreateAlreadyExistsTemplateException(): void
+    {
+        $templateArgs = [
+            'template' => [
+                'mappings' => [
+                    'properties' => [
+                        '@timestamp' => [
+                            'type' => 'date',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $name = 'component_template1';
+        $template = new ComponentTemplate($this->_getClient(), $name);
+        $template->create($templateArgs);
+        try {
+            $template->create($templateArgs);
+        } catch (ClientResponseException $e) {
+            $error = \json_decode((string) $e->getResponse()->getBody(), true)['error']['root_cause'][0] ?? null;
+
+            $this->assertNotEquals('index_template_already_exists_exception', $error['type']);
+            $this->assertEquals('resource_already_exists_exception', $error['type']);
+            $this->assertEquals(400, $e->getResponse()->getStatusCode());
+        }
+    }
+}

--- a/tests/ComponentTemplateTest.php
+++ b/tests/ComponentTemplateTest.php
@@ -62,7 +62,7 @@ class ComponentTemplateTest extends BaseTest
     #[Group('functional')]
     public function testCreateAlreadyExistsTemplateException(): void
     {
-        $templateArgs = [
+        $componentTemplateArgs = [
             'template' => [
                 'mappings' => [
                     'properties' => [
@@ -75,9 +75,9 @@ class ComponentTemplateTest extends BaseTest
         ];
         $name = 'component_template1';
         $template = new ComponentTemplate($this->_getClient(), $name);
-        $template->create($templateArgs);
+        $template->create($componentTemplateArgs);
         try {
-            $template->create($templateArgs);
+            $template->create($componentTemplateArgs);
         } catch (ClientResponseException $e) {
             $error = \json_decode((string) $e->getResponse()->getBody(), true)['error']['root_cause'][0] ?? null;
 

--- a/tests/IndexTemplateTest.php
+++ b/tests/IndexTemplateTest.php
@@ -42,8 +42,10 @@ class IndexTemplateTest extends BaseTest
     {
         $template = [
             'index_patterns' => 'te*',
-            'settings' => [
-                'number_of_shards' => 1,
+            'template' => [
+                'settings' => [
+                    'number_of_shards' => 1,
+                ],
             ],
         ];
         $name = 'index_template1';
@@ -59,8 +61,10 @@ class IndexTemplateTest extends BaseTest
     {
         $template = [
             'index_patterns' => 'te*',
-            'settings' => [
-                'number_of_shards' => 1,
+            'template' => [
+                'settings' => [
+                    'number_of_shards' => 1,
+                ],
             ],
         ];
         $name = 'index_template1';

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -43,7 +43,7 @@ class TemplateTest extends BaseTest
     public function testCreateTemplate(): void
     {
         $templateArgs = [
-            'index_patterns' => 'te*',
+            'index_patterns' => 'oldte*',
             'settings' => [
                 'number_of_shards' => 1,
             ],
@@ -60,7 +60,7 @@ class TemplateTest extends BaseTest
     public function testCreateAlreadyExistsTemplateException(): void
     {
         $templateArgs = [
-            'index_patterns' => 'te*',
+            'index_patterns' => 'oldte*',
             'settings' => [
                 'number_of_shards' => 1,
             ],

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -6,26 +6,28 @@ namespace Elastica\Test;
 
 use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Elastica\Exception\InvalidException;
-use Elastica\IndexTemplate;
+use Elastica\Template;
 use Elastica\Test\Base as BaseTest;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
- * IndexTemplate class tests.
+ * Template class tests.
+ *
+ * @author Dmitry Balabka <dmitry.balabka@intexsys.lv>
  *
  * @internal
  */
-class IndexTemplateTest extends BaseTest
+class TemplateTest extends BaseTest
 {
     #[Group('unit')]
     public function testInstantiate(): void
     {
-        $name = 'index_template1';
+        $name = 'template1';
         $client = $this->_getClient();
-        $indexTemplate = new IndexTemplate($client, $name);
+        $template = new Template($client, $name);
 
-        $this->assertSame($client, $indexTemplate->getClient());
-        $this->assertEquals($name, $indexTemplate->getName());
+        $this->assertSame($client, $template->getClient());
+        $this->assertEquals($name, $template->getName());
     }
 
     #[Group('unit')]
@@ -34,40 +36,40 @@ class IndexTemplateTest extends BaseTest
         $this->expectException(InvalidException::class);
 
         $client = $this->_getClient();
-        new IndexTemplate($client, null);
+        new Template($client, null);
     }
 
     #[Group('functional')]
     public function testCreateTemplate(): void
     {
-        $template = [
+        $templateArgs = [
             'index_patterns' => 'te*',
             'settings' => [
                 'number_of_shards' => 1,
             ],
         ];
-        $name = 'index_template1';
-        $indexTemplate = new IndexTemplate($this->_getClient(), $name);
-        $indexTemplate->create($template);
-        $this->assertTrue($indexTemplate->exists());
-        $indexTemplate->delete();
-        $this->assertFalse($indexTemplate->exists());
+        $name = 'template1';
+        $template = new Template($this->_getClient(), $name);
+        $template->create($templateArgs);
+        $this->assertTrue($template->exists());
+        $template->delete();
+        $this->assertFalse($template->exists());
     }
 
     #[Group('functional')]
     public function testCreateAlreadyExistsTemplateException(): void
     {
-        $template = [
+        $templateArgs = [
             'index_patterns' => 'te*',
             'settings' => [
                 'number_of_shards' => 1,
             ],
         ];
-        $name = 'index_template1';
-        $indexTemplate = new IndexTemplate($this->_getClient(), $name);
-        $indexTemplate->create($template);
+        $name = 'template1';
+        $template = new Template($this->_getClient(), $name);
+        $template->create($templateArgs);
         try {
-            $indexTemplate->create($template);
+            $template->create($templateArgs);
         } catch (ClientResponseException $e) {
             $error = \json_decode((string) $e->getResponse()->getBody(), true)['error']['root_cause'][0] ?? null;
 


### PR DESCRIPTION
Followin https://github.com/ruflin/Elastica/pull/2258#issuecomment-3124558900
this PR targets directly 9.x branch and depends on nothing else.

When using IndexTemplate, ity now uses the ` _index_template` API.
The `Template` class use the old API, like `IndexTemplate was working before this PR.

The new `Template` is marked deprecated because [ElasticSearch did so in 7.8 version](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-template)

This PR also add a `ComponentTemplate`.