### PR TITLE
test: add functional test for numeric minimum_should_match in TermsSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Backward Compatibility Breaks
 ### Added
+* Added support for numeric `minimum_should_match` values in `TermsSet` query [#2293](https://github.com/ruflin/Elastica/pull/2293)
 ### Changed
 ### Deprecated
 ### Removed

--- a/tests/Query/TermsSetTest.php
+++ b/tests/Query/TermsSetTest.php
@@ -128,6 +128,40 @@ class TermsSetTest extends BaseTest
     }
 
     #[Group('functional')]
+    public function testMinimumShouldMatchNumberSearch(): void
+    {
+        $index = $this->_createIndex();
+
+        $index->addDocuments([
+            new Document('1', ['skills' => ['php', 'js']]),
+            new Document('2', ['skills' => ['php']]),
+            new Document('3', ['skills' => ['java']]),
+        ]);
+
+        $index->refresh();
+
+        // minimum_should_match = 1: should match documents with at least 1 of the terms
+        $query = new TermsSet('skills', ['php'], 1);
+        $resultSet = $index->search($query);
+        $this->assertEquals(2, $resultSet->count());
+
+        // minimum_should_match = 1: should match documents with at least 1 of the terms
+        $query = new TermsSet('skills', ['php', 'java'], 1);
+        $resultSet = $index->search($query);
+        $this->assertEquals(3, $resultSet->count());
+
+        // minimum_should_match = 2: should match documents with at least 2 of the terms
+        $query = new TermsSet('skills', ['php', 'js'], 2);
+        $resultSet = $index->search($query);
+        $this->assertEquals(1, $resultSet->count());
+
+        // minimum_should_match = 2: should match documents with at least 2 of the terms
+        $query = new TermsSet('skills', ['php', 'java'], 2);
+        $resultSet = $index->search($query);
+        $this->assertEquals(0, $resultSet->count());
+    }
+
+    #[Group('functional')]
     public function testVariousDataTypesViaConstructor(): void
     {
         $index = $this->_createIndex();


### PR DESCRIPTION
Add functional test testMinimumShouldMatchNumberSearch() to verify numeric minimum_should_match values work correctly with Elasticsearch.

Also add CHANGELOG entry for PR #2293 which added support for numeric minimum_should_match values in TermsSet query.

Refs: #2293