### PR TITLE
chore(ci): pin third-party GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,13 +29,13 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta @ 2026-04-30
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,13 +27,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 10
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta @ 2026-04-30
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -6,10 +6,10 @@ jobs:
     name: 'Coding style'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # v4.3.1
 
       - name: 'Setup PHP'
-        uses: 'shivammathur/setup-php@v2'
+        uses: 'shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f' # 2.37.0
         with:
           php-version: '8.1'
           coverage: 'none'
@@ -29,16 +29,16 @@ jobs:
     name: 'Coding standards'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # v4.3.1
 
       - name: 'Setup PHP'
-        uses: 'shivammathur/setup-php@v2'
+        uses: 'shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f' # 2.37.0
         with:
           php-version: '8.1'
           tools: composer
 
       - name: 'Install dependencies with Composer'
-        uses: 'ramsey/composer-install@v3'
+        uses: 'ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f' # 3.2.1
         with:
           composer-options: '--prefer-dist'
 
@@ -64,10 +64,10 @@ jobs:
       fail-fast: false
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # v4.3.1
 
       - name: 'Setup PHP'
-        uses: 'shivammathur/setup-php@v2'
+        uses: 'shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f' # 2.37.0
         with:
           php-version: '${{ matrix.php }}'
           coverage: 'pcov'
@@ -75,7 +75,7 @@ jobs:
           extensions: 'curl, json, mbstring, openssl'
 
       - name: 'Install dependencies with Composer'
-        uses: 'ramsey/composer-install@v3'
+        uses: 'ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f' # 3.2.1
         with:
           dependency-versions: '${{ matrix.dependencies }}'
           composer-options: '--prefer-dist'
@@ -104,7 +104,7 @@ jobs:
           vendor/bin/phpunit --group functional --coverage-clover=build/coverage/functional-coverage.xml
 
       - name: 'Upload coverage to Codecov'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2.1.0
         with:
             files: build/coverage/unit-coverage.xml,build/coverage/functional-coverage.xml
 
@@ -119,10 +119,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@v4'
+        uses: 'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5' # v4.3.1
 
       - name: 'Setup PHP'
-        uses: 'shivammathur/setup-php@v2'
+        uses: 'shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f' # 2.37.0
         with:
           php-version: '8.1'
           coverage: 'none'
@@ -130,7 +130,7 @@ jobs:
           extensions: 'curl, json, mbstring, openssl'
 
       - name: 'Install dependencies with Composer'
-        uses: 'ramsey/composer-install@v3'
+        uses: 'ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f' # 3.2.1
         with:
           composer-options: '--prefer-dist'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 ### Security
+* Pinned every third-party GitHub Action (`actions/checkout`, `shivammathur/setup-php`, `ramsey/composer-install`, `codecov/codecov-action`, `anthropics/claude-code-action`) to a full commit SHA with a trailing version comment. Floating tags can be silently rewritten by the action publisher; pinning to a SHA prevents supply-chain hijacks (cf. the March 2025 `tj-actions/changed-files` incident).
 
 
 ## [9.0.0](https://github.com/ruflin/Elastica/compare/8.x...9.0.0)


### PR DESCRIPTION
## Summary

Floating tags such as `actions/checkout@v4` can be silently re-pointed
by the publisher (or by a compromised maintainer account, cf. the
[March 2025 \`tj-actions/changed-files\` supply-chain incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)).
Pin every third-party action used by this repository to a full commit
SHA, with a trailing comment recording the human-readable version so
Dependabot's GHA ecosystem (added in #2306) can keep them up to date
safely.

Pinned versions:

| Action | Version | SHA |
|---|---|---|
| `actions/checkout` | v4.3.1 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `shivammathur/setup-php` | 2.37.0 | `accd6127cb78bee3e8082180cb391013d204ef9f` |
| `ramsey/composer-install` | 3.2.1 | `a8d0d959dab41457692a5e2041bd9b757a119e3f` |
| `codecov/codecov-action` | v2.1.0 | `f32b3a3741e1053eb607407145bc9619351dc93b` |
| `anthropics/claude-code-action` | beta @ 2026-04-30 | `28f83620103c48a57093dcc2837eec89e036bb9f` |

\`codecov/codecov-action\` is intentionally left at v2 in this PR so it
can be diffed in isolation. The major bump to v5 lands in #2307.

Identified during a P0/P1 code-review pass.

## Test plan

- [x] CI matrix (PHP 8.1–8.5) runs successfully against the SHA-pinned
      actions.
- [x] \`grep -rn 'uses:' .github/workflows/\` shows no remaining
      tag-only references for third-party actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CD workflows now use pinned GitHub Actions versions instead of floating tags for improved build consistency and security.
  * Enhanced infrastructure reliability and reproducibility across automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->