### PR TITLE
chore(ci): add lowest-deps PHPUnit job to lock minimum constraints

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -113,6 +113,37 @@ jobs:
         run: |
           docker compose --file=docker/compose.proxy.yaml --file=docker/compose.es.yaml logs es01 es02
 
+  phpunit-lowest:
+    runs-on: 'ubuntu-24.04'
+    name: 'PHPUnit (lowest deps, PHP ${{ matrix.php }})'
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        php:
+          - '8.1'
+      fail-fast: false
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
+
+      - name: 'Setup PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '${{ matrix.php }}'
+          coverage: 'none'
+          tools: 'composer:v2'
+          extensions: 'curl, json, mbstring, openssl'
+
+      - name: 'Install dependencies with Composer (lowest)'
+        uses: 'ramsey/composer-install@v3'
+        with:
+          dependency-versions: 'lowest'
+          composer-options: '--prefer-dist --prefer-stable'
+
+      - name: 'Run unit tests'
+        run: |
+          vendor/bin/phpunit --group unit
+
   phpstan:
     runs-on: 'ubuntu-24.04'
     name: 'PHPStan'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for "search after" based pagination [#1645](https://github.com/ruflin/Elastica/issues/1645)
 * Added support for the `seq_no_primary_term` search option and the `if_seq_no` / `if_primary_term` index options to enable optimistic concurrency control [#2284](https://github.com/ruflin/Elastica/pull/2284)
 ### Changed
+* Added a `phpunit-lowest` CI job that installs dependencies with `--prefer-lowest --prefer-stable` and runs the unit tests on PHP 8.1, ensuring that the minimum constraints declared in `composer.json` keep working.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for the `seq_no_primary_term` search option and the `if_seq_no` / `if_primary_term` index options to enable optimistic concurrency control [#2284](https://github.com/ruflin/Elastica/pull/2284)
 ### Changed
 * `Elastica\Util::convertDate()` now throws `Elastica\Exception\InvalidException` when given a string that `strtotime()` cannot parse, instead of silently producing `1970-01-01T00:00:00Z`. The return type has also been narrowed to `string` and a typo-prone `null` argument is no longer accepted at runtime.
+* Added a `phpunit-lowest` CI job that installs dependencies with `--prefer-lowest --prefer-stable` and runs the unit tests on PHP 8.1, ensuring that the minimum constraints declared in `composer.json` keep working.
 ### Deprecated
 ### Removed
 ### Fixed


### PR DESCRIPTION
## Summary

Without a `--prefer-lowest` job the minimum versions declared in
`composer.json` are never tested. Add a unit-only PHPUnit job on PHP 8.1
that installs dependencies with `--prefer-lowest --prefer-stable` so any
accidental tightening of a `composer.json` constraint is caught early.

Functional tests intentionally stay out of this job to avoid doubling
the cost of the ES-backed steps.

Identified during a P0/P1 code-review pass.

## Test plan

- [x] Job runs on this PR; if it fails, expect a `composer.json`
      constraint that needs bumping.
- [x] Validate YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration testing by adding a new unit-test run using the lowest allowed dependency versions on PHP 8.1 (with no coverage generation).
* **Documentation**
  * Updated the Unreleased changelog to reflect the new CI coverage for minimum dependency compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->