### PR TITLE
docs: refresh AGENTS.md, README.md, and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,17 +40,19 @@ Sources live under `src/` (PSR-4 `Elastica\\`); tests under `tests/`
 ## Coding standards
 
 - `declare(strict_types=1);` everywhere.
-- All classes in the `Elastica` namespace; `final` unless designed for extension.
+- All classes live in the `Elastica` namespace. Follow the existing public API
+  design when deciding on visibility and `final`.
 - All methods, properties, and parameters typed; PHPDoc where it adds info.
 - Coding style: PHP-CS-Fixer with `@PSR2`, `@Symfony`, `@PhpCsFixer`,
   `@PHP80Migration(:risky)`, `@PHPUnit100Migration:risky` rule sets.
 - Static analysis: PHPStan level 5 must pass.
-- Testing: PHPUnit 10.5; methods need `@covers` and `@group unit|functional`.
+- Testing: PHPUnit 10.5.
 
 ## Architecture
 
-Core components: `Client` (entry point, extends `elasticsearch-php`), `Index`,
-`Search`, `Query`, `Document`.
+Core components: `Client` (entry point, implements `Elastic\Elasticsearch\ClientInterface`
+and reuses traits/transport from the official `elasticsearch-php` client),
+`Index`, `Search`, `Query`, `Document`.
 
 Key namespaces:
 
@@ -69,7 +71,10 @@ shared `Param` base for parameter handling, traits for reuse.
 
 - Test layout mirrors `src/` under `tests/`.
 - Test classes extend `Elastica\Test\Base` and live in `Elastica\Test`.
-- Method names start with `test`; require `@covers` and a `@group` annotation.
+- Method names start with `test`.
+- Every test must declare exactly one group via the PHPUnit attribute
+  `#[Group('unit')]`, `#[Group('functional')]`, or `#[Group('benchmark')]`
+  (enforced in `Elastica\Test\Base::setUp`).
 
 ## Configuration files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,187 +1,79 @@
 # Agents
 
-This file provides guidance to AI agents when working with code in this repository.
+Guidance for AI agents working in this repository.
 
 ## Identity
 
-- **Persona**: A helpful and knowledgeable AI assistant specializing in PHP and Elasticsearch development.
-- **Purpose**: To assist developers in maintaining and extending the Elastica library, ensuring high standards of code quality, testing, and documentation.
-- **Operating Instructions**:
-    - Adhere strictly to the coding standards and architectural patterns established in the project.
-    - Use the provided development environment and commands for all tasks.
-    - Prioritize backward compatibility and type safety in all code changes.
-    - Ensure comprehensive test coverage for any new or modified code.
-    - Keep the `CHANGELOG.md` file updated with all significant changes.
+- **Persona**: AI assistant specialised in PHP and Elasticsearch development.
+- **Purpose**: Help maintain and extend the Elastica library with high standards
+  for code quality, testing, and documentation.
+- **Operating rules**:
+  - Follow the project's coding standards and architectural patterns.
+  - Use the Docker-based development environment.
+  - Preserve backward compatibility and type safety.
+  - Add tests for any new or changed behaviour.
+  - Update `CHANGELOG.md` for every functional change (test-only changes excluded).
 
-## Tools
+## Environment
 
-### Development Environment
+- PHP 8.1–8.5
+- Elasticsearch 9.x
+- Composer, Make, Docker / Docker Compose
 
-- **Docker and Docker Compose**: Used for a consistent development environment.
-- **PHP 8.1+**: The required PHP version for this project.
-- **Composer**: For managing PHP dependencies.
-- **Make**: For running common development tasks.
+## Key commands
 
-### Key Commands
+- `make docker-start` / `make docker-stop` / `make docker-shell`
+- `make docker-run-phpunit` — run all tests
+- `make docker-run-phpunit PHPUNIT_OPTIONS="--group=unit"` — unit tests
+- `make docker-run-phpunit PHPUNIT_OPTIONS="--group=functional"` — functional tests
+- `make docker-run-phpunit PHPUNIT_OPTIONS="--filter=ClientTest"` — filter by name
+- `make docker-run-phpcs` / `make docker-fix-phpcs` — coding standards
+- `make docker-run-phpstan` — static analysis
+- `make composer-install` / `make composer-update`
 
-- `make docker-start`: Start the development environment.
-- `make docker-stop`: Stop the development environment.
-- `make docker-shell`: Access the container shell.
-- `make docker-run-phpunit`: Run all tests.
-- `make docker-run-phpunit PHPUNIT_OPTIONS="--group=unit"`: Run unit tests.
-- `make docker-run-phpunit PHPUNIT_OPTIONS="--group=functional"`: Run functional tests.
-- `make docker-run-phpunit PHPUNIT_OPTIONS="tests/ClientTest.php"`: Run a specific test class.
-- `make docker-run-phpunit PHPUNIT_OPTIONS="--filter=ClientTest"`: Filter tests by name.
-- `make docker-run-phpcs`: Check coding standards.
-- `make docker-fix-phpcs`: Fix coding standards automatically.
-- `make run-phpstan`: Run static analysis.
-- `make composer-install`: Install dependencies.
-- `make composer-update`: Update dependencies.
+## Project overview
 
-## Workflows
+Elastica is a PHP client for Elasticsearch with an object-oriented architecture.
+Sources live under `src/` (PSR-4 `Elastica\\`); tests under `tests/`
+(PSR-4 `Elastica\Test\\`).
 
-### Testing
+## Coding standards
 
-- **Running all tests**: `make docker-run-phpunit`
-- **Running specific test groups**: `make docker-run-phpunit PHPUNIT_OPTIONS="--group=<group_name>"`
-- **Running specific test files**: `make docker-run-phpunit PHPUNIT_OPTIONS="<path_to_test_file>"`
+- `declare(strict_types=1);` everywhere.
+- All classes in the `Elastica` namespace; `final` unless designed for extension.
+- All methods, properties, and parameters typed; PHPDoc where it adds info.
+- Coding style: PHP-CS-Fixer with `@PSR2`, `@Symfony`, `@PhpCsFixer`,
+  `@PHP80Migration(:risky)`, `@PHPUnit100Migration:risky` rule sets.
+- Static analysis: PHPStan level 5 must pass.
+- Testing: PHPUnit 10.5; methods need `@covers` and `@group unit|functional`.
 
-### Code Quality
+## Architecture
 
-- **Checking coding standards**: `make run-phpcs`
-- **Fixing coding standards**: `make fix-phpcs`
-- **Running static analysis**: `make run-phpstan`
+Core components: `Client` (entry point, extends `elasticsearch-php`), `Index`,
+`Search`, `Query`, `Document`.
 
-## Knowledge
+Key namespaces:
 
-### Project Overview
+- `Query/` — query types extending `AbstractQuery`.
+- `Aggregation/` — analytics with shared traits.
+- `Bulk/` — bulk operations.
+- `ResultSet/` — result processing pipeline.
+- `Exception/` — exception hierarchy (`ClientException`, `BulkException`,
+  `InvalidException`, `NotFoundException`).
+- `Script/`, `QueryBuilder/`.
 
-Elastica is a PHP client library for Elasticsearch with a well-structured, object-oriented architecture. This is an open-source project that requires careful attention to code quality, testing, and documentation standards.
+Patterns in use: factory (`Query::create`), strategy (`BuilderInterface`),
+shared `Param` base for parameter handling, traits for reuse.
 
-### General Instructions
+## Testing requirements
 
-- This project is written in PHP and requires PHP 8.1 or higher.
-- The project uses a Docker-based development environment for consistency.
-- All code must be compatible with Elasticsearch 9.0 or newer.
-- Each code change requires an entry in the `CHANGELOG.md` file (except test changes).
-- All contributions must follow the established coding standards and architecture patterns.
+- Test layout mirrors `src/` under `tests/`.
+- Test classes extend `Elastica\Test\Base` and live in `Elastica\Test`.
+- Method names start with `test`; require `@covers` and a `@group` annotation.
 
-### Coding Standards
+## Configuration files
 
-#### PHP Requirements
-
-- All code must be PSR-2 compliant.
-- Strict type declarations required (`declare(strict_types=1);`).
-- All classes must be in the `Elastica` namespace.
-- All classes must be final unless designed for extension.
-- All methods, properties, and parameters must have type declarations.
-- Comprehensive PHPDoc annotations required for all elements.
-
-#### Documentation Standards
-
-- All classes, methods, and properties must have docblocks.
-- Methods calling Elasticsearch APIs must include links to official Elasticsearch documentation.
-- Test methods must include `@covers` and `@group` annotations.
-- Use `@group unit` for unit tests and `@group functional` for functional tests.
-
-#### Code Quality Tools
-
-- PHPStan level 5 static analysis must pass.
-- php-cs-fixer enforces PSR-2 compliance.
-- PHPUnit 10.5 for testing with comprehensive coverage.
-
-### Architecture Guidelines
-
-#### Core Components
-
-- **Client**: Central entry point extending official elasticsearch-php client.
-- **Index**: Represents Elasticsearch indices, implements SearchableInterface.
-- **Search**: Orchestrates search operations across indices.
-- **Query**: Container for query components using factory pattern.
-- **Document**: Represents individual Elasticsearch documents with change tracking.
-
-#### Key Namespaces and Their Purpose
-
-- `Query/`: All query types (BoolQuery, MatchQuery, TermQuery) extending AbstractQuery.
-- `Aggregation/`: Analytics functionality with shared traits for code reuse.
-- `Bulk/`: Bulk operation handling with individual actions and response processing.
-- `ResultSet/`: Result processing pipeline with BuilderInterface strategy pattern.
-- `Exception/`: Comprehensive error handling hierarchy.
-- `Script/`: Script query support and script field handling.
-- `QueryBuilder/`: DSL for programmatic query construction.
-
-#### Design Patterns Used
-
-- **Factory Pattern**: `Query::create()` handles multiple input types.
-- **Strategy Pattern**: `BuilderInterface` for flexible result set construction.
-- **Parameter Management**: The Base `Param` class provides a consistent interface for managing parameters across different components. It standardizes how parameters are set, retrieved, and validated, ensuring uniformity and reducing code duplication. This pattern is particularly useful for handling complex configurations and query parameters in a predictable and reusable manner.
-- **Traits**: Extensive use for code reuse (BucketsPathTrait, GapPolicyTrait).
-
-### Testing Requirements
-
-#### Test Structure
-
-- Tests mirror `src/` structure under `tests/` directory.
-- All test classes must extend `Elastica\Test\Base`.
-- All test classes must be in the `Elastica\Test` namespace.
-- Test methods must start with `test` prefix.
-
-#### Test Annotations
-
-- All test methods require `@covers` annotation specifying covered method.
-- All test methods require `@group` annotation (unit and/or functional).
-- Separate execution with `--group=unit` and `--group=functional`.
-
-### Implementation Guidelines
-
-#### Query Construction Patterns
-
-Support multiple query construction methods:
-
-```php
-// String query
-$query = Query::create('search term');
-
-// Array query
-$query = Query::create(['match' => ['field' => 'value']]);
-
-// Object query
-$matchQuery = new MatchQuery('field', 'value');
-$query = Query::create($matchQuery);
-```
-
-#### Error Handling
-
-Use the established exception hierarchy:
-
-- `ClientException` for transport/client errors.
-- `BulkException` for bulk operation failures.
-- `InvalidException` for validation errors.
-- `NotFoundException` for missing resources.
-
-### Best Practices
-
-- Maintain backward compatibility when possible.
-- Follow existing code patterns and conventions.
-- Use dependency injection where appropriate.
-- Implement proper parameter validation.
-- Ensure comprehensive test coverage.
-- Focus on flexibility and type safety.
-
-### File Organization
-
-#### Source Code Structure
-
-- Main classes in `src/` following PSR-4 autoloading.
-- Interfaces define contracts (SearchableInterface, ArrayableInterface).
-- Abstract classes provide common functionality.
-- Final classes implement specific features.
-
-#### Configuration Files
-
-- `composer.json` defines dependencies and autoloading.
-- `phpstan.neon` configures static analysis.
-- `.php-cs-fixer.dist.php` defines coding standards.
-- `docker-compose.yml` sets up development environment.
-
-The codebase emphasizes clean architecture, comprehensive testing, and maintainable code that integrates seamlessly with Elasticsearch functionality.
+- `composer.json` — dependencies and autoloading
+- `phpstan.neon` — static analysis config
+- `.php-cs-fixer.dist.php` — coding-style rules
+- `docker/compose.*.yaml` — development environment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,11 @@ Use `make docker-start DOCKER_OPTIONS="--detach"` to start the containers in a d
 The docker containers can be stopped with `make docker-stop`.
 
 The ES server version started by that command can be configured by passing a `ES_VERSION=` parameter.
-As an example, running `make docker-start ES_VERSION=7.5.0` will use `7.5.0` release.
-If you specify an ES version, use the same version when stopping the containers: `make docker-stop ES_VERSION=7.5.0`.
+As an example, running `make docker-start ES_VERSION=9.1.0` will use the `9.1.0` release.
+If you specify an ES version, use the same version when stopping the containers: `make docker-stop ES_VERSION=9.1.0`.
 
 ### Local Docker configuration
 For ES to properly run, the `vm.max_map_count=262144` system configuration is needed by ES to properly spin up the nodes.
-for further information.
 To update such configuration:
  - For Linux: `sudo sysctl -w vm.max_map_count=262144`
  - For macOS with 'Docker for Mac':
@@ -77,7 +76,7 @@ arguments to the invocation of the tool.
 Examples:
  - run a specific group of tests: `make docker-run-phpunit PHPUNIT_OPTIONS="--group=unit"`
  - filter the test to run: `make docker-run-phpunit PHPUNIT_OPTIONS="--filter=ClientTest"`
- - run tests for a specific test-class: `make docker-run-phpunit PHPUNIT_OPTIONS="test/Elastica/ClientTest.php"`
+ - run tests for a specific test-class: `make docker-run-phpunit PHPUNIT_OPTIONS="tests/ClientTest.php"`
 
 ## Troubleshooting
 
@@ -90,12 +89,12 @@ If you encounter Elasticsearch version compatibility errors during testing:
 
 2. **Set Correct ES Version**: Use the `ES_VERSION` parameter when starting Docker:
    ```bash
-   make docker-start ES_VERSION=9.0.0
+   make docker-start ES_VERSION=9.1.0
    ```
 
 3. **Version Mismatch Errors**: If you see errors like "Accept version must be either version 8 or 7, but found 9":
    - Stop containers: `make docker-stop`
-   - Start with correct version: `make docker-start ES_VERSION=9.0.0`
+   - Start with correct version: `make docker-start ES_VERSION=9.1.0`
    - For 9.x branch development, ES 9.x is required
 
 ### GPG/Network Issues
@@ -113,13 +112,13 @@ If you encounter GPG keyserver or network connectivity issues:
 ## Coding
 
 ### Rules
-* Pull requests are made to master.
-    Changes are never pushed directly (without pull request) into master.
+* Pull requests are made against the default branch (currently `9.x`).
+    Changes are never pushed directly (without pull request) into the default branch.
 * We use the Forking Workflow.
     https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow
 * Follow the coding guidelines.
 * Use a feature branch for every pull request.
-    Don't open a pull request from your master branch.
+    Don't open a pull request from your default branch.
 
 ### Pull Requests
 * One change per pull requests: Keep your pull requests as small as possible.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ All library issues should go to the [issue tracker from GitHub](https://github.c
 
 This release is compatible with all Elasticsearch 9.0 releases and onwards.
 
-The testsuite is run against the most recent minor version of Elasticsearch, currently 9.0.0
+The testsuite is run against the most recent minor version of Elasticsearch, currently 9.1.
 
 ## Contributing
 
 Contributions are always welcome.
-For details on how to contribute, check the [CONTRIBUTING](https://github.com/ruflin/Elastica/blob/master/CONTRIBUTING.md) file.
+For details on how to contribute, check the [CONTRIBUTING](CONTRIBUTING.md) file.
 
 ## Versions & Dependencies
 
@@ -30,7 +30,7 @@ It is generally recommended to use the latest point release of the relevant bran
 
 | Elastica branch                                    | ElasticSearch | elasticsearch-php | PHP            |
 |----------------------------------------------------|---------------|-------------------|----------------|
-| [9.x](https://github.com/ruflin/Elastica/tree/9.x) | 9.x           | ^9.0              | >=8.1 <8.5     |
+| [9.x](https://github.com/ruflin/Elastica/tree/9.x) | 9.x           | ^9.0              | >=8.1 <8.6     |
 | [8.x](https://github.com/ruflin/Elastica/tree/8.x) | 8.x           | ^8.4              | >=8.0 <8.4     |
 | [7.x](https://github.com/ruflin/Elastica/tree/7.x) | 7.x           | ^7.0              | ^7.2 \|\| ^8.0 |
 | [6.x](https://github.com/ruflin/Elastica/tree/6.x) | 6.x           | ^6.0              | ^7.0 \|\| ^8.0 |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All library issues should go to the [issue tracker from GitHub](https://github.c
 
 This release is compatible with all Elasticsearch 9.0 releases and onwards.
 
-The testsuite is run against the most recent minor version of Elasticsearch, currently 9.1.
+The testsuite is run against the most recent minor version of Elasticsearch, currently 9.1.0.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- **AGENTS.md**: trimmed aggressively (~190 → ~80 lines). Dropped the verbose tutorial-style query example and "best practices" filler. Aligned commands with the Docker-based workflow used elsewhere (e.g. `make docker-run-phpcs` instead of `make run-phpcs`). Replaced the misleading "PSR-2 compliant" claim with the actual PHP-CS-Fixer rule sets in use (`@PSR2`, `@Symfony`, `@PhpCsFixer`, `@PHP80Migration(:risky)`, `@PHPUnit100Migration:risky`). Tightened the supported PHP range to `8.1–8.5` to match `composer.json`.
- **README.md**: bumped tested Elasticsearch version from 9.0.0 to 9.1, made the `CONTRIBUTING` link branch-agnostic (relative), and updated the supported PHP range from `>=8.1 <8.5` to `>=8.1 <8.6` (PHP 8.5 is supported per `composer.json`).
- **CONTRIBUTING.md**: updated `ES_VERSION` examples from `7.5.0` to `9.1.0`, fixed the stale test path (`test/Elastica/ClientTest.php` → `tests/ClientTest.php`), removed a dangling "for further information." sentence, and updated the "pull requests against master" wording to reflect that the default branch is now `9.x`.

## Test plan

- [ ] Render the three files on GitHub and confirm formatting/links look correct
- [ ] Confirm the listed `make` targets still exist in the `Makefile`
- [ ] Sanity-check the PHP range matches `composer.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated system requirements and compatibility (Elasticsearch 9.1.0; PHP range adjusted to 8.1–8.5 / <8.6 where applicable)
  * Streamlined developer guidance: condensed operating rules, environment and key commands, and reorganized workflow/reference sections
  * Revised contribution and setup instructions, branch/PR workflow wording, and local Docker examples
  * Clarified testing guidance: PHPUnit now uses #[Group(...)] attributes with a single declared group requirement
<!-- end of auto-generated comment: release notes by coderabbit.ai -->