### PR TITLE
fix: scope Index::refresh() to the target index (#2313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* `Elastica\Index::refresh()` now refreshes only the targeted index instead of the entire cluster (previously it issued `POST /_refresh`, now it issues `POST /{index}/_refresh`) [#2313](https://github.com/ruflin/Elastica/issues/2313)
 ### Security
 
 

--- a/src/Index.php
+++ b/src/Index.php
@@ -470,7 +470,7 @@ class Index implements SearchableInterface
     public function refresh(): Response
     {
         return $this->_client->toElasticaResponse(
-            $this->_client->indices()->refresh()
+            $this->_client->indices()->refresh(['index' => $this->getName()])
         );
     }
 

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -1028,4 +1028,23 @@ class IndexTest extends BaseTest
         $this->expectException(ClientResponseException::class);
         $index->addDocument($second);
     }
+
+    #[Group('functional')]
+    public function testRefreshTargetsIndexAndNotCluster(): void
+    {
+        $index = $this->_createIndex();
+        $client = $index->getClient();
+
+        $response = $index->refresh();
+
+        $this->assertTrue($response->isOk());
+
+        $lastRequest = $client->getLastRequest();
+        $this->assertNotNull($lastRequest);
+        $this->assertSame(
+            \sprintf('/%s/_refresh', $index->getName()),
+            $lastRequest->getUri()->getPath(),
+            'Index::refresh() must target the specific index, not the whole cluster'
+        );
+    }
 }

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -18,6 +18,7 @@ use Elastica\Script\Script;
 use Elastica\Status;
 use Elastica\Test\Base as BaseTest;
 use PHPUnit\Framework\Attributes\Group;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @internal
@@ -1040,7 +1041,7 @@ class IndexTest extends BaseTest
         $this->assertTrue($response->isOk());
 
         $lastRequest = $client->getLastRequest();
-        $this->assertNotNull($lastRequest);
+        $this->assertInstanceOf(RequestInterface::class, $lastRequest);
         $this->assertSame(
             \sprintf('/%s/_refresh', $index->getName()),
             $lastRequest->getUri()->getPath(),


### PR DESCRIPTION
## Summary

Fixes #2313.

`Elastica\Index::refresh()` was calling `indices()->refresh()` on the underlying [`elastic/elasticsearch`](https://github.com/elastic/elasticsearch-php) client without passing the `index` parameter. That maps to `POST /_refresh` — a **cluster-wide** refresh — instead of the expected `POST /{index}/_refresh`.

That is surprising for an instance method on `Elastica\Index`, especially because every neighboring method (`delete()`, `exists()`, `open()`, `close()`, `setSettings()`, `analyze()`, `forcemerge()`, …) does pass `['index' => $this->getName()]`. In practice, code like:

\`\`\`php
\$client->getIndex('my-index')->refresh();
\`\`\`

was silently refreshing **every** index in the cluster on every call, which is expensive on shared/large clusters.

### Change

- `src/Index.php`: pass `['index' => \$this->getName()]` to `indices()->refresh()` so the request is correctly scoped to the current index.
- `Client::refreshAll()` is unchanged — it is the explicit cluster-wide refresh and still calls `indices()->refresh()` without an index, mapping to `POST /_refresh`.

### Backward compatibility

This is a bug fix. Anyone who was actually relying on `\$index->refresh()` to refresh the whole cluster (almost certainly nobody, given the method name and surrounding API) can call `\$client->refreshAll()` instead, which has been the dedicated API for that since at least 8.x.

## Test plan

- [x] Added a functional test `IndexTest::testRefreshTargetsIndexAndNotCluster` that asserts `\$client->getLastRequest()->getUri()->getPath()` equals `/{index}/_refresh` after calling `\$index->refresh()` (same pattern used by `ClientFunctionalTest::testLastRequestResponse`).
- [x] Verified unit test group still passes locally (`vendor/bin/phpunit --group unit --filter IndexTest`).
- [x] Verified phpstan is clean on the changed files.
- [ ] CI runs the functional suite against Elasticsearch.

## Changelog

Added an entry under \`### Fixed\` in the \`Unreleased\` section of \`CHANGELOG.md\` referencing #2313.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the refresh behavior so it affects only the intended index instead of refreshing the entire cluster.

* **Tests**
  * Added a functional test that verifies the refresh request targets the specific index and not the cluster-level endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ruflin/Elastica/pull/2315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->