### PR TITLE
refactor: throw typed Elastica exceptions for unsupported features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for "search after" based pagination [#1645](https://github.com/ruflin/Elastica/issues/1645)
 * Added support for the `seq_no_primary_term` search option and the `if_seq_no` / `if_primary_term` index options to enable optimistic concurrency control [#2284](https://github.com/ruflin/Elastica/pull/2284)
 ### Changed
+* `Elastica\Client::setAsync()`, `getAsync()`, `setResponseException()`, `getResponseException()` and `setServerless()` now throw `Elastica\Exception\NotImplementedException` (a `BadMethodCallException` implementing `Elastica\Exception\ExceptionInterface`) instead of a generic `\Exception` when called. Callers can now catch a typed exception.
+* `Elastica\Task::cancel()` now throws `Elastica\Exception\InvalidException` (instead of a generic `\Exception`) when no task id is set.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for the `seq_no_primary_term` search option and the `if_seq_no` / `if_primary_term` index options to enable optimistic concurrency control [#2284](https://github.com/ruflin/Elastica/pull/2284)
 ### Changed
 * `Elastica\Util::convertDate()` now throws `Elastica\Exception\InvalidException` when given a string that `strtotime()` cannot parse, instead of silently producing `1970-01-01T00:00:00Z`. The return type has also been narrowed to `string` and a typo-prone `null` argument is no longer accepted at runtime.
+* `Elastica\Client::setAsync()`, `getAsync()`, `setResponseException()`, `getResponseException()` and `setServerless()` now throw `Elastica\Exception\NotImplementedException` (a `BadMethodCallException` implementing `Elastica\Exception\ExceptionInterface`) instead of a generic `\Exception` when called. Callers can now catch a typed exception.
+* `Elastica\Task::cancel()` now throws `Elastica\Exception\InvalidException` (instead of a generic `\Exception`) when no task id is set.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -24,6 +24,7 @@ use Elastica\Bulk\ResponseSet;
 use Elastica\Exception\Bulk\ResponseException as BulkResponseException;
 use Elastica\Exception\ClientException;
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\NotImplementedException;
 use Elastica\Script\AbstractScript;
 use Psr\Http\Client\ClientInterface as HttpClientInterface;
 use Psr\Http\Message\RequestInterface;
@@ -80,12 +81,12 @@ class Client implements ClientInterface
 
     public function setAsync(bool $async): self
     {
-        throw new \Exception('Not supported');
+        throw new NotImplementedException('Async mode is not supported by Elastica.');
     }
 
     public function getAsync(): bool
     {
-        throw new \Exception('Not supported');
+        throw new NotImplementedException('Async mode is not supported by Elastica.');
     }
 
     public function setElasticMetaHeader(bool $active): self
@@ -102,17 +103,17 @@ class Client implements ClientInterface
 
     public function setResponseException(bool $active): self
     {
-        throw new \Exception('Not supported');
+        throw new NotImplementedException('Toggling the response-exception behaviour is not supported by Elastica.');
     }
 
     public function getResponseException(): bool
     {
-        throw new \Exception('Not supported');
+        throw new NotImplementedException('Toggling the response-exception behaviour is not supported by Elastica.');
     }
 
     public function setServerless(bool $value): ClientInterface
     {
-        throw new \Exception('Not supported');
+        throw new NotImplementedException('Serverless mode is not supported by Elastica.');
     }
 
     public function getServerless(): bool

--- a/src/Task.php
+++ b/src/Task.php
@@ -9,6 +9,7 @@ use Elastic\Elasticsearch\Exception\MissingParameterException;
 use Elastic\Elasticsearch\Exception\ServerResponseException;
 use Elastic\Transport\Exception\NoNodeAvailableException;
 use Elastica\Exception\ClientException;
+use Elastica\Exception\InvalidException;
 
 /**
  * Represents elasticsearch task.
@@ -107,12 +108,15 @@ class Task extends Param
     }
 
     /**
-     * @throws \Exception
+     * @throws InvalidException        if no task id is set
+     * @throws ClientResponseException if the status code of response is 4xx
+     * @throws ServerResponseException if the status code of response is 5xx
+     * @throws ClientException
      */
     public function cancel(): Response
     {
         if ('' === $this->_id) {
-            throw new \Exception('No task id given');
+            throw new InvalidException('No task id given');
         }
 
         return $this->_client->toElasticaResponse(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -6,8 +6,11 @@ namespace Elastica\Test;
 
 use Elastica\Client;
 use Elastica\ClientConfiguration;
+use Elastica\Exception\ExceptionInterface;
 use Elastica\Exception\InvalidException;
+use Elastica\Exception\NotImplementedException;
 use Elastica\Test\Base as BaseTest;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -250,5 +253,40 @@ class ClientTest extends BaseTest
         // Verify that string '0' is properly converted to integer 0
         $transport = $client->getTransport();
         $this->assertEquals(0, $transport->getRetries());
+    }
+
+    /**
+     * @return iterable<string, array{0: callable(Client): mixed}>
+     */
+    public static function unsupportedClientFeaturesProvider(): iterable
+    {
+        yield 'setAsync' => [static fn (Client $client) => $client->setAsync(true)];
+        yield 'getAsync' => [static fn (Client $client) => $client->getAsync()];
+        yield 'setResponseException' => [static fn (Client $client) => $client->setResponseException(true)];
+        yield 'getResponseException' => [static fn (Client $client) => $client->getResponseException()];
+        yield 'setServerless' => [static fn (Client $client) => $client->setServerless(true)];
+    }
+
+    #[DataProvider('unsupportedClientFeaturesProvider')]
+    public function testUnsupportedFeaturesThrowNotImplementedException(callable $invocation): void
+    {
+        $client = new Client();
+
+        $this->expectException(NotImplementedException::class);
+
+        $invocation($client);
+    }
+
+    public function testNotImplementedExceptionIsCatchableAsElasticaException(): void
+    {
+        $client = new Client();
+
+        try {
+            $client->setAsync(true);
+            $this->fail('Expected NotImplementedException was not thrown.');
+        } catch (ExceptionInterface $e) {
+            $this->assertInstanceOf(NotImplementedException::class, $e);
+            $this->assertInstanceOf(\BadMethodCallException::class, $e);
+        }
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -100,48 +100,12 @@ class ClientTest extends BaseTest
         $this->assertTrue($client->getConfig('bigintConversion'));
     }
 
-    public function testGetAsync(): void
-    {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Not supported');
-
-        $client = new Client();
-        $client->getAsync();
-    }
-
     public function testSetElasticMetaHeader(): void
     {
         $client = new Client();
         $client->setElasticMetaHeader(true);
 
         $this->assertTrue($client->getElasticMetaHeader());
-    }
-
-    public function testSetAsync(): void
-    {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Not supported');
-
-        $client = new Client();
-        $client->setAsync(true);
-    }
-
-    public function testSetResponseException(): void
-    {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Not supported');
-
-        $client = new Client();
-        $client->setResponseException(true);
-    }
-
-    public function testGetResponseException(): void
-    {
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Not supported');
-
-        $client = new Client();
-        $client->getResponseException();
     }
 
     public function testClientConnectionWithCloudId(): void
@@ -255,26 +219,30 @@ class ClientTest extends BaseTest
         $this->assertEquals(0, $transport->getRetries());
     }
 
-    /**
-     * @return iterable<string, array{0: callable(Client): mixed}>
-     */
-    public static function unsupportedClientFeaturesProvider(): iterable
-    {
-        yield 'setAsync' => [static fn (Client $client) => $client->setAsync(true)];
-        yield 'getAsync' => [static fn (Client $client) => $client->getAsync()];
-        yield 'setResponseException' => [static fn (Client $client) => $client->setResponseException(true)];
-        yield 'getResponseException' => [static fn (Client $client) => $client->getResponseException()];
-        yield 'setServerless' => [static fn (Client $client) => $client->setServerless(true)];
-    }
-
     #[DataProvider('unsupportedClientFeaturesProvider')]
-    public function testUnsupportedFeaturesThrowNotImplementedException(callable $invocation): void
+    public function testUnsupportedFeaturesThrowNotImplementedException(callable $invocation, string $expectedMessage): void
     {
         $client = new Client();
 
         $this->expectException(NotImplementedException::class);
+        $this->expectExceptionMessage($expectedMessage);
 
         $invocation($client);
+    }
+
+    /**
+     * @return iterable<string, array{0: callable(Client): mixed, 1: string}>
+     */
+    public static function unsupportedClientFeaturesProvider(): iterable
+    {
+        $async = 'Async mode is not supported by Elastica.';
+        $responseException = 'Toggling the response-exception behaviour is not supported by Elastica.';
+
+        yield 'setAsync' => [static fn (Client $client) => $client->setAsync(true), $async];
+        yield 'getAsync' => [static fn (Client $client) => $client->getAsync(), $async];
+        yield 'setResponseException' => [static fn (Client $client) => $client->setResponseException(true), $responseException];
+        yield 'getResponseException' => [static fn (Client $client) => $client->getResponseException(), $responseException];
+        yield 'setServerless' => [static fn (Client $client) => $client->setServerless(true), 'Serverless mode is not supported by Elastica.'];
     }
 
     public function testNotImplementedExceptionIsCatchableAsElasticaException(): void
@@ -285,7 +253,9 @@ class ClientTest extends BaseTest
             $client->setAsync(true);
             $this->fail('Expected NotImplementedException was not thrown.');
         } catch (ExceptionInterface $e) {
-            $this->assertInstanceOf(NotImplementedException::class, $e);
+            // Reaching this block already proves the exception is part of the Elastica
+            // umbrella; asserting the SPL parent pins the guarantee that callers
+            // catching \BadMethodCallException keep working.
             $this->assertInstanceOf(\BadMethodCallException::class, $e);
         }
     }

--- a/tests/TaskTest.php
+++ b/tests/TaskTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Elastica\Test;
 
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Index;
 use Elastica\Task;
 use PHPUnit\Framework\Attributes\Group;
@@ -61,7 +62,7 @@ class TaskTest extends Base
     #[Group('unit')]
     public function testCancelThrowsExceptionWithEmptyTaskId(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(InvalidException::class);
         $this->expectExceptionMessage('No task id given');
 
         $task = new Task($this->_getClient(), '');


### PR DESCRIPTION
## Summary

Replace `throw new \Exception('Not supported')` calls in `Elastica\Client`
and `Elastica\Task` with the existing typed Elastica exceptions:

- `Elastica\Client::setAsync()`, `getAsync()`, `setResponseException()`,
  `getResponseException()` and `setServerless()` now throw
  `Elastica\Exception\NotImplementedException` (already extends
  `\BadMethodCallException` and implements
  `Elastica\Exception\ExceptionInterface`).
- `Elastica\Task::cancel()`'s missing-id guard now throws
  `Elastica\Exception\InvalidException`.

This lets callers catch a typed exception (or the
`Elastica\Exception\ExceptionInterface` umbrella) instead of relying on
the SPL root.

Identified during a P0/P1 code-review pass.

## Test plan

- [x] Unit test using a `DataProvider` covers all five Client methods.
- [x] Additional test asserts the exception is catchable via
      `ExceptionInterface` *and* `\BadMethodCallException`.
- [x] Existing `TaskTest::testCancelThrowsExceptionWithEmptyTaskId`
      tightened to expect `InvalidException`.
- [x] CI matrix (PHP 8.1–8.5)
- [x] PHPStan + php-cs-fixer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated exception behavior for unsupported `Client` features to throw `NotImplementedException` (with method-specific messages).
  * Updated `Task::cancel()` to throw `InvalidException` when no task id is provided, instead of a generic exception.
* **Tests**
  * Revised and consolidated `Client` tests to assert the new `NotImplementedException` type and verify it’s catchable via Elastica’s exception interface.
  * Updated `Task` tests to expect `InvalidException` when cancelling with an empty task id.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->