### PR TITLE
Allow numeric `minimum_should_match` values for terms set query

### DIFF
--- a/src/Query/TermsSet.php
+++ b/src/Query/TermsSet.php
@@ -15,8 +15,9 @@ class TermsSet extends AbstractQuery
     private string $field;
 
     /**
+     * @param string                       $field
      * @param array<bool|float|int|string> $terms
-     * @param AbstractScript|string        $minimumShouldMatch
+     * @param AbstractScript|string|int    $minimumShouldMatch
      */
     public function __construct(string $field, array $terms, $minimumShouldMatch)
     {
@@ -27,7 +28,9 @@ class TermsSet extends AbstractQuery
         $this->field = $field;
         $this->setTerms($terms);
 
-        if (\is_string($minimumShouldMatch)) {
+        if (\is_int($minimumShouldMatch)) {
+            $this->setMinimumShouldMatch($minimumShouldMatch);
+        } elseif (\is_string($minimumShouldMatch)) {
             $this->setMinimumShouldMatchField($minimumShouldMatch);
         } elseif ($minimumShouldMatch instanceof AbstractScript) {
             $this->setMinimumShouldMatchScript($minimumShouldMatch);
@@ -42,6 +45,11 @@ class TermsSet extends AbstractQuery
     public function setTerms(array $terms): self
     {
         return $this->addParam($this->field, $terms, 'terms');
+    }
+
+    public function setMinimumShouldMatch(int $minimumShouldMatch): self
+    {
+        return $this->addParam($this->field, $minimumShouldMatch, 'minimum_should_match');
     }
 
     public function setMinimumShouldMatchField(string $minimumShouldMatchField): self

--- a/src/Query/TermsSet.php
+++ b/src/Query/TermsSet.php
@@ -15,7 +15,6 @@ class TermsSet extends AbstractQuery
     private string $field;
 
     /**
-     * @param string                       $field
      * @param array<bool|float|int|string> $terms
      * @param AbstractScript|int|string    $minimumShouldMatch
      */

--- a/src/Query/TermsSet.php
+++ b/src/Query/TermsSet.php
@@ -17,7 +17,7 @@ class TermsSet extends AbstractQuery
     /**
      * @param string                       $field
      * @param array<bool|float|int|string> $terms
-     * @param AbstractScript|string|int    $minimumShouldMatch
+     * @param AbstractScript|int|string    $minimumShouldMatch
      */
     public function __construct(string $field, array $terms, $minimumShouldMatch)
     {

--- a/tests/Query/TermsSetTest.php
+++ b/tests/Query/TermsSetTest.php
@@ -34,6 +34,23 @@ class TermsSetTest extends BaseTest
     }
 
     #[Group('unit')]
+    public function testMinimumShouldMatchNumber(): void
+    {
+        $expected = [
+            'terms_set' => [
+                'field' => [
+                    'terms' => ['foo', 'bar'],
+                    'minimum_should_match' => 1,
+                ],
+            ],
+        ];
+
+        $query = new TermsSet('field', ['foo', 'bar'], 1);
+
+        $this->assertSame($expected, $query->toArray());
+    }
+
+    #[Group('unit')]
     public function testEmptyField(): void
     {
         $this->expectException(InvalidException::class);


### PR DESCRIPTION
Docs says that `minimum_should_match` field is also supported and it can be numeric or percentage. Added support for numbers.

Ref https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-terms-set-query