### PR TITLE
fix: send search_type=query_then_fetch as a top-level param in Search::count()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* Fixed `Elastica\Search::count()` silently dropping the `search_type=query_then_fetch` option due to a malformed array literal that wrapped it in a numeric-keyed sub-array.
 ### Security
 
 

--- a/src/Search.php
+++ b/src/Search.php
@@ -329,7 +329,7 @@ class Search
 
         $params = [
             'body' => $query->toArray(),
-            [self::OPTION_SEARCH_TYPE => self::OPTION_SEARCH_TYPE_QUERY_THEN_FETCH],
+            self::OPTION_SEARCH_TYPE => self::OPTION_SEARCH_TYPE_QUERY_THEN_FETCH,
         ];
 
         if ($indices = $this->getIndices()) {

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -504,6 +504,32 @@ class SearchTest extends BaseTest
     }
 
     #[Group('functional')]
+    public function testCountSendsSearchTypeQueryThenFetch(): void
+    {
+        $client = $this->_getClient();
+        $index = $client->getIndex('count_search_type_test');
+        $index->create([], ['recreate' => true]);
+        $index->addDocument(new Document('1', ['foo' => 'bar']));
+        $index->refresh();
+
+        $search = new Search($client);
+        $search->addIndex($index);
+        $search->count(new MatchAll());
+
+        $lastRequest = $client->getLastRequest();
+        $this->assertNotNull($lastRequest);
+
+        \parse_str($lastRequest->getUri()->getQuery(), $query);
+
+        // Without the fix, the search_type option was wrapped in a numeric-keyed
+        // sub-array of $params and silently dropped from the request.
+        $this->assertSame(
+            Search::OPTION_SEARCH_TYPE_QUERY_THEN_FETCH,
+            $query[Search::OPTION_SEARCH_TYPE] ?? null
+        );
+    }
+
+    #[Group('functional')]
     public function testCountRequestGet(): void
     {
         $client = $this->_getClient();


### PR DESCRIPTION
## Summary

`Elastica\Search::count()` built its parameter array like this:

```php
$params = [
    'body' => $query->toArray(),
    [self::OPTION_SEARCH_TYPE => self::OPTION_SEARCH_TYPE_QUERY_THEN_FETCH],
];
```

That second entry is a numeric-keyed sub-array, which the upstream
`elasticsearch-php` `Client::search()` ignores. The intended
`search_type=query_then_fetch` query parameter never made it to
Elasticsearch.

The fix flattens it back to a string-keyed entry. A new functional test
asserts that the option arrives in the HTTP request's query string.

Identified during a P0/P1 code-review pass.

## Test plan

- [x] \`make docker-run-phpunit PHPUNIT_OPTIONS=\"--filter=testCountSendsSearchTypeQueryThenFetch\"\`
- [x] CI matrix (PHP 8.1–8.5)
- [x] PHPStan + php-cs-fixer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the count method where the `search_type=query_then_fetch` option was not being properly preserved due to incorrect parameter structure.

* **Tests**
  * Added test coverage to verify that the `search_type` parameter is correctly set and included in search requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->