### PR TITLE
refactor: mark leaf exception classes as final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/ruflin/Elastica/compare/9.0.0...9.x)
 
 ### Backward Compatibility Breaks
+* Marked the leaf exception classes `Elastica\Exception\ClientException`, `Elastica\Exception\InvalidException`, `Elastica\Exception\NotFoundException`, `Elastica\Exception\QueryBuilderException`, `Elastica\Exception\RequestEntityTooLargeException`, `Elastica\Exception\RuntimeException`, `Elastica\Exception\DeprecatedException`, `Elastica\Exception\Bulk\Response\ActionException` and `Elastica\Exception\Bulk\ResponseException` as `final`. Per the convention documented in `AGENTS.md`, classes that are not explicitly meant to be extended should be `final`. These nine exceptions never had subclasses inside the project; in the unlikely case downstream code subclassed one of them, switch to composition or open an issue describing the use case.
 ### Added
 * Added support for numeric `minimum_should_match` values in `TermsSet` query [#2293](https://github.com/ruflin/Elastica/pull/2293)
 * Added support for "search after" based pagination [#1645](https://github.com/ruflin/Elastica/issues/1645)

--- a/src/Exception/Bulk/Response/ActionException.php
+++ b/src/Exception/Bulk/Response/ActionException.php
@@ -8,7 +8,7 @@ use Elastica\Bulk\Action;
 use Elastica\Bulk\Response;
 use Elastica\Exception\BulkException;
 
-class ActionException extends BulkException
+final class ActionException extends BulkException
 {
     protected Response $_response;
 

--- a/src/Exception/Bulk/ResponseException.php
+++ b/src/Exception/Bulk/ResponseException.php
@@ -11,7 +11,7 @@ use Elastica\Exception\BulkException;
 /**
  * Bulk Response exception.
  */
-class ResponseException extends BulkException
+final class ResponseException extends BulkException
 {
     /**
      * @var ResponseSet ResponseSet object

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -9,6 +9,6 @@ namespace Elastica\Exception;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  */
-class ClientException extends \RuntimeException implements ExceptionInterface
+final class ClientException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/DeprecatedException.php
+++ b/src/Exception/DeprecatedException.php
@@ -11,6 +11,6 @@ namespace Elastica\Exception;
  *
  * @author Evgeniy Sokolov <ewgraf@gmail.com>
  */
-class DeprecatedException extends NotImplementedException
+final class DeprecatedException extends NotImplementedException
 {
 }

--- a/src/Exception/InvalidException.php
+++ b/src/Exception/InvalidException.php
@@ -9,6 +9,6 @@ namespace Elastica\Exception;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  */
-class InvalidException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -9,6 +9,6 @@ namespace Elastica\Exception;
  *
  * @author Nicolas Ruflin <spam@ruflin.com>
  */
-class NotFoundException extends \RuntimeException implements ExceptionInterface
+final class NotFoundException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/QueryBuilderException.php
+++ b/src/Exception/QueryBuilderException.php
@@ -9,6 +9,6 @@ namespace Elastica\Exception;
  *
  * @author Manuel Andreo Garcia <andreo.garcia@googlemail.com>
  */
-class QueryBuilderException extends \RuntimeException implements ExceptionInterface
+final class QueryBuilderException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/RequestEntityTooLargeException.php
+++ b/src/Exception/RequestEntityTooLargeException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Elastica\Exception;
 
-class RequestEntityTooLargeException extends \RuntimeException implements ExceptionInterface
+final class RequestEntityTooLargeException extends \RuntimeException implements ExceptionInterface
 {
     public function __construct(?\Throwable $previous = null)
     {

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -9,6 +9,6 @@ namespace Elastica\Exception;
  *
  * @author Mikhail Shamin <munk13@gmail.com>
  */
-class RuntimeException extends \RuntimeException implements ExceptionInterface
+final class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 }


### PR DESCRIPTION
## Summary

`AGENTS.md` documents the convention that *"all classes must be final
unless meant to be extended"*. Apply this to the leaf exception classes
that have no internal subclasses anywhere in `src/` or `tests/`:

- `Elastica\Exception\ClientException`
- `Elastica\Exception\InvalidException`
- `Elastica\Exception\NotFoundException`
- `Elastica\Exception\QueryBuilderException`
- `Elastica\Exception\RequestEntityTooLargeException`
- `Elastica\Exception\RuntimeException`
- `Elastica\Exception\DeprecatedException`
- `Elastica\Exception\Bulk\Response\ActionException`
- `Elastica\Exception\Bulk\ResponseException`

`BulkException` and `NotImplementedException` keep their open
inheritance because they have legitimate subclasses in the codebase.

This is technically a BC-break for any consumer that subclassed one of
these exceptions in their own code, so the change is recorded in the
**Backward Compatibility Breaks** section of `CHANGELOG.md`. The wider
sweep across queries, suggesters, processors and aggregations is left
for a follow-up because many of those classes are meaningfully extended
both inside the codebase (e.g. `MatchPhrasePrefix → MatchPhrase`) and
in real-world projects.

Identified during a P0/P1 code-review pass.

## Test plan

- [x] \`vendor/bin/phpunit --group unit\` (496 tests / 2363 assertions, all green)
- [x] CI matrix (PHP 8.1–8.5)
- [x] PHPStan + php-cs-fixer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Backward Compatibility Breaks**
  * Nine exception classes are now declared final, preventing external inheritance. Applications extending these exceptions will require code updates for compatibility with this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->