### PR TITLE
Fix: Allow zero retries in Client configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 * `Elastica\Query\BoolQuery::toArray` no longer changes `$this->_params` to \stdClass when empty [#2241](https://github.com/ruflin/Elastica/pull/2241)
+* Fixed Client retries configuration to allow zero retries by changing condition from `> 0` to `>= 0` [#2278](https://github.com/ruflin/Elastica/pull/2278)
 ### Security
 
 ## [8.1.0](https://github.com/ruflin/Elastica/compare/8.0.0...8.1.0)

--- a/src/Client.php
+++ b/src/Client.php
@@ -598,8 +598,8 @@ class Client implements ClientInterface
         $transport = $builder->build();
 
         // The default retries is equal to the number of hosts
-        if (isset($config['retries']) && (int) $config['retries'] > 0) {
-            $transport->setRetries($config['retries']);
+        if (isset($config['retries']) && (int) $config['retries'] >= 0) {
+            $transport->setRetries((int) $config['retries']);
         } else {
             $transport->setRetries(\count($hosts));
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -183,7 +183,7 @@ class ClientTest extends BaseTest
     public function testRetriesConfigurationWithZeroRetries(): void
     {
         $client = new Client(['retries' => 0]);
-        
+
         // Verify that zero retries is properly set on the transport
         $transport = $client->getTransport();
         $this->assertEquals(0, $transport->getRetries());
@@ -195,7 +195,7 @@ class ClientTest extends BaseTest
     public function testRetriesConfigurationWithPositiveRetries(): void
     {
         $client = new Client(['retries' => 3]);
-        
+
         // Verify that positive retries is properly set on the transport
         $transport = $client->getTransport();
         $this->assertEquals(3, $transport->getRetries());
@@ -207,7 +207,7 @@ class ClientTest extends BaseTest
     public function testRetriesConfigurationWithNegativeRetries(): void
     {
         $client = new Client(['retries' => -1]);
-        
+
         // Verify that negative retries falls back to default (number of hosts)
         $transport = $client->getTransport();
         $this->assertEquals(1, $transport->getRetries()); // Default host count
@@ -220,9 +220,9 @@ class ClientTest extends BaseTest
     {
         $client = new Client([
             'hosts' => ['localhost:9200', 'localhost:9201', 'localhost:9202'],
-            'retries' => 0
+            'retries' => 0,
         ]);
-        
+
         // Verify that zero retries is properly set even with multiple hosts
         $transport = $client->getTransport();
         $this->assertEquals(0, $transport->getRetries());
@@ -234,7 +234,7 @@ class ClientTest extends BaseTest
     public function testRetriesConfigurationDefaultBehavior(): void
     {
         $client = new Client(['hosts' => ['localhost:9200', 'localhost:9201']]);
-        
+
         // Verify that when no retries is specified, it defaults to host count
         $transport = $client->getTransport();
         $this->assertEquals(2, $transport->getRetries()); // Number of hosts
@@ -246,7 +246,7 @@ class ClientTest extends BaseTest
     public function testRetriesConfigurationWithStringZero(): void
     {
         $client = new Client(['retries' => '0']);
-        
+
         // Verify that string '0' is properly converted to integer 0
         $transport = $client->getTransport();
         $this->assertEquals(0, $transport->getRetries());

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -176,4 +176,79 @@ class ClientTest extends BaseTest
 
         self::assertSame(['Authorization' => \sprintf('ApiKey %s', $apiKey)], $client->getTransport()->getHeaders());
     }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationWithZeroRetries(): void
+    {
+        $client = new Client(['retries' => 0]);
+        
+        // Verify that zero retries is properly set on the transport
+        $transport = $client->getTransport();
+        $this->assertEquals(0, $transport->getRetries());
+    }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationWithPositiveRetries(): void
+    {
+        $client = new Client(['retries' => 3]);
+        
+        // Verify that positive retries is properly set on the transport
+        $transport = $client->getTransport();
+        $this->assertEquals(3, $transport->getRetries());
+    }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationWithNegativeRetries(): void
+    {
+        $client = new Client(['retries' => -1]);
+        
+        // Verify that negative retries falls back to default (number of hosts)
+        $transport = $client->getTransport();
+        $this->assertEquals(1, $transport->getRetries()); // Default host count
+    }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationWithMultipleHosts(): void
+    {
+        $client = new Client([
+            'hosts' => ['localhost:9200', 'localhost:9201', 'localhost:9202'],
+            'retries' => 0
+        ]);
+        
+        // Verify that zero retries is properly set even with multiple hosts
+        $transport = $client->getTransport();
+        $this->assertEquals(0, $transport->getRetries());
+    }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationDefaultBehavior(): void
+    {
+        $client = new Client(['hosts' => ['localhost:9200', 'localhost:9201']]);
+        
+        // Verify that when no retries is specified, it defaults to host count
+        $transport = $client->getTransport();
+        $this->assertEquals(2, $transport->getRetries()); // Number of hosts
+    }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationWithStringZero(): void
+    {
+        $client = new Client(['retries' => '0']);
+        
+        // Verify that string '0' is properly converted to integer 0
+        $transport = $client->getTransport();
+        $this->assertEquals(0, $transport->getRetries());
+    }
 }


### PR DESCRIPTION
- Changed retries condition from `> 0` to `>= 0` to allow zero retries
- Fixed type casting issue by casting retries value to int when passing to setRetries()
- Added comprehensive tests for zero retries functionality
- Updated CHANGELOG.md to document the fix

Fixes #2278