### PR TITLE
chore(ci): bump codecov-action from v2 to v5

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -104,9 +104,14 @@ jobs:
           vendor/bin/phpunit --group functional --coverage-clover=build/coverage/functional-coverage.xml
 
       - name: 'Upload coverage to Codecov'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
-            files: build/coverage/unit-coverage.xml,build/coverage/functional-coverage.xml
+          files: build/coverage/unit-coverage.xml,build/coverage/functional-coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          # Tokenless uploads from forks are flaky in v5; only request OIDC
+          # when the workflow is running on the head repository.
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
 
       - name: Elasticsearch Logs
         if: always()

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -49,6 +49,11 @@ jobs:
     runs-on: 'ubuntu-24.04'
     name: 'PHPUnit (PHP ${{ matrix.php }}, ES ${{ matrix.elasticsearch }})'
     timeout-minutes: 10
+    permissions:
+      contents: read
+      # Required for the Codecov OIDC token exchange below. id-token is never
+      # granted by default, so it has to be requested explicitly.
+      id-token: write
     strategy:
       matrix:
         php:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for "search after" based pagination [#1645](https://github.com/ruflin/Elastica/issues/1645)
 * Added support for the `seq_no_primary_term` search option and the `if_seq_no` / `if_primary_term` index options to enable optimistic concurrency control [#2284](https://github.com/ruflin/Elastica/pull/2284)
 ### Changed
+* Bumped `codecov/codecov-action` from `v2` to `v5` and aligned it with the v5 input contract (`token`, `fail_ci_if_error: false`, conditional `use_oidc`).
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for the `seq_no_primary_term` search option and the `if_seq_no` / `if_primary_term` index options to enable optimistic concurrency control [#2284](https://github.com/ruflin/Elastica/pull/2284)
 ### Changed
 * `Elastica\Util::convertDate()` now throws `Elastica\Exception\InvalidException` when given a string that `strtotime()` cannot parse, instead of silently producing `1970-01-01T00:00:00Z`. The return type has also been narrowed to `string` and a typo-prone `null` argument is no longer accepted at runtime.
+* Bumped `codecov/codecov-action` from `v2` to `v5` and aligned it with the v5 input contract (`token`, `fail_ci_if_error: false`, conditional `use_oidc`).
 ### Deprecated
 ### Removed
 ### Fixed


### PR DESCRIPTION
## Summary

`codecov/codecov-action@v2` is several majors behind the current v5.5.x
line. Bump to v5 and align with the new input contract:

- Pass `token` from the `CODECOV_TOKEN` secret (still works for the
  tokenless fallback if no secret is configured).
- Set `fail_ci_if_error: false` so a flaky upload does not block the
  build.
- Conditionally enable `use_oidc` to work around the
  [v5.4.1 regression](https://github.com/codecov/codecov-action/issues/1821)
  that breaks OIDC token requests on fork pull requests.

Identified during a P0/P1 code-review pass.

## Test plan

- [x] Run the workflow once on this PR; confirm coverage upload succeeds.
- [x] Validate YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration workflow’s Codecov upload step to the latest action version, with improved coverage upload handling and more secure token-based integration.
  * Adjusted the workflow behavior so OIDC is only used when appropriate, and CI won’t fail solely due to coverage upload errors.
  * Reflected the CI change in the Unreleased changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->