### PR TITLE
#1645: add support for "search after" pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Backward Compatibility Breaks
 ### Added
 * Added support for numeric `minimum_should_match` values in `TermsSet` query [#2293](https://github.com/ruflin/Elastica/pull/2293)
+* Added support for "search after" based pagination [#1645](https://github.com/ruflin/Elastica/issues/1645)
 ### Changed
 ### Deprecated
 ### Removed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,12 +37,6 @@ parameters:
 			path: tests/Bulk/Action/AbstractDocumentTest.php
 
 		-
-			message: '#^Parameter \#1 \$expected of method PHPUnit\\Framework\\Assert\:\:assertSame\(\) contains unresolvable type\.$#'
-			identifier: argument.unresolvableType
-			count: 1
-			path: tests/Bulk/Action/UpdateDocumentTest.php
-
-		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Elastica\\\\Bulk\\\\Response'' and Elastica\\Bulk\\Response will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
 			count: 1

--- a/src/Document.php
+++ b/src/Document.php
@@ -235,11 +235,9 @@ class Document extends AbstractUpdateAction
     }
 
     /**
-     * @see \Elastica\Query::setSearchAfter()
-     *
      * Returns the sort position for this document, which can be used as starting offset to search next hits page.
      *
-     * @return array
+     * @see \Elastica\Query::setSearchAfter()
      */
     public function getSort(): array
     {

--- a/src/Document.php
+++ b/src/Document.php
@@ -235,6 +235,18 @@ class Document extends AbstractUpdateAction
     }
 
     /**
+     * @see \Elastica\Query::setSearchAfter()
+     *
+     * Returns the sort position for this document, which can be used as starting offset to search next hits page.
+     *
+     * @return array
+     */
+    public function getSort(): array
+    {
+        return $this->getParam('sort');
+    }
+
+    /**
      * Returns the document as an array.
      */
     public function toArray(): array

--- a/src/Index.php
+++ b/src/Index.php
@@ -551,17 +551,7 @@ class Index implements SearchableInterface
      */
     public function each($query = '', int $batchSize = 100, ?array $options = null): \Generator
     {
-        if ($batchSize < 1) {
-            throw new InvalidException('Batch size must be greater than 0.');
-        }
-
-        $query = clone Query::create($query);
-
-        if (!$query->hasParam('sort')) {
-            throw new InvalidException('Query must have "sort" parameter in order to use "search after" based iteration.');
-        }
-
-        $query->setSize($batchSize);
+        $query = $this->prepareSearchAfterIteratorQuery($query, $batchSize);
 
         while (true) {
             $resultSet = $this->search($query, $options);
@@ -589,17 +579,7 @@ class Index implements SearchableInterface
      */
     public function batch($query = '', int $batchSize = 100, ?array $options = null): \Generator
     {
-        if ($batchSize < 1) {
-            throw new InvalidException('Batch size must be greater than 0.');
-        }
-
-        $query = clone Query::create($query);
-
-        if (!$query->hasParam('sort')) {
-            throw new InvalidException('Query must have "sort" parameter in order to use "search after" based iteration.');
-        }
-
-        $query->setSize($batchSize);
+        $query = $this->prepareSearchAfterIteratorQuery($query, $batchSize);
 
         while (true) {
             $resultSet = $this->search($query, $options);
@@ -619,6 +599,27 @@ class Index implements SearchableInterface
 
             $query->setSearchAfter($lastDocument->getSort());
         }
+    }
+
+    private function prepareSearchAfterIteratorQuery(mixed $query, int $batchSize): Query
+    {
+        if ($batchSize < 1) {
+            throw new InvalidException('Batch size must be greater than 0.');
+        }
+
+        $query = clone Query::create($query); // if original query is object - keep it intact
+
+        if (!$query->hasParam('sort')) {
+            throw new InvalidException('Query must have "sort" parameter in order to use "search after" based iteration.');
+        }
+
+        if ($query->hasParam('from') && 0 !== $query->getParam('from')) {
+            throw new InvalidException('Query must not specify "from" parameter in order to use "search after" based iteration.');
+        }
+
+        $query->setSize($batchSize);
+
+        return $query;
     }
 
     /**

--- a/src/Index.php
+++ b/src/Index.php
@@ -540,6 +540,88 @@ class Index implements SearchableInterface
     }
 
     /**
+     * Iterates over all documents, matching given query, using "search after" based pagination.
+     *
+     * @see \Elastica\Query::setSearchAfter()
+     *
+     * @param mixed $query search query with sort by unique document field.
+     * @param int $batchSize the number of rows to be returned in each batch (e.g. each query size).
+     * @param array|null $options search request options.
+     * @return \Generator|\Elastica\Document[] list of all documents matched the given query as iterator.
+     */
+    public function each($query = '', int $batchSize = 100, ?array $options = null): \Generator
+    {
+        if ($batchSize < 1) {
+            throw new InvalidException('Batch size must be greater than 0.');
+        }
+
+        $query = clone Query::create($query);
+
+        if (!$query->hasParam('sort')) {
+            throw new InvalidException('Query must have "sort" parameter in order to use "search after" based iteration.');
+        }
+
+        $query->setSize($batchSize);
+
+        while (true) {
+            $resultSet = $this->search($query, $options);
+            foreach ($resultSet->getDocuments() as $document) {
+                yield $document;
+            }
+
+            if (count($resultSet->getDocuments()) < $batchSize) {
+                break;
+            }
+
+            $query->setSearchAfter($document->getSort());
+        }
+    }
+
+    /**
+     * Iterates over all documents in batches, matching given query, using "search after" based pagination.
+     *
+     * @see \Elastica\Query::setSearchAfter()
+     *
+     * @param mixed $query search query with sort by unique document field.
+     * @param int $batchSize the number of rows to be returned in each batch (e.g. each query size).
+     * @param array|null $options search request options.
+     * @return \Generator|\Elastica\Document[][] list of document batches matched the given query as iterator.
+     */
+    public function batch($query = '', int $batchSize = 100, ?array $options = null): \Generator
+    {
+        if ($batchSize < 1) {
+            throw new InvalidException('Batch size must be greater than 0.');
+        }
+
+        $query = clone Query::create($query);
+
+        if (!$query->hasParam('sort')) {
+            throw new InvalidException('Query must have "sort" parameter in order to use "search after" based iteration.');
+        }
+
+        $query->setSize($batchSize);
+
+        while (true) {
+            $resultSet = $this->search($query, $options);
+
+            $documents = $resultSet->getDocuments();
+            if (empty($documents)) {
+                break;
+            }
+
+            yield $documents;
+
+            if (count($documents) < $batchSize) {
+                break;
+            }
+
+            $lastDocument = array_pop($documents);
+
+            $query->setSearchAfter($lastDocument->getSort());
+        }
+    }
+
+    /**
      * Opens an index.
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html

--- a/src/Index.php
+++ b/src/Index.php
@@ -542,62 +542,66 @@ class Index implements SearchableInterface
     /**
      * Iterates over all documents, matching given query, using "search after" based pagination.
      *
+     * @param mixed      $query     search query with sort by unique document field
+     * @param int        $batchSize the number of rows to be returned in each batch (e.g. each query size).
+     * @param array|null $options   search request options
+     *
      * @see \Elastica\Query::setSearchAfter()
      *
-     * @param mixed $query search query with sort by unique document field.
-     * @param int $batchSize the number of rows to be returned in each batch (e.g. each query size).
-     * @param array|null $options search request options.
-     * @return \Generator|\Elastica\Document[] list of all documents matched the given query as iterator.
+     * @return Document[]|\Generator list of all documents matched the given query as iterator
      */
     public function each($query = '', int $batchSize = 100, ?array $options = null): \Generator
     {
         $query = $this->prepareSearchAfterIteratorQuery($query, $batchSize);
 
         while (true) {
-            $resultSet = $this->search($query, $options);
-            foreach ($resultSet->getDocuments() as $document) {
-                yield $document;
-            }
-
-            if (count($resultSet->getDocuments()) < $batchSize) {
+            $documents = $this->search($query, $options)->getDocuments();
+            $count = \count($documents);
+            if (0 === $count) {
                 break;
             }
 
-            $query->setSearchAfter($document->getSort());
+            foreach ($documents as $document) {
+                yield $document;
+            }
+
+            if ($count < $batchSize) {
+                break;
+            }
+
+            $query->setSearchAfter($documents[$count - 1]->getSort());
         }
     }
 
     /**
      * Iterates over all documents in batches, matching given query, using "search after" based pagination.
      *
+     * @param mixed      $query     search query with sort by unique document field
+     * @param int        $batchSize the number of rows to be returned in each batch (e.g. each query size).
+     * @param array|null $options   search request options
+     *
      * @see \Elastica\Query::setSearchAfter()
      *
-     * @param mixed $query search query with sort by unique document field.
-     * @param int $batchSize the number of rows to be returned in each batch (e.g. each query size).
-     * @param array|null $options search request options.
-     * @return \Generator|\Elastica\Document[][] list of document batches matched the given query as iterator.
+     * @return Document[][]|\Generator list of document batches matched the given query as iterator
      */
     public function batch($query = '', int $batchSize = 100, ?array $options = null): \Generator
     {
         $query = $this->prepareSearchAfterIteratorQuery($query, $batchSize);
 
         while (true) {
-            $resultSet = $this->search($query, $options);
-
-            $documents = $resultSet->getDocuments();
-            if (empty($documents)) {
+            $documents = $this->search($query, $options)->getDocuments();
+            $count = \count($documents);
+            if (0 === $count) {
                 break;
             }
 
             yield $documents;
 
-            if (count($documents) < $batchSize) {
+            if ($count < $batchSize) {
                 break;
             }
 
-            $lastDocument = array_pop($documents);
-
-            $query->setSearchAfter($lastDocument->getSort());
+            $query->setSearchAfter($documents[$count - 1]->getSort());
         }
     }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -478,13 +478,15 @@ class Query extends Param
     }
 
     /**
-     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after
-     *
      * Allows retrieval of the next page of hits using sort values from previous page.
+     *
      * The value of {@see \Elastica\Document::getSort()} should be passed as argument here.
      *
-     * @param array $searchAfter the sort of the last document from previous search result set.
-     * @return static self reference.
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after
+     *
+     * @param array $searchAfter the sort of the last document from previous search result set
+     *
+     * @return static self reference
      */
     public function setSearchAfter(array $searchAfter): self
     {

--- a/src/Query.php
+++ b/src/Query.php
@@ -476,4 +476,20 @@ class Query extends Param
 
         return $this->setParam('track_total_hits', $trackTotalHits);
     }
+
+    /**
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after
+     *
+     * Allows retrieval of the next page of hits using sort values from previous page.
+     * The value of {@see \Elastica\Document::getSort()} should be passed as argument here.
+     *
+     * @param array $searchAfter the sort of the last document from previous search result set.
+     * @return static self reference.
+     */
+    public function setSearchAfter(array $searchAfter): self
+    {
+        $this->setParam('search_after', $searchAfter);
+
+        return $this;
+    }
 }

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -7,6 +7,7 @@ namespace Elastica\Test;
 use Elastic\Elasticsearch\Exception\ClientResponseException;
 use Elastica\Client;
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Mapping;
 use Elastica\Query;
@@ -918,5 +919,56 @@ class IndexTest extends BaseTest
         }
 
         $this->assertEquals(['3', '2', '1'], $documentIds);
+    }
+
+    #[Group('functional')]
+    public function testIterateThrowsWhenSortIsMissing(): void
+    {
+        $index = $this->_createIndex();
+
+        $this->expectException(InvalidException::class);
+        $this->expectExceptionMessageMatches('/sort/');
+
+        \iterator_to_array($index->each(new Query(), 10));
+    }
+
+    #[Group('functional')]
+    public function testIterateThrowsWhenFromIsNonZero(): void
+    {
+        $index = $this->_createIndex();
+
+        $query = new Query();
+        $query->setSort(['_id' => 'asc']);
+        $query->setFrom(5);
+
+        $this->expectException(InvalidException::class);
+        $this->expectExceptionMessageMatches('/from/');
+
+        \iterator_to_array($index->each($query, 10));
+    }
+
+    #[Group('functional')]
+    public function testIterateThrowsWhenBatchSizeIsZero(): void
+    {
+        $index = $this->_createIndex();
+
+        $query = new Query();
+        $query->setSort(['_id' => 'asc']);
+
+        $this->expectException(InvalidException::class);
+        $this->expectExceptionMessageMatches('/[Bb]atch size/');
+
+        \iterator_to_array($index->each($query, 0));
+    }
+
+    #[Group('functional')]
+    public function testBatchIterateThrowsWhenSortIsMissing(): void
+    {
+        $index = $this->_createIndex();
+
+        $this->expectException(InvalidException::class);
+        $this->expectExceptionMessageMatches('/sort/');
+
+        \iterator_to_array($index->batch(new Query(), 10));
     }
 }

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -9,6 +9,7 @@ use Elastica\Client;
 use Elastica\Document;
 use Elastica\Index;
 use Elastica\Mapping;
+use Elastica\Query;
 use Elastica\Query\QueryString;
 use Elastica\Query\SimpleQueryString;
 use Elastica\Query\Term;
@@ -855,5 +856,67 @@ class IndexTest extends BaseTest
         $index->forcemerge();
 
         $this->assertEquals([], $index->getAliases());
+    }
+
+    #[Group('functional')]
+    public function testIterateEach(): void
+    {
+        $index = $this->_createIndex();
+        $index->setMapping(new Mapping([
+            'country_id' => ['type' => 'integer'],
+            'region_id' => ['type' => 'integer'],
+        ]));
+
+        $index->addDocuments([
+            new Document('1', ['country_id' => 1, 'region_id' => 1]),
+            new Document('2', ['country_id' => 1, 'region_id' => 2]),
+            new Document('3', ['country_id' => 2, 'region_id' => 3]),
+        ]);
+        $index->refresh();
+
+        $query = new Query();
+        $query->setSize(2);
+        $query->setSort([
+            'region_id' => 'desc',
+        ]);
+
+        $documentIds = [];
+        foreach ($index->each($query, 2) as $document) {
+            $documentIds[] = $document->getId();
+        }
+
+        $this->assertEquals(['3', '2', '1'], $documentIds);
+    }
+
+    #[Group('functional')]
+    public function testIterateBatch(): void
+    {
+        $index = $this->_createIndex();
+        $index->setMapping(new Mapping([
+            'country_id' => ['type' => 'integer'],
+            'region_id' => ['type' => 'integer'],
+        ]));
+
+        $index->addDocuments([
+            new Document('1', ['country_id' => 1, 'region_id' => 1]),
+            new Document('2', ['country_id' => 1, 'region_id' => 2]),
+            new Document('3', ['country_id' => 2, 'region_id' => 3]),
+        ]);
+        $index->refresh();
+
+        $query = new Query();
+        $query->setSize(2);
+        $query->setSort([
+            'region_id' => 'desc',
+        ]);
+
+        $documentIds = [];
+        foreach ($index->batch($query, 2) as $documents) {
+            foreach ($documents as $document) {
+                $documentIds[] = $document->getId();
+            }
+        }
+
+        $this->assertEquals(['3', '2', '1'], $documentIds);
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -621,4 +621,44 @@ class QueryTest extends BaseTest
         $this->assertEquals(25, $resultSet->getTotalHits());
         $this->assertEquals('gte', $resultSet->getTotalHitsRelation());
     }
+
+    #[Group('functional')]
+    public function testSearchAfter(): void
+    {
+        $index = $this->_createIndex();
+        $index->setMapping(new Mapping([
+            'country_id' => ['type' => 'integer'],
+            'region_id' => ['type' => 'integer'],
+        ]));
+
+        $index->addDocuments([
+            new Document('1', ['country_id' => 1, 'region_id' => 1]),
+            new Document('2', ['country_id' => 1, 'region_id' => 2]),
+            new Document('3', ['country_id' => 2, 'region_id' => 3]),
+        ]);
+        $index->refresh();
+
+        $query = new Query();
+        $query->setSize(2);
+        $query->setSort([
+            'country_id' => 'desc',
+            'region_id' => 'asc',
+        ]);
+        $firstPageResultSet = $index->search($query);
+
+        $documents = $firstPageResultSet->getDocuments();
+        $this->assertCount(2, $documents);
+
+        /** @var Document $lastDocument */
+        $lastDocument = array_pop($documents);
+        $lastDocument->getParam('sort');
+
+        $this->assertNotEmpty($lastDocument->getSort());
+
+        $query->setSearchAfter($lastDocument->getSort());
+
+        $secondPageResultSet = $index->search($query);
+        $documents = $secondPageResultSet->getDocuments();
+        $this->assertCount(1, $documents);
+    }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -650,8 +650,7 @@ class QueryTest extends BaseTest
         $this->assertCount(2, $documents);
 
         /** @var Document $lastDocument */
-        $lastDocument = array_pop($documents);
-        $lastDocument->getParam('sort');
+        $lastDocument = \array_pop($documents);
 
         $this->assertNotEmpty($lastDocument->getSort());
 
@@ -660,5 +659,6 @@ class QueryTest extends BaseTest
         $secondPageResultSet = $index->search($query);
         $documents = $secondPageResultSet->getDocuments();
         $this->assertCount(1, $documents);
+        $this->assertSame('2', $documents[0]->getId());
     }
 }


### PR DESCRIPTION
Resolves #1645.

Adds support for "search after" pagination and infinite documents scroll.

See: https://www.elastic.co/guide/en/elasticsearch/reference/8.18/paginate-search-results.html#search-after

Covers "9.x" branch.
Should be ported to "8.x" separately, if PR is accepted.

Migrated from #2298.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "search after" pagination and new iteration APIs to traverse results as individual items or batches with configurable batch sizes.

* **Documentation**
  * Updated changelog to note the new pagination support.

* **Tests**
  * Added functional tests validating search-after pagination, batch/each iteration behavior, ordering, and error conditions for invalid iteration parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->