### PR TITLE
Backport: Fix Client retries configuration to allow zero retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 * `Elastica\Query\BoolQuery::toArray` no longer changes `$this->_params` to \stdClass when empty [#2241](https://github.com/ruflin/Elastica/pull/2241)
+* Fixed Client retries configuration to allow zero retries by changing condition from `> 0` to `>= 0` [#2278](https://github.com/ruflin/Elastica/pull/2278)
 ### Security
 
 ## [8.1.0](https://github.com/ruflin/Elastica/compare/8.0.0...8.1.0)

--- a/src/Aggregation/ScriptedMetric.php
+++ b/src/Aggregation/ScriptedMetric.php
@@ -23,7 +23,7 @@ class ScriptedMetric extends AbstractAggregation
         ?string $initScript = null,
         ?string $mapScript = null,
         ?string $combineScript = null,
-        ?string $reduceScript = null
+        ?string $reduceScript = null,
     ) {
         parent::__construct($name);
         if ($initScript) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -110,6 +110,16 @@ class Client implements ClientInterface
         throw new \Exception('Not supported');
     }
 
+    public function setServerless(bool $value): ClientInterface
+    {
+        throw new \Exception('Not supported');
+    }
+
+    public function getServerless(): bool
+    {
+        return false;
+    }
+
     /**
      * Get current version.
      *
@@ -589,8 +599,8 @@ class Client implements ClientInterface
         $transport = $builder->build();
 
         // The default retries is equal to the number of hosts
-        if (isset($config['retries']) && (int) $config['retries'] > 0) {
-            $transport->setRetries($config['retries']);
+        if (isset($config['retries']) && (int) $config['retries'] >= 0) {
+            $transport->setRetries((int) $config['retries']);
         } else {
             $transport->setRetries(\count($hosts));
         }

--- a/src/Index.php
+++ b/src/Index.php
@@ -157,12 +157,11 @@ class Index implements SearchableInterface
     /**
      * Update entries in the db based on a query.
      *
-     * @param AbstractQuery|array|Query|string|null $query Query object or array
+     * @param AbstractQuery|array|Query|string|null $query   Query object or array
+     * @param AbstractScript                        $script  Script
+     * @param array                                 $options Optional params
      *
      * @phpstan-param TCreateQueryArgsMatching $query
-     *
-     * @param AbstractScript $script  Script
-     * @param array          $options Optional params
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html
      *
@@ -341,11 +340,10 @@ class Index implements SearchableInterface
     /**
      * Deletes documents matching the given query.
      *
-     * @param AbstractQuery|array|Query|string|null $query Query object or array
+     * @param AbstractQuery|array|Query|string|null $query   Query object or array
+     * @param array                                 $options Optional params
      *
      * @phpstan-param TCreateQueryArgsMatching $query
-     *
-     * @param array $options Optional params
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
      *

--- a/src/Query/FunctionScore.php
+++ b/src/Query/FunctionScore.php
@@ -76,7 +76,7 @@ class FunctionScore extends AbstractQuery
         string $functionType,
         $functionParams,
         ?AbstractQuery $filter = null,
-        ?float $weight = null
+        ?float $weight = null,
     ): self {
         $function = [
             $functionType => $functionParams,
@@ -133,7 +133,7 @@ class FunctionScore extends AbstractQuery
         ?float $decay = null,
         ?float $weight = null,
         ?AbstractQuery $filter = null,
-        ?string $multiValueMode = null
+        ?string $multiValueMode = null,
     ) {
         $functionParams = [
             $field => [
@@ -164,7 +164,7 @@ class FunctionScore extends AbstractQuery
         ?string $modifier = null,
         ?float $missing = null,
         ?float $weight = null,
-        ?AbstractQuery $filter = null
+        ?AbstractQuery $filter = null,
     ): self {
         $functionParams = [
             'field' => $field,
@@ -210,7 +210,7 @@ class FunctionScore extends AbstractQuery
         int $seed,
         ?AbstractQuery $filter = null,
         ?float $weight = null,
-        ?string $field = null
+        ?string $field = null,
     ): self {
         $functionParams = [
             'seed' => $seed,

--- a/src/Query/GeoShapePreIndexed.php
+++ b/src/Query/GeoShapePreIndexed.php
@@ -48,7 +48,7 @@ class GeoShapePreIndexed extends AbstractGeoShape
         string $path,
         string $indexedId,
         string $indexedIndex,
-        string $indexedPath
+        string $indexedPath,
     ) {
         $this->_path = $path;
         $this->_indexedId = $indexedId;

--- a/src/Query/HasChild.php
+++ b/src/Query/HasChild.php
@@ -19,10 +19,9 @@ class HasChild extends AbstractQuery
 {
     /**
      * @param AbstractQuery|array|BaseQuery|string|null $query
+     * @param string|null                               $type  Parent document type
      *
      * @phpstan-param TCreateQueryArgsMatching $query
-     *
-     * @param string|null $type Parent document type
      */
     public function __construct($query, ?string $type = null)
     {

--- a/src/Query/HasParent.php
+++ b/src/Query/HasParent.php
@@ -17,10 +17,9 @@ class HasParent extends AbstractQuery
 {
     /**
      * @param AbstractQuery|array|BaseQuery|string|null $query
+     * @param string                                    $type  Parent document type
      *
      * @phpstan-param TCreateQueryArgsMatching $query
-     *
-     * @param string $type Parent document type
      */
     public function __construct($query, string $type)
     {

--- a/src/QueryBuilder/DSL/Aggregation.php
+++ b/src/QueryBuilder/DSL/Aggregation.php
@@ -240,7 +240,7 @@ class Aggregation implements DSL
         ?string $initScript = null,
         ?string $mapScript = null,
         ?string $combineScript = null,
-        ?string $reduceScript = null
+        ?string $reduceScript = null,
     ): ScriptedMetric {
         return new ScriptedMetric($name, $initScript, $mapScript, $combineScript, $reduceScript);
     }

--- a/src/Search.php
+++ b/src/Search.php
@@ -272,10 +272,9 @@ class Search
      * Search in the set indices.
      *
      * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest|null $query
+     * @param array<string, mixed>|null                                              $options associative array of options (option=>value)
      *
      * @phpstan-param TCreateQueryArgs $query
-     *
-     * @param array<string, mixed>|null $options associative array of options (option=>value)
      *
      * @throws InvalidException
      * @throws NoNodeAvailableException if all the hosts are offline

--- a/src/SearchableInterface.php
+++ b/src/SearchableInterface.php
@@ -38,12 +38,11 @@ interface SearchableInterface
      *      }
      * }
      *
-     * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest|null $query Array with all query data inside or a Elastica\Query object
+     * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest|null $query   Array with all query data inside or a Elastica\Query object
+     * @param array<string, mixed>|null                                              $options associative array of options (option=>value)
+     * @param string                                                                 $method  Request method, see Request's constants
      *
      * @phpstan-param TCreateQueryArgs $query
-     *
-     * @param array<string, mixed>|null $options associative array of options (option=>value)
-     * @param string                    $method  Request method, see Request's constants
      *
      * @throws NoNodeAvailableException if all the hosts are offline
      * @throws ClientResponseException  if the status code of response is 4xx
@@ -58,11 +57,10 @@ interface SearchableInterface
      *
      * If no query is set, matchall query is created
      *
-     * @param AbstractQuery|array|Query|string|null $query Array with all query data inside or a Elastica\Query object
+     * @param AbstractQuery|array|Query|string|null $query  Array with all query data inside or a Elastica\Query object
+     * @param string                                $method Request method, see Request's constants
      *
      * @phpstan-param TCreateQueryArgsMatching $query
-     *
-     * @param string $method Request method, see Request's constants
      *
      * @throws NoNodeAvailableException if all the hosts are offline
      * @throws ClientResponseException  if the status code of response is 4xx
@@ -75,10 +73,9 @@ interface SearchableInterface
 
     /**
      * @param AbstractQuery|AbstractSuggest|array|Collapse|Query|string|Suggest|null $query
+     * @param array<string, mixed>|null                                              $options
      *
      * @phpstan-param TCreateQueryArgs $query
-     *
-     * @param array<string, mixed>|null $options
      */
     public function createSearch($query = '', ?array $options = null): Search;
 }

--- a/tests/Aggregation/CardinalityTest.php
+++ b/tests/Aggregation/CardinalityTest.php
@@ -46,16 +46,6 @@ class CardinalityTest extends BaseAggregationTest
         $this->assertEquals(4, $results['value']);
     }
 
-    public function validPrecisionThresholdProvider(): array
-    {
-        return [
-            'negative-int' => [-140],
-            'zero' => [0],
-            'positive-int' => [150],
-            'more-than-max' => [40001],
-        ];
-    }
-
     /**
      * @dataProvider validPrecisionThresholdProvider
      *
@@ -68,6 +58,16 @@ class CardinalityTest extends BaseAggregationTest
 
         $this->assertNotNull($agg->getParam('precision_threshold'));
         $this->assertIsInt($agg->getParam('precision_threshold'));
+    }
+
+    public function validPrecisionThresholdProvider(): array
+    {
+        return [
+            'negative-int' => [-140],
+            'zero' => [0],
+            'positive-int' => [150],
+            'more-than-max' => [40001],
+        ];
     }
 
     /**

--- a/tests/Aggregation/TermsTest.php
+++ b/tests/Aggregation/TermsTest.php
@@ -163,7 +163,7 @@ class TermsTest extends BaseAggregationTest
     public function testTermsSetMissingBucketFunctional(
         string $field,
         int $expectedCountValues,
-        bool $isSetMissingBucket
+        bool $isSetMissingBucket,
     ): void {
         $terms = new Terms('terms');
         $terms->setField($field);

--- a/tests/Aggregation/TopHitsTest.php
+++ b/tests/Aggregation/TopHitsTest.php
@@ -243,14 +243,6 @@ class TopHitsTest extends BaseAggregationTest
         $this->assertEquals([2, 4], $resultDocs);
     }
 
-    public function limitedSourceProvider(): array
-    {
-        return [
-            'string source' => ['title'],
-            'array source' => [['title']],
-        ];
-    }
-
     /**
      * @group functional
      *
@@ -270,6 +262,14 @@ class TopHitsTest extends BaseAggregationTest
                 $this->assertArrayNotHasKey('last_activity_date', $doc['_source']);
             }
         }
+    }
+
+    public function limitedSourceProvider(): array
+    {
+        return [
+            'string source' => ['title'],
+            'array source' => [['title']],
+        ];
     }
 
     /**

--- a/tests/Bulk/ResponseSetTest.php
+++ b/tests/Bulk/ResponseSetTest.php
@@ -41,6 +41,15 @@ class ResponseSetTest extends BaseTest
         $this->assertEquals($expected, $responseSet->isOk());
     }
 
+    public function isOkDataProvider(): \Generator
+    {
+        [$responseData, $actions] = $this->_getFixture();
+
+        yield [$responseData, $actions, true];
+        $responseData['items'][2]['index']['ok'] = false;
+        yield [$responseData, $actions, false];
+    }
+
     /**
      * @group unit
      */
@@ -128,15 +137,6 @@ class ResponseSetTest extends BaseTest
 
         $this->assertEquals(0, $responseSet->key());
         $this->assertTrue($responseSet->valid());
-    }
-
-    public function isOkDataProvider(): \Generator
-    {
-        [$responseData, $actions] = $this->_getFixture();
-
-        yield [$responseData, $actions, true];
-        $responseData['items'][2]['index']['ok'] = false;
-        yield [$responseData, $actions, false];
     }
 
     protected function _createResponseSet(array $responseData, array $actions): ResponseSet

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -176,4 +176,79 @@ class ClientTest extends BaseTest
 
         self::assertSame(['Authorization' => \sprintf('ApiKey %s', $apiKey)], $client->getTransport()->getHeaders());
     }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationWithZeroRetries(): void
+    {
+        $client = new Client(['retries' => 0]);
+
+        // Verify that zero retries is properly set on the transport
+        $transport = $client->getTransport();
+        $this->assertEquals(0, $transport->getRetries());
+    }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationWithPositiveRetries(): void
+    {
+        $client = new Client(['retries' => 3]);
+
+        // Verify that positive retries is properly set on the transport
+        $transport = $client->getTransport();
+        $this->assertEquals(3, $transport->getRetries());
+    }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationWithNegativeRetries(): void
+    {
+        $client = new Client(['retries' => -1]);
+
+        // Verify that negative retries falls back to default (number of hosts)
+        $transport = $client->getTransport();
+        $this->assertEquals(1, $transport->getRetries()); // Default host count
+    }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationWithMultipleHosts(): void
+    {
+        $client = new Client([
+            'hosts' => ['localhost:9200', 'localhost:9201', 'localhost:9202'],
+            'retries' => 0,
+        ]);
+
+        // Verify that zero retries is properly set even with multiple hosts
+        $transport = $client->getTransport();
+        $this->assertEquals(0, $transport->getRetries());
+    }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationDefaultBehavior(): void
+    {
+        $client = new Client(['hosts' => ['localhost:9200', 'localhost:9201']]);
+
+        // Verify that when no retries is specified, it defaults to host count
+        $transport = $client->getTransport();
+        $this->assertEquals(2, $transport->getRetries()); // Number of hosts
+    }
+
+    /**
+     * @covers \Elastica\Client::_buildTransport
+     */
+    public function testRetriesConfigurationWithStringZero(): void
+    {
+        $client = new Client(['retries' => '0']);
+
+        // Verify that string '0' is properly converted to integer 0
+        $transport = $client->getTransport();
+        $this->assertEquals(0, $transport->getRetries());
+    }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -622,14 +622,6 @@ class QueryTest extends BaseTest
         $this->assertFalse($query->getParam('track_total_hits'));
     }
 
-    public function provideSetTrackTotalHitsInvalidValue(): iterable
-    {
-        yield 'string' => ['string string'];
-        yield 'null' => [null];
-        yield 'object' => [new \stdClass()];
-        yield 'array' => [[]];
-    }
-
     /**
      * @group functional
      *
@@ -640,6 +632,14 @@ class QueryTest extends BaseTest
         $this->expectException(InvalidException::class);
 
         (new Query())->setTrackTotalHits($value);
+    }
+
+    public function provideSetTrackTotalHitsInvalidValue(): iterable
+    {
+        yield 'string' => ['string string'];
+        yield 'null' => [null];
+        yield 'object' => [new \stdClass()];
+        yield 'array' => [[]];
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,17 +8,17 @@ if (isset($_SERVER['ES_VERSION']) && \str_contains($_SERVER['ES_VERSION'], 'SNAP
 }
 
 // Suppress specific deprecation notices for PHP 8.5 compatibility
-if (PHP_VERSION_ID >= 80500) {
-    set_error_handler(function ($severity, $message, $file, $line) {
+if (\PHP_VERSION_ID >= 80500) {
+    \set_error_handler(static function ($severity, $message, $file, $line) {
         // Suppress deprecation notices for __sleep() and __wakeup() magic methods
-        if ($severity === E_DEPRECATED && 
-            (strpos($message, '__sleep()') !== false || strpos($message, '__wakeup()') !== false)) {
+        if (\E_DEPRECATED === $severity
+            && (\str_contains($message, '__sleep()') || \str_contains($message, '__wakeup()'))) {
             return true; // Suppress the error
         }
-        
+
         // Let other errors be handled normally
         return false;
-    }, E_DEPRECATED);
+    }, \E_DEPRECATED);
 }
 
 require_once __DIR__.'/../vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,4 +7,18 @@ if (isset($_SERVER['ES_VERSION']) && \str_contains($_SERVER['ES_VERSION'], 'SNAP
     $_SERVER['ES_VERSION'] = \str_replace('-SNAPSHOT', '', $_SERVER['ES_VERSION']);
 }
 
+// Suppress specific deprecation notices for PHP 8.5 compatibility
+if (PHP_VERSION_ID >= 80500) {
+    set_error_handler(function ($severity, $message, $file, $line) {
+        // Suppress deprecation notices for __sleep() and __wakeup() magic methods
+        if ($severity === E_DEPRECATED && 
+            (strpos($message, '__sleep()') !== false || strpos($message, '__wakeup()') !== false)) {
+            return true; // Suppress the error
+        }
+        
+        // Let other errors be handled normally
+        return false;
+    }, E_DEPRECATED);
+}
+
 require_once __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
    - Changed retries condition from > 0 to >= 0 to allow zero retries
    - Fixed type casting issue by casting retries value to int when passing to setRetries()
    - Added comprehensive tests for zero retries functionality
    - Updated CHANGELOG.md to document the fix
    - Added missing setServerless() and getServerless() methods for interface compliance

    Backport of #2282