### PR TITLE
`Client::deleteIds` type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* `Client::deleteIds()` now accepts integer document IDs again by casting them to string before `Action::setId()` [#2316](https://github.com/ruflin/Elastica/issues/2316)
 ### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-* `Client::deleteIds()` now accepts integer document IDs again by casting them to string before `Action::setId()` [#2316](https://github.com/ruflin/Elastica/issues/2316)
+* `Client::deleteIds()` now accepts integer document IDs again by casting them to string before `Action::setId()` [#2316](https://github.com/ruflin/Elastica/issues/2316) [#2318](https://github.com/ruflin/Elastica/pull/2318)
 ### Security
 
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -414,7 +414,7 @@ class Client implements ClientInterface
 
         foreach ($ids as $id) {
             $action = new Action(Action::OP_TYPE_DELETE);
-            $action->setId($id);
+            $action->setId((string) $id);
 
             if (!empty($routing)) {
                 $action->setRouting($routing);

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -348,6 +348,27 @@ class ClientFunctionalTest extends BaseTest
         $this->assertEquals(0, $totalHits);
     }
 
+    /**
+     * Integer IDs must be accepted by deleteIds() after strict_types made
+     * Action::setId(string) reject implicit int-to-string coercion.
+     *
+     * @see https://github.com/ruflin/Elastica/issues/2316
+     */
+    #[Group('functional')]
+    public function testDeleteIdsWithIntegerIds(): void
+    {
+        $index = $this->_createIndex();
+        $index->addDocument(new Document('185755', ['username' => 'hans']));
+        $index->refresh();
+
+        $this->assertEquals(1, $index->search('username:hans')->getTotalHits());
+
+        $index->getClient()->deleteIds([185755], $index);
+        $index->refresh();
+
+        $this->assertEquals(0, $index->search('username:hans')->getTotalHits());
+    }
+
     public function testOneInvalidConnection(): void
     {
         $client = $this->_getClient([


### PR DESCRIPTION
Fixes #2316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk deletion reliability by consistently handling document IDs as strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->