### PR TITLE
[6.x] fix PHP8.4 deprecations

### DIFF
--- a/lib/Elastica/Aggregation/BucketSelector.php
+++ b/lib/Elastica/Aggregation/BucketSelector.php
@@ -14,7 +14,7 @@ class BucketSelector extends AbstractSimpleAggregation
      * @param array|null  $bucketsPath
      * @param string|null $script
      */
-    public function __construct(string $name, array $bucketsPath = null, string $script = null)
+    public function __construct(string $name, ?array $bucketsPath = null, ?string $script = null)
     {
         parent::__construct($name);
 

--- a/lib/Elastica/Aggregation/Derivative.php
+++ b/lib/Elastica/Aggregation/Derivative.php
@@ -15,7 +15,7 @@ class Derivative extends AbstractAggregation
      * @param string      $name
      * @param string|null $bucketsPath
      */
-    public function __construct(string $name, string $bucketsPath = null)
+    public function __construct(string $name, ?string $bucketsPath = null)
     {
         parent::__construct($name);
 

--- a/lib/Elastica/Aggregation/Filter.php
+++ b/lib/Elastica/Aggregation/Filter.php
@@ -16,7 +16,7 @@ class Filter extends AbstractAggregation
      * @param string        $name
      * @param AbstractQuery $filter
      */
-    public function __construct($name, AbstractQuery $filter = null)
+    public function __construct($name, ?AbstractQuery $filter = null)
     {
         parent::__construct($name);
 

--- a/lib/Elastica/Client.php
+++ b/lib/Elastica/Client.php
@@ -84,7 +84,7 @@ class Client
      * @param callback        $callback OPTIONAL Callback function which can be used to be notified about errors (for example connection down)
      * @param LoggerInterface $logger
      */
-    public function __construct(array $config = [], $callback = null, LoggerInterface $logger = null)
+    public function __construct(array $config = [], $callback = null, ?LoggerInterface $logger = null)
     {
         $this->_callback = $callback;
 

--- a/lib/Elastica/Exception/Connection/GuzzleException.php
+++ b/lib/Elastica/Exception/Connection/GuzzleException.php
@@ -24,7 +24,7 @@ class GuzzleException extends ConnectionException
      * @param \Elastica\Request                       $request
      * @param \Elastica\Response                      $response
      */
-    public function __construct(TransferException $guzzleException, Request $request = null, Response $response = null)
+    public function __construct(TransferException $guzzleException, ?Request $request = null, ?Response $response = null)
     {
         $this->_guzzleException = $guzzleException;
         $message = $this->getErrorMessage($this->getGuzzleException());

--- a/lib/Elastica/Exception/Connection/HttpException.php
+++ b/lib/Elastica/Exception/Connection/HttpException.php
@@ -27,7 +27,7 @@ class HttpException extends ConnectionException
      * @param \Elastica\Request  $request
      * @param \Elastica\Response $response
      */
-    public function __construct($error, Request $request = null, Response $response = null)
+    public function __construct($error, ?Request $request = null, ?Response $response = null)
     {
         $this->_error = $error;
 

--- a/lib/Elastica/Exception/ConnectionException.php
+++ b/lib/Elastica/Exception/ConnectionException.php
@@ -29,7 +29,7 @@ class ConnectionException extends \RuntimeException implements ExceptionInterfac
      * @param \Elastica\Request  $request
      * @param \Elastica\Response $response
      */
-    public function __construct($message, Request $request = null, Response $response = null)
+    public function __construct($message, ?Request $request = null, ?Response $response = null)
     {
         $this->_request = $request;
         $this->_response = $response;

--- a/lib/Elastica/Index.php
+++ b/lib/Elastica/Index.php
@@ -339,7 +339,7 @@ class Index implements SearchableInterface
      *
      * @return Search
      */
-    public function createSearch($query = '', $options = null, BuilderInterface $builder = null)
+    public function createSearch($query = '', $options = null, ?BuilderInterface $builder = null)
     {
         $search = new Search($this->getClient(), $builder);
         $search->addIndex($this);

--- a/lib/Elastica/Multi/Search.php
+++ b/lib/Elastica/Multi/Search.php
@@ -47,7 +47,7 @@ class Search
      * @param \Elastica\Client      $client  Client object
      * @param MultiBuilderInterface $builder
      */
-    public function __construct(Client $client, MultiBuilderInterface $builder = null)
+    public function __construct(Client $client, ?MultiBuilderInterface $builder = null)
     {
         $this->_builder = $builder ?: new MultiBuilder();
         $this->_client = $client;

--- a/lib/Elastica/Query/ConstantScore.php
+++ b/lib/Elastica/Query/ConstantScore.php
@@ -16,7 +16,7 @@ class ConstantScore extends AbstractQuery
      *
      * @param AbstractQuery|array|null $filter
      */
-    public function __construct(AbstractQuery $filter = null)
+    public function __construct(?AbstractQuery $filter = null)
     {
         if (!is_null($filter)) {
             $this->setFilter($filter);

--- a/lib/Elastica/Query/FunctionScore.php
+++ b/lib/Elastica/Query/FunctionScore.php
@@ -72,7 +72,7 @@ class FunctionScore extends AbstractQuery
      *
      * @return $this
      */
-    public function addFunction($functionType, $functionParams, AbstractQuery $filter = null, $weight = null)
+    public function addFunction($functionType, $functionParams, ?AbstractQuery $filter = null, $weight = null)
     {
         $function = [
             $functionType => $functionParams,
@@ -100,7 +100,7 @@ class FunctionScore extends AbstractQuery
      *
      * @return $this
      */
-    public function addScriptScoreFunction(AbstractScript $script, AbstractQuery $filter = null, $weight = null)
+    public function addScriptScoreFunction(AbstractScript $script, ?AbstractQuery $filter = null, $weight = null)
     {
         return $this->addFunction('script_score', $script, $filter, $weight);
     }
@@ -128,7 +128,7 @@ class FunctionScore extends AbstractQuery
         $offset = null,
         $decay = null,
         $weight = null,
-        AbstractQuery $filter = null,
+        ?AbstractQuery $filter = null,
         $multiValueMode = null
     ) {
         $functionParams = [
@@ -157,7 +157,7 @@ class FunctionScore extends AbstractQuery
         $modifier = null,
         $missing = null,
         $weight = null,
-        AbstractQuery $filter = null
+        ?AbstractQuery $filter = null
     ) {
         $functionParams = [
             'field' => $field,
@@ -184,7 +184,7 @@ class FunctionScore extends AbstractQuery
      *
      * @return $this
      */
-    public function addWeightFunction($weight, AbstractQuery $filter = null)
+    public function addWeightFunction($weight, ?AbstractQuery $filter = null)
     {
         return $this->addFunction('weight', $weight, $filter);
     }
@@ -199,7 +199,7 @@ class FunctionScore extends AbstractQuery
      *
      * @return $this
      */
-    public function addRandomScoreFunction($seed, AbstractQuery $filter = null, $weight = null, $field = null)
+    public function addRandomScoreFunction($seed, ?AbstractQuery $filter = null, $weight = null, $field = null)
     {
         $functionParams = [
             'seed' => $seed,

--- a/lib/Elastica/Query/SpanContaining.php
+++ b/lib/Elastica/Query/SpanContaining.php
@@ -17,7 +17,7 @@ class SpanContaining extends AbstractSpanQuery
      * @param AbstractSpanQuery $little OPTIONAL
      * @param AbstractSpanQuery $big    OPTIONAL
      */
-    public function __construct(AbstractSpanQuery $little = null, AbstractSpanQuery $big = null)
+    public function __construct(?AbstractSpanQuery $little = null, ?AbstractSpanQuery $big = null)
     {
         if (null !== $little) {
             $this->setLittle($little);

--- a/lib/Elastica/Query/SpanNot.php
+++ b/lib/Elastica/Query/SpanNot.php
@@ -17,7 +17,7 @@ class SpanNot extends AbstractSpanQuery
      * @param AbstractSpanQuery $include OPTIONAL
      * @param AbstractSpanQuery $exclude OPTIONAL
      */
-    public function __construct(AbstractSpanQuery $include = null, AbstractSpanQuery $exclude = null)
+    public function __construct(?AbstractSpanQuery $include = null, ?AbstractSpanQuery $exclude = null)
     {
         if (null !== $include) {
             $this->setInclude($include);

--- a/lib/Elastica/Query/SpanWithin.php
+++ b/lib/Elastica/Query/SpanWithin.php
@@ -17,7 +17,7 @@ class SpanWithin extends AbstractSpanQuery
      * @param AbstractSpanQuery $little OPTIONAL
      * @param AbstractSpanQuery $big    OPTIONAL
      */
-    public function __construct(AbstractSpanQuery $little = null, AbstractSpanQuery $big = null)
+    public function __construct(?AbstractSpanQuery $little = null, ?AbstractSpanQuery $big = null)
     {
         if (null !== $little) {
             $this->setLittle($little);

--- a/lib/Elastica/QueryBuilder.php
+++ b/lib/Elastica/QueryBuilder.php
@@ -29,7 +29,7 @@ class QueryBuilder
      *
      * @param Version $version
      */
-    public function __construct(Version $version = null)
+    public function __construct(?Version $version = null)
     {
         $this->_version = $version ?: new Version\Latest();
 

--- a/lib/Elastica/QueryBuilder/DSL/Aggregation.php
+++ b/lib/Elastica/QueryBuilder/DSL/Aggregation.php
@@ -293,7 +293,7 @@ class Aggregation implements DSL
      *
      * @return FilterAggregation
      */
-    public function filter($name, AbstractQuery $filter = null)
+    public function filter($name, ?AbstractQuery $filter = null)
     {
         return new FilterAggregation($name, $filter);
     }

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -425,7 +425,7 @@ class Query implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-not-query.html
      */
-    public function span_not(AbstractSpanQuery $include = null, AbstractSpanQuery $exclude = null)
+    public function span_not(?AbstractSpanQuery $include = null, ?AbstractSpanQuery $exclude = null)
     {
         return new SpanNot($include, $exclude);
     }
@@ -468,7 +468,7 @@ class Query implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-containing-query.html
      */
-    public function span_containing(AbstractSpanQuery $little = null, AbstractSpanQuery $big = null)
+    public function span_containing(?AbstractSpanQuery $little = null, ?AbstractSpanQuery $big = null)
     {
         return new SpanContaining($little, $big);
     }
@@ -483,7 +483,7 @@ class Query implements DSL
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-within-query.html
      */
-    public function span_within(AbstractSpanQuery $little = null, AbstractSpanQuery $big = null)
+    public function span_within(?AbstractSpanQuery $little = null, ?AbstractSpanQuery $big = null)
     {
         return new SpanWithin($little, $big);
     }

--- a/lib/Elastica/Request.php
+++ b/lib/Elastica/Request.php
@@ -36,7 +36,7 @@ class Request extends Param
      *
      * @return \Elastica\Request OPTIONAL Connection object
      */
-    public function __construct($path, $method = self::GET, $data = [], array $query = [], Connection $connection = null, $contentType = self::DEFAULT_CONTENT_TYPE)
+    public function __construct($path, $method = self::GET, $data = [], array $query = [], ?Connection $connection = null, $contentType = self::DEFAULT_CONTENT_TYPE)
     {
         $this->setPath($path);
         $this->setMethod($method);

--- a/lib/Elastica/Script/AbstractScript.php
+++ b/lib/Elastica/Script/AbstractScript.php
@@ -88,7 +88,7 @@ abstract class AbstractScript extends AbstractUpdateAction
      * @param string|null $lang       Script language, see constants
      * @param string|null $documentId Document ID the script action should be performed on (only relevant in update context)
      */
-    public function __construct(array $params = null, $lang = null, $documentId = null)
+    public function __construct(?array $params = null, $lang = null, $documentId = null)
     {
         if ($params) {
             $this->setParams($params);

--- a/lib/Elastica/Script/Script.php
+++ b/lib/Elastica/Script/Script.php
@@ -24,7 +24,7 @@ class Script extends AbstractScript
      * @param string|null $lang
      * @param string|null $documentId Document ID the script action should be performed on (only relevant in update context)
      */
-    public function __construct($scriptCode, array $params = null, $lang = null, $documentId = null)
+    public function __construct($scriptCode, ?array $params = null, $lang = null, $documentId = null)
     {
         parent::__construct($params, $lang, $documentId);
 

--- a/lib/Elastica/Script/ScriptId.php
+++ b/lib/Elastica/Script/ScriptId.php
@@ -23,7 +23,7 @@ class ScriptId extends AbstractScript
      * @param string|null $lang
      * @param string|null $documentId Document ID the script action should be performed on (only relevant in update context)
      */
-    public function __construct($scriptId, array $params = null, $lang = null, $documentId = null)
+    public function __construct($scriptId, ?array $params = null, $lang = null, $documentId = null)
     {
         parent::__construct($params, $lang, $documentId);
 

--- a/lib/Elastica/Search.php
+++ b/lib/Elastica/Search.php
@@ -80,7 +80,7 @@ class Search
      * @param \Elastica\Client $client  Client object
      * @param BuilderInterface $builder
      */
-    public function __construct(Client $client, BuilderInterface $builder = null)
+    public function __construct(Client $client, ?BuilderInterface $builder = null)
     {
         $this->_builder = $builder ?: new DefaultBuilder();
         $this->_client = $client;

--- a/lib/Elastica/Suggest.php
+++ b/lib/Elastica/Suggest.php
@@ -15,7 +15,7 @@ class Suggest extends Param
     /**
      * @param AbstractSuggest $suggestion
      */
-    public function __construct(AbstractSuggest $suggestion = null)
+    public function __construct(?AbstractSuggest $suggestion = null)
     {
         if (!is_null($suggestion)) {
             $this->addSuggestion($suggestion);

--- a/lib/Elastica/Transport/AbstractTransport.php
+++ b/lib/Elastica/Transport/AbstractTransport.php
@@ -24,7 +24,7 @@ abstract class AbstractTransport extends Param
      *
      * @param \Elastica\Connection $connection Connection object
      */
-    public function __construct(Connection $connection = null)
+    public function __construct(?Connection $connection = null)
     {
         if ($connection) {
             $this->setConnection($connection);

--- a/lib/Elastica/Transport/HttpAdapter.php
+++ b/lib/Elastica/Transport/HttpAdapter.php
@@ -32,7 +32,7 @@ class HttpAdapter extends AbstractTransport
      * @param Connection           $connection
      * @param HttpAdapterInterface $httpAdapter
      */
-    public function __construct(Connection $connection = null, HttpAdapterInterface $httpAdapter)
+    public function __construct(?Connection $connection = null, HttpAdapterInterface $httpAdapter)
     {
         parent::__construct($connection);
         $this->httpAdapter = $httpAdapter;

--- a/lib/Elastica/Type.php
+++ b/lib/Elastica/Type.php
@@ -119,7 +119,7 @@ class Type implements SearchableInterface
      *
      * @return Response
      */
-    public function addObject($object, Document $doc = null)
+    public function addObject($object, ?Document $doc = null)
     {
         if (!isset($this->_serializer)) {
             throw new RuntimeException('No serializer defined');
@@ -336,7 +336,7 @@ class Type implements SearchableInterface
      *
      * @return Search
      */
-    public function createSearch($query = '', $options = null, BuilderInterface $builder = null)
+    public function createSearch($query = '', $options = null, ?BuilderInterface $builder = null)
     {
         $search = $this->getIndex()->createSearch($query, $options, $builder);
         $search->addType($this);

--- a/lib/Elastica/Type/AbstractType.php
+++ b/lib/Elastica/Type/AbstractType.php
@@ -97,7 +97,7 @@ abstract class AbstractType implements SearchableInterface
      *
      * @throws \Elastica\Exception\InvalidException
      */
-    public function __construct(Client $client = null)
+    public function __construct(?Client $client = null)
     {
         if (!$client) {
             $client = new Client();

--- a/lib/Elastica/Type/Mapping.php
+++ b/lib/Elastica/Type/Mapping.php
@@ -35,7 +35,7 @@ class Mapping
      * @param \Elastica\Type $type       OPTIONAL Type object
      * @param array          $properties OPTIONAL Properties
      */
-    public function __construct(Type $type = null, array $properties = [])
+    public function __construct(?Type $type = null, array $properties = [])
     {
         if ($type) {
             $this->setType($type);

--- a/test/Elastica/Base.php
+++ b/test/Elastica/Base.php
@@ -64,7 +64,7 @@ class Base extends TestCase
      *
      * @return Client
      */
-    protected function _getClient(array $params = [], $callback = null, LoggerInterface $logger = null)
+    protected function _getClient(array $params = [], $callback = null, ?LoggerInterface $logger = null)
     {
         $config = [
             'host' => $this->_getHost(),

--- a/test/Elastica/BasePipeline.php
+++ b/test/Elastica/BasePipeline.php
@@ -15,7 +15,7 @@ class BasePipeline extends BaseTest
      *
      * @return Pipeline
      */
-    protected function _createPipeline(string $id = null, string $description = '')
+    protected function _createPipeline(?string $id = null, string $description = '')
     {
         if (is_null($id)) {
             $id = preg_replace('/[^a-z]/i', '', strtolower(get_called_class()).uniqid());

--- a/test/Elastica/ErrorsCollector.php
+++ b/test/Elastica/ErrorsCollector.php
@@ -18,7 +18,7 @@ class ErrorsCollector
      */
     private $testCase;
 
-    public function __construct(TestCase $testCase = null)
+    public function __construct(?TestCase $testCase = null)
     {
         $this->testCase = $testCase;
     }


### PR DESCRIPTION
I know this deprecations are handled on superior versions, but in our company we are still on Elastic Search 6.x so we need this version.
