### PR TITLE
fix: throw InvalidException on unparseable Util::convertDate input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for "search after" based pagination [#1645](https://github.com/ruflin/Elastica/issues/1645)
 * Added support for the `seq_no_primary_term` search option and the `if_seq_no` / `if_primary_term` index options to enable optimistic concurrency control [#2284](https://github.com/ruflin/Elastica/pull/2284)
 ### Changed
+* `Elastica\Util::convertDate()` now throws `Elastica\Exception\InvalidException` when given a string that `strtotime()` cannot parse, instead of silently producing `1970-01-01T00:00:00Z`. The return type has also been narrowed to `string` and a typo-prone `null` argument is no longer accepted at runtime.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/Util.php
+++ b/src/Util.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Elastica;
 
+use Elastica\Exception\InvalidException;
+
 /**
  * Elastica tools.
  *
@@ -173,18 +175,24 @@ class Util
     /**
      * Converts given time to format: 1995-12-31T23:59:59Z.
      *
-     * This is the lucene date format
+     * This is the lucene date format.
      *
-     * @param int|string $date Date input (could be string etc.) -> must be supported by strtotime
+     * @param int|string $date Unix timestamp (int) or a string accepted by `strtotime`
+     *
+     * @throws InvalidException if `$date` is a string that cannot be parsed
      *
      * @return string Converted date string
      */
-    public static function convertDate($date)
+    public static function convertDate($date): string
     {
         if (\is_int($date)) {
             $timestamp = $date;
         } else {
             $timestamp = \strtotime($date);
+
+            if (false === $timestamp) {
+                throw new InvalidException(\sprintf('Unparseable date: "%s"', $date));
+            }
         }
 
         return \date('Y-m-d\TH:i:s\Z', $timestamp);

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Elastica\Test;
 
+use Elastica\Exception\InvalidException;
 use Elastica\Test\Base as BaseTest;
 use Elastica\Util;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -176,5 +177,14 @@ class UtilTest extends BaseTest
         $date = \date('Y-m-d\TH:i:s\Z', \strtotime($dateString));
 
         $this->assertEquals($convertedString, $date);
+    }
+
+    #[Group('unit')]
+    public function testConvertDateWithUnparseableStringThrows(): void
+    {
+        $this->expectException(InvalidException::class);
+        $this->expectExceptionMessage('Unparseable date: "definitely not a date"');
+
+        Util::convertDate('definitely not a date');
     }
 }


### PR DESCRIPTION
## Summary

`Util::convertDate()` ignored the `false` return of `strtotime()` for
invalid strings. PHP then coerced it to `0`, producing a silent
`1970-01-01T00:00:00Z` result that masked the underlying bug at the
caller.

The fix:

- Throws `Elastica\Exception\InvalidException` with a helpful message
  when the input string cannot be parsed.
- Narrows the documented return type to `string` (was undeclared).
- Adds a unit test for the failure path. Existing valid-input tests
  continue to pass unchanged.

Identified during a P0/P1 code-review pass.

## Test plan

- [x] \`vendor/bin/phpunit tests/UtilTest.php\` (35 tests / 74 assertions, all green)
- [x] CI matrix (PHP 8.1–8.5)
- [x] PHPStan + php-cs-fixer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or unparseable date strings now throw an exception instead of silently converting to epoch time.
  * Return type is now explicitly defined as `string`.

* **Documentation**
  * Updated changelog to document the new error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->