### PR TITLE
refactor: throw Elastica\Exception\InvalidException for argument-validation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for the `seq_no_primary_term` search option and the `if_seq_no` / `if_primary_term` index options to enable optimistic concurrency control [#2284](https://github.com/ruflin/Elastica/pull/2284)
 ### Changed
 * `Elastica\Util::convertDate()` now throws `Elastica\Exception\InvalidException` when given a string that `strtotime()` cannot parse, instead of silently producing `1970-01-01T00:00:00Z`. The return type has also been narrowed to `string` and a typo-prone `null` argument is no longer accepted at runtime.
+* `Elastica\Bulk::addData()`, `Elastica\Bulk\Action\AbstractDocument::setData()` / `::create()`, and `Elastica\Index::updateDocument()` now throw `Elastica\Exception\InvalidException` (which still extends `\InvalidArgumentException`, so existing catch blocks keep working) instead of a bare `\InvalidArgumentException`. This makes the failures catchable through `Elastica\Exception\ExceptionInterface` like the rest of the library.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/Bulk.php
+++ b/src/Bulk.php
@@ -209,7 +209,7 @@ class Bulk
             } elseif ($actionData instanceof Document) {
                 $this->addDocument($actionData, $opType);
             } else {
-                throw new \InvalidArgumentException('Data should be a Document, a Script or an array containing Documents and/or Scripts');
+                throw new InvalidException('Data should be a Document, a Script or an array containing Documents and/or Scripts');
             }
         }
 

--- a/src/Bulk/Action/AbstractDocument.php
+++ b/src/Bulk/Action/AbstractDocument.php
@@ -7,6 +7,7 @@ namespace Elastica\Bulk\Action;
 use Elastica\AbstractUpdateAction;
 use Elastica\Bulk\Action;
 use Elastica\Document;
+use Elastica\Exception\InvalidException;
 use Elastica\Script\AbstractScript;
 
 abstract class AbstractDocument extends Action
@@ -58,7 +59,7 @@ abstract class AbstractDocument extends Action
     /**
      * @param AbstractScript|Document $data
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidException
      *
      * @return $this
      */
@@ -69,7 +70,7 @@ abstract class AbstractDocument extends Action
         } elseif ($data instanceof Document) {
             $this->setDocument($data);
         } else {
-            throw new \InvalidArgumentException('Data should be a Document or a Script.');
+            throw new InvalidException('Data should be a Document or a Script.');
         }
 
         return $this;
@@ -120,21 +121,20 @@ abstract class AbstractDocument extends Action
      */
     public static function create($data, ?string $opType = null): self
     {
-        // Check type
         if (!$data instanceof Document && !$data instanceof AbstractScript) {
-            throw new \InvalidArgumentException('The data needs to be a Document or a Script.');
+            throw new InvalidException('The data needs to be a Document or a Script.');
         }
 
         if (null === $opType && $data->hasOpType()) {
             $opType = $data->getOpType();
         }
 
-        // Check that scripts can only be used for updates
+        // Scripts can only be used for updates.
         if ($data instanceof AbstractScript) {
             if (null === $opType) {
                 $opType = self::OP_TYPE_UPDATE;
             } elseif (self::OP_TYPE_UPDATE !== $opType) {
-                throw new \InvalidArgumentException('Scripts can only be used with the update operation type.');
+                throw new InvalidException('Scripts can only be used with the update operation type.');
             }
         }
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -878,7 +878,7 @@ class Index implements SearchableInterface
     public function updateDocument($data, array $options = []): Response
     {
         if (!($data instanceof Document) && !($data instanceof AbstractScript)) {
-            throw new \InvalidArgumentException('Data should be a Document or Script');
+            throw new InvalidException('Data should be a Document or Script');
         }
 
         if (!$data->hasId()) {


### PR DESCRIPTION
## Summary

Replace every remaining `throw new \InvalidArgumentException(...)` in the
public surface with the existing `Elastica\Exception\InvalidException`:

- `Elastica\Bulk::addData()`
- `Elastica\Bulk\Action\AbstractDocument::setData()`
- `Elastica\Bulk\Action\AbstractDocument::create()`
- `Elastica\Index::updateDocument()`

`InvalidException` already `extends \InvalidArgumentException` and
`implements Elastica\Exception\ExceptionInterface`, so any existing
caller that catches the SPL exception keeps working while new callers
can rely on the typed Elastica umbrella.

`@throws` tags are tightened accordingly. No behavioural change.

Identified during a P0/P1 code-review pass.

## Test plan

- [x] \`vendor/bin/phpunit --group unit\` (496 tests / 2363 assertions, all green)
- [x] \`grep -rn 'throw new \\\\InvalidArgumentException' src/\` returns nothing
- [x] CI matrix (PHP 8.1–8.5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Bulk, Document, and Index mutation methods now throw library-specific exceptions for invalid input, improving consistency with the exception hierarchy and enabling more precise error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->