### PR TITLE
fix: scope Bulk auto-populate config branch to Document payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* Fixed `Elastica\Bulk::_processResponse()` running version-param population on `Script` payloads. A missing pair of parentheses caused the `document.autoPopulate` config branch to fire for any payload due to PHP `&&`/`||` precedence; it now correctly applies only to `Document` instances.
 ### Security
 
 

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -343,8 +343,8 @@ class Bulk
 
                 if ($action instanceof AbstractDocumentAction) {
                     $data = $action->getData();
-                    if ($data instanceof Document && $data->isAutoPopulate()
-                        || $this->_client->getConfigValue(['document', 'autoPopulate'], false)
+                    if ($data instanceof Document
+                        && ($data->isAutoPopulate() || $this->_client->getConfigValue(['document', 'autoPopulate'], false))
                     ) {
                         if (!$data->hasId() && isset($bulkResponseData['_id'])) {
                             $data->setId($bulkResponseData['_id']);

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -708,6 +708,49 @@ class BulkTest extends BaseTest
         $this->assertSame($bulk, $bulk->setShardTimeout('10s'));
     }
 
+    /**
+     * Regression: when the global `document.autoPopulate` config is enabled,
+     * `Bulk::_processResponse()` must not invoke `setVersionParams()` on a
+     * Script payload. Prior to the fix, operator precedence caused the
+     * fallback branch to fire for any payload, including Scripts.
+     */
+    #[Group('unit')]
+    public function testProcessResponseDoesNotPopulateScriptWhenAutoPopulateEnabled(): void
+    {
+        $client = $this->_getClient();
+        $client->setConfigValue('document', ['autoPopulate' => true]);
+
+        $script = new Script('ctx._source.foo = "bar"');
+        $script->setId('1');
+
+        $bulk = new Bulk($client);
+        $bulk->addScript($script, Action::OP_TYPE_UPDATE);
+
+        // Synthesise a successful bulk response carrying version metadata that
+        // would otherwise be copied onto the Script via setVersionParams().
+        $response = new ElasticaResponse([
+            'errors' => false,
+            'items' => [
+                [
+                    'update' => [
+                        '_id' => '1',
+                        '_version' => 99,
+                        '_seq_no' => 42,
+                        '_primary_term' => 7,
+                        'status' => 200,
+                    ],
+                ],
+            ],
+        ], 200);
+
+        $reflection = new \ReflectionMethod(Bulk::class, '_processResponse');
+        $reflection->invoke($bulk, $response);
+
+        $this->assertFalse($script->hasVersion(), 'Scripts must not be auto-populated with _version');
+        $this->assertFalse($script->hasSequenceNumber(), 'Scripts must not be auto-populated with _seq_no');
+        $this->assertFalse($script->hasPrimaryTerm(), 'Scripts must not be auto-populated with _primary_term');
+    }
+
     #[Group('unit')]
     public function testSetRequestParam(): void
     {


### PR DESCRIPTION
## Summary

`Elastica\Bulk::_processResponse()` had a precedence bug:

```php
if ($data instanceof Document && $data->isAutoPopulate()
    || $this->_client->getConfigValue(['document', 'autoPopulate'], false)
)
```

Because `&&` binds tighter than `||`, the global `document.autoPopulate`
config caused `setVersionParams()` to run on any bulk action data —
including `Script` payloads — polluting them with response metadata
(`_version`, `_seq_no`, `_primary_term`) they have no use for.

The fix wraps the disjunction so the `Document` instance check applies
to the whole condition.

A new unit test synthesises a bulk response and asserts a Script payload
remains untouched. The test fails on the previous code and passes after
the fix (verified locally on PHP 8.5).

Identified during a P0/P1 code-review pass.

## Test plan

- [x] \`vendor/bin/phpunit --filter testProcessResponseDoesNotPopulateScriptWhenAutoPopulateEnabled\` (passes after fix, fails before)
- [x] \`vendor/bin/phpunit --group unit tests/BulkTest.php\` (13 tests / 54 assertions, all green)
- [x] CI matrix (PHP 8.1–8.5)
- [x] PHPStan + php-cs-fixer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect application of document auto-population behavior to Script payloads in bulk operations. Auto-population now correctly applies only to Document instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->