### PR TITLE
fix: forward $args in Index::forcemerge to Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* Fixed `Elastica\Index::forcemerge()` silently dropping the `$args` argument due to a malformed `array_merge()` call. Additional options such as `max_num_segments` and `flush` are now forwarded to Elasticsearch as documented.
 ### Security
 
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -449,10 +449,10 @@ class Index implements SearchableInterface
      * @throws ServerResponseException   if the status code of response is 5xx
      * @throws ClientException
      */
-    public function forcemerge($args = []): Response
+    public function forcemerge(array $args = []): Response
     {
         return $this->_client->toElasticaResponse(
-            $this->_client->indices()->forcemerge(\array_merge(['index' => $this->getName(), $args]))
+            $this->_client->indices()->forcemerge(\array_merge(['index' => $this->getName()], $args))
         );
     }
 

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -795,6 +795,26 @@ class IndexTest extends BaseTest
     }
 
     #[Group('functional')]
+    public function testForcemergeForwardsArgsToRequest(): void
+    {
+        $index = $this->_createIndex();
+        $index->addDocument(new Document('1', ['foo' => 'bar']));
+        $index->refresh();
+
+        $index->forcemerge(['max_num_segments' => 1, 'flush' => 'true']);
+
+        $lastRequest = $index->getClient()->getLastRequest();
+        $this->assertNotNull($lastRequest);
+
+        \parse_str($lastRequest->getUri()->getQuery(), $query);
+
+        // Without the fix the additional arguments are silently dropped by
+        // a malformed array_merge() call in Index::forcemerge().
+        $this->assertSame('1', $query['max_num_segments'] ?? null);
+        $this->assertSame('true', $query['flush'] ?? null);
+    }
+
+    #[Group('functional')]
     public function testAnalyze(): void
     {
         $index = $this->_createIndex();


### PR DESCRIPTION
## Summary

`Elastica\Index::forcemerge()` had a malformed `array_merge()` call:

```php
\array_merge(['index' => $this->getName(), $args])
```

This is a *single*-argument `array_merge`, so `$args` ended up as a numeric
key inside the metadata array and was never sent to Elasticsearch. Options
like `max_num_segments`, `flush`, or `only_expunge_deletes` were silently
ignored.

The fix:

- Properly merge with `array_merge(['index' => $name], $args)`.
- Tighten the parameter type from untyped to `array` (matches PHPDoc).
- Add a functional test that asserts the options arrive in the last HTTP
  request's query string.

Identified during a P0/P1 code-review pass.

## Test plan

- [x] `make docker-run-phpunit PHPUNIT_OPTIONS="--filter=testForcemerge"`
- [x] CI matrix (PHP 8.1–8.5)
- [x] PHPStan + php-cs-fixer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the forcemerge functionality was not properly forwarding additional configuration options to Elasticsearch. Extra parameters are now correctly passed through as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->