### PR TITLE
test: add changelog and integer-ID coverage for Client::deleteIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* `Client::deleteIds()` now accepts integer document IDs again by casting them to string before `Action::setId()` [#2316](https://github.com/ruflin/Elastica/issues/2316)
 ### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
-* `Client::deleteIds()` now accepts integer document IDs again by casting them to string before `Action::setId()` [#2316](https://github.com/ruflin/Elastica/issues/2316)
+* `Client::deleteIds()` now accepts integer document IDs again by casting them to string before `Action::setId()` [#2316](https://github.com/ruflin/Elastica/issues/2316) [#2318](https://github.com/ruflin/Elastica/pull/2318)
 ### Security
 
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -414,7 +414,7 @@ class Client implements ClientInterface
 
         foreach ($ids as $id) {
             $action = new Action(Action::OP_TYPE_DELETE);
-            $action->setId($id);
+            $action->setId((string) $id);
 
             if (!empty($routing)) {
                 $action->setRouting($routing);

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -348,6 +348,27 @@ class ClientFunctionalTest extends BaseTest
         $this->assertEquals(0, $totalHits);
     }
 
+    /**
+     * Integer IDs must be accepted by deleteIds() after strict_types made
+     * Action::setId(string) reject implicit int-to-string coercion.
+     *
+     * @see https://github.com/ruflin/Elastica/issues/2316
+     */
+    #[Group('functional')]
+    public function testDeleteIdsWithIntegerIds(): void
+    {
+        $index = $this->_createIndex();
+        $index->addDocument(new Document('185755', ['username' => 'hans']));
+        $index->refresh();
+
+        $this->assertEquals(1, $index->search('username:hans')->getTotalHits());
+
+        $index->getClient()->deleteIds([185755], $index);
+        $index->refresh();
+
+        $this->assertEquals(0, $index->search('username:hans')->getTotalHits());
+    }
+
     public function testOneInvalidConnection(): void
     {
         $client = $this->_getClient([


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Same changelog + integer-ID test as now pushed to AntoineRoue’s `9.x` branch on #2317.

A PR opened *against* that fork branch was not possible (GitHub App cannot create pull requests on `AntoineRoue/Elastica`). Instead the two follow-up commits were pushed to #2317 via maintainer edits.

This PR remains a same-repo fallback targeting `9.x`. It can be closed if #2317 is merged with those commits.

## Changes

- Keep AntoineRoue's one-line cast in `Client::deleteIds()`.
- Document the fix under Unreleased → Fixed in `CHANGELOG.md`.
- Add `testDeleteIdsWithIntegerIds()` in `tests/ClientFunctionalTest.php`.

Fixes #2316

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-450066a1-3de9-4732-80dc-b3d28a1a4cae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-450066a1-3de9-4732-80dc-b3d28a1a4cae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

